### PR TITLE
Fix consecutive Authorizations

### DIFF
--- a/Source/ARTAuth+Private.h
+++ b/Source/ARTAuth+Private.h
@@ -39,6 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSObject<ARTCancellable> *)_authorize:(nullable ARTTokenParams *)tokenParams options:(nullable ARTAuthOptions *)authOptions
          callback:(void (^)(ARTTokenDetails *_Nullable, NSError *_Nullable))callback;
+- (void)cancelAuthorization:(nullable ARTErrorInfo *)error;
 
 - (nullable NSObject<ARTCancellable> *)_requestToken:(ARTTokenParams *_Nullable)tokenParams withOptions:(ARTAuthOptions *_Nullable)authOptions callback:(void (^)(ARTTokenDetails *_Nullable, NSError *_Nullable))callback;
 
@@ -82,14 +83,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *_Nullable)clientId;
 
 - (NSString *_Nullable)appId;
-
-@end
-
-#pragma mark - ARTEvent
-
-@interface ARTEvent (AuthorizationState)
-- (instancetype)initWithAuthorizationState:(ARTAuthorizationState)value;
-+ (instancetype)newWithAuthorizationState:(ARTAuthorizationState)value;
 
 @end
 

--- a/Source/ARTAuth+Private.h
+++ b/Source/ARTAuth+Private.h
@@ -37,10 +37,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) BOOL authorizing;
 @property (readonly) BOOL authorizing_nosync;
 
-- (void)_authorize:(nullable ARTTokenParams *)tokenParams options:(nullable ARTAuthOptions *)authOptions
+- (nullable NSObject<ARTCancellable> *)_authorize:(nullable ARTTokenParams *)tokenParams options:(nullable ARTAuthOptions *)authOptions
          callback:(void (^)(ARTTokenDetails *_Nullable, NSError *_Nullable))callback;
 
-- (void)_requestToken:(ARTTokenParams *_Nullable)tokenParams withOptions:(ARTAuthOptions *_Nullable)authOptions callback:(void (^)(ARTTokenDetails *_Nullable, NSError *_Nullable))callback;
+- (nullable NSObject<ARTCancellable> *)_requestToken:(ARTTokenParams *_Nullable)tokenParams withOptions:(ARTAuthOptions *_Nullable)authOptions callback:(void (^)(ARTTokenDetails *_Nullable, NSError *_Nullable))callback;
 
 @end
 
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSMutableURLRequest *)buildRequest:(nullable ARTAuthOptions *)options withParams:(nullable ARTTokenParams *)params;
 
 // Execute the received ARTTokenRequest
-- (void)executeTokenRequest:(ARTTokenRequest *)tokenRequest callback:(void (^)(ARTTokenDetails *_Nullable tokenDetails, NSError *_Nullable error))callback;
+- (nullable NSObject<ARTCancellable> *)executeTokenRequest:(ARTTokenRequest *)tokenRequest callback:(void (^)(ARTTokenDetails *_Nullable tokenDetails, NSError *_Nullable error))callback;
 
 // CONNECTED ProtocolMessage may contain a clientId
 - (void)setProtocolClientId:(NSString *)clientId;

--- a/Source/ARTAuth+Private.h
+++ b/Source/ARTAuth+Private.h
@@ -19,8 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Messages related to the ARTAuth
 @protocol ARTAuthDelegate <NSObject>
-@property (nonatomic, readonly) ARTEventEmitter<ARTEvent *, id> *authorizationEmitter;
-- (void)auth:(ARTAuth *)auth didAuthorize:(ARTTokenDetails *)tokenDetails;
+- (void)auth:(ARTAuth *)auth didAuthorize:(ARTTokenDetails *)tokenDetails completion:(void (^)(ARTAuthorizationState, ARTErrorInfo *_Nullable))completion;
 @end
 
 @interface ARTAuth ()
@@ -35,7 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, readonly, strong) NSNumber *timeOffset;
 
 @property (nullable, weak) id<ARTAuthDelegate> delegate;
-@property (readonly, assign) BOOL authorizing;
+@property (readonly) BOOL authorizing;
+@property (readonly) BOOL authorizing_nosync;
 
 - (void)_authorize:(nullable ARTTokenParams *)tokenParams options:(nullable ARTAuthOptions *)authOptions
          callback:(void (^)(ARTTokenDetails *_Nullable, NSError *_Nullable))callback;

--- a/Source/ARTAuth.m
+++ b/Source/ARTAuth.m
@@ -32,6 +32,7 @@
     ARTTokenParams *_tokenParams;
     // Dedicated to Protocol Message
     NSString *_protocolClientId;
+    NSInteger _authorizationsCount;
 }
 
 - (instancetype)init:(ARTRest *)rest withOptions:(ARTClientOptions *)options {
@@ -45,6 +46,7 @@ ART_TRY_OR_REPORT_CRASH_START(rest) {
         _logger = rest.logger;
         _protocolClientId = nil;
         _tokenParams = options.defaultTokenParams ? : [[ARTTokenParams alloc] initWithOptions:self.options];
+        _authorizationsCount = 0;
         [self validate:options];
 
         [[NSNotificationCenter defaultCenter] addObserver:self
@@ -432,6 +434,20 @@ ART_TRY_OR_REPORT_CRASH_START(_rest) {
 } ART_TRY_OR_REPORT_CRASH_END
 }
 
+- (BOOL)authorizing {
+ART_TRY_OR_REPORT_CRASH_START(_rest) {
+    __block NSInteger count;
+    dispatch_sync(_queue, ^{
+        count = self->_authorizationsCount;
+    });
+    return count > 0;
+} ART_TRY_OR_REPORT_CRASH_END
+}
+
+- (BOOL)authorizing_nosync {
+    return _authorizationsCount > 0;
+}
+
 - (void)authorize:(void (^)(ARTTokenDetails *, NSError *))callback {
 ART_TRY_OR_REPORT_CRASH_START(_rest) {
     [self authorize:_options.defaultTokenParams options:_options callback:callback];
@@ -454,84 +470,39 @@ dispatch_async(_queue, ^{
 });
 }
 
-- (void)_authorize:(ARTTokenParams *)tokenParams options:(ARTAuthOptions *)authOptions callback:(void (^)(ARTTokenDetails *, NSError *))callback {
+- (nullable NSObject<ARTCancellable> *)_authorize:(ARTTokenParams *)tokenParams options:(ARTAuthOptions *)authOptions callback:(void (^)(ARTTokenDetails *, NSError *))callback {
 ART_TRY_OR_REPORT_CRASH_START(_rest) {
-    __block BOOL completed = false;
-
     ARTAuthOptions *replacedOptions = [authOptions copy] ? : [self.options copy];
     [self storeOptions:replacedOptions];
 
     ARTTokenParams *currentTokenParams = [self mergeParams:tokenParams];
     [self storeParams:currentTokenParams];
 
-    // Success
-    void (^successBlock)(ARTTokenDetails *) = ^(ARTTokenDetails *tokenDetails) {
-        [self.logger verbose:@"RS:%p ARTAuth: token request succeeded: %@", self->_rest, tokenDetails];
-        if (callback) {
-            callback(self.tokenDetails, nil);
-        }
-        self->_authorizing = false;
-    };
-
-    // Failure
-    void (^failureBlock)(NSError *) = ^(NSError *error) {
-        [self.logger verbose:@"RS:%p ARTAuth: token request failed: %@", self->_rest, error];
-        if (callback) {
-            callback(nil, error);
-        }
-        self->_authorizing = false;
-    };
-
     __weak id<ARTAuthDelegate> lastDelegate = self.delegate;
-    if (lastDelegate) {
-        // Only the last request should remain
-        [lastDelegate.authorizationEmitter off];
 
-        [lastDelegate.authorizationEmitter once:[ARTEvent newWithAuthorizationState:ARTAuthorizationSucceeded] callback:^(id null) {
-            successBlock(self->_tokenDetails);
-            [lastDelegate.authorizationEmitter off];
-        }];
-
-        [lastDelegate.authorizationEmitter once:[ARTEvent newWithAuthorizationState:ARTAuthorizationFailed] callback:^(NSError *error) {
-            if (completed) {
-                [self.logger debug:__FILE__ line:__LINE__ message:@"RS:%p authorization failed with \"%@\" but the request token has already been completed", self->_rest, error];
-                failureBlock(error);
-            }
-            else {
-                completed = true;
-                failureBlock(error);
-            }
-            [lastDelegate.authorizationEmitter off];
-        }];
-
-        [lastDelegate.authorizationEmitter once:[ARTEvent newWithAuthorizationState:ARTAuthorizationCancelled] callback:^(id null) {
-            NSError *cancelled = [ARTErrorInfo createWithCode:kCFURLErrorCancelled message:@"Authorization has been cancelled"];
-            if (completed) {
-                [self.logger debug:__FILE__ line:__LINE__ message:@"RS:%p authorization cancelled but the request token has already been completed", self->_rest];
-                failureBlock(cancelled);
-            }
-            else {
-                completed = true;
-                failureBlock(cancelled);
-            }
-            [lastDelegate.authorizationEmitter off];
-        }];
-    }
-
+    NSString *authorizeId = [[NSUUID new] UUIDString];
     // Request always a new token
-    [self.logger verbose:@"RS:%p ARTAuth: requesting new token.", _rest];
-    _authorizing = true;
+    [self.logger verbose:@"RS:%p ARTAuth [authorize.%@, delegate=%@]: requesting new token", _rest, authorizeId, lastDelegate ? @"YES" : @"NO"];
+    self->_authorizationsCount += 1;
     [self _requestToken:currentTokenParams withOptions:replacedOptions callback:^(ARTTokenDetails *tokenDetails, NSError *error) {
-        if (completed) {
-            return;
-        }
-        completed = true;
+        self->_authorizationsCount -= 1;
+
+        void (^successBlock)(void) = ^{
+            [self.logger verbose:@"RS:%p ARTAuth [authorize.%@]: token request succeeded: %@", self->_rest, authorizeId, tokenDetails];
+            if (callback) {
+                callback(tokenDetails, nil);
+            }
+        };
+
+        void (^failureBlock)(NSError *) = ^(NSError *error) {
+            [self.logger verbose:@"RS:%p ARTAuth [authorize.%@]: token request failed: %@", self->_rest, authorizeId, error];
+            if (callback) {
+                callback(nil, error);
+            }
+        };
 
         if (error) {
             failureBlock(error);
-            if (lastDelegate) {
-                [lastDelegate.authorizationEmitter off];
-            }
             return;
         }
 
@@ -542,10 +513,26 @@ ART_TRY_OR_REPORT_CRASH_START(_rest) {
             failureBlock([ARTErrorInfo createWithCode:0 message:@"Token details are empty"]);
         }
         else if (lastDelegate) {
-            [lastDelegate auth:self didAuthorize:tokenDetails];
+            [lastDelegate auth:self didAuthorize:tokenDetails completion:^(ARTAuthorizationState state, ARTErrorInfo *error) {
+                switch (state) {
+                    case ARTAuthorizationSucceeded:
+                        successBlock();
+                        break;
+                    case ARTAuthorizationFailed:
+                        [self.logger debug:__FILE__ line:__LINE__ message:@"RS:%p authorization failed with \"%@\" but the request token has already completed", self->_rest, error];
+                        failureBlock(error);
+                        break;
+                    case ARTAuthorizationCancelled: {
+                        NSError *cancelled = [ARTErrorInfo createWithCode:kCFURLErrorCancelled message:@"Authorization has been cancelled"];
+                        [self.logger debug:__FILE__ line:__LINE__ message:@"RS:%p authorization cancelled but the request token has already completed", self->_rest];
+                        failureBlock(cancelled);
+                        break;
+                    }
+                }
+            }];
         }
         else {
-            successBlock(tokenDetails);
+            successBlock();
         }
     }];
 } ART_TRY_OR_REPORT_CRASH_END

--- a/Source/ARTHttp.h
+++ b/Source/ARTHttp.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol ARTHTTPExecutor
 
 - (ARTLog *)logger;
-- (void)executeRequest:(NSURLRequest *)request completion:(nullable void (^)(NSHTTPURLResponse *_Nullable, NSData *_Nullable, NSError *_Nullable))callback;
+- (nullable NSObject<ARTCancellable> *)executeRequest:(NSURLRequest *)request completion:(nullable void (^)(NSHTTPURLResponse *_Nullable, NSData *_Nullable, NSError *_Nullable))callback;
 
 @end
 
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id<ARTEncoder>)defaultEncoder;
 
-- (void)executeRequest:(NSMutableURLRequest *)request withAuthOption:(ARTAuthentication)authOption completion:(void (^)(NSHTTPURLResponse *_Nullable, NSData * _Nullable, NSError * _Nullable))callback;
+- (nullable NSObject<ARTCancellable> *)executeRequest:(NSMutableURLRequest *)request withAuthOption:(ARTAuthentication)authOption completion:(void (^)(NSHTTPURLResponse *_Nullable, NSData * _Nullable, NSError * _Nullable))callback;
 
 @end
 

--- a/Source/ARTHttp.m
+++ b/Source/ARTHttp.m
@@ -40,11 +40,11 @@
     [_urlSession finishTasksAndInvalidate];
 }
 
-- (void)executeRequest:(NSMutableURLRequest *)request completion:(void (^)(NSHTTPURLResponse *_Nullable, NSData *_Nullable, NSError *_Nullable))callback {
+- (NSObject<ARTCancellable> *)executeRequest:(NSMutableURLRequest *)request completion:(void (^)(NSHTTPURLResponse *_Nullable, NSData *_Nullable, NSError *_Nullable))callback {
     [self.logger debug:@"%@ %@", request.HTTPMethod, request.URL.absoluteString];
     [self.logger verbose:@"Headers %@", request.allHTTPHeaderFields];
 
-    [_urlSession get:request completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    return [_urlSession get:request completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
         if (error) {
             [self.logger error:@"%@ %@: error %@", request.HTTPMethod, request.URL.absoluteString, error];

--- a/Source/ARTRealtime+Private.h
+++ b/Source/ARTRealtime+Private.h
@@ -30,6 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, strong, nonatomic) ARTEventEmitter<ARTEvent *, ARTConnectionStateChange *> *internalEventEmitter;
 @property (readonly, strong, nonatomic) ARTEventEmitter<ARTEvent *, NSNull *> *connectedEventEmitter;
 
+@property (readonly, nonatomic) NSMutableArray<void (^)(ARTRealtimeConnectionState, ARTErrorInfo *_Nullable)> *pendingAuthorizations;
+
 // State properties
 - (BOOL)shouldSendEvents;
 - (BOOL)shouldQueueEvents;

--- a/Source/ARTRealtimeTransport.h
+++ b/Source/ARTRealtimeTransport.h
@@ -80,6 +80,7 @@ typedef NS_ENUM(NSUInteger, ARTRealtimeTransportState) {
 @property (readonly, assign, nonatomic) ARTRealtimeTransportState state;
 @property (nullable, readwrite, strong, nonatomic) id<ARTRealtimeTransportDelegate> delegate;
 @property (readonly, strong, nonatomic) ARTLog *protocolMessagesLogger;
+@property (nonatomic, readonly) ARTEventEmitter<ARTEvent *, id> *stateEmitter;
 
 - (BOOL)send:(NSData *)data withSource:(nullable id)decodedObject;
 - (void)receive:(ARTProtocolMessage *)msg;

--- a/Source/ARTRest+Private.h
+++ b/Source/ARTRest+Private.h
@@ -45,17 +45,17 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readwrite, assign, nonatomic) int fallbackCount;
 
 - (instancetype)initWithOptions:(ARTClientOptions *)options realtime:(ARTRealtime *_Nullable)realtime;
-- (void)_time:(void (^)(NSDate *_Nullable, NSError *_Nullable))callback;
+- (nullable NSObject<ARTCancellable> *)_time:(void (^)(NSDate *_Nullable, NSError *_Nullable))callback;
 
 // MARK: ARTHTTPExecutor
 
-- (void)executeRequest:(NSURLRequest *)request completion:(void (^)(NSHTTPURLResponse *_Nullable, NSData *_Nullable, NSError *_Nullable))callback;
+- (nullable NSObject<ARTCancellable> *)executeRequest:(NSURLRequest *)request completion:(nullable void (^)(NSHTTPURLResponse *_Nullable, NSData *_Nullable, NSError *_Nullable))callback;
 
 // MARK: Internal
 
-- (void)executeRequest:(NSURLRequest *)request withAuthOption:(ARTAuthentication)authOption completion:(void (^)(NSHTTPURLResponse *_Nullable, NSData *_Nullable, NSError *_Nullable))callback;
+- (nullable NSObject<ARTCancellable> *)executeRequest:(NSMutableURLRequest *)request withAuthOption:(ARTAuthentication)authOption completion:(void (^)(NSHTTPURLResponse *_Nullable, NSData * _Nullable, NSError * _Nullable))callback;
 
-- (nullable id<ARTCancellable>)internetIsUp:(void (^)(BOOL isUp))cb;
+- (nullable NSObject<ARTCancellable> *)internetIsUp:(void (^)(BOOL isUp))cb;
 
 - (void)onUncaughtException:(NSException *)e;
 - (void)reportUncaughtException:(NSException *_Nullable)exception;

--- a/Source/ARTTypes.h
+++ b/Source/ARTTypes.h
@@ -140,7 +140,6 @@ NSTimeInterval millisecondsToTimeInterval(uint64_t msecs);
 
 NSString *generateNonce(void);
 
-// FIXME: review
 @protocol ARTCancellable
 - (void)cancel;
 @end
@@ -227,6 +226,9 @@ NSString *generateNonce(void);
 - (void)enqueue:(id)object;
 - (id)dequeue;
 - (id)peek;
+@end
+
+@interface NSURLSessionTask (ARTCancellable) <ARTCancellable>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/ARTURLSessionServerTrust.h
+++ b/Source/ARTURLSessionServerTrust.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init:(dispatch_queue_t)queue;
 
-- (void)get:(NSURLRequest *)request completion:(void (^)(NSHTTPURLResponse *_Nullable, NSData *_Nullable, NSError *_Nullable))callback;
+- (NSURLSessionTask *)get:(NSURLRequest *)request completion:(void (^)(NSHTTPURLResponse *_Nullable, NSData *_Nullable, NSError *_Nullable))callback;
 
 - (void)finishTasksAndInvalidate;
 

--- a/Source/ARTURLSessionServerTrust.m
+++ b/Source/ARTURLSessionServerTrust.m
@@ -29,13 +29,14 @@
     [_session finishTasksAndInvalidate];
 }
 
-- (void)get:(NSURLRequest *)request completion:(void (^)(NSHTTPURLResponse *_Nullable, NSData *_Nullable, NSError *_Nullable))callback {
+- (NSURLSessionTask *)get:(NSURLRequest *)request completion:(void (^)(NSHTTPURLResponse *_Nullable, NSData *_Nullable, NSError *_Nullable))callback {
     NSURLSessionDataTask *task = [_session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         dispatch_async(self->_queue, ^{
             callback((NSHTTPURLResponse *)response, data, error);
         });
     }];
     [task resume];
+    return task;
 }
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler {

--- a/Source/ARTWebSocketTransport+Private.h
+++ b/Source/ARTWebSocketTransport+Private.h
@@ -30,4 +30,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+#pragma mark - ARTEvent
+
+@interface ARTEvent (TransportState)
+- (instancetype)initWithTransportState:(ARTRealtimeTransportState)value;
++ (instancetype)newWithTransportState:(ARTRealtimeTransportState)value;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -334,7 +334,7 @@ class Auth : QuickSpec {
                     }
                 }
 
-                // RSA4b1
+                // RSA4b
                 context("local token validity check") {
                     it("should be done if queryTime is true and local time is in sync with server") {
                         let options = AblyTests.commonAppSetup()
@@ -383,7 +383,7 @@ class Auth : QuickSpec {
                             }
                         }
 
-                        expect(rest.auth.tokenDetails).to(beNil())
+                        expect(rest.auth.tokenDetails).toNot(beNil())
                     }
 
                     it("should NOT be done if queryTime is false and local time is NOT in sync with server") {

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -3622,6 +3622,154 @@ class Auth : QuickSpec {
 
             }
 
+            context("two consecutive authorizations") {
+                it("using REST, should call each authorize callback") {
+                    let options = AblyTests.commonAppSetup()
+                    options.useTokenAuth = true
+                    let rest = ARTRest(options: options)
+
+                    var tokenDetailsFirst: ARTTokenDetails?
+                    var tokenDetailsLast: ARTTokenDetails?
+                    waitUntil(timeout: testTimeout) { done in
+                        let partialDone = AblyTests.splitDone(2, done: done)
+                        rest.auth.authorize { tokenDetails, error in
+                            if let error = error {
+                                fail(error.localizedDescription); partialDone(); return
+                            }
+                            expect(tokenDetails).toNot(beNil())
+                            if tokenDetailsFirst == nil {
+                                tokenDetailsFirst = tokenDetails
+                            }
+                            else {
+                                tokenDetailsLast = tokenDetails
+                            }
+                            partialDone()
+                        }
+                        rest.auth.authorize { tokenDetails, error in
+                            if let error = error {
+                                fail(error.localizedDescription); partialDone(); return
+                            }
+                            expect(tokenDetails).toNot(beNil())
+                            if tokenDetailsFirst == nil {
+                                tokenDetailsFirst = tokenDetails
+                            }
+                            else {
+                                tokenDetailsLast = tokenDetails
+                            }
+                            partialDone()
+                        }
+                    }
+
+                    expect(tokenDetailsFirst?.token).toNot(equal(tokenDetailsLast?.token))
+                    expect(rest.auth.tokenDetails).to(beIdenticalTo(tokenDetailsLast))
+                    expect(rest.auth.tokenDetails?.token).to(equal(tokenDetailsLast?.token))
+                }
+                it("using Realtime and connection is CONNECTING, should call each Realtime authorize callback") {
+                    let options = AblyTests.commonAppSetup()
+                    options.useTokenAuth = true
+                    let realtime = AblyTests.newRealtime(options)
+                    defer { realtime.close(); realtime.dispose() }
+
+                    var connectedStateCount = 0
+                    realtime.connection.on(.connected) { _ in
+                        connectedStateCount += 1
+                    }
+
+                    var tokenDetailsFirst: ARTTokenDetails?
+                    var tokenDetailsLast: ARTTokenDetails?
+                    waitUntil(timeout: testTimeout) { done in
+                        let partialDone = AblyTests.splitDone(2, done: done)
+                        realtime.auth.authorize { tokenDetails, error in
+                            if let error = error, (error as NSError).code != URLError.cancelled.rawValue {
+                                fail(error.localizedDescription); partialDone(); return
+                            }
+                            expect(tokenDetails).toNot(beNil())
+                            if tokenDetailsFirst == nil {
+                                tokenDetailsFirst = tokenDetails
+                            }
+                            else {
+                                tokenDetailsLast = tokenDetails
+                            }
+                            partialDone()
+                        }
+                        realtime.auth.authorize { tokenDetails, error in
+                            if let error = error, (error as NSError).code != URLError.cancelled.rawValue {
+                                fail(error.localizedDescription); partialDone(); return
+                            }
+                            expect(tokenDetails).toNot(beNil())
+                            if tokenDetailsFirst == nil {
+                                tokenDetailsFirst = tokenDetails
+                            }
+                            else {
+                                tokenDetailsLast = tokenDetails
+                            }
+                            partialDone()
+                        }
+                    }
+
+                    expect(tokenDetailsFirst?.token).toNot(equal(tokenDetailsLast?.token))
+                    expect(realtime.auth.tokenDetails).to(beIdenticalTo(tokenDetailsLast))
+                    expect(realtime.auth.tokenDetails?.token).to(equal(tokenDetailsLast?.token))
+
+                    if let transport = realtime.transport as? TestProxyTransport, let query = transport.lastUrl?.query {
+                        expect(query).to(haveParam("accessToken", withValue: realtime.auth.tokenDetails?.token ?? ""))
+                    }
+                    else {
+                        XCTFail("MockTransport is not working")
+                    }
+
+                    expect(connectedStateCount) == 1
+                }
+                it("using Realtime and connection is CONNECTED, should call each Realtime authorize callback") {
+                    let options = AblyTests.commonAppSetup()
+                    options.useTokenAuth = true
+                    let realtime = ARTRealtime(options: options)
+                    defer { realtime.close(); realtime.dispose() }
+
+                    waitUntil(timeout: testTimeout) { done in
+                        realtime.connection.once(.connected) { state in
+                            done()
+                        }
+                    }
+
+                    var tokenDetailsFirst: ARTTokenDetails?
+                    var tokenDetailsLast: ARTTokenDetails?
+                    waitUntil(timeout: testTimeout) { done in
+                        let partialDone = AblyTests.splitDone(2, done: done)
+                        realtime.auth.authorize { tokenDetails, error in
+                            if let error = error {
+                                fail(error.localizedDescription); partialDone(); return
+                            }
+                            expect(tokenDetails).toNot(beNil())
+                            if tokenDetailsFirst == nil {
+                                tokenDetailsFirst = tokenDetails
+                            }
+                            else {
+                                tokenDetailsLast = tokenDetails
+                            }
+                            partialDone()
+                        }
+                        realtime.auth.authorize { tokenDetails, error in
+                            if let error = error {
+                                fail(error.localizedDescription); partialDone(); return
+                            }
+                            expect(tokenDetails).toNot(beNil())
+                            if tokenDetailsFirst == nil {
+                                tokenDetailsFirst = tokenDetails
+                            }
+                            else {
+                                tokenDetailsLast = tokenDetails
+                            }
+                            partialDone()
+                        }
+                    }
+
+                    expect(tokenDetailsFirst?.token).toNot(equal(tokenDetailsLast?.token))
+                    expect(realtime.auth.tokenDetails).to(beIdenticalTo(tokenDetailsLast))
+                    expect(realtime.auth.tokenDetails?.token).to(equal(tokenDetailsLast?.token))
+                }
+            }
+
         }
 
         describe("TokenParams") {

--- a/Spec/RealtimeClient.swift
+++ b/Spec/RealtimeClient.swift
@@ -784,11 +784,11 @@ class RealtimeClient: QuickSpec {
                     }
                     defer { hook1?.remove() }
 
-                    var connectionsOpened = 0
-                    let hook2 = TestProxyTransport.testSuite_injectIntoClassMethod(#selector(TestProxyTransport.webSocketDidOpen)) {
-                        connectionsOpened += 1
+                    var connectionsConnected = 0
+                    let hook2 = client.connection.on(.connected) { _ in
+                        connectionsConnected += 1
                     }
-                    defer { hook2?.remove() }
+                    defer { client.connection.off(hook2) }
 
                     waitUntil(timeout: testTimeout) { done in
                         client.connection.once(.connecting) { stateChange in
@@ -816,7 +816,7 @@ class RealtimeClient: QuickSpec {
                     }
 
                     expect(connections) == 2
-                    expect(connectionsOpened) == 1
+                    expect(connectionsConnected) == 1
 
                     expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
                 }

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -4350,7 +4350,7 @@ class RealtimeClientConnection: QuickSpec {
                                 "Accept" : "application/json",
                                 "Content-Type" : "application/json"
                             ]
-                            client.rest.execute(request as URLRequest, withAuthOption: .on, completion: { _, _, err in
+                            client.rest.execute(request, withAuthOption: .on, completion: { _, _, err in
                                 if let err = err {
                                     fail("\(err)")
                                 }
@@ -4374,7 +4374,7 @@ class RealtimeClientConnection: QuickSpec {
                                 let request = NSMutableURLRequest(url: URL(string: "/channels/\(channel.name)/messages?limit=1")! as URL)
                                 request.httpMethod = "GET"
                                 request.allHTTPHeaderFields = ["Accept" : "application/json"]
-                                client.rest.execute(request as URLRequest, withAuthOption: .on, completion: { _, data, err in
+                                client.rest.execute(request, withAuthOption: .on, completion: { _, data, err in
                                     if let err = err {
                                         fail("\(err)")
                                         done()
@@ -4436,7 +4436,7 @@ class RealtimeClientConnection: QuickSpec {
                                 "Accept" : "application/json",
                                 "Content-Type" : "application/json"
                             ]
-                            restPublishClient.execute(request as URLRequest, withAuthOption: .on, completion: { _, _, err in
+                            restPublishClient.execute(request, withAuthOption: .on, completion: { _, _, err in
                                 if let err = err {
                                     fail("\(err)")
                                 }
@@ -4477,7 +4477,7 @@ class RealtimeClientConnection: QuickSpec {
                                 let request = NSMutableURLRequest(url: URL(string: "/channels/\(restPublishChannel.name)/messages?limit=1")! as URL)
                                 request.httpMethod = "GET"
                                 request.allHTTPHeaderFields = ["Accept" : "application/json"]
-                                restRetrieveClient.execute(request as URLRequest, withAuthOption: .on, completion: { _, data, err in
+                                restRetrieveClient.execute(request, withAuthOption: .on, completion: { _, data, err in
                                     if let err = err {
                                         fail("\(err)")
                                         done()

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -660,7 +660,7 @@ class MockHTTP: ARTHttp {
         super.init(AblyTests.queue, logger: logger)
     }
 
-    override public func execute(_ request: URLRequest, completion callback: ((HTTPURLResponse?, Data?, Error?) -> Void)? = nil) {
+    override public func execute(_ request: URLRequest, completion callback: ((HTTPURLResponse?, Data?, Error?) -> Void)? = nil) -> (ARTCancellable & NSObjectProtocol)? {
         delay(0.0) { // Delay to simulate asynchronicity.
             switch self.network {
             case .noInternet:
@@ -677,6 +677,7 @@ class MockHTTP: ARTHttp {
                 callback?(HTTPURLResponse(url: URL(string: "http://ios.test.suite")!, statusCode: 400, httpVersion: nil, headerFields: nil), nil, nil)
             }
         }
+        return nil
     }
 
 }
@@ -732,28 +733,30 @@ class MockHTTPExecutor: NSObject, ARTHTTPAuthenticatedExecutor {
         return self.encoder
     }
 
-    func execute(_ request: NSMutableURLRequest, withAuthOption authOption: ARTAuthentication, completion callback: @escaping (HTTPURLResponse?, Data?, Error?) -> Void) {
+    func execute(_ request: NSMutableURLRequest, withAuthOption authOption: ARTAuthentication, completion callback: @escaping (HTTPURLResponse?, Data?, Error?) -> Void) -> (ARTCancellable & NSObjectProtocol)? {
         self.requests.append(request as URLRequest)
 
         if var simulatedError = errorSimulator, var requestURL = request.url {
             defer { errorSimulator = nil }
             callback(nil, nil, simulatedError)
-            return
+            return nil
         }
 
         callback(HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: ["X-Ably-HTTPExecutor": "MockHTTPExecutor"]), nil, nil)
+        return nil
     }
 
-    func execute(_ request: URLRequest, completion callback: ((HTTPURLResponse?, Data?, Error?) -> Void)? = nil) {
+    func execute(_ request: URLRequest, completion callback: ((HTTPURLResponse?, Data?, Error?) -> Void)? = nil) -> (ARTCancellable & NSObjectProtocol)? {
         self.requests.append(request)
         
         if var simulatedError = errorSimulator, var requestURL = request.url {
             defer { errorSimulator = nil }
             callback?(nil, nil, simulatedError)
-            return
+            return nil
         }
 
         callback?(HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: ["X-Ably-HTTPExecutor": "MockHTTPExecutor"]), nil, nil)
+        return nil
     }
 
     func simulateIncomingErrorOnNextRequest(_ error: NSError) {
@@ -786,9 +789,9 @@ class TestProxyHTTPExecutor: NSObject, ARTHTTPExecutor {
     var afterRequest: Optional<(URLRequest, ((HTTPURLResponse?, Data?, NSError?) -> Void)?)->()> = nil
     var beforeProcessingDataResponse: Optional<(Data?)->(Data)> = nil
 
-    public func execute(_ request: URLRequest, completion callback: ((HTTPURLResponse?, Data?, Error?) -> Void)? = nil) {
+    public func execute(_ request: URLRequest, completion callback: ((HTTPURLResponse?, Data?, Error?) -> Void)? = nil) -> (ARTCancellable & NSObjectProtocol)? {
         guard let http = self.http else {
-            return
+            return nil
         }
         self.requests.append(request)
 
@@ -797,20 +800,20 @@ class TestProxyHTTPExecutor: NSObject, ARTHTTPExecutor {
                 errorSimulator = nil
             }
             if simulatedError.shouldPerformRequest {
-                http.execute(request, completion: { response, data, error in
+                return http.execute(request, completion: { response, data, error in
                     callback?(simulatedError.stubResponse(requestURL), simulatedError.stubData, nil)
                 })
             }
             else {
                 callback?(simulatedError.stubResponse(requestURL), simulatedError.stubData, nil)
-            }
-            return
+                return nil
+            }            
         }
 
         if let performEvent = beforeRequest {
             performEvent(request, callback)
         }
-        http.execute(request, completion: { response, data, error in
+        let task = http.execute(request, completion: { response, data, error in
             if let httpResponse = response {
                 self.responses.append(httpResponse)
             }
@@ -824,6 +827,7 @@ class TestProxyHTTPExecutor: NSObject, ARTHTTPExecutor {
         if let performEvent = afterRequest {
             performEvent(request, callback)
         }
+        return task
     }
 
     func simulateIncomingServerErrorOnNextRequest(_ errorValue: Int, description: String) {


### PR DESCRIPTION
I noticed this issue while testing the Push Demo application.

Steps to reproduce:
 - Run app for the first time
 - Create a Realtime instance with an app key
 - Call `push.activate` (start a token request **A** for the device registration) and right after start the Realtime connection (start a token request **B** for web socket connection)
 - If the request **B** finishes first, then the `push.activate` will not end because the `authorize` callback isn't reached.