### PR TITLE
Fix Push Activation State Machine: WaitingForRegistrationUpdate bad state

### DIFF
--- a/Source/ARTPushActivationState.m
+++ b/Source/ARTPushActivationState.m
@@ -212,7 +212,7 @@
         [local setAndPersistIdentityTokenDetails:registrationUpdatedEvent.identityTokenDetails];
         #endif
         [self.machine callActivatedCallback:nil];
-        return [ARTPushActivationStateWaitingForRegistrationUpdate newWithMachine:self.machine];
+        return [ARTPushActivationStateWaitingForNewPushDeviceDetails newWithMachine:self.machine];
     }
     else if ([event isKindOfClass:[ARTPushActivationEventUpdatingRegistrationFailed class]]) {
         [self.machine callUpdateFailedCallback:[(ARTPushActivationEventUpdatingRegistrationFailed *)event error]];

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -458,7 +458,8 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
 dispatch_sync(_queue, ^{
 ART_TRY_OR_MOVE_TO_FAILED_START(self->_realtime) {
     if (self.state_nosync == ARTRealtimeChannelFailed) {
-        if (onAttach) onAttach([ARTErrorInfo createWithCode:0 message:@"attempted to subscribe while channel is in Failed state."]);
+        if (onAttach) onAttach([ARTErrorInfo createWithCode:0 message:@"attempted to subscribe while channel is in FAILED state."]);
+        [self.logger warn:@"R:%p C:%p (%@) subscribe has been ignored (attempted to subscribe while channel is in FAILED state)", self->_realtime, self, self.name];
         return;
     }
     [self _attach:onAttach];
@@ -498,7 +499,8 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
 dispatch_sync(_queue, ^{
 ART_TRY_OR_MOVE_TO_FAILED_START(self->_realtime) {
     if (self.state_nosync == ARTRealtimeChannelFailed) {
-        if (onAttach) onAttach([ARTErrorInfo createWithCode:0 message:@"attempted to subscribe while channel is in Failed state."]);
+        if (onAttach) onAttach([ARTErrorInfo createWithCode:0 message:@"attempted to subscribe while channel is in FAILED state."]);
+        [self.logger warn:@"R:%p C:%p (%@) subscribe of '%@' has been ignored (attempted to subscribe while channel is in FAILED state)", self->_realtime, self, self.name, name];
         return;
     }
     [self _attach:onAttach];

--- a/Spec/PushActivationStateMachine.swift
+++ b/Spec/PushActivationStateMachine.swift
@@ -722,7 +722,7 @@ class PushActivationStateMachine : QuickSpec {
                     )
 
                     stateMachine.send(ARTPushActivationEventRegistrationUpdated(identityTokenDetails: testIdentityTokenDetails))
-                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForRegistrationUpdate.self))
+                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
                     expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
                 }
 

--- a/Spec/PushActivationStateMachine.swift
+++ b/Spec/PushActivationStateMachine.swift
@@ -785,7 +785,7 @@ class PushActivationStateMachine : QuickSpec {
                             expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForRegistrationUpdate.self))
                         }
 
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForRegistrationUpdate.self))
+                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
                         expect(httpExecutor.requests.count) == 0
                     }
 
@@ -903,7 +903,7 @@ class PushActivationStateMachine : QuickSpec {
                         }
 
                         expect(stateMachine.rest.device.identityTokenDetails).to(beNil())
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForRegistrationUpdate.self))
+                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
                         expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
                         expect(httpExecutor.requests.count) == 1
                         let requests = httpExecutor.requests.compactMap({ $0.url?.path }).filter({ $0 == "/push/deviceRegistrations/\(stateMachine.rest.device.id)" })
@@ -988,7 +988,7 @@ class PushActivationStateMachine : QuickSpec {
                             expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForRegistrationUpdate.self))
                         }
 
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForRegistrationUpdate.self))
+                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
                         expect(httpExecutor.requests.count) == 0
                     }
 
@@ -1104,7 +1104,7 @@ class PushActivationStateMachine : QuickSpec {
                         }
 
                         expect(stateMachine.rest.device.identityTokenDetails).to(beNil())
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForRegistrationUpdate.self))
+                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
                         expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
                         expect(httpExecutor.requests.count) == 1
                         let requests = httpExecutor.requests.compactMap({ $0.url?.path }).filter({ $0 == "/push/deviceRegistrations/\(stateMachine.rest.device.id)" })


### PR DESCRIPTION
> (RSH3e) State WaitingForRegistrationUpdate:
>  * (RSH3e2) On event RegistrationUpdated:
>    * ([RSH3e2a](https://docs.ably.io/client-lib-development-guide/features/#RSH3e2a)) Transitions to WaitingForNewPushDeviceDetails.

Related with #863