### PR TITLE
Push Device Update Registration: fix request authentication

### DIFF
--- a/Source/ARTLocalDevice.m
+++ b/Source/ARTLocalDevice.m
@@ -75,7 +75,9 @@ NSString *const ARTDevicePushTransportType = @"apns";
     }
     device.secret = deviceSecret;
 
-    device->_identityTokenDetails = [ARTDeviceIdentityTokenDetails unarchive:[storage objectForKey:ARTDeviceIdentityTokenKey]];
+    id identityTokenDetailsInfo = [storage objectForKey:ARTDeviceIdentityTokenKey];
+    ARTDeviceIdentityTokenDetails *identityTokenDetails = [ARTDeviceIdentityTokenDetails unarchive:identityTokenDetailsInfo];
+    device->_identityTokenDetails = identityTokenDetails;
 
     [device setDeviceToken:[storage objectForKey:ARTDeviceTokenKey]];
 

--- a/Source/ARTLocalDeviceStorage.m
+++ b/Source/ARTLocalDeviceStorage.m
@@ -59,16 +59,20 @@
 
     if (value == nil) {
         [SAMKeychain deletePasswordForService:ARTDeviceSecretKey account:(NSString *)deviceId error:&error];
+
+        if ([error code] == errSecItemNotFound) {
+            [_logger warn:@"Device Secret can't be deleted because it doesn't exist"];
+        }
+        else if (error) {
+            [_logger error:@"Device Secret couldn't be updated (%@)", [error localizedDescription]];
+        }
     }
     else {
         [SAMKeychain setPassword:value forService:ARTDeviceSecretKey account:(NSString *)deviceId error:&error];
-    }
 
-    if ([error code] == errSecItemNotFound) {
-        [_logger debug:__FILE__ line:__LINE__ message:@"Device Secret not found"];
-    }
-    else if (error) {
-        [_logger error:@"Device Secret couldn't be updated (%@)", [error localizedDescription]];
+        if (error) {
+            [_logger error:@"Device Secret couldn't be updated (%@)", [error localizedDescription]];
+        }
     }
 }
 

--- a/Source/ARTNSMutableRequest+ARTPush.m
+++ b/Source/ARTNSMutableRequest+ARTPush.m
@@ -21,7 +21,7 @@
 
 - (void)setDeviceAuthentication:(ARTDeviceId *)deviceId localDevice:(ARTLocalDevice *)localDevice logger:(ARTLog *)logger {
     if ([localDevice.id isEqualToString:deviceId]) {
-        if (localDevice.identityTokenDetails) {
+        if (localDevice.identityTokenDetails.token) {
             [logger debug:__FILE__ line:__LINE__ message:@"adding device authentication using local device identity token"];
             [self setValue:[localDevice.identityTokenDetails.token base64Encoded] forHTTPHeaderField:@"X-Ably-DeviceIdentityToken"];
         }

--- a/Source/ARTNSMutableRequest+ARTPush.m
+++ b/Source/ARTNSMutableRequest+ARTPush.m
@@ -23,7 +23,7 @@
     if ([localDevice.id isEqualToString:deviceId]) {
         if (localDevice.identityTokenDetails.token) {
             [logger debug:__FILE__ line:__LINE__ message:@"adding device authentication using local device identity token"];
-            [self setValue:[localDevice.identityTokenDetails.token base64Encoded] forHTTPHeaderField:@"X-Ably-DeviceIdentityToken"];
+            [self setValue:[localDevice.identityTokenDetails.token base64Encoded] forHTTPHeaderField:@"X-Ably-DeviceToken"];
         }
         else if (localDevice.secret) {
             [logger debug:__FILE__ line:__LINE__ message:@"adding device authentication using local device secret"];

--- a/Source/ARTPushActivationEvent.h
+++ b/Source/ARTPushActivationEvent.h
@@ -34,12 +34,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// Event with Device Identity Token details
 @interface ARTPushActivationDeviceIdentityEvent : ARTPushActivationEvent
 
-@property (nonatomic, readonly) ARTDeviceIdentityTokenDetails *identityTokenDetails;
+@property (nonatomic, readonly, nullable) ARTDeviceIdentityTokenDetails *identityTokenDetails;
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
-+ (instancetype)new UNAVAILABLE_ATTRIBUTE;
++ (instancetype)new;
 
-- (instancetype)initWithIdentityTokenDetails:(ARTDeviceIdentityTokenDetails *)identityTokenDetails;
+- (instancetype)initWithIdentityTokenDetails:(nullable ARTDeviceIdentityTokenDetails *)identityTokenDetails;
 + (instancetype)newWithIdentityTokenDetails:(ARTDeviceIdentityTokenDetails *)identityTokenDetails;
 
 @end

--- a/Source/ARTPushActivationEvent.m
+++ b/Source/ARTPushActivationEvent.m
@@ -112,6 +112,10 @@ NSString *const ARTCoderIdentityTokenDetailsKey = @"identityTokenDetails";
     return self;
 }
 
++ (instancetype)new {
+    return [[self alloc] initWithIdentityTokenDetails:nil];
+}
+
 + (instancetype)newWithIdentityTokenDetails:(ARTDeviceIdentityTokenDetails *)identityTokenDetails {
     return [[self alloc] initWithIdentityTokenDetails:identityTokenDetails];
 }

--- a/Source/ARTPushActivationState.m
+++ b/Source/ARTPushActivationState.m
@@ -30,7 +30,7 @@
 }
 
 - (void)logEventTransition:(ARTPushActivationEvent *)event file:(const char *)file line:(NSUInteger)line {
-    NSLog(@"%@ state: transitioning to %@ event", NSStringFromClass(self.class), NSStringFromClass(event.class));
+    NSLog(@"%@ state: handling %@ event", NSStringFromClass(self.class), NSStringFromClass(event.class));
 }
 
 - (ARTPushActivationState *)transition:(ARTPushActivationEvent *)event {

--- a/Source/ARTPushActivationState.m
+++ b/Source/ARTPushActivationState.m
@@ -208,8 +208,10 @@
     else if ([event isKindOfClass:[ARTPushActivationEventRegistrationUpdated class]]) {
         #if TARGET_OS_IOS
         ARTPushActivationEventRegistrationUpdated *registrationUpdatedEvent = (ARTPushActivationEventRegistrationUpdated *)event;
-        ARTLocalDevice *local = self.machine.rest.device_nosync;
-        [local setAndPersistIdentityTokenDetails:registrationUpdatedEvent.identityTokenDetails];
+        if (registrationUpdatedEvent.identityTokenDetails) {
+            ARTLocalDevice *local = self.machine.rest.device_nosync;
+            [local setAndPersistIdentityTokenDetails:registrationUpdatedEvent.identityTokenDetails];
+        }
         #endif
         [self.machine callActivatedCallback:nil];
         return [ARTPushActivationStateWaitingForNewPushDeviceDetails newWithMachine:self.machine];

--- a/Source/ARTPushActivationStateMachine.m
+++ b/Source/ARTPushActivationStateMachine.m
@@ -224,9 +224,6 @@ dispatch_async(_queue, ^{
     }
 
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[[NSURL URLWithString:@"/push/deviceRegistrations"] URLByAppendingPathComponent:local.id]];
-    NSData *tokenData = [local.identityTokenDetails.token dataUsingEncoding:NSUTF8StringEncoding];
-    NSString *tokenBase64 = [tokenData base64EncodedStringWithOptions:0];
-    [request setValue:[NSString stringWithFormat:@"Bearer %@", tokenBase64] forHTTPHeaderField:@"Authorization"];
     request.HTTPMethod = @"PATCH";
     request.HTTPBody = [[_rest defaultEncoder] encode:@{
         @"push": @{
@@ -237,7 +234,7 @@ dispatch_async(_queue, ^{
     [request setDeviceAuthentication:local];
 
     [[_rest logger] debug:__FILE__ line:__LINE__ message:@"update device with request %@", request];
-    [_rest executeRequest:request withAuthOption:ARTAuthenticationOff completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [_rest executeRequest:request withAuthOption:ARTAuthenticationOn completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             [[self->_rest logger] error:@"%@: update device failed (%@)", NSStringFromClass(self.class), error.localizedDescription];
             [self sendEvent:[ARTPushActivationEventUpdatingRegistrationFailed newWithError:[ARTErrorInfo createFromNSError:error]]];

--- a/Source/ARTPushActivationStateMachine.m
+++ b/Source/ARTPushActivationStateMachine.m
@@ -240,14 +240,7 @@ dispatch_async(_queue, ^{
             [self sendEvent:[ARTPushActivationEventUpdatingRegistrationFailed newWithError:[ARTErrorInfo createFromNSError:error]]];
             return;
         }
-        NSError *decodeError = nil;
-        ARTDeviceIdentityTokenDetails *identityTokenDetails = [[self->_rest defaultEncoder] decodeDeviceIdentityTokenDetails:data error:&decodeError];
-        if (decodeError) {
-            [[self->_rest logger] error:@"%@: decode identity token details failed (%@)", NSStringFromClass(self.class), error.localizedDescription];
-            [self sendEvent:[ARTPushActivationEventUpdatingRegistrationFailed newWithError:[ARTErrorInfo createFromNSError:error]]];
-            return;
-        }
-        [self sendEvent:[ARTPushActivationEventRegistrationUpdated newWithIdentityTokenDetails:identityTokenDetails]];
+        [self sendEvent:[ARTPushActivationEventRegistrationUpdated new]];
     }];
     #endif
 }

--- a/Spec/PushActivationStateMachine.swift
+++ b/Spec/PushActivationStateMachine.swift
@@ -638,7 +638,7 @@ class PushActivationStateMachine : QuickSpec {
                         expect(url.query).to(contain(rest.device.id))
                         expect(rest.device.identityTokenDetails).to(beNil())
                         expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
-                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
                         expect(deviceAuthorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
                     }
 
@@ -878,7 +878,7 @@ class PushActivationStateMachine : QuickSpec {
                         expect(body.value(forKey: "formFactor")).to(beNil())
                         expect(body.value(forKey: "platform")).to(beNil())
                         expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
-                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
                         expect(deviceAuthorization).to(equal(deviceIdentityToken))
                     }
 
@@ -937,7 +937,7 @@ class PushActivationStateMachine : QuickSpec {
                         expect(body.value(forKey: "formFactor")).to(beNil())
                         expect(body.value(forKey: "platform")).to(beNil())
                         expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
-                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
                         expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
                         expect(deviceAuthorization).to(equal(deviceIdentityToken))
                     }
@@ -1079,7 +1079,7 @@ class PushActivationStateMachine : QuickSpec {
                         expect(body.value(forKey: "formFactor")).to(beNil())
                         expect(body.value(forKey: "platform")).to(beNil())
                         expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
-                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
                         expect(deviceAuthorization).to(equal(deviceIdentityToken))
                     }
 
@@ -1141,7 +1141,7 @@ class PushActivationStateMachine : QuickSpec {
                         expect(body.value(forKey: "formFactor")).to(beNil())
                         expect(body.value(forKey: "platform")).to(beNil())
                         expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
-                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
                         expect(deviceAuthorization).to(equal(deviceIdentityToken.base64Encoded()))
                     }
 
@@ -1310,7 +1310,7 @@ class PushActivationStateMachine : QuickSpec {
                         expect(url.query).to(contain(rest.device.id))
                         expect(rest.device.identityTokenDetails).to(beNil())
                         expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
-                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
                         expect(deviceAuthorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
                     }
 

--- a/Spec/PushActivationStateMachine.swift
+++ b/Spec/PushActivationStateMachine.swift
@@ -386,6 +386,8 @@ class PushActivationStateMachine : QuickSpec {
                             stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
                             expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForDeviceRegistration.self))
                         }
+
+                        expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
                     }
 
                 }
@@ -888,9 +890,8 @@ class PushActivationStateMachine : QuickSpec {
                         
                         let deviceIdentityToken = stateMachine.rest.device.identityTokenDetails?.token.base64Encoded()
 
-                        var setAndPersistIdentityTokenDetailsCalled = false
                         let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
-                            setAndPersistIdentityTokenDetailsCalled = true
+                            fail("'setAndPersistIdentityTokenDetails:' should not be called")
                         }
                         defer { hookDevice.remove() }
 
@@ -905,9 +906,8 @@ class PushActivationStateMachine : QuickSpec {
                             expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForRegistrationUpdate.self))
                         }
 
-                        expect(stateMachine.rest.device.identityTokenDetails).to(beNil())
+                        expect(stateMachine.rest.device.identityTokenDetails).toNot(beNil())
                         expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
-                        expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
                         expect(httpExecutor.requests.count) == 1
                         let requests = httpExecutor.requests.compactMap({ $0.url?.path }).filter({ $0 == "/push/deviceRegistrations/\(stateMachine.rest.device.id)" })
                         expect(requests).to(haveCount(1))
@@ -938,6 +938,7 @@ class PushActivationStateMachine : QuickSpec {
                         expect(body.value(forKey: "platform")).to(beNil())
                         expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
                         let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                        expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
                         expect(deviceAuthorization).to(equal(deviceIdentityToken))
                     }
 
@@ -947,9 +948,8 @@ class PushActivationStateMachine : QuickSpec {
                         let delegate = StateMachineDelegate()
                         stateMachine.delegate = delegate
 
-                        var setAndPersistIdentityTokenDetailsCalled = false
                         let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
-                            setAndPersistIdentityTokenDetailsCalled = true
+                            fail("'setAndPersistIdentityTokenDetails:' should not be called")
                         }
                         defer { hookDevice.remove() }
 
@@ -1089,11 +1089,13 @@ class PushActivationStateMachine : QuickSpec {
                         let delegate = StateMachineDelegate()
                         stateMachine.delegate = delegate
 
-                        let deviceIdentityToken = stateMachine.rest.device.identityTokenDetails?.token.base64Encoded()
+                        guard let deviceIdentityToken = stateMachine.rest.device.identityTokenDetails?.token else {
+                            fail("Unexpected 'identityTokenDetails' is nil")
+                            return
+                        }
 
-                        var setAndPersistIdentityTokenDetailsCalled = false
                         let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
-                            setAndPersistIdentityTokenDetailsCalled = true
+                            fail("'setAndPersistIdentityTokenDetails:' should not be called")
                         }
                         defer { hookDevice.remove() }
 
@@ -1108,9 +1110,8 @@ class PushActivationStateMachine : QuickSpec {
                             expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForRegistrationUpdate.self))
                         }
 
-                        expect(stateMachine.rest.device.identityTokenDetails).to(beNil())
+                        expect(stateMachine.rest.device.identityTokenDetails?.token).to(equal(deviceIdentityToken))
                         expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
-                        expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
                         expect(httpExecutor.requests.count) == 1
                         let requests = httpExecutor.requests.compactMap({ $0.url?.path }).filter({ $0 == "/push/deviceRegistrations/\(stateMachine.rest.device.id)" })
                         expect(requests).to(haveCount(1))
@@ -1141,7 +1142,7 @@ class PushActivationStateMachine : QuickSpec {
                         expect(body.value(forKey: "platform")).to(beNil())
                         expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
                         let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
-                        expect(deviceAuthorization).to(equal(deviceIdentityToken))
+                        expect(deviceAuthorization).to(equal(deviceIdentityToken.base64Encoded()))
                     }
 
                     it("should transition to WaitingForRegistrationUpdate") {
@@ -1150,9 +1151,8 @@ class PushActivationStateMachine : QuickSpec {
                         let delegate = StateMachineDelegate()
                         stateMachine.delegate = delegate
 
-                        var setAndPersistIdentityTokenDetailsCalled = false
                         let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
-                            setAndPersistIdentityTokenDetailsCalled = true
+                            fail("'setAndPersistIdentityTokenDetails:' should not be called")
                         }
                         defer { hookDevice.remove() }
 
@@ -1357,9 +1357,8 @@ class PushActivationStateMachine : QuickSpec {
                         let delegate = StateMachineDelegate()
                         stateMachine.delegate = delegate
 
-                        var setAndPersistIdentityTokenDetailsCalled = false
                         let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
-                            setAndPersistIdentityTokenDetailsCalled = true
+                            fail("'setAndPersistIdentityTokenDetails:' should not be called")
                         }
                         defer { hookDevice.remove() }
 

--- a/Spec/PushActivationStateMachine.swift
+++ b/Spec/PushActivationStateMachine.swift
@@ -1493,7 +1493,18 @@ class PushActivationStateMachine : QuickSpec {
             }
 
         }
+
+        it("should remove identityTokenDetails from cache and storage") {
+            let storage = MockDeviceStorage()
+            rest.storage = storage
+            rest.device.setAndPersistIdentityTokenDetails(nil)
+            rest.resetDeviceOnceToken()
+            expect(rest.device.identityTokenDetails).to(beNil())
+            expect(rest.device.isRegistered()) == false
+            expect(storage.object(forKey: ARTDeviceIdentityTokenKey)).to(beNil())
+        }
     }
+
 }
 
 class StateMachineDelegate: NSObject, ARTPushRegistererDelegate {

--- a/Spec/PushActivationStateMachine.swift
+++ b/Spec/PushActivationStateMachine.swift
@@ -584,8 +584,9 @@ class PushActivationStateMachine : QuickSpec {
                         expect(url.host).to(equal(rest.options.restUrl().host))
                         expect(request.httpMethod) == "DELETE"
                         expect(url.query).to(contain(rest.device.id))
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
-                        expect(authorization).to(equal(rest.device.secret))
+                        expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
+                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
+                        expect(deviceAuthorization).to(equal(rest.device.secret))
                     }
 
                     // RSH3d2b, RSH3d2c, RSH3d2d
@@ -634,8 +635,9 @@ class PushActivationStateMachine : QuickSpec {
                         expect(request.httpMethod) == "DELETE"
                         expect(url.query).to(contain(rest.device.id))
                         expect(rest.device.identityTokenDetails).to(beNil())
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
-                        expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
+                        expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
+                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                        expect(deviceAuthorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
                     }
 
                     // RSH3d2c
@@ -873,8 +875,9 @@ class PushActivationStateMachine : QuickSpec {
                         expect(body.value(forKey: "push") as? [String: [String: String]]).to(equal(["recipient": ["transportType": "apns"]]))
                         expect(body.value(forKey: "formFactor")).to(beNil())
                         expect(body.value(forKey: "platform")).to(beNil())
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
-                        expect(authorization).to(equal(deviceIdentityToken))
+                        expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
+                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                        expect(deviceAuthorization).to(equal(deviceIdentityToken))
                     }
 
                     it("should fire RegistrationUpdated event and include device auth") {
@@ -933,8 +936,9 @@ class PushActivationStateMachine : QuickSpec {
                         expect(body.value(forKey: "push") as? [String: [String: String]]).to(equal(["recipient": ["transportType": "apns"]]))
                         expect(body.value(forKey: "formFactor")).to(beNil())
                         expect(body.value(forKey: "platform")).to(beNil())
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
-                        expect(authorization).to(equal(deviceIdentityToken))
+                        expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
+                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                        expect(deviceAuthorization).to(equal(deviceIdentityToken))
                     }
 
                     it("should transition to WaitingForRegistrationUpdate") {
@@ -1074,8 +1078,9 @@ class PushActivationStateMachine : QuickSpec {
                         expect(body.value(forKey: "push") as? [String: [String: String]]).to(equal(["recipient": ["transportType": "apns"]]))
                         expect(body.value(forKey: "formFactor")).to(beNil())
                         expect(body.value(forKey: "platform")).to(beNil())
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
-                        expect(authorization).to(equal(deviceIdentityToken))
+                        expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
+                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                        expect(deviceAuthorization).to(equal(deviceIdentityToken))
                     }
 
                     it("should fire RegistrationUpdated event and include device auth") {
@@ -1134,8 +1139,9 @@ class PushActivationStateMachine : QuickSpec {
                         expect(body.value(forKey: "push") as? [String: [String: String]]).to(equal(["recipient": ["transportType": "apns"]]))
                         expect(body.value(forKey: "formFactor")).to(beNil())
                         expect(body.value(forKey: "platform")).to(beNil())
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
-                        expect(authorization).to(equal(deviceIdentityToken))
+                        expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
+                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                        expect(deviceAuthorization).to(equal(deviceIdentityToken))
                     }
 
                     it("should transition to WaitingForRegistrationUpdate") {
@@ -1254,8 +1260,9 @@ class PushActivationStateMachine : QuickSpec {
                         expect(url.host).to(equal(rest.options.restUrl().host))
                         expect(request.httpMethod) == "DELETE"
                         expect(url.query).to(contain(rest.device.id))
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
-                        expect(authorization).to(equal(rest.device.secret))
+                        expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
+                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
+                        expect(deviceAuthorization).to(equal(rest.device.secret))
                     }
 
                     it("should fire Deregistered event and include DeviceIdentityToken HTTP header") {
@@ -1302,8 +1309,9 @@ class PushActivationStateMachine : QuickSpec {
                         expect(request.httpMethod) == "DELETE"
                         expect(url.query).to(contain(rest.device.id))
                         expect(rest.device.identityTokenDetails).to(beNil())
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
-                        expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
+                        expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
+                        let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                        expect(deviceAuthorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
                     }
 
                     it("should fire DeregistrationFailed event") {

--- a/Spec/PushAdmin.swift
+++ b/Spec/PushAdmin.swift
@@ -400,7 +400,7 @@ class PushAdmin : QuickSpec {
                             return
                         }
 
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
                         expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
                     }
 
@@ -504,7 +504,7 @@ class PushAdmin : QuickSpec {
                     }
 
                     expect(request.httpMethod) == "DELETE"
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]).to(beNil())
+                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
                 }
             }
@@ -529,7 +529,7 @@ class PushAdmin : QuickSpec {
                     }
 
                     expect(request.httpMethod) == "PUT"
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]).to(beNil())
+                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
                 }
 
@@ -565,7 +565,7 @@ class PushAdmin : QuickSpec {
                         }
                         expect(request.httpMethod).to(equal("PUT"))
 
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
                         expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
                     }
 
@@ -633,7 +633,7 @@ class PushAdmin : QuickSpec {
                     }
 
                     expect(request.httpMethod) == "DELETE"
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]).to(beNil())
+                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
 
                     waitUntil(timeout: testTimeout) { done in
@@ -700,7 +700,7 @@ class PushAdmin : QuickSpec {
                     }
 
                     expect(request.httpMethod).to(equal("POST"))
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]).to(beNil())
+                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
                 }
 
@@ -761,7 +761,7 @@ class PushAdmin : QuickSpec {
                             return
                         }
 
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
                         expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
                     }
 
@@ -847,7 +847,7 @@ class PushAdmin : QuickSpec {
                     }
 
                     expect(request.httpMethod).to(equal("DELETE"))
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]).to(beNil())
+                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
 
                     waitUntil(timeout: testTimeout) { done in
@@ -893,7 +893,7 @@ class PushAdmin : QuickSpec {
                             return
                         }
 
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
                         expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
                     }
 

--- a/Spec/PushChannel.swift
+++ b/Spec/PushChannel.swift
@@ -80,7 +80,7 @@ class PushChannel : QuickSpec {
                     expect(body.value(forKey: "deviceId") as? String).to(equal(rest.device.id))
                     expect(body.value(forKey: "channel") as? String).to(equal(channel.name))
 
-                    let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                    let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
                     expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecrect"]).to(beNil())
                 }
@@ -147,7 +147,7 @@ class PushChannel : QuickSpec {
                     expect(body.value(forKey: "clientId") as? String).to(equal(rest.device.clientId))
                     expect(body.value(forKey: "channel") as? String).to(equal(channel.name))
 
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]).to(beNil())
+                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecrect"]).to(beNil())
                 }
             }
@@ -195,7 +195,7 @@ class PushChannel : QuickSpec {
                     expect(query).to(haveParam("deviceId", withValue: rest.device.id))
                     expect(query).to(haveParam("channel", withValue: channel.name))
 
-                    let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]
+                    let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
                     expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecrect"]).to(beNil())
                 }
@@ -252,7 +252,7 @@ class PushChannel : QuickSpec {
                     expect(query).to(haveParam("clientId", withValue: rest.device.clientId!))
                     expect(query).to(haveParam("channel", withValue: channel.name))
 
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceIdentityToken"]).to(beNil())
+                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecrect"]).to(beNil())
                 }
             }


### PR DESCRIPTION
 - `deviceUpdateRegistration` method was setting a wrong Authorization header and was trying to read an updated `deviceIdentityToken` from the response body. Since that field doesn't exist, the local `deviceIdentityTokenDetails` was updated with a `token=nil`.