### PR TITLE
Tests using `echo.ably.io` were failing intermittently with "Request mac does not match"

### DIFF
--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -3005,9 +3005,9 @@ class Auth : QuickSpec {
                     }
 
                     options.authUrl = URL(string: "http://echo.ably.io")! as URL
-                    options.authParams = [NSURLQueryItem]() as [URLQueryItem]?
-                    options.authParams?.append(NSURLQueryItem(name: "type", value: "json") as URLQueryItem)
-                    options.authParams?.append(NSURLQueryItem(name: "body", value: tokenRequestJSON as String) as URLQueryItem)
+                    options.authParams = [URLQueryItem]()
+                    options.authParams?.append(URLQueryItem(name: "type", value: "json"))
+                    options.authParams?.append(URLQueryItem(name: "body", value: tokenRequestJSON))
                     options.key = nil
                     rest = ARTRest(options: options)
 


### PR DESCRIPTION
https://travis-ci.org/ably/ably-cocoa/jobs/552920920#L2002

Example of test that was failing: https://github.com/ably/ably-cocoa/blob/0054046ea315741b0124461f6404b48d6384e530/Spec/Auth.swift#L1488

Discussed with Simon:
> @ricardopereira The bug is that you aren't properly URI-encoding the token request when sending it as a QS param to the echo server. In particular, `+`s appear to not be being uri-encoded; they should be encoded to `%2B`.
(So you're getting the result back and the literal pluses are intrepreted as spaces in the url, so you're getting a mac of  `h5qZ BFGbbcPc /llzOLracCqBgsz/g94KtJgoiYUE=` when it should be `+h5qZ+BFGbbcPc+/llzOLracCqBgsz/g94KtJgoiYUE=`)