### PR TITLE
[WIP] Replace weak refs by explicit cycle breaking where possible.

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -649,6 +649,12 @@
 		EB0505FC1C5BD7C4006BA7E2 /* ARTBaseMessage+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = EB0505FB1C5BD7C4006BA7E2 /* ARTBaseMessage+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EB1AE0CC1C5C1EB200D62250 /* ARTEventEmitter+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = EB1AE0CB1C5C1EB200D62250 /* ARTEventEmitter+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EB1AE0CE1C5C3A4900D62250 /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1AE0CD1C5C3A4900D62250 /* Utilities.swift */; };
+		EB1B53F122EC5354006A59AC /* ARTFlusher.h in Headers */ = {isa = PBXBuildFile; fileRef = EB1B53F022EC5354006A59AC /* ARTFlusher.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EB1B53F222EC5354006A59AC /* ARTFlusher.h in Headers */ = {isa = PBXBuildFile; fileRef = EB1B53F022EC5354006A59AC /* ARTFlusher.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EB1B53F322EC5354006A59AC /* ARTFlusher.h in Headers */ = {isa = PBXBuildFile; fileRef = EB1B53F022EC5354006A59AC /* ARTFlusher.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EB1B53F522EC53AE006A59AC /* ARTFlusher.m in Sources */ = {isa = PBXBuildFile; fileRef = EB1B53F422EC53AE006A59AC /* ARTFlusher.m */; };
+		EB1B53F622EC53AE006A59AC /* ARTFlusher.m in Sources */ = {isa = PBXBuildFile; fileRef = EB1B53F422EC53AE006A59AC /* ARTFlusher.m */; };
+		EB1B53F722EC53AE006A59AC /* ARTFlusher.m in Sources */ = {isa = PBXBuildFile; fileRef = EB1B53F422EC53AE006A59AC /* ARTFlusher.m */; };
 		EB20F8D71C653F2300EF3978 /* ARTPresence+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = EB20F8D61C653F1E00EF3978 /* ARTPresence+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EB2D5A911CC941A700AD1A67 /* ARTRealtimeTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = EB2D5A901CC941A700AD1A67 /* ARTRealtimeTransport.m */; };
 		EB2D84F71CD75CCE00F23CDA /* ARTReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = EB2D84F61CD75CCE00F23CDA /* ARTReachability.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -992,6 +998,8 @@
 		EB0505FB1C5BD7C4006BA7E2 /* ARTBaseMessage+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ARTBaseMessage+Private.h"; sourceTree = "<group>"; };
 		EB1AE0CB1C5C1EB200D62250 /* ARTEventEmitter+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ARTEventEmitter+Private.h"; sourceTree = "<group>"; };
 		EB1AE0CD1C5C3A4900D62250 /* Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
+		EB1B53F022EC5354006A59AC /* ARTFlusher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARTFlusher.h; sourceTree = "<group>"; };
+		EB1B53F422EC53AE006A59AC /* ARTFlusher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTFlusher.m; sourceTree = "<group>"; };
 		EB20F8D61C653F1E00EF3978 /* ARTPresence+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ARTPresence+Private.h"; sourceTree = "<group>"; };
 		EB2D5A901CC941A700AD1A67 /* ARTRealtimeTransport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTRealtimeTransport.m; sourceTree = "<group>"; };
 		EB2D84F61CD75CCE00F23CDA /* ARTReachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARTReachability.h; sourceTree = "<group>"; };
@@ -1378,6 +1386,8 @@
 				EBD947B51EBB8F2B0005DD16 /* ARTSentry.m */,
 				D3AD0EBB215E2FB000312105 /* ARTNSString+ARTUtil.h */,
 				D3AD0EBC215E2FB000312105 /* ARTNSString+ARTUtil.m */,
+				EB1B53F022EC5354006A59AC /* ARTFlusher.h */,
+				EB1B53F422EC53AE006A59AC /* ARTFlusher.m */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -1515,6 +1525,7 @@
 				EB89D4091C61C5ED007FA5B7 /* ARTRealtimeChannels.h in Headers */,
 				96E408431A38939E00087F77 /* ARTProtocolMessage.h in Headers */,
 				D78D780921271FB10016808B /* ARTHTTPPaginatedResponse+Private.h in Headers */,
+				EB1B53F122EC5354006A59AC /* ARTFlusher.h in Headers */,
 				D746AE381BBC3201003ECEF8 /* ARTMessage.h in Headers */,
 				D746AE471BBD6FE9003ECEF8 /* ARTQueuedMessage.h in Headers */,
 				1C2B0FFD1B136A6D00E3633C /* ARTPresenceMap.h in Headers */,
@@ -1633,6 +1644,7 @@
 				D710D68121949EB3008F54AD /* ARTReachability.h in Headers */,
 				D710D58921949D29008F54AD /* ARTBaseMessage.h in Headers */,
 				D710D55721949C8C008F54AD /* ARTPushActivationEvent.h in Headers */,
+				EB1B53F222EC5354006A59AC /* ARTFlusher.h in Headers */,
 				D710D4CE21949BB2008F54AD /* ARTWebSocketTransport+Private.h in Headers */,
 				D710D56C21949CB9008F54AD /* ARTPushChannelSubscriptions.h in Headers */,
 				D710D56721949CA1008F54AD /* ARTPushActivationStateMachine+Private.h in Headers */,
@@ -1751,6 +1763,7 @@
 				D710D68321949EB4008F54AD /* ARTReachability.h in Headers */,
 				D710D5AF21949D2A008F54AD /* ARTBaseMessage.h in Headers */,
 				D710D55D21949C8D008F54AD /* ARTPushActivationEvent.h in Headers */,
+				EB1B53F322EC5354006A59AC /* ARTFlusher.h in Headers */,
 				D710D4D021949BB3008F54AD /* ARTWebSocketTransport+Private.h in Headers */,
 				D710D57221949CBA008F54AD /* ARTPushChannelSubscriptions.h in Headers */,
 				D710D56921949CA2008F54AD /* ARTPushActivationStateMachine+Private.h in Headers */,
@@ -2142,6 +2155,7 @@
 				96E408441A38939E00087F77 /* ARTProtocolMessage.m in Sources */,
 				D71966E51E5DF360000974DD /* ARTPushActivationStateMachine.m in Sources */,
 				EB9121401CA0AD8200BA0A40 /* ARTMsgPackEncoder.m in Sources */,
+				EB1B53F522EC53AE006A59AC /* ARTFlusher.m in Sources */,
 				96BF61651A35CDE1004CF2B3 /* ARTBaseMessage.m in Sources */,
 				D7F1D3781BF4DE72001A4B5E /* ARTRealtimePresence.m in Sources */,
 				D7DF738B1EA645300013CD36 /* ARTLocalDeviceStorage.m in Sources */,
@@ -2274,6 +2288,7 @@
 				D710D5D421949D78008F54AD /* ARTTokenDetails.m in Sources */,
 				D710D49B21949ACA008F54AD /* ARTRestChannels.m in Sources */,
 				D710D62E21949E03008F54AD /* ARTURLSessionServerTrust.m in Sources */,
+				EB1B53F622EC53AE006A59AC /* ARTFlusher.m in Sources */,
 				D710D66B21949E78008F54AD /* ARTJsonEncoder.m in Sources */,
 				D710D67321949E79008F54AD /* ARTSentry.m in Sources */,
 				D710D5D521949D78008F54AD /* ARTClientOptions.m in Sources */,
@@ -2354,6 +2369,7 @@
 				D710D5FA21949D79008F54AD /* ARTTokenDetails.m in Sources */,
 				D710D4A521949ACB008F54AD /* ARTRestChannels.m in Sources */,
 				D710D63E21949E04008F54AD /* ARTURLSessionServerTrust.m in Sources */,
+				EB1B53F722EC53AE006A59AC /* ARTFlusher.m in Sources */,
 				D710D65121949E77008F54AD /* ARTJsonEncoder.m in Sources */,
 				D710D65921949E77008F54AD /* ARTSentry.m in Sources */,
 				D710D5FB21949D79008F54AD /* ARTClientOptions.m in Sources */,

--- a/Source/ARTAuth+Private.h
+++ b/Source/ARTAuth+Private.h
@@ -29,11 +29,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) ARTClientOptions *options;
 @property (nonatomic, readonly, assign) ARTAuthMethod method;
 
-@property (nonatomic, weak) ARTLog *logger;
+@property (nonatomic, strong) ARTLog *logger;
 
 @property (nullable, nonatomic, readonly, strong) NSNumber *timeOffset;
 
-@property (nullable, weak) id<ARTAuthDelegate> delegate;
+@property (nullable, weak) id<ARTAuthDelegate> delegate; // weak because delegates outlive their counterpart
 @property (readonly) BOOL authorizing;
 @property (readonly) BOOL authorizing_nosync;
 

--- a/Source/ARTAuth.m
+++ b/Source/ARTAuth.m
@@ -26,7 +26,7 @@
 #import "ARTEventEmitter+Private.h"
 
 @implementation ARTAuth {
-    __weak ARTRest *_rest;
+    __weak ARTRest *_rest; // weak because rest owns auth
     dispatch_queue_t _userQueue;
     dispatch_queue_t _queue;
     ARTTokenParams *_tokenParams;

--- a/Source/ARTChannel.m
+++ b/Source/ARTChannel.m
@@ -18,7 +18,7 @@
 #import "ARTDefault.h"
 
 @implementation ARTChannel {
-    __weak ARTRest *_rest;
+    __weak ARTRest *_rest; // weak because rest owns self
     dispatch_queue_t _queue;
 }
 

--- a/Source/ARTChannels+Private.h
+++ b/Source/ARTChannels+Private.h
@@ -37,7 +37,7 @@ extern NSString* (^_Nullable ARTChannels_getChannelNamePrefix)(void);
 - (BOOL)_exists:(NSString *)name;
 - (ChannelType)_get:(NSString *)name;
 - (ChannelType)_getChannel:(NSString *)name options:(ARTChannelOptions * _Nullable)options addPrefix:(BOOL)addPrefix;
-- (void)_release:(NSString *)name;
+- (void)_remove:(NSString *)name;
 
 - (instancetype)initWithDelegate:(id<ARTChannelsDelegate>)delegate dispatchQueue:(dispatch_queue_t)queue;
 

--- a/Source/ARTChannels.m
+++ b/Source/ARTChannels.m
@@ -16,7 +16,7 @@
 NSString* (^_Nullable ARTChannels_getChannelNamePrefix)(void);
 
 @interface ARTChannels() {
-    __weak id<ARTChannelsDelegate> _delegate;
+    __weak id<ARTChannelsDelegate> _delegate; // weak because delegates outlive their counterpart
     dispatch_queue_t _queue;
 }
 
@@ -67,11 +67,11 @@ dispatch_sync(_queue, ^{
 
 - (void)release:(NSString *)name {
 dispatch_sync(_queue, ^{
-    [self _release:name];
+    [self _remove:name];
 });
 }
 
-- (void)_release:(NSString *)name {
+- (void)_remove:(NSString *)name {
     [self->_channels removeObjectForKey:[ARTChannels addPrefix:name]];
 }
 

--- a/Source/ARTConnection+Private.h
+++ b/Source/ARTConnection+Private.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)recoveryKey_nosync;
 
 @property (readonly, strong, nonatomic) ARTEventEmitter<ARTEvent *, ARTConnectionStateChange *> *eventEmitter;
-@property(weak, nonatomic) ARTRealtime* realtime;
+@property(weak, nonatomic) ARTRealtime* realtime; // weak because realtime owns self
 
 @end
 

--- a/Source/ARTCrypto+Private.h
+++ b/Source/ARTCrypto+Private.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ARTCipherParams ()
 
 @property (readonly, strong, nonatomic, nullable) NSData *iv;
-@property (nonatomic, weak) ARTLog *logger;
+@property (nonatomic, strong) ARTLog *logger;
 - (instancetype)initWithAlgorithm:(NSString *)algorithm key:(id<ARTCipherKeyCompatible>)key iv:(NSData *_Nullable)iv;
 
 @end
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)cbcCipherWithParams:(ARTCipherParams *)cipherParams;
 
 
-@property (nonatomic, weak) ARTLog *logger;
+@property (nonatomic, strong) ARTLog *logger;
 @property (readonly, strong, nonatomic) NSData *keySpec;
 @property NSData *iv;
 @property (readonly) NSUInteger blockLength;

--- a/Source/ARTCrypto.m
+++ b/Source/ARTCrypto.m
@@ -20,7 +20,7 @@
 
 @interface ARTCrypto ()
 
-@property (nonatomic, weak) ARTLog * logger;
+@property (nonatomic, strong) ARTLog * logger;
 
 @end
 

--- a/Source/ARTDataQuery+Private.h
+++ b/Source/ARTDataQuery+Private.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ARTRealtimeHistoryQuery ()
 
-@property (weak, readwrite) ARTRealtimeChannel *realtimeChannel;
+@property (strong, readwrite) ARTRealtimeChannel *realtimeChannel;
 
 @end
 

--- a/Source/ARTEventEmitter+Private.h
+++ b/Source/ARTEventEmitter+Private.h
@@ -8,6 +8,7 @@
 
 #include <Ably/ARTEventEmitter.h>
 #include <Ably/ARTRest.h>
+#include "ARTFlusher.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -16,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ARTEventListener ()
 
 @property (nonatomic, readonly) NSString *eventId;
-@property (weak, nonatomic, readonly) id<NSObject> token;
+@property (nonatomic, readonly) id<NSObject> token;
 @property (nonatomic, readonly) NSUInteger count;
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -53,6 +54,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithQueue:(dispatch_queue_t)queue;
 - (instancetype)initWithQueues:(dispatch_queue_t)queue userQueue:(_Nullable dispatch_queue_t)userQueue;
 
+@end
+
+@interface ARTEventEmitter () <ARTFlushable>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/ARTEventEmitter.m
+++ b/Source/ARTEventEmitter.m
@@ -60,8 +60,8 @@
 @end
 
 @implementation ARTEventListener {
-    __weak NSNotificationCenter *_center;
-    __weak ARTEventEmitter *_eventHandler;
+    NSNotificationCenter *_center;
+    __weak ARTEventEmitter *_eventHandler; // weak because eventEmitter owns self
     NSTimeInterval _timeoutDeadline;
     void (^_timeoutBlock)(void);
     dispatch_block_t _work;
@@ -132,9 +132,8 @@
         NSAssert(false, @"timer is already running");
     }
     _timerIsRunning = true;
-    __weak typeof(self) weakSelf = self;
     _work = artDispatchScheduled(_timeoutDeadline, [_eventHandler queue], ^{
-        [weakSelf timeout];
+        [self timeout];
     });
 }
 
@@ -168,68 +167,64 @@
 
 - (ARTEventListener *)on:(id<ARTEventIdentification>)event callback:(void (^)(id __art_nonnull))cb {
     NSString *eventId = [NSString stringWithFormat:@"%p-%@", self, [event identification]];
-    __weak __block ARTEventListener *weakListener;
+    __block ARTEventListener *listener;
     id<NSObject> observerToken = [_notificationCenter addObserverForName:eventId object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
-        if (weakListener == nil || [weakListener invalidated]) return;
-        if ([weakListener hasTimer] && ![weakListener timerIsRunning]) return;
-        [weakListener stopTimer];
+        if (listener == nil || [listener invalidated]) return;
+        if ([listener hasTimer] && ![listener timerIsRunning]) return;
+        [listener stopTimer];
         cb(note.object);
     }];
-    ARTEventListener *eventToken = [[ARTEventListener alloc] initWithId:eventId token:observerToken handler:self center:_notificationCenter];
-    weakListener = eventToken;
-    [self addObject:eventToken toArrayWithKey:eventToken.eventId inDictionary:self.listeners];
-    return eventToken;
+    listener = [[ARTEventListener alloc] initWithId:eventId token:observerToken handler:self center:_notificationCenter];
+    [self addObject:listener toArrayWithKey:listener.eventId inDictionary:self.listeners];
+    return listener;
 }
 
 - (ARTEventListener *)once:(id<ARTEventIdentification>)event callback:(void (^)(id __art_nonnull))cb {
     NSString *eventId = [NSString stringWithFormat:@"%p-%@", self, [event identification]];
-    __weak __block ARTEventListener *weakListener;
-    __weak typeof(self) weakSelf = self;
+    __block ARTEventListener *listener;
+    __weak typeof(self) weakSelf = self; // weak to avoid a warning, but strong should be safe too since we the cycle is broken when the notification fires or the token is cancelled
     id<NSObject> observerToken = [_notificationCenter addObserverForName:eventId object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
-        if (weakListener == nil || [weakListener invalidated]) return;
-        if ([weakListener hasTimer] && ![weakListener timerIsRunning]) return;
-        if ([weakListener handled]) return;
-        [weakListener removeObserver];
-        [weakSelf removeObject:weakListener fromArrayWithKey:[weakListener eventId] inDictionary:[weakSelf listeners]];
+        if (listener == nil || [listener invalidated]) return;
+        if ([listener hasTimer] && ![listener timerIsRunning]) return;
+        if ([listener handled]) return;
+        [listener removeObserver];
+        [weakSelf removeObject:listener fromArrayWithKey:[listener eventId] inDictionary:[weakSelf listeners]];
         cb(note.object);
     }];
-    ARTEventListener *eventToken = [[ARTEventListener alloc] initWithId:eventId token:observerToken handler:self center:_notificationCenter];
-    weakListener = eventToken;
-    [self addObject:eventToken toArrayWithKey:eventToken.eventId inDictionary:self.listeners];
-    return eventToken;
+    listener = [[ARTEventListener alloc] initWithId:eventId token:observerToken handler:self center:_notificationCenter];
+    [self addObject:listener toArrayWithKey:listener.eventId inDictionary:self.listeners];
+    return listener;
 }
 
 - (ARTEventListener *)on:(void (^)(id __art_nonnull))cb {
     NSString *eventId = [NSString stringWithFormat:@"%p", self];
-    __weak __block ARTEventListener *weakListener;
+    __block ARTEventListener *listener;
     id<NSObject> observerToken = [_notificationCenter addObserverForName:eventId object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
-        if (weakListener == nil || [weakListener invalidated]) return;
-        if ([weakListener hasTimer] && ![weakListener timerIsRunning]) return;
-        [weakListener stopTimer];
+        if (listener == nil || [listener invalidated]) return;
+        if ([listener hasTimer] && ![listener timerIsRunning]) return;
+        [listener stopTimer];
         cb(note.object);
     }];
-    ARTEventListener *eventToken = [[ARTEventListener alloc] initWithId:eventId token:observerToken handler:self center:_notificationCenter];
-    weakListener = eventToken;
-    [self.anyListeners addObject:eventToken];
-    return eventToken;
+    listener = [[ARTEventListener alloc] initWithId:eventId token:observerToken handler:self center:_notificationCenter];
+    [self.anyListeners addObject:listener];
+    return listener;
 }
 
 - (ARTEventListener *)once:(void (^)(id __art_nonnull))cb {
     NSString *eventId = [NSString stringWithFormat:@"%p", self];
-    __weak __block ARTEventListener *weakListener;
-    __weak typeof(self) weakSelf = self;
+    __block ARTEventListener *listener;
+    __weak typeof(self) weakSelf = self; // weak to avoid a warning, but strong should be safe too since we the cycle is broken when the notification fires or the token is cancelled
     id<NSObject> observerToken = [_notificationCenter addObserverForName:eventId object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
-        if (weakListener == nil || [weakListener invalidated]) return;
-        if ([weakListener hasTimer] && ![weakListener timerIsRunning]) return;
-        if ([weakListener handled]) return;
-        [weakListener removeObserver];
-        [[weakSelf anyListeners] removeObject:weakListener];
+        if (listener == nil || [listener invalidated]) return;
+        if ([listener hasTimer] && ![listener timerIsRunning]) return;
+        if ([listener handled]) return;
+        [listener removeObserver];
+        [[weakSelf anyListeners] removeObject:listener];
         cb(note.object);
     }];
-    ARTEventListener *eventToken = [[ARTEventListener alloc] initWithId:eventId token:observerToken handler:self center:_notificationCenter];
-    weakListener = eventToken;
-    [self.anyListeners addObject:eventToken];
-    return eventToken;
+    listener = [[ARTEventListener alloc] initWithId:eventId token:observerToken handler:self center:_notificationCenter];
+    [self.anyListeners addObject:listener];
+    return listener;
 }
 
 - (void)off:(id<ARTEventIdentification>)event listener:(ARTEventListener *)listener {
@@ -308,10 +303,14 @@
     }
 }
 
+- (void)flush {
+    [self off];
+}
+
 @end
 
 @implementation ARTPublicEventEmitter {
-    __weak ARTRest *_rest;
+    __weak ARTRest *_rest; // weak because rest owns self
     dispatch_queue_t _queue;
     dispatch_queue_t _userQueue;
 }

--- a/Source/ARTFlusher.h
+++ b/Source/ARTFlusher.h
@@ -1,0 +1,33 @@
+//
+//  ARTFlusher.h
+//  Ably
+//
+//  Created by Toni Cárdenas on 27/07/2019.
+//  Copyright © 2019 Ably. All rights reserved.
+//
+
+#ifndef ARTFlusher_h
+#define ARTFlusher_h
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol ARTFlushable <NSObject>
+
+- (void)flush;
+
+@end
+
+@interface ARTFlusher : NSObject
+
+- (instancetype)init;
+- (void)add:(id<ARTFlushable>)flushable;
+- (void)remove:(id<ARTFlushable>)flushable;
+- (void)flush;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* ARTFlusher_h */

--- a/Source/ARTFlusher.m
+++ b/Source/ARTFlusher.m
@@ -1,0 +1,36 @@
+//
+//  ARTFlushable.m
+//  Ably
+//
+//  Created by Toni Cárdenas on 27/07/2019.
+//  Copyright © 2019 Ably. All rights reserved.
+//
+
+#import "ARTFlusher.h"
+
+@implementation ARTFlusher {
+    NSMutableSet<id<ARTFlushable>> *_flushables;
+}
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _flushables = [[NSMutableSet alloc] init];
+    }
+    return self;
+}
+
+- (void)add:(id<ARTFlushable>)flushable {
+    [self->_flushables addObject:flushable];
+}
+
+- (void)remove:(id<ARTFlushable>)flushable {
+    [self->_flushables removeObject:flushable];
+}
+
+- (void)flush {
+    for (id<ARTFlushable> flushable in _flushables) {
+        [flushable flush];
+    }
+}
+
+@end

--- a/Source/ARTJsonLikeEncoder.m
+++ b/Source/ARTJsonLikeEncoder.m
@@ -33,8 +33,8 @@
 #import "ARTPushChannelSubscription.h"
 
 @implementation ARTJsonLikeEncoder {
-    __weak ARTRest *_rest;
-    __weak ARTLog *_logger;
+    __weak ARTRest *_rest; // weak because rest owns self
+    ARTLog *_logger;
 }
 
 - (instancetype)init {

--- a/Source/ARTLocalDeviceStorage.m
+++ b/Source/ARTLocalDeviceStorage.m
@@ -12,7 +12,7 @@
 #import <SAMKeychain/SAMKeychain.h>
 
 @implementation ARTLocalDeviceStorage {
-    __weak ARTLog *_logger;
+    ARTLog *_logger;
 }
 
 - (instancetype)initWithLogger:(ARTLog *)logger {

--- a/Source/ARTPaginatedResult.m
+++ b/Source/ARTPaginatedResult.m
@@ -15,7 +15,7 @@
 #import "ARTNSHTTPURLResponse+ARTPaginated.h"
 
 @implementation ARTPaginatedResult {
-    __weak ARTRest *_rest;
+    ARTRest *_rest;
     dispatch_queue_t _userQueue;
     dispatch_queue_t _queue;
     NSMutableURLRequest *_relFirst;

--- a/Source/ARTPresenceMap.h
+++ b/Source/ARTPresenceMap.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// The key is the clientId and the value is the latest relevant ARTPresenceMessage for that clientId.
 @property (readonly, atomic) NSMutableSet<ARTPresenceMessage *> *localMembers;
 
-@property (nullable, weak) id<ARTPresenceMapDelegate> delegate;
+@property (nullable, weak) id<ARTPresenceMapDelegate> delegate; // weak because delegates outlive their counterpart
 
 @property (readwrite, nonatomic, assign) int64_t syncMsgSerial;
 @property (readwrite, nonatomic, nullable) NSString *syncChannelSerial;

--- a/Source/ARTPresenceMap.m
+++ b/Source/ARTPresenceMap.m
@@ -53,7 +53,7 @@ NSString *ARTPresenceSyncStateToStr(ARTPresenceSyncState state) {
 @end
 
 @implementation ARTPresenceMap {
-    __weak ARTLog *_logger;
+    ARTLog *_logger;
 }
 
 - (instancetype)initWithQueue:(_Nonnull dispatch_queue_t)queue logger:(ARTLog *)logger { 

--- a/Source/ARTPush.m
+++ b/Source/ARTPush.m
@@ -33,7 +33,7 @@ NSString *const ARTDeviceTokenKey = @"ARTDeviceToken";
 
 @implementation ARTPush {
     ARTRest *_rest;
-    __weak ARTLog *_logger;
+    ARTLog *_logger;
 }
 
 - (instancetype)init:(ARTRest *)rest {

--- a/Source/ARTPushActivationStateMachine+Private.h
+++ b/Source/ARTPushActivationStateMachine+Private.h
@@ -15,7 +15,7 @@ extern NSString *const ARTPushActivationPendingEventsKey;
 
 @interface ARTPushActivationStateMachine ()
 
-@property (weak, nonatomic) id delegate;
+@property (weak, nonatomic) id delegate; // weak because delegates outlive their counterpart
 @property (nonatomic, copy, nullable) void (^transitions)(ARTPushActivationEvent *event, ARTPushActivationState *from, ARTPushActivationState *to);
 @property (readonly, nonatomic) ARTPushActivationEvent *lastEvent;
 @property (readonly, nonatomic) ARTPushActivationEvent *lastEvent_nosync;

--- a/Source/ARTPushAdmin.m
+++ b/Source/ARTPushAdmin.m
@@ -17,7 +17,7 @@
 
 @implementation ARTPushAdmin {
     ARTRest *_rest;
-    __weak ARTLog *_logger;
+    ARTLog *_logger;
     dispatch_queue_t _userQueue;
     dispatch_queue_t _queue;
 }

--- a/Source/ARTPushChannel.m
+++ b/Source/ARTPushChannel.m
@@ -21,9 +21,9 @@
 const NSUInteger ARTDefaultLimit = 100;
 
 @implementation ARTPushChannel {
-    __weak ARTRest *_rest;
-    __weak ARTLog *_logger;
-    __weak ARTChannel *_channel;
+    __weak ARTRest *_rest; // weak because rest may own self and always outlives it
+    ARTLog *_logger;
+    __weak ARTChannel *_channel; // weak because channel owns self
 }
 
 - (instancetype)init:(ARTRest *)rest withChannel:(ARTChannel *)channel {

--- a/Source/ARTPushChannelSubscriptions.m
+++ b/Source/ARTPushChannelSubscriptions.m
@@ -19,8 +19,8 @@
 #import "ARTNSMutableRequest+ARTPush.h"
 
 @implementation ARTPushChannelSubscriptions {
-    __weak ARTRest *_rest;
-    __weak ARTLog* _logger;
+    __weak ARTRest *_rest; // weak because rest owns self
+    ARTLog* _logger;
     dispatch_queue_t _queue;
     dispatch_queue_t _userQueue;
 }

--- a/Source/ARTPushDeviceRegistrations.m
+++ b/Source/ARTPushDeviceRegistrations.m
@@ -20,8 +20,8 @@
 #import "ARTNSMutableRequest+ARTPush.h"
 
 @implementation ARTPushDeviceRegistrations {
-    __weak ARTRest *_rest;
-    __weak ARTLog* _logger;
+    __weak ARTRest *_rest; // weak because rest owns self
+    ARTLog* _logger;
     dispatch_queue_t _queue;
     dispatch_queue_t _userQueue;
 }

--- a/Source/ARTRealtimeChannel+Private.h
+++ b/Source/ARTRealtimeChannel+Private.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (ARTErrorInfo *)errorReason_nosync;
 - (NSString *_Nullable)clientId_nosync;
 
-@property (readonly, weak, nonatomic) ARTRealtime *realtime;
+@property (readonly, weak, nonatomic) ARTRealtime *realtime; // weak because realtime owns self
 @property (readonly, strong, nonatomic) ARTRestChannel *restChannel;
 @property (readwrite, strong, nonatomic) NSMutableArray *queuedMessages;
 @property (readwrite, strong, nonatomic, nullable) NSString *attachSerial;
@@ -79,6 +79,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sync;
 - (void)sync:(nullable void (^)(ARTErrorInfo *_Nullable))callback;
 - (void)requestContinueSync;
+
+- (void)close;
 
 @end
 

--- a/Source/ARTRealtimeChannels+Private.h
+++ b/Source/ARTRealtimeChannels+Private.h
@@ -8,6 +8,7 @@
 //
 
 #import <Ably/ARTRealtimeChannels.h>
+#import "ARTFlusher.h"
 
 @class ARTRealtimeChannel;
 
@@ -19,6 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, getter=getCollection) NSMutableDictionary<NSString *, ARTRealtimeChannel *> *collection;
 - (ARTRealtimeChannel *)_getChannel:(NSString *)name options:(ARTChannelOptions * _Nullable)options addPrefix:(BOOL)addPrefix;
 
+@end
+
+@interface ARTRealtimeChannels () <ARTFlushable>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/ARTRealtimePresence.m
+++ b/Source/ARTRealtimePresence.m
@@ -35,7 +35,7 @@
 #pragma mark - ARTRealtimePresence
 
 @implementation ARTRealtimePresence {
-    __weak ARTRealtimeChannel *_channel;
+    __weak ARTRealtimeChannel *_channel; // weak because channel owns self
     dispatch_queue_t _userQueue;
     dispatch_queue_t _queue;
 }

--- a/Source/ARTRest+Private.h
+++ b/Source/ARTRest+Private.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ARTRest () <ARTHTTPAuthenticatedExecutor>
 
 @property (nonatomic, strong, readonly) ARTClientOptions *options;
-@property (nonatomic, weak, nullable) ARTRealtime *realtime;
+@property (nonatomic, weak, nullable) ARTRealtime *realtime; // weak because realtime owns self
 @property (readonly, strong, nonatomic) id<ARTEncoder> defaultEncoder;
 @property (readonly, strong, nonatomic) NSString *defaultEncoding; //Content-Type
 @property (readonly, strong, nonatomic) NSDictionary<NSString *, id<ARTEncoder>> *encoders;
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 // Must be atomic!
 @property (readwrite, strong, atomic, nullable) NSString *prioritizedHost;
 
-@property (nonatomic, weak) id<ARTHTTPExecutor> httpExecutor;
+@property (nonatomic, strong) id<ARTHTTPExecutor> httpExecutor;
 @property (nonatomic) id<ARTDeviceStorage> storage;
 
 @property (nonatomic, readonly, getter=getBaseUrl) NSURL *baseUrl;

--- a/Source/ARTRestChannel+Private.h
+++ b/Source/ARTRestChannel+Private.h
@@ -13,7 +13,7 @@
 
 - (instancetype)initWithName:(NSString *)name withOptions:(ARTChannelOptions *)options andRest:(ARTRest *)rest;
 
-@property (nonatomic, weak) ARTRest *rest;
+@property (nonatomic, weak) ARTRest *rest; // weak because rest owns self
 
 @end
 

--- a/Source/ARTRestChannels.m
+++ b/Source/ARTRestChannels.m
@@ -14,7 +14,7 @@
 
 @interface ARTRestChannels ()
 
-@property (weak, nonatomic) ARTRest *rest;
+@property (weak, nonatomic) ARTRest *rest; // weak because rest owns self
 
 @end
 

--- a/Source/ARTRestPresence.m
+++ b/Source/ARTRestPresence.m
@@ -59,7 +59,7 @@
 @end
 
 @implementation ARTRestPresence {
-    __weak ARTRestChannel *_channel;
+    __weak ARTRestChannel *_channel; // weak because channel owns self
     dispatch_queue_t _userQueue;
     dispatch_queue_t _queue;
 }

--- a/Source/ARTTypes.h
+++ b/Source/ARTTypes.h
@@ -11,6 +11,7 @@
 
 #import <Ably/ARTStatus.h>
 #import <Ably/ARTEventEmitter.h>
+#import "ARTFlusher.h"
 
 @class ARTStatus;
 @class ARTHttpResponse;
@@ -142,6 +143,10 @@ NSString *generateNonce(void);
 
 @protocol ARTCancellable
 - (void)cancel;
+@end
+
+@interface ARTCancelOnFlush : NSObject<ARTCancellable, ARTFlushable>
+- (instancetype)init:(id<ARTCancellable>)cancellable;
 @end
 
 #pragma mark - ARTConnectionStateChange

--- a/Source/ARTTypes.m
+++ b/Source/ARTTypes.m
@@ -309,3 +309,26 @@ NSString *ARTChannelEventToStr(ARTChannelEvent event) {
 }
 
 @end
+
+@implementation ARTCancelOnFlush {
+    id<ARTCancellable> _cancellable;
+}
+
+- (instancetype)init:(id<ARTCancellable>)cancellable {
+    self = [self init];
+    if (self) {
+        _cancellable = cancellable;
+    }
+    return self;
+}
+
+- (void)cancel {
+    [_cancellable cancel];
+}
+
+- (void)flush {
+    [self cancel];
+}
+
+@end
+

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -45,5 +45,6 @@ framework module Ably {
         header "ARTNSHTTPURLResponse+ARTPaginated.h"
         header "ARTNSMutableURLRequest+ARTPaginated.h"
         header "ARTNSDate+ARTUtil.h"
+        header "ARTFlusher.h"
     }
 }


### PR DESCRIPTION
Throughout the codebase, we were liberally using weak references to
break all possible ref cycles, even those that are temporary and should
be broken explicitly. Other weak refs are there just for no good reason,
just to signify that we don't expect an object to lose all other
references to it before our reference is lost.

This by itself results in brittle code. The default should be strong,
which ensures a reference won't disappear before you expected. In other
cases, a more explicit handling of the reference lifecycle (e. g.
explicitly calling a "close" or "cancel" method) makes things clearer.

This PR removes all weak references except those where there's a stable
cycle and the ownership relationship between the objects in the cycle
is clear; for example, ARTRealtime clearly "owns" ARTRest, insofar their
lifetimes are entangled: ARTRealtime initializes ARTRest, and when the
ARTRealtime is released, so should be its ARTRest, which should have no
other references to it. All those cases have been documented.

In some places, we relied on weak references to implicitly invalidate
timers, enqueued operations and things like that. The pattern looks like
this:

    __weak MyClass *weakSelf = self;
    scheduleBlockToBeCalledLater(^{
        [weakSelf someMethod];
    });

The intent here is to cancel scheduled operations on the object if we
stop being interested in the object. And this "interest" is expressed
as holding a reference to the object somewhere.

This way we're forcing the user to hold on to their reference to (say)
ARTRealtime even if they're not going to use it anymore. That's not
what one would expect in a garbage-collected language, in which other
client libraries are written. In those, you would explicitly call
realtime.close if you want it to stop operating.

So this change makes this behavior uniform with other client libraries,
but now we're forced to explicitly unschedule the operations on close.

For this, a little helper class called ARTFlusher to register things
that should be "flushed" (cancelled, emptied, etc.) once we call "close"
or similar on the object they operate on. We flush this way event
listeners, timers, enqueued messages, etc. related to a realtime or
realtime channel instance.