### PR TITLE
Copy channels for public iterate() on internal queue.

### DIFF
--- a/Source/ARTChannels.h
+++ b/Source/ARTChannels.h
@@ -18,6 +18,6 @@
 - (ChannelType)get:(NSString *)name;
 - (ChannelType)get:(NSString *)name options:(ARTChannelOptions *)options;
 - (void)release:(NSString *)name;
-- (id<NSFastEnumeration>)iterate;
+- (id<NSFastEnumeration>)copyIntoIteratorWithMapper:(id (^)(ChannelType))mapper;
 
 @end

--- a/Source/ARTChannels.m
+++ b/Source/ARTChannels.m
@@ -33,10 +33,14 @@ NSString* (^_Nullable ARTChannels_getChannelNamePrefix)(void);
     return self;
 }
 
-- (id<NSFastEnumeration>)iterate {
+- (id<NSFastEnumeration>)copyIntoIteratorWithMapper:(id (^)(id))mapper {
     __block id<NSFastEnumeration>ret;
 dispatch_sync(_queue, ^{
-    ret = [self getNosyncIterable];
+    NSMutableArray *channels = [[NSMutableArray alloc] init];
+    for (id internalChannel in [self getNosyncIterable]) {
+        [channels addObject:mapper(internalChannel)];
+    }
+    ret = [channels objectEnumerator];
 });
     return ret;
 }

--- a/Source/ARTRealtimeChannels+Private.h
+++ b/Source/ARTRealtimeChannels+Private.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (ARTRealtimeChannelInternal *)get:(NSString *)name;
 - (ARTRealtimeChannelInternal *)get:(NSString *)name options:(ARTChannelOptions *)options;
+- (id<NSFastEnumeration>)copyIntoIteratorWithMapper:(ARTRealtimeChannel *(^)(ARTRealtimeChannelInternal *))mapper;
 
 - (instancetype)initWithRealtime:(ARTRealtimeInternal *)realtime;
 

--- a/Source/ARTRealtimeChannels.h
+++ b/Source/ARTRealtimeChannels.h
@@ -20,7 +20,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)exists:(NSString *)name;
 - (void)release:(NSString *)name callback:(nullable void (^)(ARTErrorInfo *_Nullable))errorInfo;
 - (void)release:(NSString *)name;
-- (id<NSFastEnumeration>)iterate;
 
 @end
 
@@ -28,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (ARTRealtimeChannel *)get:(NSString *)name;
 - (ARTRealtimeChannel *)get:(NSString *)name options:(ARTChannelOptions *)options;
+- (id<NSFastEnumeration>)iterate;
 
 @end
 

--- a/Source/ARTRealtimeChannels.m
+++ b/Source/ARTRealtimeChannels.m
@@ -47,11 +47,9 @@
 }
 
 - (id<NSFastEnumeration>)iterate {
-    NSMutableArray *channels = [[NSMutableArray alloc] init];
-    for (ARTRealtimeChannelInternal *internalChannel in [_internal iterate]) {
-        [channels addObject:[[ARTRealtimeChannel alloc] initWithInternal:internalChannel queuedDealloc:_dealloc]];
-    }
-    return channels;
+    return [_internal copyIntoIteratorWithMapper:^ARTRealtimeChannel *(ARTRealtimeChannelInternal *internalChannel) {
+        return [[ARTRealtimeChannel alloc] initWithInternal:internalChannel queuedDealloc:self->_dealloc];
+    }];
 }
 
 @end
@@ -86,8 +84,8 @@ ART_TRY_OR_MOVE_TO_FAILED_START(realtime) {
     return [ARTRealtimeChannelInternal channelWithRealtime:_realtime andName:name withOptions:options];
 }
 
-- (id<NSFastEnumeration>)iterate {
-    return [_channels iterate];
+- (id<NSFastEnumeration>)copyIntoIteratorWithMapper:(ARTRealtimeChannel *(^)(ARTRealtimeChannelInternal *))mapper {
+    return [_channels copyIntoIteratorWithMapper:mapper];
 }
 
 - (ARTRealtimeChannelInternal *)get:(NSString *)name {

--- a/Source/ARTRestChannels+Private.h
+++ b/Source/ARTRestChannels+Private.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (ARTRestChannelInternal *)get:(NSString *)name;
 - (ARTRestChannelInternal *)get:(NSString *)name options:(ARTChannelOptions *)options;
+- (id<NSFastEnumeration>)copyIntoIteratorWithMapper:(ARTRestChannel *(^)(ARTRestChannelInternal *))mapper;
 
 - (instancetype)initWithRest:(ARTRestInternal *)rest;
 - (ARTRestChannelInternal *)_getChannel:(NSString *)name options:(ARTChannelOptions * _Nullable)options addPrefix:(BOOL)addPrefix;

--- a/Source/ARTRestChannels.h
+++ b/Source/ARTRestChannels.h
@@ -19,7 +19,6 @@ NS_ASSUME_NONNULL_BEGIN
 // Thus, we can't make ARTRestChannels inherit from ARTChannels; we have to compose them instead.
 - (BOOL)exists:(NSString *)name;
 - (void)release:(NSString *)name;
-- (id<NSFastEnumeration>)iterate;
 
 @end
 
@@ -27,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (ARTRestChannel *)get:(NSString *)name;
 - (ARTRestChannel *)get:(NSString *)name options:(ARTChannelOptions *)options;
+- (id<NSFastEnumeration>)iterate;
 
 @end
 

--- a/Source/ARTRestChannels.m
+++ b/Source/ARTRestChannels.m
@@ -42,11 +42,9 @@
 }
 
 - (id<NSFastEnumeration>)iterate {
-    NSMutableArray *channels = [[NSMutableArray alloc] init];
-    for (ARTRestChannelInternal *internalChannel in [_internal iterate]) {
-        [channels addObject:[[ARTRestChannel alloc] initWithInternal:internalChannel queuedDealloc:_dealloc]];
-    }
-    return channels;
+    return [_internal copyIntoIteratorWithMapper:^ARTRestChannel *(ARTRestChannelInternal *internalChannel) {
+        return [[ARTRestChannel alloc] initWithInternal:internalChannel queuedDealloc:self->_dealloc];
+    }];
 }
 
 @end
@@ -80,9 +78,9 @@ ART_TRY_OR_REPORT_CRASH_START(_rest) {
 } ART_TRY_OR_REPORT_CRASH_END
 }
 
-- (id<NSFastEnumeration>)iterate {
+- (id<NSFastEnumeration>)copyIntoIteratorWithMapper:(ARTRestChannel *(^)(ARTRestChannelInternal *))mapper {
 ART_TRY_OR_REPORT_CRASH_START(_rest) {
-    return [_channels iterate];
+    return [_channels copyIntoIteratorWithMapper:mapper];
 } ART_TRY_OR_REPORT_CRASH_END
 }
 


### PR DESCRIPTION
We were getting the iterator in the internal queue, but then doing the
copy into public wrappers in the caller's queue. So the internal queue
could then concurrently run a task that mutates the collection while
it's being copied.

Now the copying is done while still on the internal queue, on the common
ARTChannels; Rest and Realtime just provide mappers to copy into the
right public channel type.

Fixes #918 (probably?).