### PR TITLE
Move channels to FAILED only after their iterator is done. 

### DIFF
--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -714,7 +714,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(self) {
         // invalidating the iterator and causing a crashing.
         //
         // So fail later, when we're done using the iterator.
-        NSMutableArray<ARTRealtimeChannelInternal *> *toFail = [[NSMutableArray alloc] init];
+        NSMutableArray<ARTRealtimeChannelInternal *> * const toFail = [[NSMutableArray alloc] init];
 
         for (ARTRealtimeChannelInternal *channel in self.channels.nosyncIterable) {
             if (stateChange.current == ARTRealtimeClosing) {

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -1253,6 +1253,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
             [_attachedEventEmitter once:^(ARTErrorInfo *errorInfo) {
                 if (callback && errorInfo) {
                     callback(errorInfo);
+                    return;
                 }
                 [self _detach:callback];
             }];

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -461,6 +461,40 @@ class RealtimeClientChannel: QuickSpec {
 
                         expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
                     }
+                    
+                    it("channel being released waiting for DETACH shouldn't crash (issue #918)") {
+                        let options = AblyTests.commonAppSetup()
+                        options.autoConnect = false
+                        let client = ARTRealtime(options: options)
+                        client.internal.setTransport(TestProxyTransport.self)
+                        client.connect()
+                        defer { client.dispose(); client.close() }
+                        
+                        // Force the callback on .release below to be triggered by our
+                        // forced FAILED message, not by a DETACHED.
+                        let transport = client.internal.transport as! TestProxyTransport
+                        transport.actionsIgnored += [.detached]
+                        
+                        for i in (0..<100) { // We need a few channels to trigger iterator invalidation.
+                            let channel = client.channels.get("test\(i)")
+                            channel.attach() // No need to wait; ATTACHING state is good enough.
+                            expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attaching), timeout: testTimeout)
+                        }
+
+                        waitUntil(timeout: testTimeout) { done in
+                            let partialDone = AblyTests.splitDone(2, done: done)
+                            
+                            client.channels.release("test0") { _ in
+                                partialDone()
+                            }
+                            
+                            AblyTests.queue.async {
+                                let pmError = AblyTests.newErrorProtocolMessage()
+                                client.internal.onError(pmError)
+                                partialDone()
+                            }
+                        }
+                    }
 
                 }
 
@@ -502,7 +536,6 @@ class RealtimeClientChannel: QuickSpec {
                         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
                         expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closed))
                     }
-
                 }
 
                 // RTL3c


### PR DESCRIPTION
The move to FAILED triggers the detached event emitter, which in turn
can cause .release() to remove the channel from the collection. If this
is done while channels are being iterated, that's iterator invalidation
which can cause a crash.

Fixes #918.