### PR TITLE
Prevent mutate-channels-while-iterating for suspend too.

### DIFF
--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -571,6 +571,39 @@ class RealtimeClientChannel: QuickSpec {
                         client.internal.onSuspended()
                         expect(channel.state).to(equal(ARTRealtimeChannelState.suspended))
                     }
+                    
+                    it("channel being released waiting for DETACH shouldn't crash (issue #918)") {
+                        let options = AblyTests.commonAppSetup()
+                        options.autoConnect = false
+                        let client = ARTRealtime(options: options)
+                        client.internal.setTransport(TestProxyTransport.self)
+                        client.connect()
+                        defer { client.dispose(); client.close() }
+                        
+                        // Force the callback on .release below to be triggered by our
+                        // forced SUSPENDED message, not by a DETACHED.
+                        let transport = client.internal.transport as! TestProxyTransport
+                        transport.actionsIgnored += [.detached]
+                        
+                        for i in (0..<100) { // We need a few channels to trigger iterator invalidation.
+                            let channel = client.channels.get("test\(i)")
+                            channel.attach() // No need to wait; ATTACHING state is good enough.
+                            expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attaching), timeout: testTimeout)
+                        }
+
+                        waitUntil(timeout: testTimeout) { done in
+                            let partialDone = AblyTests.splitDone(2, done: done)
+                            
+                            client.channels.release("test0") { _ in
+                                partialDone()
+                            }
+                            
+                            AblyTests.queue.async {
+                                client.internal.onSuspended()
+                                partialDone()
+                            }
+                        }
+                    }
 
                 }
 


### PR DESCRIPTION
Turns out #920 wasn't enough, and we need to do that for suspend too.

Now we just copy the whole collection of channels and then operate on
the copy, so we don't have to worry about this in any circumstance.

Fixes #918.