### PR TITLE
Revert "Should not force token auth when clientId is set"

### DIFF
--- a/Source/ARTClientOptions.m
+++ b/Source/ARTClientOptions.m
@@ -136,6 +136,7 @@ NSString *const ARTDefaultProduction = @"production";
 - (BOOL)isBasicAuth {
     return self.useTokenAuth == false &&
     self.key != nil &&
+    self.clientId == nil &&
     self.token == nil &&
     self.tokenDetails == nil &&
     self.authUrl == nil &&

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -4393,13 +4393,6 @@ class Auth : QuickSpec {
                     }
                 }
             }
-
-            // https://github.com/ably/ably-cocoa/issues/849
-            it("should not force token auth when clientId is set") {
-                let options = AblyTests.commonAppSetup()
-                options.clientId = "foo"
-                expect(options.isBasicAuth()).to(beTrue())
-            }
         }
     }
 }

--- a/Spec/Push.swift
+++ b/Spec/Push.swift
@@ -16,17 +16,13 @@ class Push : QuickSpec {
         var rest: ARTRest!
         var mockHttpExecutor: MockHTTPExecutor!
         var storage: MockDeviceStorage!
-        var stateMachineDelegate: StateMachineDelegate!
 
         beforeEach {
             rest = ARTRest(key: "xxxx:xxxx")
-            rest.internal.resetDeviceSingleton()
             mockHttpExecutor = MockHTTPExecutor()
             rest.internal.httpExecutor = mockHttpExecutor
             storage = MockDeviceStorage()
             rest.internal.storage = storage
-            stateMachineDelegate = StateMachineDelegate()
-            rest.push.internal.activationMachine().delegate = stateMachineDelegate
         }
 
         // RSH2

--- a/Spec/PushActivationStateMachine.swift
+++ b/Spec/PushActivationStateMachine.swift
@@ -1598,7 +1598,7 @@ class StateMachineDelegate: NSObject, ARTPushRegistererDelegate {
 
 typealias ARTDeviceId = String
 
-private class StateMachineDelegateCustomCallbacks: StateMachineDelegate {
+class StateMachineDelegateCustomCallbacks: StateMachineDelegate {
 
     var onPushCustomRegister: ((ARTErrorInfo?, ARTDeviceDetails?) -> NSError?)?
     var onPushCustomDeregister: ((ARTErrorInfo?, ARTDeviceId?) -> NSError?)?

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -110,7 +110,6 @@ class RealtimeClientConnection: QuickSpec {
                 it("should connect with query string params including clientId") {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "client_string"
-                    options.useTokenAuth = true
                     options.autoConnect = false
                     options.echoMessages = false
 
@@ -1366,7 +1365,7 @@ class RealtimeClientConnection: QuickSpec {
                 }
 
                 // RTN10b
-                it("should not update when a message is sent but increments by one when ACK is received") {
+                fit("should not update when a message is sent but increments by one when ACK is received") {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer {
                         client.dispose()

--- a/Spec/RestClient.swift
+++ b/Spec/RestClient.swift
@@ -361,7 +361,6 @@ class RestClient: QuickSpec {
                 expect(requestUrlA.scheme).to(equal("https"))
 
                 options.clientId = "client_http"
-                options.useTokenAuth = true
                 options.tls = false
                 let clientHttp = ARTRest(options: options)
                 testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)

--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -200,7 +200,6 @@ class RestClientChannel: QuickSpec {
                     it("should be unnecessary to set clientId of the Message before publishing") {
                         let options = AblyTests.commonAppSetup()
                         options.clientId = "john"
-                        options.useTokenAuth = true
                         let client = ARTRest(options: options)
                         let channel = client.channels.get("test")
 

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -78,7 +78,7 @@ class AblyTests {
         }
     }
 
-    class var authTokenCases: [String: (ARTAuthOptions) -> Void] {
+    class var authTokenCases: [String: (ARTAuthOptions) -> ()] {
         get { return [
             "useTokenAuth": { $0.useTokenAuth = true; $0.key = "fake:key" },
             "authUrl": { $0.authUrl = URL(string: "http://test.com") },


### PR DESCRIPTION
Build has possibly been broken by this, so reverting.

Reverts ably/ably-cocoa#898