### PR TITLE
Set logLevel=verbose every time setupOptions is called with debug=true

### DIFF
--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -148,7 +148,6 @@ class AblyTests {
             testApplication = try! JSON(data: responseData!)
             
             if debug {
-                options.logLevel = .verbose
                 print(testApplication!)
             }
 
@@ -159,6 +158,9 @@ class AblyTests {
         options.key = key["keyStr"].stringValue
         options.dispatchQueue = userQueue
         options.internalDispatchQueue = queue
+        if debug {
+            options.logLevel = .verbose
+        }
         return options
     }
     


### PR DESCRIPTION
We were only setting it when testApplication was nil, ie. on the first
test or if forceNewApp was also true. But that option has nothing to
do with the testApplication, it applies to the ClientOptions instance
produced, whether it's for a fresh Ably application or not.

This allows you to see verbose logs for any given test, not just the
first one.