### PR TITLE
Remove 'crypto-data-256-variable-lengths' reference

### DIFF
--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -28,7 +28,6 @@ class CryptoTest {
     )] = [
         ("crypto-data-128", aes128, 128),
         ("crypto-data-256", aes256, 256),
-        ("crypto-data-256-variable-lengths", aes256, 256),
     ];
 }
 


### PR DESCRIPTION
Test suite was crashing because the file `ably-common/test-resources/crypto-data-256-variable-lengths.json` file doesn't exist.