### PR TITLE
Simplify random fallback host selection.

### DIFF
--- a/Source/ARTFallback+Private.h
+++ b/Source/ARTFallback+Private.h
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern int (^ARTFallback_getRandomHostIndex)(int count);
+extern void (^ARTFallback_shuffleArray)(NSMutableArray *);
 
 @interface ARTFallback ()
 

--- a/Source/ARTFallback.m
+++ b/Source/ARTFallback.m
@@ -13,8 +13,10 @@
 #import "ARTHttp.h"
 #import "ARTClientOptions.h"
 
-int (^ARTFallback_getRandomHostIndex)(int count) = ^int(int count) {
-    return arc4random() % count;
+void (^ARTFallback_shuffleArray)(NSMutableArray *) = ^void(NSMutableArray *a) {
+    for (NSUInteger i = a.count; i > 1; i--) {
+        [a exchangeObjectAtIndex:i - 1 withObjectAtIndex:arc4random_uniform((u_int32_t)i)];
+    }
 };
 
 @interface ARTFallback ()
@@ -29,14 +31,8 @@ int (^ARTFallback_getRandomHostIndex)(int count) = ^int(int count) {
         if (fallbackHosts != nil && fallbackHosts.count == 0) {
             return nil;
         }
-        self.hosts = [NSMutableArray array];
-        NSMutableArray * hostArray = [[NSMutableArray alloc] initWithArray: fallbackHosts ? fallbackHosts : [ARTDefault fallbackHosts]];
-        size_t count = [hostArray count];
-        for (int i=0; i <count; i++) {
-            int randomIndex = ARTFallback_getRandomHostIndex((int)[hostArray count]);
-            [self.hosts addObject:[hostArray objectAtIndex:randomIndex]];
-            [hostArray removeObjectAtIndex:randomIndex];
-        }
+        self.hosts = [[NSMutableArray alloc] initWithArray: fallbackHosts ? fallbackHosts : [ARTDefault fallbackHosts]];
+        ARTFallback_shuffleArray(self.hosts);
     }
     return self;
 }

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -3149,36 +3149,19 @@ class RealtimeClientConnection: QuickSpec {
             // RTN17
             context("Host Fallback") {
                 let expectedHostOrder = [3, 4, 0, 2, 1]
-                let originalARTFallback_getRandomHostIndex = ARTFallback_getRandomHostIndex
+                let originalARTFallback_shuffleArray = ARTFallback_shuffleArray
 
                 beforeEach {
-                    ARTFallback_getRandomHostIndex = {
-                        let hostIndexes = [1, 1, 0, 0, 0]
-                        var i = 0
-                        return { count in
-                            assert(count > 0, "Fallback array is empty")
-
-                            let hostIndex: Int32
-                            if i < Int(count) {
-                                hostIndex = Int32(hostIndexes[i])
-                            }
-                            else {
-                                hostIndex = count - 1
-                            }
-
-                            if i < hostIndexes.count {
-                                i += 1
-                            }
-                            else {
-                                i = 0
-                            }
-                            return Int32(hostIndex)
+                    ARTFallback_shuffleArray = { array in
+                        let arranged = expectedHostOrder.reversed().map { array[$0] }
+                        for (i, element) in arranged.enumerated() {
+                            array[i] = element
                         }
-                    }()
+                    }
                 }
 
                 afterEach {
-                    ARTFallback_getRandomHostIndex = originalARTFallback_getRandomHostIndex
+                    ARTFallback_shuffleArray = originalARTFallback_shuffleArray
                 }
 
                 // RTN17b

--- a/Spec/RestClient.swift
+++ b/Spec/RestClient.swift
@@ -953,22 +953,19 @@ class RestClient: QuickSpec {
                 context("retry hosts in random order") {
                     let expectedHostOrder = [4, 3, 0, 2, 1]
 
-                    let originalARTFallback_getRandomHostIndex = ARTFallback_getRandomHostIndex
+                    let originalARTFallback_shuffleArray = ARTFallback_shuffleArray
 
                     beforeEach {
-                        ARTFallback_getRandomHostIndex = {
-                            let hostIndexes = [1, 1, 0, 0, 0]
-                            var i = 0
-                            return { count in
-                                let hostIndex = hostIndexes[i]
-                                i += 1
-                                return Int32(hostIndex)
+                        ARTFallback_shuffleArray = { array in
+                            let arranged = expectedHostOrder.reversed().map { array[$0] }
+                            for (i, element) in arranged.enumerated() {
+                                array[i] = element
                             }
-                        }()
+                        }
                     }
 
                     afterEach {
-                        ARTFallback_getRandomHostIndex = originalARTFallback_getRandomHostIndex
+                        ARTFallback_shuffleArray = originalARTFallback_shuffleArray
                     }
 
                     it("default fallback hosts should match @[a-e].ably-realtime.com@") {


### PR DESCRIPTION
The previous way made test mocks pretty incomprehensible.

Just shuffle the given array. In tests, arrange in predefined order.