### PR TITLE
Simplify hooks on RTP2f test

### DIFF
--- a/Source/ARTPresenceMap.h
+++ b/Source/ARTPresenceMap.h
@@ -55,6 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)onceSyncFails:(void (^)(ARTErrorInfo *))callback;
 
 - (void)internalAdd:(ARTPresenceMessage *)message;
+- (void)internalAdd:(ARTPresenceMessage *)message withSessionId:(NSUInteger)sessionId;
 
 @end
 


### PR DESCRIPTION
Now we have a single hook, directly on the presence map add method, so
that we can't possibly miss an ABSENT message.

Also, attach has been moved to after the hook and event subscription are
set, so that we can't miss those events.

May fix #938.