### PR TITLE
Allow library to be used from Objective-C++ (.mm) files again

### DIFF
--- a/Source/ARTHttp.h
+++ b/Source/ARTHttp.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ARTHttp : NSObject<ARTHTTPExecutor>
 
-+ (void)setURLSessionClass:(Class)class;
++ (void)setURLSessionClass:(Class)urlSessionClass;
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
 - (instancetype)init:(dispatch_queue_t)queue logger:(ARTLog *)logger;

--- a/Source/ARTHttp.m
+++ b/Source/ARTHttp.m
@@ -25,8 +25,8 @@ Class configuredUrlSessionClass = nil;
     _Nullable dispatch_queue_t _queue;
 }
 
-+ (void)setURLSessionClass:(Class)class {
-    configuredUrlSessionClass = class;
++ (void)setURLSessionClass:(const Class)urlSessionClass {
+    configuredUrlSessionClass = urlSessionClass;
 }
 
 - (instancetype)init:(dispatch_queue_t)queue logger:(ARTLog *)logger {

--- a/Source/ARTWebSocketTransport+Private.h
+++ b/Source/ARTWebSocketTransport+Private.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ARTWebSocketTransport () <ARTWebSocketDelegate>
 
-+ (void)setWebSocketClass:(Class)class;
++ (void)setWebSocketClass:(Class)webSocketClass;
 
 // From RestClient
 @property (readwrite, strong, nonatomic) id<ARTEncoder> encoder;

--- a/Source/ARTWebSocketTransport.m
+++ b/Source/ARTWebSocketTransport.m
@@ -56,8 +56,8 @@ Class configuredWebsocketClass = nil;
 @synthesize delegate = _delegate;
 @synthesize stateEmitter = _stateEmitter;
 
-+ (void)setWebSocketClass:(Class)class {
-    configuredWebsocketClass = class;
++ (void)setWebSocketClass:(const Class)webSocketClass {
+    configuredWebsocketClass = webSocketClass;
 }
 
 - (instancetype)initWithRest:(ARTRestInternal *)rest options:(ARTClientOptions *)options resumeKey:(NSString *)resumeKey connectionSerial:(NSNumber *)connectionSerial {


### PR DESCRIPTION
Fixes #964 

This was broken by a recent change that utilised `class` as an argument name for a new method, breaking compilation in a C++ context as `class` is a reserved keyword in that language.