### PR TITLE
If waiting for push device details and got them persisted, re-emit them.

### DIFF
--- a/Source/ARTPushActivationStateMachine+Private.h
+++ b/Source/ARTPushActivationStateMachine+Private.h
@@ -19,6 +19,7 @@ extern NSString *const ARTPushActivationPendingEventsKey;
 
 @property (nonatomic, strong) ARTRestInternal *rest;
 - (instancetype)init:(ARTRestInternal *)rest;
+- (instancetype)init:(ARTRestInternal *)rest delegate:(nullable id)delegate;
 
 @property (weak, nonatomic) id delegate; // weak because delegates outlive their counterpart
 @property (nonatomic, copy, nullable) void (^transitions)(ARTPushActivationEvent *event, ARTPushActivationState *from, ARTPushActivationState *to);

--- a/Spec/PushActivationStateMachine.swift
+++ b/Spec/PushActivationStateMachine.swift
@@ -409,7 +409,24 @@ class PushActivationStateMachine : QuickSpec {
                     }
 
                 }
+                
+                // https://github.com/ably/ably-cocoa/issues/966
+                it("when initializing from persistent state with a deviceToken, GotPushDeviceDetails should be re-emitted") {
+                    storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForPushDeviceDetails(machine: initialStateMachine))
+                    rest.internal.storage = storage
+                    rest.device.setAndPersistDeviceToken("foo")
+                    
+                    var registered = false
 
+                    let delegate = StateMachineDelegateCustomCallbacks()
+                    stateMachine = ARTPushActivationStateMachine(rest.internal, delegate: delegate)
+                    delegate.onPushCustomRegister = { error, deviceDetails in
+                        registered = true
+                        return nil
+                    }
+
+                    expect(registered).toEventually(beTrue())
+                }
             }
 
             // RSH3c

--- a/Spec/PushActivationStateMachine.swift
+++ b/Spec/PushActivationStateMachine.swift
@@ -415,6 +415,7 @@ class PushActivationStateMachine : QuickSpec {
                     storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForPushDeviceDetails(machine: initialStateMachine))
                     rest.internal.storage = storage
                     rest.device.setAndPersistDeviceToken("foo")
+                    defer { rest.device.setAndPersistDeviceToken(nil) }
                     
                     var registered = false
 


### PR DESCRIPTION
While once #966 is fixed new apps won't get into that "illegal"
persisted state, we still need to recover from it for old apps.

This also serves as a workaround, so that the "proper" fix for #966 is
not urgent.