### PR TITLE
Don't have push state machine singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ This client library is currently *not compatible* with some of the Ably features
 | [Remember fallback host during failures](https://ably.io/documentation/realtime/usage#client-options) | 
 | [ErrorInfo URLs to help debug issues](https://ably.io/documentation/realtime/types#error-info) |
 
+### Concurrent push-receiving Ably instances
+
+Only one instance of `ARTRest` or `ARTRealtime` at a time must be [activated for receiving push notifications](https://www.ably.io/documentation/general/push/activate-subscribe). Having more than one activated instance at a time may have unexpected consequences.
+
 ## Documentation
 
 Visit [ably.io/documentation](https://www.ably.io/documentation) for a complete API reference and more examples.

--- a/Source/ARTPush+Private.h
+++ b/Source/ARTPush+Private.h
@@ -24,7 +24,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if TARGET_OS_IOS
 - (ARTPushActivationStateMachine *)activationMachine;
-- (void)resetActivationStateMachineSingleton;
 #endif
 
 @end

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -763,6 +763,14 @@ void ARTstopHandlingUncaughtExceptions(ARTRestInternal *self) {
 static dispatch_once_t *device_once_token;
 
 - (ARTLocalDevice *)device_nosync {
+    // The device is shared in a static variable because it's a reflection
+    // of what's persisted. Having a device instance per ARTRest instance
+    // could leave some instances in a stale state, if, through another
+    // instance, the persisted state is changed.
+    //
+    // As a side effect, the first instance "wins" at setting the device's
+    // client ID.
+
     static dispatch_once_t once;
     device_once_token = &once;
     static id device;

--- a/Spec/Push.swift
+++ b/Spec/Push.swift
@@ -103,7 +103,6 @@ class Push : QuickSpec {
                 rest.internal.storage = storage
                 
                 rest.internal.resetDeviceSingleton()
-                rest.push.internal.resetActivationStateMachineSingleton()
 
                 let stateMachine = rest.push.internal.activationMachine()
                 let testDeviceToken = "xxxx-xxxx-xxxx-xxxx-xxxx"


### PR DESCRIPTION
Instead, just cache it in the Rest instance.

Otherwise, if the user stops using the first instance and activates push
through a new instance, push activation will still use the first
instance an things won't work as expected.

Unfortunately, this now means that it's possible to have more than one
state machines per process, which is bad; RSH3 mandates that the state
machine must be a single app-wide concurrent process.

Once #966 is fixed, this drawback may be lifted. For now, is has been
documented in the README.