### PR TITLE
Channel options (per 1.2 spec)

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -581,6 +581,12 @@
 		D768C6AD1E4B5B0200436011 /* ARTDevicePushDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = D768C6AB1E4B5B0200436011 /* ARTDevicePushDetails.m */; };
 		D769E15321270F3400DC5CD1 /* ARTHTTPPaginatedResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = D769E15121270F3400DC5CD1 /* ARTHTTPPaginatedResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D769E15421270F3400DC5CD1 /* ARTHTTPPaginatedResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = D769E15221270F3400DC5CD1 /* ARTHTTPPaginatedResponse.m */; };
+		D76F153B23DB010C00B5133C /* ARTRealtimeChannelOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = D76F153923DB010C00B5133C /* ARTRealtimeChannelOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D76F153C23DB010C00B5133C /* ARTRealtimeChannelOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = D76F153A23DB010C00B5133C /* ARTRealtimeChannelOptions.m */; };
+		D76F153D23DB012100B5133C /* ARTRealtimeChannelOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = D76F153923DB010C00B5133C /* ARTRealtimeChannelOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D76F153E23DB012100B5133C /* ARTRealtimeChannelOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = D76F153923DB010C00B5133C /* ARTRealtimeChannelOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D76F153F23DB013000B5133C /* ARTRealtimeChannelOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = D76F153A23DB010C00B5133C /* ARTRealtimeChannelOptions.m */; };
+		D76F154023DB013000B5133C /* ARTRealtimeChannelOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = D76F153A23DB010C00B5133C /* ARTRealtimeChannelOptions.m */; };
 		D77394031C6F6FFE00F5478F /* ARTProtocolMessage+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = D77394021C6F6FFE00F5478F /* ARTProtocolMessage+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D777EEE0206285CF002EBA03 /* ARTDeviceIdentityTokenDetails.h in Headers */ = {isa = PBXBuildFile; fileRef = D777EEDE206285CF002EBA03 /* ARTDeviceIdentityTokenDetails.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D777EEE1206285CF002EBA03 /* ARTDeviceIdentityTokenDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = D777EEDF206285CF002EBA03 /* ARTDeviceIdentityTokenDetails.m */; };
@@ -999,6 +1005,8 @@
 		D768C6AB1E4B5B0200436011 /* ARTDevicePushDetails.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTDevicePushDetails.m; sourceTree = "<group>"; };
 		D769E15121270F3400DC5CD1 /* ARTHTTPPaginatedResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARTHTTPPaginatedResponse.h; sourceTree = "<group>"; };
 		D769E15221270F3400DC5CD1 /* ARTHTTPPaginatedResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTHTTPPaginatedResponse.m; sourceTree = "<group>"; };
+		D76F153923DB010C00B5133C /* ARTRealtimeChannelOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARTRealtimeChannelOptions.h; sourceTree = "<group>"; };
+		D76F153A23DB010C00B5133C /* ARTRealtimeChannelOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTRealtimeChannelOptions.m; sourceTree = "<group>"; };
 		D77394021C6F6FFE00F5478F /* ARTProtocolMessage+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ARTProtocolMessage+Private.h"; sourceTree = "<group>"; };
 		D777EEDE206285CF002EBA03 /* ARTDeviceIdentityTokenDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARTDeviceIdentityTokenDetails.h; sourceTree = "<group>"; };
 		D777EEDF206285CF002EBA03 /* ARTDeviceIdentityTokenDetails.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTDeviceIdentityTokenDetails.m; sourceTree = "<group>"; };
@@ -1384,6 +1392,8 @@
 				D746AE3A1BBC5AE1003ECEF8 /* ARTRealtimeChannel.h */,
 				D746AE421BBC5CD0003ECEF8 /* ARTRealtimeChannel+Private.h */,
 				D746AE3B1BBC5AE1003ECEF8 /* ARTRealtimeChannel.m */,
+				D76F153923DB010C00B5133C /* ARTRealtimeChannelOptions.h */,
+				D76F153A23DB010C00B5133C /* ARTRealtimeChannelOptions.m */,
 				D7D29B401BE3DD0600374295 /* ARTConnection.h */,
 				EB89D40E1C62303E007FA5B7 /* ARTConnection+Private.h */,
 				D7D29B411BE3DEB300374295 /* ARTConnection.m */,
@@ -1716,6 +1726,7 @@
 				D746AE3C1BBC5AE1003ECEF8 /* ARTRealtimeChannel.h in Headers */,
 				D7B621941E4A6FE600684474 /* ARTDeviceDetails.h in Headers */,
 				96BF61701A35FB7C004CF2B3 /* ARTAuth.h in Headers */,
+				D76F153B23DB010C00B5133C /* ARTRealtimeChannelOptions.h in Headers */,
 				D74CBC07212EB5B900D090E4 /* ARTNSMutableURLRequest+ARTPaginated.h in Headers */,
 				96A507A11A377AA50077CDF8 /* ARTPresenceMessage.h in Headers */,
 				850BFB4C1B79323C009D0ADD /* ARTPaginatedResult.h in Headers */,
@@ -1840,6 +1851,7 @@
 				D710D50721949C18008F54AD /* ARTConnectionDetails+Private.h in Headers */,
 				D7BDDD3E21959CC100CC0632 /* CompatibilityMacros.h in Headers */,
 				D710D51B21949C42008F54AD /* ARTDeviceIdentityTokenDetails.h in Headers */,
+				D76F153D23DB012100B5133C /* ARTRealtimeChannelOptions.h in Headers */,
 				D710D48021949A42008F54AD /* ARTDefault.h in Headers */,
 				D710D58021949D28008F54AD /* ARTAuthDetails.h in Headers */,
 				D710D54D21949C66008F54AD /* ARTLocalDevice+Private.h in Headers */,
@@ -1964,6 +1976,7 @@
 				D710D51321949C19008F54AD /* ARTConnectionDetails+Private.h in Headers */,
 				D7BDDD3F21959CC200CC0632 /* CompatibilityMacros.h in Headers */,
 				D710D52D21949C44008F54AD /* ARTDeviceIdentityTokenDetails.h in Headers */,
+				D76F153E23DB012100B5133C /* ARTRealtimeChannelOptions.h in Headers */,
 				D710D48221949A43008F54AD /* ARTDefault.h in Headers */,
 				D710D5A621949D2A008F54AD /* ARTAuthDetails.h in Headers */,
 				D710D55321949C67008F54AD /* ARTLocalDevice+Private.h in Headers */,
@@ -2341,6 +2354,7 @@
 				D7B621991E4A762A00684474 /* ARTPushChannel.m in Sources */,
 				EB89D40B1C61C6EA007FA5B7 /* ARTRealtimeChannels.m in Sources */,
 				D746AE231BBB60EE003ECEF8 /* ARTChannel.m in Sources */,
+				D76F153C23DB010C00B5133C /* ARTRealtimeChannelOptions.m in Sources */,
 				D769E15421270F3400DC5CD1 /* ARTHTTPPaginatedResponse.m in Sources */,
 				D7DEAFD21E65926D00D23F24 /* ARTLocalDevice.m in Sources */,
 				EB2D84FD1CD769B800F23CDA /* ARTOSReachability.m in Sources */,
@@ -2478,6 +2492,7 @@
 				D710D62F21949E03008F54AD /* ARTDataQuery.m in Sources */,
 				D710D53121949C54008F54AD /* ARTPush.m in Sources */,
 				D710D5E021949D78008F54AD /* ARTStats.m in Sources */,
+				D76F153F23DB013000B5133C /* ARTRealtimeChannelOptions.m in Sources */,
 				D710D4F121949C0D008F54AD /* ARTQueuedMessage.m in Sources */,
 				D710D49521949AC2008F54AD /* ARTRest.m in Sources */,
 				D710D53921949C54008F54AD /* ARTNSMutableRequest+ARTPush.m in Sources */,
@@ -2559,6 +2574,7 @@
 				D710D63F21949E04008F54AD /* ARTDataQuery.m in Sources */,
 				D710D54321949C55008F54AD /* ARTPush.m in Sources */,
 				D710D60621949D79008F54AD /* ARTStats.m in Sources */,
+				D76F154023DB013000B5133C /* ARTRealtimeChannelOptions.m in Sources */,
 				D710D50121949C0E008F54AD /* ARTQueuedMessage.m in Sources */,
 				D710D49721949AC3008F54AD /* ARTRest.m in Sources */,
 				D710D54B21949C55008F54AD /* ARTNSMutableRequest+ARTPush.m in Sources */,

--- a/Source/ARTChannel+Private.h
+++ b/Source/ARTChannel+Private.h
@@ -18,12 +18,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithName:(NSString *)name andOptions:(ARTChannelOptions *)options rest:(ARTRestInternal *)rest;
 
 @property (readonly, getter=getLogger) ARTLog *logger;
-@property (nonatomic, strong, null_resettable) ARTChannelOptions *options;
 @property (nonatomic, strong, readonly) ARTDataEncoder *dataEncoder;
 
 - (void)internalPostMessages:(id)data callback:(nullable void (^)(ARTErrorInfo *_Nullable error))callback;
-- (void)setOptions_nosync:(ARTChannelOptions *_Nullable)options;
 - (BOOL)exceedMaxSize:(NSArray<ARTBaseMessage *> *)messages;
+
+- (nullable ARTChannelOptions *)options;
+- (nullable ARTChannelOptions *)options_nosync;
+- (void)setOptions:(ARTChannelOptions *_Nullable)options;
+- (void)setOptions_nosync:(ARTChannelOptions *_Nullable)options;
 
 @end
 

--- a/Source/ARTChannel+Private.h
+++ b/Source/ARTChannel+Private.h
@@ -17,6 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithName:(NSString *)name andOptions:(ARTChannelOptions *)options rest:(ARTRestInternal *)rest;
 
+@property (readonly, nullable) ARTChannelOptions *options;
+
 @property (readonly, getter=getLogger) ARTLog *logger;
 @property (nonatomic, strong, readonly) ARTDataEncoder *dataEncoder;
 

--- a/Source/ARTChannel+Private.h
+++ b/Source/ARTChannel+Private.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) ARTDataEncoder *dataEncoder;
 
 - (void)internalPostMessages:(id)data callback:(nullable void (^)(ARTErrorInfo *_Nullable error))callback;
-- (void)_setOptions:(ARTChannelOptions *_Nullable)options;
+- (void)setOptions_nosync:(ARTChannelOptions *_Nullable)options;
 
 @end
 

--- a/Source/ARTChannel+Private.h
+++ b/Source/ARTChannel+Private.h
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)internalPostMessages:(id)data callback:(nullable void (^)(ARTErrorInfo *_Nullable error))callback;
 - (void)setOptions_nosync:(ARTChannelOptions *_Nullable)options;
+- (BOOL)exceedMaxSize:(NSArray<ARTBaseMessage *> *)messages;
 
 @end
 

--- a/Source/ARTChannel.h
+++ b/Source/ARTChannel.h
@@ -43,8 +43,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)history:(void(^)(ARTPaginatedResult<ARTMessage *> *_Nullable result, ARTErrorInfo *_Nullable error))callback;
 
-- (BOOL)exceedMaxSize:(NSArray<ARTBaseMessage *> *)messages;
-
 @end
 
 @interface ARTChannel : NSObject<ARTChannelProtocol>

--- a/Source/ARTChannel.m
+++ b/Source/ARTChannel.m
@@ -57,11 +57,7 @@
 }
 
 - (void)setOptions_nosync:(ARTChannelOptions *)options {
-    if (!options) {
-        _options = [[ARTChannelOptions alloc] initWithCipher:nil];
-    } else {
-        _options = options;
-    }
+    _options = options;
 }
 
 - (void)publish:(NSString *)name data:(id)data {

--- a/Source/ARTChannel.m
+++ b/Source/ARTChannel.m
@@ -19,6 +19,7 @@
 
 @implementation ARTChannel {
     dispatch_queue_t _queue;
+    ARTChannelOptions *_options;
 }
 
 - (instancetype)initWithName:(NSString *)name andOptions:(ARTChannelOptions *)options rest:(ARTRestInternal *)rest {
@@ -26,7 +27,7 @@
         _name = name;
         _logger = rest.logger;
         _queue = rest.queue;
-        [self setOptions_nosync:options];
+        _options = options;
         NSError *error = nil;
         _dataEncoder = [[ARTDataEncoder alloc] initWithCipherParams:_options.cipher error:&error];
         if (error != nil) {
@@ -35,6 +36,18 @@
         }
     }
     return self;
+}
+
+- (ARTChannelOptions *)options {
+    __block ARTChannelOptions *ret;
+    dispatch_sync(_queue, ^{
+        ret = [self options_nosync];
+    });
+    return ret;
+}
+
+- (ARTChannelOptions *)options_nosync {
+    return _options;
 }
 
 - (void)setOptions:(ARTChannelOptions *)options {

--- a/Source/ARTChannel.m
+++ b/Source/ARTChannel.m
@@ -26,7 +26,7 @@
         _name = name;
         _logger = rest.logger;
         _queue = rest.queue;
-        [self _setOptions:options];
+        [self setOptions_nosync:options];
         NSError *error = nil;
         _dataEncoder = [[ARTDataEncoder alloc] initWithCipherParams:_options.cipher error:&error];
         if (error != nil) {
@@ -39,11 +39,11 @@
 
 - (void)setOptions:(ARTChannelOptions *)options {
     dispatch_sync(_queue, ^{
-        [self _setOptions:options];
+        [self setOptions_nosync:options];
     });
 }
 
-- (void)_setOptions:(ARTChannelOptions *)options {
+- (void)setOptions_nosync:(ARTChannelOptions *)options {
     if (!options) {
         _options = [[ARTChannelOptions alloc] initWithCipher:nil];
     } else {

--- a/Source/ARTChannelOptions.h
+++ b/Source/ARTChannelOptions.h
@@ -17,7 +17,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, nullable) ARTCipherParams *cipher;
 
-
 - (instancetype)initWithCipher:(id<ARTCipherParamsCompatible> _Nullable)cipherParams;
 - (instancetype)initWithCipherKey:(id<ARTCipherKeyCompatible>)key;
 

--- a/Source/ARTChannels.m
+++ b/Source/ARTChannels.m
@@ -96,7 +96,7 @@ dispatch_sync(_queue, ^{
         channel = [_delegate makeChannel:name options:options];
         [self->_channels setObject:channel forKey:name];
     } else if (options) {
-        [channel _setOptions:options];
+        [channel setOptions_nosync:options];
     }
     return channel;
 }

--- a/Source/ARTJsonLikeEncoder.m
+++ b/Source/ARTJsonLikeEncoder.m
@@ -501,6 +501,14 @@
         output[@"auth"] = [self authDetailsToDictionary:message.auth];
     }
 
+    if (message.flags) {
+        output[@"flags"] = [NSNumber numberWithLongLong:message.flags];
+    }
+
+    if (message.params) {
+        output[@"params"] = message.params;
+    }
+
     [_logger verbose:@"RS:%p ARTJsonLikeEncoder<%@>: protocolMessageToDictionary %@", _rest, [_delegate formatAsString], output];
     return output;
 }
@@ -732,6 +740,7 @@
     message.flags = [[input artNumber:@"flags"] longLongValue];
     message.connectionDetails = [self connectionDetailsFromDictionary:[input valueForKey:@"connectionDetails"]];
     message.auth = [self authDetailsFromDictionary:[input valueForKey:@"auth"]];
+    message.params = [input valueForKey:@"params"];
 
     NSDictionary *error = [input valueForKey:@"error"];
     if (error) {

--- a/Source/ARTProtocolMessage.h
+++ b/Source/ARTProtocolMessage.h
@@ -65,6 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readwrite, assign, nonatomic) int64_t flags;
 @property (nullable, readwrite, nonatomic) ARTConnectionDetails *connectionDetails;
 @property (nullable, nonatomic) ARTAuthDetails *auth;
+@property (nonatomic, strong, nullable) NSDictionary<NSString *, NSString *> *params;
 
 @end
 

--- a/Source/ARTProtocolMessage.m
+++ b/Source/ARTProtocolMessage.m
@@ -61,6 +61,7 @@
     [description appendFormat:@" flags.hasBacklog: %@,\n", NSStringFromBOOL(self.hasBacklog)];
     [description appendFormat:@" flags.resumed: %@,\n", NSStringFromBOOL(self.resumed)];
     [description appendFormat:@" messages: %@\n", self.messages];
+    [description appendFormat:@" params: %@\n", self.params];
     [description appendFormat:@"}"];
     return description;
 }
@@ -83,6 +84,7 @@
     pm.flags = self.flags;
     pm.error = self.error;
     pm.connectionDetails = self.connectionDetails;
+    pm.params = self.params;
     return pm;
 }
 

--- a/Source/ARTRealtimeChannel+Private.h
+++ b/Source/ARTRealtimeChannel+Private.h
@@ -47,8 +47,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readwrite, strong, nonatomic) ARTPresenceMap *presenceMap;
 @property (readwrite, assign, nonatomic) ARTPresenceAction lastPresenceAction;
 
-- (instancetype)initWithRealtime:(ARTRealtimeInternal *)realtime andName:(NSString *)name withOptions:(ARTChannelOptions *)options;
-+ (instancetype)channelWithRealtime:(ARTRealtimeInternal *)realtime andName:(NSString *)name withOptions:(ARTChannelOptions *)options;
+- (instancetype)initWithRealtime:(ARTRealtimeInternal *)realtime andName:(NSString *)name withOptions:(ARTRealtimeChannelOptions *)options;
++ (instancetype)channelWithRealtime:(ARTRealtimeInternal *)realtime andName:(NSString *)name withOptions:(ARTRealtimeChannelOptions *)options;
 
 - (bool)isLastChannelSerial:(NSString *)channelSerial;
 

--- a/Source/ARTRealtimeChannel+Private.h
+++ b/Source/ARTRealtimeChannel+Private.h
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readwrite, assign, nonatomic) ARTRealtimeChannelState state;
 @property (readonly, strong, nonatomic, nullable) ARTErrorInfo *errorReason;
+@property (readonly, nullable, getter=getOptions_nosync) ARTRealtimeChannelOptions *options_nosync;
 
 - (ARTRealtimeChannelState)state_nosync;
 - (ARTErrorInfo *)errorReason_nosync;

--- a/Source/ARTRealtimeChannel.h
+++ b/Source/ARTRealtimeChannel.h
@@ -45,6 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)history:(ARTRealtimeHistoryQuery *_Nullable)query callback:(void(^)(ARTPaginatedResult<ARTMessage *> *_Nullable result, ARTErrorInfo *_Nullable error))callback error:(NSError *_Nullable *_Nullable)errorPtr;
 
+- (void)setOptions:(ARTChannelOptions *_Nullable)options callback:(nullable void (^)(ARTErrorInfo *_Nullable))cb;
+
 ART_EMBED_INTERFACE_EVENT_EMITTER(ARTChannelEvent, ARTChannelStateChange *)
 
 @end

--- a/Source/ARTRealtimeChannel.h
+++ b/Source/ARTRealtimeChannel.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly) ARTRealtimeChannelState state;
 @property (readonly, nullable) ARTErrorInfo *errorReason;
+@property (readonly, nullable, getter=getOptions) ARTRealtimeChannelOptions *options;
 
 - (void)attach;
 - (void)attach:(nullable void (^)(ARTErrorInfo *_Nullable))callback;

--- a/Source/ARTRealtimeChannel.h
+++ b/Source/ARTRealtimeChannel.h
@@ -19,6 +19,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class ARTRealtimePresence;
+@class ARTRealtimeChannelOptions;
 #if TARGET_OS_IPHONE
 @class ARTPushChannel;
 #endif
@@ -45,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)history:(ARTRealtimeHistoryQuery *_Nullable)query callback:(void(^)(ARTPaginatedResult<ARTMessage *> *_Nullable result, ARTErrorInfo *_Nullable error))callback error:(NSError *_Nullable *_Nullable)errorPtr;
 
-- (void)setOptions:(ARTChannelOptions *_Nullable)options callback:(nullable void (^)(ARTErrorInfo *_Nullable))cb;
+- (void)setOptions:(ARTRealtimeChannelOptions *_Nullable)options callback:(nullable void (^)(ARTErrorInfo *_Nullable))cb;
 
 ART_EMBED_INTERFACE_EVENT_EMITTER(ARTChannelEvent, ARTChannelStateChange *)
 

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -197,8 +197,12 @@
     return [_internal on:event callback:cb];
 }
 
+- (ARTRealtimeChannelOptions *)getOptions {
+    return [_internal getOptions];
+}
+
 - (void)setOptions:(ARTRealtimeChannelOptions *_Nullable)options callback:(nullable void (^)(ARTErrorInfo *_Nullable))cb {
-    return [_internal setOptions:options callback:cb];
+    [_internal setOptions:options callback:cb];
 }
 
 @end
@@ -322,7 +326,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(self->_realtime) {
     msg.action = ARTProtocolMessageMessage;
     msg.channel = self.name;
     msg.messages = data;
-    
+
     [self publishProtocolMessage:msg callback:^void(ARTStatus *status) {
         if (callback) callback(status.errorInfo);
     }];
@@ -1436,8 +1440,33 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
     return size > maxSize;
 }
 
-- (void)setOptions:(ARTRealtimeChannelOptions *_Nullable)options callback:(nullable void (^)(ARTErrorInfo *_Nullable))callback {
+- (ARTRealtimeChannelOptions *)getOptions {
+    return (ARTRealtimeChannelOptions *)[self options];
+}
 
+- (ARTRealtimeChannelOptions *)getOptions_nosync {
+    return (ARTRealtimeChannelOptions *)[self options_nosync];
+}
+
+- (void)setOptions:(ARTRealtimeChannelOptions *_Nullable)options callback:(nullable void (^)(ARTErrorInfo *_Nullable))callback {
+    if (callback) {
+        void (^userCallback)(ARTErrorInfo *_Nullable error) = callback;
+        callback = ^(ARTErrorInfo *_Nullable error) {
+            ART_EXITING_ABLY_CODE(self->_realtime.rest);
+            dispatch_async(self->_userQueue, ^{
+                userCallback(error);
+            });
+        };
+    }
+    dispatch_sync(_queue, ^{
+        [self setOptions_nosync:options callback:callback];
+    });
+}
+
+- (void)setOptions_nosync:(ARTRealtimeChannelOptions *_Nullable)options callback:(nullable void (^)(ARTErrorInfo *_Nullable))callback {
+ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
+    [self setOptions_nosync:options];
+} ART_TRY_OR_MOVE_TO_FAILED_END
 }
 
 @end

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -1213,6 +1213,8 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
     ARTProtocolMessage *attachMessage = [[ARTProtocolMessage alloc] init];
     attachMessage.action = ARTProtocolMessageAttach;
     attachMessage.channel = self.name;
+    attachMessage.params = self.options_nosync.params;
+    attachMessage.flags = self.options_nosync.modes;
 
     [self.realtime send:attachMessage sentCallback:^(ARTErrorInfo *error) {
         if (error) {
@@ -1466,6 +1468,22 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
 - (void)setOptions_nosync:(ARTRealtimeChannelOptions *_Nullable)options callback:(nullable void (^)(ARTErrorInfo *_Nullable))callback {
 ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
     [self setOptions_nosync:options];
+
+    if (!options.modes && !options.params) {
+        callback(nil);
+        return;
+    }
+
+    switch (self.state_nosync) {
+        case ARTRealtimeChannelAttached:
+        case ARTRealtimeChannelAttaching:
+            [self.realtime.logger debug:__FILE__ line:__LINE__ message:@"RT:%p C:%p (%@) set options in %@ state", _realtime, self, self.name, ARTRealtimeChannelStateToStr(self.state_nosync)];
+            [self internalAttach:callback withReason:nil];
+            break;
+        default:
+            callback(nil);
+            break;
+    }
 } ART_TRY_OR_MOVE_TO_FAILED_END
 }
 

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -196,6 +196,10 @@
     return [_internal on:event callback:cb];
 }
 
+- (void)setOptions:(ARTChannelOptions *_Nullable)options callback:(nullable void (^)(ARTErrorInfo *_Nullable))cb {
+    return [_internal setOptions:options callback:cb];
+}
+
 @end
 
 @interface ARTRealtimeChannelInternal () {
@@ -1429,6 +1433,10 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
         maxSize = self.realtime.connection.maxMessageSize;
     }
     return size > maxSize;
+}
+
+- (void)setOptions:(ARTChannelOptions *_Nullable)options callback:(nullable void (^)(ARTErrorInfo *_Nullable))callback {
+
 }
 
 @end

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -226,7 +226,7 @@
     ARTErrorInfo *_errorReason;
 }
 
-- (instancetype)initWithRealtime:(ARTRealtimeInternal *)realtime andName:(NSString *)name withOptions:(ARTChannelOptions *)options {
+- (instancetype)initWithRealtime:(ARTRealtimeInternal *)realtime andName:(NSString *)name withOptions:(ARTRealtimeChannelOptions *)options {
 ART_TRY_OR_MOVE_TO_FAILED_START(realtime) {
     self = [super initWithName:name andOptions:options rest:realtime.rest];
     if (self) {
@@ -251,7 +251,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(realtime) {
 } ART_TRY_OR_MOVE_TO_FAILED_END
 }
 
-+ (instancetype)channelWithRealtime:(ARTRealtimeInternal *)realtime andName:(NSString *)name withOptions:(ARTChannelOptions *)options {
++ (instancetype)channelWithRealtime:(ARTRealtimeInternal *)realtime andName:(NSString *)name withOptions:(ARTRealtimeChannelOptions *)options {
 ART_TRY_OR_MOVE_TO_FAILED_START(realtime) {
     return [[ARTRealtimeChannelInternal alloc] initWithRealtime:realtime andName:name withOptions:options];
 } ART_TRY_OR_MOVE_TO_FAILED_END

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -17,6 +17,7 @@
 #import "ARTRealtimePresence+Private.h"
 #import "ARTChannel.h"
 #import "ARTChannelOptions.h"
+#import "ARTRealtimeChannelOptions.h"
 #import "ARTProtocolMessage.h"
 #import "ARTProtocolMessage+Private.h"
 #import "ARTPresenceMap.h"
@@ -196,7 +197,7 @@
     return [_internal on:event callback:cb];
 }
 
-- (void)setOptions:(ARTChannelOptions *_Nullable)options callback:(nullable void (^)(ARTErrorInfo *_Nullable))cb {
+- (void)setOptions:(ARTRealtimeChannelOptions *_Nullable)options callback:(nullable void (^)(ARTErrorInfo *_Nullable))cb {
     return [_internal setOptions:options callback:cb];
 }
 
@@ -1435,7 +1436,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
     return size > maxSize;
 }
 
-- (void)setOptions:(ARTChannelOptions *_Nullable)options callback:(nullable void (^)(ARTErrorInfo *_Nullable))callback {
+- (void)setOptions:(ARTRealtimeChannelOptions *_Nullable)options callback:(nullable void (^)(ARTErrorInfo *_Nullable))callback {
 
 }
 

--- a/Source/ARTRealtimeChannelOptions.h
+++ b/Source/ARTRealtimeChannelOptions.h
@@ -1,0 +1,29 @@
+//
+//  ARTRealtimeChannelOptions.h
+//  Ably-iOS
+//
+//  Created by Ricardo Pereira on 24/01/2020.
+//  Copyright © 2020 Ably. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import <Ably/ARTChannelOptions.h>
+
+typedef NS_OPTIONS(NSUInteger, ARTChannelMode) {
+    ARTChannelModePresence = 0,
+    ARTChannelModePublish = 1 << 0,
+    ARTChannelModeSubscribe = 1 << 1,
+    ARTChannelModePresenceSubscribe = 1 << 2
+};
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARTRealtimeChannelOptions : ARTChannelOptions
+
+@property (nonatomic, strong, nullable) NSDictionary<NSString *, NSString *> *params;
+@property (nonatomic, assign) ARTChannelMode modes;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/ARTRealtimeChannelOptions.h
+++ b/Source/ARTRealtimeChannelOptions.h
@@ -10,11 +10,14 @@
 
 #import <Ably/ARTChannelOptions.h>
 
+/**
+ ARTChannelMode bitmask matching the ARTProtocolMessageFlag.
+ */
 typedef NS_OPTIONS(NSUInteger, ARTChannelMode) {
-    ARTChannelModePresence = 0,
-    ARTChannelModePublish = 1 << 0,
-    ARTChannelModeSubscribe = 1 << 1,
-    ARTChannelModePresenceSubscribe = 1 << 2
+    ARTChannelModePresence = 1 << 16,
+    ARTChannelModePublish = 1 << 17,
+    ARTChannelModeSubscribe = 1 << 18,
+    ARTChannelModePresenceSubscribe = 1 << 19
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Source/ARTRealtimeChannelOptions.m
+++ b/Source/ARTRealtimeChannelOptions.m
@@ -1,0 +1,13 @@
+//
+//  ARTRealtimeChannelOptions.m
+//  Ably-iOS
+//
+//  Created by Ricardo Pereira on 24/01/2020.
+//  Copyright © 2020 Ably. All rights reserved.
+//
+
+#import "ARTRealtimeChannelOptions.h"
+
+@implementation ARTRealtimeChannelOptions
+
+@end

--- a/Source/ARTRealtimeChannels+Private.h
+++ b/Source/ARTRealtimeChannels+Private.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ARTRealtimeChannelsInternal : NSObject<ARTRealtimeChannelsProtocol>
 
 - (ARTRealtimeChannelInternal *)get:(NSString *)name;
-- (ARTRealtimeChannelInternal *)get:(NSString *)name options:(ARTChannelOptions *)options;
+- (ARTRealtimeChannelInternal *)get:(NSString *)name options:(ARTRealtimeChannelOptions *)options;
 - (id<NSFastEnumeration>)copyIntoIteratorWithMapper:(ARTRealtimeChannel *(^)(ARTRealtimeChannelInternal *))mapper;
 
 - (instancetype)initWithRealtime:(ARTRealtimeInternal *)realtime;

--- a/Source/ARTRealtimeChannels.h
+++ b/Source/ARTRealtimeChannels.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ARTRealtimeChannels : NSObject<ARTRealtimeChannelsProtocol>
 
 - (ARTRealtimeChannel *)get:(NSString *)name;
-- (ARTRealtimeChannel *)get:(NSString *)name options:(ARTChannelOptions *)options;
+- (ARTRealtimeChannel *)get:(NSString *)name options:(ARTRealtimeChannelOptions *)options;
 - (id<NSFastEnumeration>)iterate;
 
 @end

--- a/Source/ARTRealtimeChannels.m
+++ b/Source/ARTRealtimeChannels.m
@@ -34,8 +34,8 @@
     return [[ARTRealtimeChannel alloc] initWithInternal:[_internal get:(NSString *)name] queuedDealloc:_dealloc];
 }
 
-- (ARTRealtimeChannel *)get:(NSString *)name options:(ARTChannelOptions *)options {
-    return [[ARTRealtimeChannel alloc] initWithInternal:[_internal get:(NSString *)name options:(ARTChannelOptions *)options] queuedDealloc:_dealloc];
+- (ARTRealtimeChannel *)get:(NSString *)name options:(ARTRealtimeChannelOptions *)options {
+    return [[ARTRealtimeChannel alloc] initWithInternal:[_internal get:(NSString *)name options:options] queuedDealloc:_dealloc];
 }
 
 - (void)release:(NSString *)name callback:(nullable void (^)(ARTErrorInfo *_Nullable))errorInfo {
@@ -80,7 +80,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(realtime) {
 } ART_TRY_OR_MOVE_TO_FAILED_END
 }
 
-- (id)makeChannel:(NSString *)name options:(ARTChannelOptions *)options {
+- (id)makeChannel:(NSString *)name options:(ARTRealtimeChannelOptions *)options {
     return [ARTRealtimeChannelInternal channelWithRealtime:_realtime andName:name withOptions:options];
 }
 

--- a/Source/ARTRestChannel.h
+++ b/Source/ARTRestChannel.h
@@ -19,6 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ARTRestChannelProtocol <ARTChannelProtocol>
 
+@property (readonly, nullable) ARTChannelOptions *options;
+
 - (BOOL)history:(nullable ARTDataQuery *)query callback:(void(^)(ARTPaginatedResult<ARTMessage *> *_Nullable result, ARTErrorInfo *_Nullable error))callback error:(NSError *_Nullable *_Nullable)errorPtr;
 
 - (void)setOptions:(ARTChannelOptions *_Nullable)options;

--- a/Source/ARTRestChannel.h
+++ b/Source/ARTRestChannel.h
@@ -21,6 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)history:(nullable ARTDataQuery *)query callback:(void(^)(ARTPaginatedResult<ARTMessage *> *_Nullable result, ARTErrorInfo *_Nullable error))callback error:(NSError *_Nullable *_Nullable)errorPtr;
 
+- (void)setOptions:(ARTChannelOptions *_Nullable)options;
+
 @end
 
 @interface ARTRestChannel : NSObject <ARTRestChannelProtocol>

--- a/Source/ARTRestChannel.m
+++ b/Source/ARTRestChannel.m
@@ -96,8 +96,6 @@
     [_internal history:callback];
 }
 
-- (BOOL)exceedMaxSize:(NSArray<ARTBaseMessage *> *)messages {
-    return [_internal exceedMaxSize:messages];
 }
 
 @end

--- a/Source/ARTRestChannel.m
+++ b/Source/ARTRestChannel.m
@@ -96,6 +96,10 @@
     [_internal history:callback];
 }
 
+- (ARTChannelOptions *)options {
+    return [_internal options];
+}
+
 - (void)setOptions:(ARTChannelOptions *_Nullable)options {
     [_internal setOptions:options];
 }
@@ -112,6 +116,8 @@ static const NSUInteger kIdempotentLibraryGeneratedIdLength = 9; //bytes
 @public
     NSString *_basePath;
 }
+
+@dynamic options;
 
 - (instancetype)initWithName:(NSString *)name withOptions:(ARTChannelOptions *)options andRest:(ARTRestInternal *)rest {
 ART_TRY_OR_REPORT_CRASH_START(rest) {

--- a/Source/ARTRestChannel.m
+++ b/Source/ARTRestChannel.m
@@ -96,6 +96,8 @@
     [_internal history:callback];
 }
 
+- (void)setOptions:(ARTChannelOptions *_Nullable)options {
+    [_internal setOptions:options];
 }
 
 @end

--- a/Source/Ably.h
+++ b/Source/Ably.h
@@ -46,6 +46,7 @@ FOUNDATION_EXPORT const unsigned char ablyVersionString[];
 #import <Ably/ARTRestPresence.h>
 #import <Ably/ARTRealtime.h>
 #import <Ably/ARTRealtimeChannel.h>
+#import <Ably/ARTRealtimeChannelOptions.h>
 #import <Ably/ARTRealtimePresence.h>
 #import <Ably/ARTStats.h>
 #import <Ably/ARTEncoder.h>

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -3602,6 +3602,62 @@ class RealtimeClientChannel: QuickSpec {
                     expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
                 }
 
+                // RTL16
+                context("Channel options") {
+
+                    // RTL16a
+                    context("setOptions") {
+                        it("should send an ATTACH message with params & modes if the channel is attached") {
+                            let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+                            defer { client.dispose(); client.close() }
+                            let channel = client.channels.get("foo")
+
+                            waitUntil(timeout: testTimeout) { done in
+                                channel.attach() { error in
+                                    expect(error).to(beNil())
+                                    done()
+                                }
+                            }
+
+                            guard let transport = client.internal.transport as? TestProxyTransport else {
+                                fail("Expecting TestProxyTransport"); return
+                            }
+
+                            let channelOptions = ARTRealtimeChannelOptions()
+                            channelOptions.modes = [.subscribe, .publish]
+                            channelOptions.params = [
+                                "codec": "vcdiff"
+                            ]
+
+                            waitUntil(timeout: testTimeout) { done in
+                                channel.setOptions(channelOptions) { error in
+                                    expect(error).to(beNil())
+                                    done()
+                                }
+                            }
+
+                            let attach = transport.protocolMessagesSent.filter({ $0.action == .attach }).last!
+                            expect(attach.flags & Int64(ARTChannelMode.publish.rawValue)).to(beGreaterThan(0)) //true
+                            expect(attach.flags & Int64(ARTChannelMode.subscribe.rawValue)).to(beGreaterThan(0)) //true
+                            expect(attach.params).to(equal(channelOptions.params))
+
+                            let attached = transport.protocolMessagesReceived.filter({ $0.action == .attached }).last!
+                            expect(attached.flags & Int64(ARTChannelMode.publish.rawValue)).to(beGreaterThan(0)) //true
+                            expect(attached.flags & Int64(ARTChannelMode.subscribe.rawValue)).to(beGreaterThan(0)) //true
+                            expect(attached.params).to(equal(channelOptions.params))
+                        }
+
+                        it("should send an ATTACH message with params & modes if the channel is attaching") {
+                            //TODO
+                        }
+
+                        it("should success immediately if channel is not attaching or attached") {
+                            //TODO
+                        }
+                    }
+
+                }
+
             }
 
             context("crypto") {

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -2799,7 +2799,7 @@ class RealtimeClientChannel: QuickSpec {
                             let testMessage = messages[0]
 
                             let cipherParams = ARTCipherParams(algorithm: "aes", key: keyData as ARTCipherKeyCompatible, iv: ivData)
-                            let channelOptions = ARTChannelOptions(cipher: cipherParams)
+                            let channelOptions = ARTRealtimeChannelOptions(cipher: cipherParams)
                             let channel = client.channels.get("test", options: channelOptions)
 
                             let transport = client.internal.transport as! TestProxyTransport
@@ -2863,7 +2863,7 @@ class RealtimeClientChannel: QuickSpec {
                         client.connect()
                         defer { client.dispose(); client.close() }
 
-                        let channelOptions = ARTChannelOptions(cipher: ["key":ARTCrypto.generateRandomKey()] as ARTCipherParamsCompatible)
+                        let channelOptions = ARTRealtimeChannelOptions(cipher: ["key":ARTCrypto.generateRandomKey()] as ARTCipherParamsCompatible)
                         let channel = client.channels.get("test", options: channelOptions)
 
                         let expectedMessage = ["key":1]
@@ -3676,8 +3676,8 @@ class RealtimeClientChannel: QuickSpec {
                     clientReceiver.connect()
 
                     let key = ARTCrypto.generateRandomKey()
-                    let sender = clientSender.channels.get("test", options: ARTChannelOptions(cipherKey: key as ARTCipherKeyCompatible))
-                    let receiver = clientReceiver.channels.get("test", options: ARTChannelOptions(cipherKey: key as ARTCipherKeyCompatible))
+                    let sender = clientSender.channels.get("test", options: ARTRealtimeChannelOptions(cipherKey: key as ARTCipherKeyCompatible))
+                    let receiver = clientReceiver.channels.get("test", options: ARTRealtimeChannelOptions(cipherKey: key as ARTCipherKeyCompatible))
 
                     var received = [ARTMessage]()
 

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -3626,7 +3626,7 @@ class RealtimeClientChannel: QuickSpec {
                             let channelOptions = ARTRealtimeChannelOptions()
                             channelOptions.modes = [.subscribe, .publish]
                             channelOptions.params = [
-                                "codec": "vcdiff"
+                                "delta": "vcdiff"
                             ]
 
                             waitUntil(timeout: testTimeout) { done in
@@ -3636,23 +3636,207 @@ class RealtimeClientChannel: QuickSpec {
                                 }
                             }
 
-                            let attach = transport.protocolMessagesSent.filter({ $0.action == .attach }).last!
-                            expect(attach.flags & Int64(ARTChannelMode.publish.rawValue)).to(beGreaterThan(0)) //true
-                            expect(attach.flags & Int64(ARTChannelMode.subscribe.rawValue)).to(beGreaterThan(0)) //true
-                            expect(attach.params).to(equal(channelOptions.params))
+                            expect(channel.options?.modes).to(equal(channelOptions.modes))
+                            expect(channel.options?.params).to(equal(channelOptions.params))
 
-                            let attached = transport.protocolMessagesReceived.filter({ $0.action == .attached }).last!
-                            expect(attached.flags & Int64(ARTChannelMode.publish.rawValue)).to(beGreaterThan(0)) //true
-                            expect(attached.flags & Int64(ARTChannelMode.subscribe.rawValue)).to(beGreaterThan(0)) //true
-                            expect(attached.params).to(equal(channelOptions.params))
+                            let attachMessages = transport.protocolMessagesSent.filter({ $0.action == .attach })
+                            expect(attachMessages).to(haveCount(2))
+                            guard let lastAttach = attachMessages.last else {
+                                fail("Last ATTACH message is missing"); return
+                            }
+                            expect(lastAttach.flags & Int64(ARTChannelMode.publish.rawValue)).to(beGreaterThan(0)) //true
+                            expect(lastAttach.flags & Int64(ARTChannelMode.subscribe.rawValue)).to(beGreaterThan(0)) //true
+                            expect(lastAttach.params).to(equal(channelOptions.params))
+
+                            let attachedMessages = transport.protocolMessagesReceived.filter({ $0.action == .attached })
+                            expect(attachMessages).to(haveCount(2))
+                            guard let lastAttached = attachedMessages.last else {
+                                fail("Last ATTACH message is missing"); return
+                            }
+                            expect(lastAttached.flags & Int64(ARTChannelMode.publish.rawValue)).to(beGreaterThan(0)) //true
+                            expect(lastAttached.flags & Int64(ARTChannelMode.subscribe.rawValue)).to(beGreaterThan(0)) //true
+                            expect(lastAttached.params).to(equal(channelOptions.params))
                         }
 
                         it("should send an ATTACH message with params & modes if the channel is attaching") {
-                            //TODO
+                            let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+                            defer { client.dispose(); client.close() }
+                            let channel = client.channels.get("foo")
+
+                            waitUntil(timeout: testTimeout) { done in
+                                client.connection.once(.connected) { _ in
+                                    done()
+                                }
+                            }
+
+                            guard let transport = client.internal.transport as? TestProxyTransport else {
+                                fail("Expecting TestProxyTransport"); return
+                            }
+
+                            let channelOptions = ARTRealtimeChannelOptions()
+                            channelOptions.modes = [.subscribe]
+                            channelOptions.params = [
+                                "delta": "vcdiff"
+                            ]
+
+                            waitUntil(timeout: testTimeout) { done in
+                                let partialDone = AblyTests.splitDone(3, done: done)
+                                channel.once(.attaching) { _ in
+                                    channel.setOptions(channelOptions) { error in
+                                        expect(error).to(beNil())
+                                        partialDone()
+                                    }
+                                }
+                                channel.once(.attached) { _ in
+                                    partialDone()
+                                }
+                                channel.once(.update) { _ in
+                                    partialDone()
+                                }
+                                channel.attach()
+                            }
+
+                            let subscribeFlag = Int64(ARTChannelMode.subscribe.rawValue)
+
+                            let attachMessages = transport.protocolMessagesSent.filter({ $0.action == .attach })
+                            expect(attachMessages).to(haveCount(2))
+                            guard let lastAttach = attachMessages.last else {
+                                fail("Last ATTACH message is missing"); return
+                            }
+                            expect(lastAttach.flags & subscribeFlag).to(equal(subscribeFlag))
+                            expect(lastAttach.params).to(equal(channelOptions.params))
+
+                            let attachedMessages = transport.protocolMessagesReceived.filter({ $0.action == .attached })
+                            expect(attachedMessages).to(haveCount(2))
+                            guard let lastAttached = attachedMessages.last else {
+                                fail("Last ATTACH message is missing"); return
+                            }
+                            expect(lastAttached.flags & subscribeFlag).to(equal(subscribeFlag))
+                            expect(lastAttached.params).to(equal(channelOptions.params))
                         }
 
                         it("should success immediately if channel is not attaching or attached") {
-                            //TODO
+                            let options = AblyTests.commonAppSetup()
+                            options.autoConnect = false
+                            let client = AblyTests.newRealtime(options)
+                            defer { client.dispose(); client.close() }
+                            let channel = client.channels.get("foo")
+
+                            let channelOptions = ARTRealtimeChannelOptions()
+                            channelOptions.modes = [.subscribe]
+                            channelOptions.params = [
+                                "delta": "vcdiff"
+                            ]
+
+                            channel.setOptions(channelOptions) { error in
+                                expect(error).to(beNil())
+                            }
+
+                            expect(channel.state).to(equal(.initialized))
+                            expect(channel.options?.modes).to(equal(channelOptions.modes))
+                            expect(channel.options?.params).to(equal(channelOptions.params))
+                        }
+
+                        it("should fail if the attach moves to FAILED") {
+                            let options = AblyTests.commonAppSetup()
+                            options.token = getTestToken(capability: "{\"secret\":[\"subscribe\"]}") //access denied
+                            let client = AblyTests.newRealtime(options)
+                            defer { client.dispose(); client.close() }
+                            let channel = client.channels.get("foo")
+
+                            waitUntil(timeout: testTimeout) { done in
+                                client.connection.once(.connected) { _ in
+                                    done()
+                                }
+                            }
+
+                            guard let transport = client.internal.transport as? TestProxyTransport else {
+                                fail("Expecting TestProxyTransport"); return
+                            }
+
+                            let channelOptions = ARTRealtimeChannelOptions()
+                            channelOptions.modes = [.subscribe]
+                            channelOptions.params = [
+                                "delta": "vcdiff"
+                            ]
+
+                            waitUntil(timeout: testTimeout) { done in
+                                let partialDone = AblyTests.splitDone(2, done: done)
+                                channel.once(.failed) { stateChange in
+                                    expect(stateChange?.reason?.code).to(equal(40160))
+                                    partialDone()
+                                }
+                                channel.attach()
+                                channel.setOptions(channelOptions) { error in
+                                    expect(error?.code).to(equal(40160))
+                                    partialDone()
+                                }
+                            }
+
+                            let subscribeFlag = Int64(ARTChannelMode.subscribe.rawValue)
+
+                            let attachMessages = transport.protocolMessagesSent.filter({ $0.action == .attach })
+                            expect(attachMessages).to(haveCount(2))
+                            guard let lastAttach = attachMessages.last else {
+                                fail("Last ATTACH message is missing"); return
+                            }
+                            expect(lastAttach.flags & subscribeFlag).to(equal(subscribeFlag))
+                            expect(lastAttach.params).to(equal(channelOptions.params))
+
+                            let attachedMessages = transport.protocolMessagesReceived.filter({ $0.action == .attached })
+                            expect(attachedMessages).to(beEmpty())
+                        }
+
+                        it("should fail if the attach moves to DETACHED") {
+                            let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+                            defer { client.dispose(); client.close() }
+                            let channel = client.channels.get("foo")
+
+                            waitUntil(timeout: testTimeout) { done in
+                                client.connection.once(.connected) { _ in
+                                    done()
+                                }
+                            }
+
+                            guard let transport = client.internal.transport as? TestProxyTransport else {
+                                fail("Expecting TestProxyTransport"); return
+                            }
+
+                            let channelOptions = ARTRealtimeChannelOptions()
+                            channelOptions.modes = [.subscribe]
+                            channelOptions.params = [
+                                "delta": "vcdiff"
+                            ]
+
+                            // Convert ATTACHED to DETACHED
+                            transport.changeReceivedMessage = { protocolMessage in
+                                if protocolMessage.action == .attached {
+                                    protocolMessage.action = .detached
+                                    protocolMessage.error = ARTErrorInfo.create(withCode: 50000, status: 500, message: "internal error")
+                                }
+                                return protocolMessage
+                            }
+
+                            waitUntil(timeout: testTimeout) { done in
+                                let partialDone = AblyTests.splitDone(2, done: done)
+                                channel.attach() { _ in
+                                    partialDone()
+                                }
+                                channel.setOptions(channelOptions) { error in
+                                    expect(error?.code).to(equal(50000))
+                                    partialDone()
+                                }
+                            }
+
+                            let subscribeFlag = Int64(ARTChannelMode.subscribe.rawValue)
+
+                            let attachMessages = transport.protocolMessagesSent.filter({ $0.action == .attach })
+                            expect(attachMessages).to(haveCount(2))
+                            guard let lastAttach = attachMessages.last else {
+                                fail("Last ATTACH message is missing"); return
+                            }
+                            expect(lastAttach.flags & subscribeFlag).to(equal(subscribeFlag))
+                            expect(lastAttach.params).to(equal(channelOptions.params))
                         }
                     }
 

--- a/Spec/RealtimeClientChannels.swift
+++ b/Spec/RealtimeClientChannels.swift
@@ -61,19 +61,19 @@ class RealtimeClientChannels: QuickSpec {
                 it("should be possible to specify a ChannelOptions") {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
-                    let options = ARTChannelOptions()
+                    let options = ARTRealtimeChannelOptions()
                     let channel = client.channels.get("test", options: options)
-                    expect(channel.internal.options).to(beIdenticalTo(options))
+                    expect(channel.options).to(beIdenticalTo(options))
                 }
 
                 // RTS3c
                 it("accessing an existing Channel with options should update the options and then return the object") {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
-                    expect(client.channels.get("test").internal.options).toNot(beNil())
-                    let options = ARTChannelOptions()
+                    expect(client.channels.get("test").options).to(beNil())
+                    let options = ARTRealtimeChannelOptions()
                     let channel = client.channels.get("test", options: options)
-                    expect(channel.internal.options).to(beIdenticalTo(options))
+                    expect(channel.options).to(beIdenticalTo(options))
                 }
 
             }

--- a/Spec/RestClientChannels.swift
+++ b/Spec/RestClientChannels.swift
@@ -65,7 +65,7 @@ class RestClientChannels: QuickSpec {
                         let channel = client.channels.get(channelName, options: options)
 
                         expect(channel.internal).to(beAChannel(named: "\(ARTChannels_getChannelNamePrefix!())-\(channelName!)"))
-                        expect(channel.internal.options).to(beIdenticalTo(options))
+                        expect(channel.options).to(beIdenticalTo(options))
                     }
 
                     // RSN3b


### PR DESCRIPTION
 - (RSL7) Channel#setOptions takes a ChannelOptions object and sets or updates the stored channel options, then indicates success

 - (RTL16) Channel#setOptions takes a ChannelOptions object and sets or updates the stored channel options.
    - (RTL16a) If the user has provided either ChannelOptions.params or ChannelOptions.modes and the channel is in either the attached or attaching state, Channel#setOptions sends an ATTACH message to the server with the params & modes encoded per RTL4, and indicates success once the server has replied with an ATTACHED (or indicates failure if the channel becomes detached or failed before that happens, as with Channel#attach); else it indicates success immediately