### PR TITLE
Update KSCrash dependency

### DIFF
--- a/Ably.podspec
+++ b/Ably.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.private_header_files = 'Source/*+Private.h', 'Source/Private/*.h'
   s.module_map        = 'Source/Ably.modulemap'
   s.dependency 'SocketRocketAblyFork', '0.5.2-ably-4'
-  s.dependency 'KSCrashAblyFork', '1.15.20-ably-5'
+  s.dependency 'KSCrashAblyFork', '1.15.20-ably-6'
   s.dependency 'msgpack', '0.3.1'
   s.dependency 'ULID', '1.1.0'
   s.dependency 'SAMKeychain', '1.5.3'

--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
 github "ably-forks/SocketRocket" == 0.5.2-ably-4
-github "ably-forks/KSCrash" == 1.15.20-ably-5
+github "ably-forks/KSCrash" == 1.15.20-ably-6
 github "rvi/msgpack-objective-C" == 0.3.1
 github "whitesmith/ulid" == 1.1.0
 github "soffes/SAMKeychain" == 1.5.3


### PR DESCRIPTION
Bringing in our KSCrash fork modification (https://github.com/ably-forks/KSCrash/pull/3) to prefix all category names, as well as header file names, to prevent build clashes when combined with other libraries.