### PR TITLE
Fix handling of token error when first connecting.

### DIFF
--- a/Source/ARTAuth.m
+++ b/Source/ARTAuth.m
@@ -306,7 +306,13 @@ ART_TRY_OR_REPORT_CRASH_START(_rest) {
         if (self.tokenDetails.expires == nil) {
             return YES;
         }
-        else if (![self hasTimeOffset] || [self.tokenDetails.expires timeIntervalSinceDate:[self currentDate]] > 0) {
+        
+        // RSA4b1: Only check expiry client-side if local clock has been adjusted.
+        // If it hasn't, assume the token remains valid.
+        if (![self hasTimeOffset]) {
+            return YES;
+        }
+        if ([self.tokenDetails.expires timeIntervalSinceDate:[self currentDate]] > 0) {
             return YES;
         }
     }

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -920,14 +920,6 @@ ART_TRY_OR_MOVE_TO_FAILED_START(self) {
         [self onChannelMessage:message];
     } else {
         ARTErrorInfo *error = message.error;
-        if (error.code >= 40140 && error.code < 40150) {
-            if (![self shouldRenewToken:&error]) {
-                [self transition:ARTRealtimeFailed withErrorInfo:message.error];
-                return;
-            }
-            [self transitionToDisconnectedOrSuspendedWithError:message.error];
-            return;
-        }
         if ([self shouldRenewToken:&error]) {
             [self transportReconnectWithRenewedToken];
             return;

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -624,13 +624,12 @@ class Auth : QuickSpec {
                                 realtime.connect()
                             }
 
+                            expect(realtime.connection.state).toEventually(equal(ARTRealtimeConnectionState.disconnected), timeout: testTimeout)
                             guard let errorInfo = realtime.connection.errorReason else {
                                 fail("ErrorInfo is empty"); return
                             }
                             expect(errorInfo.code) == 80019
                             expect(errorInfo.message).to(contain("hostname could not be found"))
-
-                            expect(realtime.connection.state).toEventually(equal(ARTRealtimeConnectionState.disconnected), timeout: testTimeout)
                         }
 
                         // RSA4c3

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -983,8 +983,8 @@ class Auth : QuickSpec {
 
                         waitUntil(timeout: testTimeout) { done in
                             realtime.connection.once(.failed) { stateChange in
-                                expect(stateChange!.reason!.code).to(equal(40102))
-                                expect(stateChange!.reason!.description).to(contain("incompatible credentials"))
+                                expect(stateChange!.reason?.code).to(equal(40102))
+                                expect(stateChange!.reason?.description).to(contain("incompatible credentials"))
                                 done()
                             }
                             realtime.connect()
@@ -4172,8 +4172,8 @@ class Auth : QuickSpec {
                         waitUntil(timeout: testTimeout) { done in
                             client.connection.once(.connected) { stateChange in
                                 client.connection.once(.disconnected) { stateChange in
-                                    expect(stateChange!.reason!.code).to(equal(40142))
-                                    expect(stateChange!.reason!.description).to(contain("Key/token status changed (expire)"))
+                                    expect(stateChange!.reason?.code).to(equal(40142))
+                                    expect(stateChange!.reason?.description).to(contain("Key/token status changed (expire)"))
                                     done()
                                 }
                             }
@@ -4281,7 +4281,7 @@ class Auth : QuickSpec {
                             originalConnectionID = client.connection.id!
 
                             client.connection.once(.disconnected) { stateChange in
-                                expect(stateChange!.reason!.code).to(equal(40142))
+                                expect(stateChange!.reason?.code).to(equal(40142))
 
                                 client.connection.once(.connected) { _ in
                                     expect(client.connection.id).to(equal(originalConnectionID))

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -3001,8 +3001,8 @@ class RealtimeClientConnection: QuickSpec {
                         
                         waitUntil(timeout: testTimeout) { done in
                             client.connection.once(.failed) { stateChange in
+                                expect(stateChange?.previous).to(equal(ARTRealtimeConnectionState.connected))
                                 expect(stateChange?.reason?.code).to(equal(40142))
-                                expect(stateChange?.reason?.message).to(contain("Token expired"))
                                 done()
                             }
                             client.connect()


### PR DESCRIPTION
Removed complex and apparently unnecessary logic on error protocol message handler. No tests broken by this.

I first thought this was an issue with RSA4b, so I also added a missing test for it and some documentation.

Fixes #984.