### PR TITLE
Use tests dispatch queue, not main, to POST /apps.

### DIFF
--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -321,7 +321,9 @@ class NSURLSessionServerTrustSync: NSObject, URLSessionDelegate, URLSessionTaskD
         var requestCompleted = false
 
         let configuration = URLSessionConfiguration.default
-        let session = Foundation.URLSession(configuration:configuration, delegate:self, delegateQueue:OperationQueue.main)
+        let queue = OperationQueue()
+        queue.underlyingQueue = AblyTests.extraQueue
+        let session = Foundation.URLSession(configuration:configuration, delegate:self, delegateQueue:queue)
 
         let task = session.dataTask(with: request as URLRequest, completionHandler: { data, response, error in
             if let response = response as? HTTPURLResponse {


### PR DESCRIPTION
For some reason, test app creation started hanging forever in my
machine. Using the extras dispatch queue to perform it fixed it. I guess
it's good we don't use the main queue unless required anyway.