### PR TITLE
Fix Objective-C namespace collisions

### DIFF
--- a/Source/ARTJsonLikeEncoder.m
+++ b/Source/ARTJsonLikeEncoder.m
@@ -670,9 +670,9 @@
     NSDictionary *deviceIdentityTokenInput = input[@"deviceIdentityToken"];
     NSString *token = [deviceIdentityTokenInput artString:@"token"];
     NSNumber *issuedMsecs = [deviceIdentityTokenInput artNumber:@"issued"];
-    NSDate *issued = [NSDate dateWithMillisecondsSince1970:issuedMsecs.doubleValue];
+    NSDate *issued = [NSDate art_dateWithMillisecondsSince1970:issuedMsecs.doubleValue];
     NSNumber *expiresMsecs = [deviceIdentityTokenInput artNumber:@"expires"];
-    NSDate *expires = [NSDate dateWithMillisecondsSince1970:expiresMsecs.doubleValue];
+    NSDate *expires = [NSDate art_dateWithMillisecondsSince1970:expiresMsecs.doubleValue];
     NSString *capability = [deviceIdentityTokenInput artString:@"capability"];
     NSString *clientId = [deviceIdentityTokenInput artString:@"clientId"];
 

--- a/Source/ARTNSMutableRequest+ARTPush.m
+++ b/Source/ARTNSMutableRequest+ARTPush.m
@@ -23,7 +23,7 @@
     if ([localDevice.id isEqualToString:deviceId]) {
         if (localDevice.identityTokenDetails.token) {
             [logger debug:__FILE__ line:__LINE__ message:@"adding device authentication using local device identity token"];
-            [self setValue:[localDevice.identityTokenDetails.token base64Encoded] forHTTPHeaderField:@"X-Ably-DeviceToken"];
+            [self setValue:[localDevice.identityTokenDetails.token art_base64Encoded] forHTTPHeaderField:@"X-Ably-DeviceToken"];
         }
         else if (localDevice.secret) {
             [logger debug:__FILE__ line:__LINE__ message:@"adding device authentication using local device secret"];

--- a/Source/ARTPushChannelSubscriptions.m
+++ b/Source/ARTPushChannelSubscriptions.m
@@ -112,7 +112,7 @@ ART_TRY_OR_REPORT_CRASH_START(self->_rest) {
         else {
             [self->_logger error:@"%@: save channel subscription failed with status code %ld", NSStringFromClass(self.class), (long)response.statusCode];
             NSString *plain = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-            callback([ARTErrorInfo createWithCode:response.statusCode*100 status:response.statusCode message:[plain shortString]]);
+            callback([ARTErrorInfo createWithCode:response.statusCode*100 status:response.statusCode message:[plain art_shortString]]);
         }
     }];
 } ART_TRY_OR_REPORT_CRASH_END
@@ -242,7 +242,7 @@ ART_TRY_OR_REPORT_CRASH_START(self->_rest) {
         else {
             [self->_logger error:@"%@: remove channel subscription failed with status code %ld", NSStringFromClass(self.class), (long)response.statusCode];
             NSString *plain = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-            callback([ARTErrorInfo createWithCode:response.statusCode*100 status:response.statusCode message:[plain shortString]]);
+            callback([ARTErrorInfo createWithCode:response.statusCode*100 status:response.statusCode message:[plain art_shortString]]);
         }
     }];
 }

--- a/Source/ARTPushDeviceRegistrations.m
+++ b/Source/ARTPushDeviceRegistrations.m
@@ -121,7 +121,7 @@ ART_TRY_OR_REPORT_CRASH_START(self->_rest) {
         else {
             [self->_logger error:@"%@: save device failed with status code %ld", NSStringFromClass(self.class), (long)response.statusCode];
             NSString *plain = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-            callback([ARTErrorInfo createWithCode:response.statusCode*100 status:response.statusCode message:[plain shortString]]);
+            callback([ARTErrorInfo createWithCode:response.statusCode*100 status:response.statusCode message:[plain art_shortString]]);
         }
     }];
 } ART_TRY_OR_REPORT_CRASH_END
@@ -176,7 +176,7 @@ ART_TRY_OR_REPORT_CRASH_START(self->_rest) {
         else {
             [self->_logger error:@"%@: get device failed with status code %ld", NSStringFromClass(self.class), (long)response.statusCode];
             NSString *plain = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-            callback(nil, [ARTErrorInfo createWithCode:response.statusCode*100 status:response.statusCode message:[plain shortString]]);
+            callback(nil, [ARTErrorInfo createWithCode:response.statusCode*100 status:response.statusCode message:[plain art_shortString]]);
         }
     }];
 } ART_TRY_OR_REPORT_CRASH_END
@@ -243,7 +243,7 @@ ART_TRY_OR_REPORT_CRASH_START(self->_rest) {
         else {
             [self->_logger error:@"%@: remove device failed with status code %ld", NSStringFromClass(self.class), (long)response.statusCode];
             NSString *plain = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-            callback([ARTErrorInfo createWithCode:response.statusCode*100 status:response.statusCode message:[plain shortString]]);
+            callback([ARTErrorInfo createWithCode:response.statusCode*100 status:response.statusCode message:[plain art_shortString]]);
         }
     }];
 } ART_TRY_OR_REPORT_CRASH_END
@@ -291,7 +291,7 @@ ART_TRY_OR_REPORT_CRASH_START(self->_rest) {
         else {
             [self->_logger error:@"%@: remove devices failed with status code %ld", NSStringFromClass(self.class), (long)response.statusCode];
             NSString *plain = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-            callback([ARTErrorInfo createWithCode:response.statusCode*100 status:response.statusCode message:[plain shortString]]);
+            callback([ARTErrorInfo createWithCode:response.statusCode*100 status:response.statusCode message:[plain art_shortString]]);
         }
     }];
 } ART_TRY_OR_REPORT_CRASH_END

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -359,7 +359,7 @@ ART_TRY_OR_REPORT_CRASH_START(self) {
             if (!validContentType) {
                 NSString *plain = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
                 // Construct artificial error
-                error = [ARTErrorInfo createWithCode:response.statusCode * 100 status:response.statusCode message:[plain shortString]];
+                error = [ARTErrorInfo createWithCode:response.statusCode * 100 status:response.statusCode message:[plain art_shortString]];
                 data = nil; // Discard data; format is unreliable.
                 [self.logger error:@"Request %@ failed with %@", request, error];
             }

--- a/Source/ARTTypes.h
+++ b/Source/ARTTypes.h
@@ -201,13 +201,13 @@ NSString *generateNonce(void);
 @interface NSString (ARTJsonCompatible) <ARTJsonCompatible>
 @end
 
-@interface NSString (Utilities)
-- (NSString *)shortString;
-- (NSString *)base64Encoded;
+@interface NSString (ARTUtilities)
+- (NSString *)art_shortString NS_SWIFT_NAME(shortString());
+- (NSString *)art_base64Encoded NS_SWIFT_NAME(base64Encoded());
 @end
 
-@interface NSDate (Utilities)
-+ (NSDate *)dateWithMillisecondsSince1970:(uint64_t)msecs;
+@interface NSDate (ARTUtilities)
++ (NSDate *)art_dateWithMillisecondsSince1970:(uint64_t)msecs NS_SWIFT_NAME(date(withMillisecondsSince1970:));
 @end
 
 @interface NSDictionary (ARTJsonCompatible) <ARTJsonCompatible>

--- a/Source/ARTTypes.m
+++ b/Source/ARTTypes.m
@@ -283,27 +283,27 @@ NSString *ARTChannelEventToStr(ARTChannelEvent event) {
 
 @end
 
-#pragma mark - NSString (Utilities)
+#pragma mark - NSString (ARTUtilities)
 
-@implementation NSString (Utilities)
+@implementation NSString (ARTUtilities)
 
-- (NSString *)shortString {
+- (NSString *)art_shortString {
     NSRange stringRange = {0, MIN([self length], 1000)}; //1KB
     stringRange = [self rangeOfComposedCharacterSequencesForRange:stringRange];
     return [self substringWithRange:stringRange];
 }
 
-- (NSString *)base64Encoded {
+- (NSString *)art_base64Encoded {
     return encodeBase64(self);
 }
 
 @end
 
-#pragma mark - NSDate (Utilities)
+#pragma mark - NSDate (ARTUtilities)
 
-@implementation NSDate (Utilities)
+@implementation NSDate (ARTUtilities)
 
-+ (NSDate *)dateWithMillisecondsSince1970:(uint64_t)msecs {
++ (NSDate *)art_dateWithMillisecondsSince1970:(uint64_t)msecs {
     return [NSDate dateWithTimeIntervalSince1970:millisecondsToTimeInterval(msecs)];
 }
 


### PR DESCRIPTION
On my current project that uses Ably, I see some name collisions with other Objective-C code that defines a `Utilities` extension on `NSString` and `NSDate`. This PR renames those extensions to `ARTUtilities` and adds an `art_` prefix to these methods to avoid further Objective-C namespace collisions. I’ve used `NS_SWIFT_NAME` to ensure that the names don’t change for Swift code.