### PR TITLE
Should not wait for AblyTest.options in 'context' scope

### DIFF
--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -1735,13 +1735,22 @@ class Auth : QuickSpec {
             // RSA8b
             context("should support all TokenParams") {
 
-                let options = AblyTests.commonAppSetup()
                 let currentClientId = "client_string"
-                options.clientId = currentClientId
 
-                let rest = ARTRest(options: options)
+                var options: ARTClientOptions!
+                var rest: ARTRest!
+
+                func setupDependencies() {
+                    if (options == nil) {
+                        options = AblyTests.commonAppSetup()
+                        options.clientId = currentClientId
+                        rest = ARTRest(options: options)
+                    }
+                }
 
                 it("using defaults") {
+                    setupDependencies()
+
                     // Default values
                     let defaultTokenParams = ARTTokenParams(clientId: currentClientId)
                     defaultTokenParams.ttl = ARTDefault.ttl() as NSNumber // Set by the server.
@@ -1762,6 +1771,8 @@ class Auth : QuickSpec {
                 }
 
                 it("overriding defaults") {
+                    setupDependencies()
+
                     // Custom values
                     let expectedTtl = 4800.0
                     let expectedCapability = "{\"canpublish:*\":[\"publish\"]}"
@@ -4088,12 +4099,12 @@ class Auth : QuickSpec {
                 }
 
                 context("with invalid credentials") {
-                    options.token = getJWTToken(invalid: true)
-                    options.autoConnect = false
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-
                     it("fails to connect with reason 'invalid signature'") {
+                        options.token = getJWTToken(invalid: true)
+                        options.autoConnect = false
+                        let client = AblyTests.newRealtime(options)
+                        defer { client.dispose(); client.close() }
+
                         waitUntil(timeout: testTimeout) { done in
                             client.connection.once(.failed) { stateChange in
                                 guard let reason = stateChange?.reason else {
@@ -4112,11 +4123,20 @@ class Auth : QuickSpec {
             // RSA8g RSA8c
             context("when using authUrl") {
                 let options = AblyTests.clientOptions()
-                let keys = getKeys()
                 options.authUrl = URL(string: echoServerAddress)! as URL
+
+                var keys: [String: String]!
+
+                func setupDependencies() {
+                    if (keys == nil) {
+                        keys = getKeys()
+                    }
+                }
 
                 context("with valid credentials") {
                     it("fetches a channels and posts a message") {
+                        setupDependencies()
+
                         options.authParams = [URLQueryItem]() as [URLQueryItem]?
                         options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]) as URLQueryItem)
                         options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]) as URLQueryItem)
@@ -4138,6 +4158,8 @@ class Auth : QuickSpec {
 
                 context("with wrong credentials") {
                     it("fails to connect with reason 'invalid signature'") {
+                        setupDependencies()
+
                         options.authParams = [URLQueryItem]() as [URLQueryItem]?
                         options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]) as URLQueryItem)
                         options.authParams?.append(URLQueryItem(name: "keySecret", value: "INVALID") as URLQueryItem)
@@ -4161,6 +4183,8 @@ class Auth : QuickSpec {
                 context("when token expires") {
 
                     it ("receives a 40142 error from the server") {
+                        setupDependencies()
+
                         let tokenDuration = 5.0
                         options.authParams = [URLQueryItem]() as [URLQueryItem]?
                         options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]) as URLQueryItem)
@@ -4185,6 +4209,8 @@ class Auth : QuickSpec {
                 // RTC8a4
                 context("when the server sends and AUTH protocol message") {
                     it("client reauths correctly without going through a disconnection") {
+                        setupDependencies()
+                        
                         // The server sends an AUTH protocol message 30 seconds before a token expires
                         // We create a token that lasts 35 seconds, so there's room to receive the AUTH message
                         let tokenDuration = 35.0
@@ -4372,10 +4398,9 @@ class Auth : QuickSpec {
             let options = AblyTests.clientOptions()
             
             context("when the JWT token embeds an Ably token") {
-                options.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded")!)
-                let client = ARTRest(options: options)
-                
                 it ("pulls stats successfully") {
+                    options.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded")!)
+                    let client = ARTRest(options: options)
                     waitUntil(timeout: testTimeout) { done in
                         client.stats { stats, error in
                             expect(error).to(beNil())
@@ -4386,10 +4411,9 @@ class Auth : QuickSpec {
             }
             
             context("when the JWT token embeds an Ably token and it is requested as encrypted") {
-                options.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded", encrypted: 1)!)
-                let client = ARTRest(options: options)
-                
                 it ("pulls stats successfully") {
+                    options.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded", encrypted: 1)!)
+                    let client = ARTRest(options: options)
                     waitUntil(timeout: testTimeout) { done in
                         client.stats { stats, error in
                             expect(error).to(beNil())
@@ -4401,14 +4425,24 @@ class Auth : QuickSpec {
             
             // RSA4f, RSA8c
             context("when the JWT token is returned with application/jwt content type") {
-                let options = AblyTests.clientOptions()
-                let keys = getKeys()
-                options.authUrl = URL(string: echoServerAddress)! as URL
-                options.authParams = [URLQueryItem]() as [URLQueryItem]?
-                options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]) as URLQueryItem)
-                options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]) as URLQueryItem)
-                options.authParams?.append(URLQueryItem(name: "returnType", value: "jwt") as URLQueryItem)
-                let client = ARTRest(options: options)
+                var client: ARTRest!
+
+                func setupDependencies() {
+                    if (client == nil) {
+                        let options = AblyTests.clientOptions()
+                        let keys = getKeys()
+                        options.authUrl = URL(string: echoServerAddress)! as URL
+                        options.authParams = [URLQueryItem]() as [URLQueryItem]?
+                        options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]) as URLQueryItem)
+                        options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]) as URLQueryItem)
+                        options.authParams?.append(URLQueryItem(name: "returnType", value: "jwt") as URLQueryItem)
+                        client = ARTRest(options: options)
+                    }
+                }
+
+                beforeEach {
+                    setupDependencies()
+                }
                 
                 it("the client successfully connects and pulls stats") {
                     waitUntil(timeout: testTimeout) { done in

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -2195,15 +2195,22 @@ class RealtimeClientChannel: QuickSpec {
 
                     // RTL6c4
                     context("will result in an error if the") {
-                        let options = AblyTests.commonAppSetup()
-                        options.suspendedRetryTimeout = 0.3
-                        options.autoConnect = false
+                        var options: ARTClientOptions!
                         var client: ARTRealtime!
                         var channel: ARTRealtimeChannel!
 
                         let previousConnectionStateTtl = ARTDefault.connectionStateTtl()
 
+                        func setupDependencies() {
+                            if (options == nil) {
+                                options = AblyTests.commonAppSetup()
+                                options.suspendedRetryTimeout = 0.3
+                                options.autoConnect = false
+                            }
+                        }
+
                         beforeEach {
+                            setupDependencies()
                             ARTDefault.setConnectionStateTtl(0.3)
                             client = AblyTests.newRealtime(options)
                             channel = client.channels.get("test")

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -2833,15 +2833,15 @@ class RealtimeClientConnection: QuickSpec {
                 
                 // RTN15g RTN15g1
                 context("when connection (ttl + idle interval) period has passed since last activity") {
-                    let options = AblyTests.commonAppSetup()
-                    // We want this to be > than the sum of customTtlInterval and customIdleInterval
-                    options.disconnectedRetryTimeout = 5.0
                     var client: ARTRealtime!
                     var connectionId = ""
                     let customTtlInterval: TimeInterval = 0.1
                     let customIdleInterval: TimeInterval = 0.1
                     
                     it("uses a new connection") {
+                        let options = AblyTests.commonAppSetup()
+                        // We want this to be > than the sum of customTtlInterval and customIdleInterval
+                        options.disconnectedRetryTimeout = 5.0
                         client = AblyTests.newRealtime(options)
                         client.internal.shouldImmediatelyReconnect = false
                         client.connect()
@@ -2872,6 +2872,9 @@ class RealtimeClientConnection: QuickSpec {
                     }
                     // RTN15g3
                     it("reattaches to the same channels after a new connection has been established") {
+                        let options = AblyTests.commonAppSetup()
+                        // We want this to be > than the sum of customTtlInterval and customIdleInterval
+                        options.disconnectedRetryTimeout = 5.0
                         client = AblyTests.newRealtime(options)
                         client.internal.shouldImmediatelyReconnect = false
                         defer { client.close() }
@@ -2909,11 +2912,11 @@ class RealtimeClientConnection: QuickSpec {
                 
                 // RTN15g2
                 context("when connection (ttl + idle interval) period has NOT passed since last activity") {
-                    let options = AblyTests.commonAppSetup()
                     var client: ARTRealtime!
                     var connectionId = ""
                     
                     it("uses the same connection") {
+                        let options = AblyTests.commonAppSetup()
                         client = AblyTests.newRealtime(options)
                         client.connect()
                         defer { client.close() }
@@ -4600,13 +4603,21 @@ class RealtimeClientConnection: QuickSpec {
                     }
                 }
 
-                let jsonOptions = AblyTests.commonAppSetup()
-                jsonOptions.useBinaryProtocol = false
-                // Keep the same key and channel prefix
-                let msgpackOptions = jsonOptions.copy() as! ARTClientOptions
-                msgpackOptions.useBinaryProtocol = true
+                var jsonOptions: ARTClientOptions!
+                var msgpackOptions: ARTClientOptions!
+
+                func setupDependencies() {
+                    if (jsonOptions == nil) {
+                        jsonOptions = AblyTests.commonAppSetup()
+                        jsonOptions.useBinaryProtocol = false
+                        // Keep the same key and channel prefix
+                        msgpackOptions = jsonOptions.copy() as! ARTClientOptions
+                        msgpackOptions.useBinaryProtocol = true
+                    }
+                }
 
                 it("should send messages through raw JSON POST and retrieve equal messages through MsgPack and JSON") {
+                    setupDependencies()
                     let restPublishClient = ARTRest(options: jsonOptions)
                     let realtimeSubscribeClientMsgPack = AblyTests.newRealtime(msgpackOptions)
                     let realtimeSubscribeClientJSON = AblyTests.newRealtime(jsonOptions)
@@ -4657,6 +4668,7 @@ class RealtimeClientConnection: QuickSpec {
                 }
 
                 it("should send messages through MsgPack and JSON and retrieve equal messages through raw JSON GET") {
+                    setupDependencies()
                     let restPublishClientMsgPack = ARTRest(options: msgpackOptions)
                     let restPublishClientJSON = ARTRest(options: jsonOptions)
                     let restRetrieveClient = ARTRest(options: jsonOptions)

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -2841,7 +2841,7 @@ class RealtimeClientConnection: QuickSpec {
                     it("uses a new connection") {
                         let options = AblyTests.commonAppSetup()
                         // We want this to be > than the sum of customTtlInterval and customIdleInterval
-                        options.disconnectedRetryTimeout = 5.0
+                        options.disconnectedRetryTimeout = 5.0 + customTtlInterval + customIdleInterval
                         client = AblyTests.newRealtime(options)
                         client.internal.shouldImmediatelyReconnect = false
                         client.connect()


### PR DESCRIPTION
 - For example, if you run a solo test where you don't need internet connection, then the test will fail because there are AblyTest.commonAppSetup() calls inside of 'context' scopes which are executed even if you select only one test to run.