### PR TITLE
Improve unhandled exception handling code

### DIFF
--- a/Source/ARTRealtime+Private.h
+++ b/Source/ARTRealtime+Private.h
@@ -125,29 +125,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
-
-#define ART_TRY_OR_MOVE_TO_FAILED_START(realtime) \
+#define ART_TRY_OR_MOVE_TO_FAILED_START(REALTIME) \
 	do {\
-	ARTRealtimeInternal *__realtime = realtime;\
-    BOOL __started = ARTstartHandlingUncaughtExceptions(__realtime.rest);\
-    BOOL __caught = false;\
-	@try {\
-		do {\
+        ARTRealtimeInternal *const __realtime = REALTIME; \
+        ARTRestInternal *const __rest = __realtime.rest; \
+        const BOOL __started = [__rest startHandlingUncaughtExceptions]; \
+        BOOL __caught = false; \
+        @try { \
+            do {
 
 #define ART_TRY_OR_MOVE_TO_FAILED_END \
-		} while(0); \
-	}\
-	@catch(NSException *e) {\
-		__caught = true;\
-        if (!__started) {\
-            @throw e;\
-        }\
-		[__realtime onUncaughtException:e];\
-	}\
-	@finally {\
-		if (!__caught && __started) {\
-            ARTstopHandlingUncaughtExceptions(__realtime.rest);\
-		}\
-	}\
+            } while(0); \
+        } \
+        @catch(NSException *const e) { \
+            __caught = true; \
+            if (!__started) { \
+                @throw e; \
+            } \
+            [__realtime onUncaughtException:e]; \
+        } \
+        @finally { \
+            if (!__caught && __started) { \
+                [__rest stopHandlingUncaughtExceptions]; \
+            } \
+        } \
 	} while(0);
+
+NS_ASSUME_NONNULL_END

--- a/Source/ARTRest+Private.h
+++ b/Source/ARTRest+Private.h
@@ -74,6 +74,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)resetDeviceSingleton;
 #endif
 
+-(BOOL)startHandlingUncaughtExceptions;
+-(void)stopHandlingUncaughtExceptions;
+
 @end
 
 @interface ARTRest ()
@@ -84,34 +87,31 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-BOOL ARTstartHandlingUncaughtExceptions(ARTRestInternal *self);
-void ARTstopHandlingUncaughtExceptions(ARTRestInternal *self);
-
-#define ART_TRY_OR_REPORT_CRASH_START(rest) \
-	do {\
-	ARTRestInternal *__rest = rest;\
-    BOOL __started = ARTstartHandlingUncaughtExceptions(__rest);\
-    BOOL __caught = false;\
-	@try {\
-		do {\
+#define ART_TRY_OR_REPORT_CRASH_START(REST) \
+	do { \
+        ARTRestInternal *const __rest = REST; \
+        const BOOL __started = [__rest startHandlingUncaughtExceptions]; \
+        BOOL __caught = false; \
+        @try { \
+            do {
 
 #define ART_TRY_OR_REPORT_CRASH_END \
-		} while(0); \
-	}\
-	@catch(NSException *e) {\
-		__caught = true;\
-        if (!__started) {\
-            @throw e;\
-        }\
-		[__rest onUncaughtException:e];\
-	}\
-	@finally {\
-		if (!__caught && __started) {\
-            ARTstopHandlingUncaughtExceptions(__rest);\
-		}\
-	}\
+            } while(0); \
+        } \
+        @catch(NSException *const e) { \
+            __caught = true; \
+            if (!__started) { \
+                @throw e; \
+            } \
+            [__rest onUncaughtException:e]; \
+        } \
+        @finally { \
+            if (!__caught && __started) { \
+                [__rest stopHandlingUncaughtExceptions]; \
+            } \
+        } \
 	} while(0);
 
-#define ART_EXITING_ABLY_CODE(rest) ARTstopHandlingUncaughtExceptions(rest);
+#define ART_EXITING_ABLY_CODE(REST) [REST startHandlingUncaughtExceptions];
 
 NS_ASSUME_NONNULL_END

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -138,15 +138,10 @@
 
 @end
 
-@interface ARTRestInternal () {
-    __block NSUInteger _tokenErrorRetries;
-    BOOL _handlingUncaughtExceptions;
-}
-
-@end
-
 @implementation ARTRestInternal {
     ARTLog *_logger;
+    NSUInteger _tokenErrorRetries;
+    BOOL _handlingUncaughtExceptions;
 }
 
 @synthesize logger = _logger;

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -43,6 +43,8 @@
 #import "ARTHTTPPaginatedResponse+Private.h"
 #import <KSCrashAblyFork/KSCrash.h>
 
+static BOOL _aRestInstanceIsHandlingUncaughtExceptions = NO;
+
 @implementation ARTRest {
     ARTQueuedDealloc *_dealloc;
 }
@@ -727,21 +729,31 @@ ART_TRY_OR_REPORT_CRASH_START(self) {
     };
 }
 
-BOOL ARTstartHandlingUncaughtExceptions(ARTRestInternal *self) {
-    if (!self || self->_handlingUncaughtExceptions) {
-        return false;
+-(BOOL)startHandlingUncaughtExceptions {
+    @synchronized ([ARTRest class]) {
+        if (_handlingUncaughtExceptions || _aRestInstanceIsHandlingUncaughtExceptions) {
+            // startHandlingUncaughtExceptions has either:
+            // 1. already been called for this instance; or
+            // 2. already been called for another instance
+            return false;
+        }
+        _aRestInstanceIsHandlingUncaughtExceptions = YES;
+        _handlingUncaughtExceptions = YES;
+        [ARTSentry setUserInfo:@"reportToAbly" value:[NSNumber numberWithBool:true]];
+        return true;
     }
-    self->_handlingUncaughtExceptions = true;
-    [ARTSentry setUserInfo:@"reportToAbly" value:[NSNumber numberWithBool:true]];
-    return true;
 }
 
-void ARTstopHandlingUncaughtExceptions(ARTRestInternal *self) {
-    if (!self) {
-        return;
+-(void)stopHandlingUncaughtExceptions {
+    @synchronized ([ARTRest class]) {
+        if (!_handlingUncaughtExceptions) {
+            // startHandlingUncaughtExceptions has not been called for this instance
+            return;
+        }
+        _aRestInstanceIsHandlingUncaughtExceptions = NO;
+        _handlingUncaughtExceptions = NO;
+        [ARTSentry setUserInfo:@"reportToAbly" value:[NSNumber numberWithBool:false]];
     }
-    self->_handlingUncaughtExceptions = false;
-    [ARTSentry setUserInfo:@"reportToAbly" value:[NSNumber numberWithBool:false]];
 }
 
 #if TARGET_OS_IOS


### PR DESCRIPTION
Fixes #1030.

I've not been able to reproduce the thread sanitizer data race that the customer has experienced at runtime, so I have taken the approach of inspecting this area of the codebase and improving what I see while trying to keep the scope of change as minimal as possible.

The diff's a bit messier than I would have liked as I've also fixed some indentation and thrown in some `const`s. There's a little bit more detail in my commit messages, in particular https://github.com/ably/ably-cocoa/commit/471cce18a4b4bee35184f4ae0e498d9f5c1ec6cc.

Meanwhile I would like to invite @SlaunchaMan to try directly from this branch to see if it solves the issue, assuming it is regularly reproducible! Jeff, could you please rebuild using this Cocoapods directive instead of the one you currently have for bringing Ably in to your project and let us know if that passes the gaze of the thread sanitizer in your context?:

```
pod 'Ably', :git => 'https://github.com/ably/ably-cocoa.git', :branch => 'feature/1030-data-race'
```

Thanks all! 😁 