### PR TITLE
Fixes 40012 "Malformed message; invalid clientId" when message has no clientId and credentials can assume any clientId

### DIFF
--- a/Source/ARTHttp.m
+++ b/Source/ARTHttp.m
@@ -47,14 +47,22 @@ Class configuredUrlSessionClass = nil;
 }
 
 - (NSObject<ARTCancellable> *)executeRequest:(NSMutableURLRequest *)request completion:(void (^)(NSHTTPURLResponse *_Nullable, NSData *_Nullable, NSError *_Nullable))callback {
-    [self.logger debug:@"--> %@ %@\n  Body: %@\n  Headers: %@", request.HTTPMethod, request.URL.absoluteString, [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding], request.allHTTPHeaderFields];
+    NSString *requestBodyStr = [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding];
+    if (!requestBodyStr) {
+        requestBodyStr = [request.HTTPBody base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithCarriageReturn];
+    }
+    [self.logger debug:@"--> %@ %@\n  Body: %@\n  Headers: %@", request.HTTPMethod, request.URL.absoluteString, requestBodyStr, request.allHTTPHeaderFields];
 
     return [_urlSession get:request completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
         if (error) {
             [self.logger error:@"<-- %@ %@: error %@", request.HTTPMethod, request.URL.absoluteString, error];
         } else {
-            [self.logger debug:@"<-- %@ %@: statusCode %ld\n  Data: %@\n  Headers: %@\n", request.HTTPMethod, request.URL.absoluteString, (long)httpResponse.statusCode, [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding], httpResponse.allHeaderFields];
+            NSString *responseDataStr = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+            if (!responseDataStr) {
+                responseDataStr = [data base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithCarriageReturn];
+            }
+            [self.logger debug:@"<-- %@ %@: statusCode %ld\n  Data: %@\n  Headers: %@\n", request.HTTPMethod, request.URL.absoluteString, (long)httpResponse.statusCode, responseDataStr, httpResponse.allHeaderFields];
             NSString *headerErrorMessage = httpResponse.allHeaderFields[ARTHttpHeaderFieldErrorMessageKey];
             if (headerErrorMessage && ![headerErrorMessage isEqualToString:@""]) {
                 [self.logger warn:@"%@", headerErrorMessage];

--- a/Source/ARTRestChannel.m
+++ b/Source/ARTRestChannel.m
@@ -247,9 +247,6 @@ dispatch_async(_queue, ^{
             callback([ARTErrorInfo createWithCode:ARTStateMismatchedClientId message:@"attempted to publish message with an invalid clientId"]);
             return;
         }
-        else {
-            message.clientId = self.rest.auth.clientId_nosync;
-        }
 
         NSError *encodeError = nil;
         encodedMessage = [self.rest.defaultEncoder encodeMessage:message error:&encodeError];

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -1103,7 +1103,7 @@ class Auth : QuickSpec {
             
             // RSA7
             context("clientId and authenticated clients") {
-                // RAS7a1
+                // RSA7a1
                 it("should use assigned clientId on all operations") {
                     let expectedClientId = "client_string"
                     let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
@@ -1124,16 +1124,21 @@ class Auth : QuickSpec {
                     
                     switch extractBodyAsMsgPack(testHTTPExecutor.requests.last) {
                     case .failure(let error):
-              XCTFail(error)
+                        XCTFail(error)
                     case .success(let httpBody):
-                        guard let requestedClientId = httpBody.unbox["clientId"] as? String else { XCTFail("No clientId field in .tTPBody"); return }
+                        guard
+                            let requestedClientId = httpBody.unbox["clientId"] as? String
+                        else {
+                            XCTFail("No clientId field in HTTPBody")
+                            return
+                        }
                         expect(requestedClientId).to(equal(expectedClientId))
                     }
                     
-                    // .oDO: add more operations
+                    // TODO: add more operations
                 }
                 
-                // .sA7a2
+                // RSA7a2
                 it("should obtain a token if clientId is assigned") {
                     let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
                     options.clientId = "client_string"

--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -320,7 +320,7 @@ class RestClientChannel: QuickSpec {
             }
 
             // https://github.com/ably/ably-cocoa/issues/1074 and related with RSL1m
-            fit("should not fail sending a message with no clientId in the client options and credentials that can assume any clientId") {
+            it("should not fail sending a message with no clientId in the client options and credentials that can assume any clientId") {
                 let options = AblyTests.clientOptions()
                 options.authCallback = { _, callback in
                     getTestTokenDetails(clientId: "*") { token, error in

--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -319,6 +319,34 @@ class RestClientChannel: QuickSpec {
 
             }
 
+            // https://github.com/ably/ably-cocoa/issues/1074 and related with RSL1m
+            fit("should not fail sending a message with no clientId in the client options and credentials that can assume any clientId") {
+                let options = AblyTests.clientOptions()
+                options.authCallback = { _, callback in
+                    getTestTokenDetails(clientId: "*") { token, error in
+                        callback(token, error)
+                    }
+                }
+
+                let rest = ARTRest(options: options)
+                let channel = rest.channels.get("#1074")
+
+                waitUntil(timeout: testTimeout) { done in
+                    // The first attempt encodes the message before requesting auth credentials so there's no clientId
+                    channel.publish("first message", data: nil) { error in
+                        expect(error).to(beNil())
+                        done()
+                    }
+                }
+
+                waitUntil(timeout: testTimeout) { done in
+                    channel.publish("second message", data: nil) { error in
+                        expect(error).to(beNil())
+                        done()
+                    }
+                }
+            }
+
             // RSL1h
             it("should provide an optional argument that allows the clientId value to be specified") {
                 let options = AblyTests.commonAppSetup()


### PR DESCRIPTION
#1074