### PR TITLE
Update SocketRocket dependency to 0.5.2-ably-8

### DIFF
--- a/Ably-SoakTest-AppUITests/SoakTestWebSocket.swift
+++ b/Ably-SoakTest-AppUITests/SoakTestWebSocket.swift
@@ -10,7 +10,7 @@ import Ably.Private
 import SocketRocketAblyFork
 
 class SoakTestWebSocket: NSObject, ARTWebSocket {
-    var readyState: SRReadyState
+    var readyState: ARTSRReadyState
     var queue: DispatchQueue!
     var delegate: ARTWebSocketDelegate?
 
@@ -60,7 +60,7 @@ class SoakTestWebSocket: NSObject, ARTWebSocket {
                 }
                 
                 self.doIfStillOpen(afterSecondsBetween: 3.0 ... 300.0) {
-                    let (code, clean) : (SRStatusCode, Bool) = [
+                    let (code, clean) : (ARTSRStatusCode, Bool) = [
                         (.codeAbnormal, false),
                         (.codeNormal, true),
                         (.codeGoingAway, true),

--- a/Ably.podspec
+++ b/Ably.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.source_files      = 'Source/**/*.{h,m,swift}'
   s.private_header_files = 'Source/*+Private.h', 'Source/Private/*.h'
   s.module_map        = 'Source/Ably.modulemap'
-  s.dependency 'SocketRocketAblyFork', '0.5.2-ably-7'
+  s.dependency 'SocketRocketAblyFork', '0.5.2-ably-8'
   s.dependency 'msgpack', '0.3.1'
   s.dependency 'ULID', '1.1.0'
   s.dependency 'AblyDeltaCodec', '1.2.0'

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "ably-forks/SocketRocket" == 0.5.2-ably-7
+github "ably-forks/SocketRocket" == 0.5.2-ably-8
 github "ably/delta-codec-cocoa" == 1.2.0
 github "rvi/msgpack-objective-C" == 0.3.1
 github "whitesmith/ulid" == 1.1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,7 +1,7 @@
 github "Quick/Nimble" "v9.0.0"
 github "Quick/Quick" "v3.0.0"
 github "SwiftyJSON/SwiftyJSON" "4.3.0"
-github "ably-forks/SocketRocket" "0.5.2-ably-7"
+github "ably-forks/SocketRocket" "0.5.2-ably-8"
 github "ably/delta-codec-cocoa" "1.2.0"
 github "rvi/msgpack-objective-C" "0.3.1"
 github "whitesmith/Aspects" "1.4.2-ws1"

--- a/Source/ARTWebSocket.h
+++ b/Source/ARTWebSocket.h
@@ -15,12 +15,12 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol ARTWebSocketDelegate;
 
 /**
- This protocol has the subset of SRWebSocket we actually use.
+ This protocol has the subset of ARTSRWebSocket we actually use.
  */
 @protocol ARTWebSocket <NSObject>
 
 @property (nonatomic, weak) id <ARTWebSocketDelegate> _Nullable delegate;
-@property (atomic, assign, readonly) SRReadyState readyState;
+@property (atomic, assign, readonly) ARTSRReadyState readyState;
 
 - (instancetype)initWithURLRequest:(NSURLRequest *)request;
 

--- a/Source/ARTWebSocketTransport+Private.h
+++ b/Source/ARTWebSocketTransport+Private.h
@@ -8,7 +8,7 @@
 
 #import <Ably/ARTWebSocketTransport.h>
 #import <Ably/CompatibilityMacros.h>
-#import <SocketRocketAblyFork/SRWebSocket.h>
+#import <SocketRocketAblyFork/ARTSRWebSocket.h>
 #import <Ably/ARTEncoder.h>
 #import <Ably/ARTAuth.h>
 #import <Ably/ARTWebSocket.h>

--- a/Source/ARTWebSocketTransport.m
+++ b/Source/ARTWebSocketTransport.m
@@ -36,9 +36,9 @@ enum {
     ARTWsTlsError = 1015
 };
 
-NSString *WebSocketStateToStr(SRReadyState state);
+NSString *WebSocketStateToStr(ARTSRReadyState state);
 
-@interface SRWebSocket () <ARTWebSocket>
+@interface ARTSRWebSocket () <ARTWebSocket>
 @end
 
 Class configuredWebsocketClass = nil;
@@ -86,7 +86,7 @@ Class configuredWebsocketClass = nil;
 }
 
 - (BOOL)send:(NSData *)data withSource:(id)decodedObject {
-    if (self.websocket.readyState == SR_OPEN) {
+    if (self.websocket.readyState == ARTSR_OPEN) {
         if ([decodedObject isKindOfClass:[ARTProtocolMessage class]]) {
             [_protocolMessagesLogger info:@"send %@", [decodedObject description]];
         }
@@ -203,7 +203,7 @@ Class configuredWebsocketClass = nil;
 
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
 
-    const Class websocketClass = configuredWebsocketClass ? configuredWebsocketClass : [SRWebSocket class];
+    const Class websocketClass = configuredWebsocketClass ? configuredWebsocketClass : [ARTSRWebSocket class];
     self.websocket = [[websocketClass alloc] initWithURLRequest:request];
     [self.websocket setDelegateDispatchQueue:_workQueue];
     self.websocket.delegate = self;
@@ -254,7 +254,7 @@ Class configuredWebsocketClass = nil;
 }
 
 - (ARTRealtimeTransportState)state {
-    if (self.websocket.readyState == SR_OPEN) {
+    if (self.websocket.readyState == ARTSR_OPEN) {
         return ARTRealtimeTransportStateOpened;
     }
     return _state;
@@ -264,7 +264,7 @@ Class configuredWebsocketClass = nil;
     _state = state;
 }
 
-#pragma mark - SRWebSocketDelegate
+#pragma mark - ARTSRWebSocketDelegate
 
 // All delegate methods from SocketRocket are called from rest's serial queue,
 // since we pass it as delegate queue on setupWebSocket. So we can safely
@@ -331,8 +331,8 @@ Class configuredWebsocketClass = nil;
         type = ARTRealtimeTransportErrorTypeHostUnreachable;
     } else if ([error.domain isEqualToString:@"NSPOSIXErrorDomain"] && (error.code == 57 || error.code == 50)) {
         type = ARTRealtimeTransportErrorTypeNoInternet;
-    } else if ([error.domain isEqualToString:SRWebSocketErrorDomain] && error.code == 2132) {
-        id status = error.userInfo[SRHTTPResponseErrorKey];
+    } else if ([error.domain isEqualToString:ARTSRWebSocketErrorDomain] && error.code == 2132) {
+        id status = error.userInfo[ARTSRHTTPResponseErrorKey];
         if (status) {
             return [[ARTRealtimeTransportError alloc] initWithError:error
                                                     badResponseCode:[(NSNumber *)status integerValue]
@@ -346,7 +346,7 @@ Class configuredWebsocketClass = nil;
 - (void)webSocket:(id<ARTWebSocket>)webSocket didReceiveMessage:(id)message {
     [self.logger verbose:__FILE__ line:__LINE__ message:@"R:%p WS:%p websocket did receive message", _delegate, self];
 
-    if (self.websocket.readyState == SR_CLOSED) {
+    if (self.websocket.readyState == ARTSR_CLOSED) {
         [self.logger debug:__FILE__ line:__LINE__ message:@"R:%p WS:%p websocket is closed, message has been ignored", _delegate, self];
         return;
     }
@@ -383,15 +383,15 @@ Class configuredWebsocketClass = nil;
 
 @end
 
-NSString *WebSocketStateToStr(SRReadyState state) {
+NSString *WebSocketStateToStr(ARTSRReadyState state) {
     switch (state) {
-        case SR_CONNECTING:
+        case ARTSR_CONNECTING:
             return @"Connecting"; //0
-        case SR_OPEN:
+        case ARTSR_OPEN:
             return @"Open"; //1
-        case SR_CLOSING:
+        case ARTSR_CLOSING:
             return @"Closing"; //2
-        case SR_CLOSED:
+        case ARTSR_CLOSED:
             return @"Closed"; //3
     }
 }

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -995,7 +995,7 @@ class TestProxyTransport: ARTWebSocketTransport {
 
     private func setupFakeNetworkResponse(_ networkResponse: FakeNetworkResponse) {
         var hook: AspectToken?
-        hook = SRWebSocket.testSuite_replaceClassMethod(#selector(SRWebSocket.open)) {
+        hook = ARTSRWebSocket.testSuite_replaceClassMethod(#selector(ARTSRWebSocket.open)) {
             if TestProxyTransport.fakeNetworkResponse == nil {
                 return
             }


### PR DESCRIPTION
# What's new

This updates the SocketRocket dependency to 0.5.2-ably-8.

# Questions for reviewers

When I run `make test_iOS` with Xcode 12, I get a few test failures:

```
Ably-iOS-Tests:
       Auth.authorize__two_consecutive_authorizations__using_Realtime_and_connection_is_CONNECTING__should_call_each_Realtime_authorize_callback()
       RealtimeClientConnection.Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__and_the_library_does_not_have_a_means_to_renew_the_token_
_the_connection_will_transition_to_the_FAILED_state()
       RealtimeClientPresence.Presence__should_receive_all_250_members()
```

Is this to be expected? I'm a little unsure about what I need to do to validate that my changes haven't broken anything (although, I'd be surprised if they'd introduced any issues other than compilation errors…)