### PR TITLE
Fixed crash by adding a nil-pointer check.

### DIFF
--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -483,7 +483,10 @@ dispatch_async(_queue, ^{
 
     [_internalEventEmitter emit:[ARTEvent newWithConnectionEvent:(ARTRealtimeConnectionEvent)state] with:stateChange];
 
-    [stateChangeEventListener startTimer];
+    // stateChangeEventListener may be nil if we're in a failed state
+    if (stateChangeEventListener != nil) {
+        [stateChangeEventListener startTimer];
+    }
 }
 
 - (void)transitionToDisconnectedOrSuspended {

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -514,7 +514,10 @@ dispatch_async(_queue, ^{
 
     ARTEventListener *stateChangeEventListener = [self transitionSideEffects:stateChange];
 
-    [stateChangeEventListener startTimer];
+    // stateChangeEventListener may be nil if we're in a failed state
+    if (stateChangeEventListener != nil) {
+        [stateChangeEventListener startTimer];
+    }
 }
 
 - (ARTEventListener *)transitionSideEffects:(ARTConnectionStateChange *)stateChange {


### PR DESCRIPTION
Calling `[ARTRealtime transitionSideEffects:]` while in a failed connection state returns a nil reference to `ARTEventListener*`. 

This PR adds a nil-pointer check to avoid a crash, which fixes #1083.