### PR TITLE
Fix of RSH3a2a1 implementation when the clientId doesn't change

### DIFF
--- a/Source/ARTAuth.m
+++ b/Source/ARTAuth.m
@@ -783,14 +783,15 @@ dispatch_sync(_queue, ^{
 
 #if TARGET_OS_IOS
 - (void)setLocalDeviceClientId_nosync:(NSString *)clientId {
-    if (clientId && ![clientId isEqualToString:@"*"]) {
-        [_rest.device_nosync setClientId:clientId];
-        [_rest.push getActivationMachine:^(ARTPushActivationStateMachine *stateMachine) {
-            if (![stateMachine.current_nosync isKindOfClass:[ARTPushActivationStateNotActivated class]]) {
-                [stateMachine sendEvent:[[ARTPushActivationEventGotPushDeviceDetails alloc] init]];
-            }
-        }];
+    if (clientId == nil || [clientId isEqualToString:@"*"] || [clientId isEqualToString:_rest.device_nosync.clientId]) {
+        return;
     }
+    [_rest.device_nosync setClientId:clientId];
+    [_rest.push getActivationMachine:^(ARTPushActivationStateMachine *stateMachine) {
+        if (![stateMachine.current_nosync isKindOfClass:[ARTPushActivationStateNotActivated class]]) {
+            [stateMachine sendEvent:[[ARTPushActivationEventGotPushDeviceDetails alloc] init]];
+        }
+    }];
 }
 #endif
 


### PR DESCRIPTION
Related with https://ably-real-time.slack.com/archives/CSQEKCE81/p1615834853011400 cc @cruickshankpg 