### PR TITLE
Move deviceSecret into ARTLocalDevice

### DIFF
--- a/Source/ARTDeviceDetails.h
+++ b/Source/ARTDeviceDetails.h
@@ -16,12 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ARTDeviceDetails : NSObject
 
 @property (nonatomic) ARTDeviceId *id;
-
-/**
- Device secret generated using random data with sufficient entropy. It's a sha256 digest encoded with base64.
- */
-@property (nullable, nonatomic) ARTDeviceSecret *secret;
-
 @property (nullable, nonatomic) NSString *clientId;
 @property (nonatomic) NSString *platform;
 @property (nonatomic) NSString *formFactor;

--- a/Source/ARTJsonLikeEncoder.m
+++ b/Source/ARTJsonLikeEncoder.m
@@ -641,7 +641,6 @@
     NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
 
     dictionary[@"id"] = deviceDetails.id;
-    dictionary[@"deviceSecret"] = deviceDetails.secret;
     dictionary[@"platform"] = deviceDetails.platform;
     dictionary[@"formFactor"] = deviceDetails.formFactor;
 

--- a/Source/ARTLocalDevice.h
+++ b/Source/ARTLocalDevice.h
@@ -17,6 +17,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nullable, nonatomic, readonly) ARTDeviceIdentityTokenDetails *identityTokenDetails;
 
+/**
+ Device secret generated using random data with sufficient entropy. It's a sha256 digest encoded with base64.
+ */
+@property (nullable, nonatomic) ARTDeviceSecret *secret;
+
 - (instancetype)init NS_UNAVAILABLE;
 
 @end

--- a/Spec/PushAdmin.swift
+++ b/Spec/PushAdmin.swift
@@ -14,7 +14,6 @@ class PushAdmin : QuickSpec {
 
     private static var deviceDetails: ARTDeviceDetails = {
         let deviceDetails = ARTDeviceDetails(id: "testDeviceDetails")
-        deviceDetails.secret = ARTLocalDevice.generateSecret()
         deviceDetails.platform = "ios"
         deviceDetails.formFactor = "phone"
         deviceDetails.metadata = NSMutableDictionary()
@@ -27,7 +26,6 @@ class PushAdmin : QuickSpec {
 
     private static var deviceDetails1ClientA: ARTDeviceDetails = {
         let deviceDetails = ARTDeviceDetails(id: "deviceDetails1ClientA")
-        deviceDetails.secret = ARTLocalDevice.generateSecret()
         deviceDetails.platform = "android"
         deviceDetails.formFactor = "tablet"
         deviceDetails.clientId = "clientA"
@@ -41,7 +39,6 @@ class PushAdmin : QuickSpec {
 
     private static var deviceDetails2ClientA: ARTDeviceDetails = {
         let deviceDetails = ARTDeviceDetails(id: "deviceDetails2ClientA")
-        deviceDetails.secret = ARTLocalDevice.generateSecret()
         deviceDetails.platform = "android"
         deviceDetails.formFactor = "tablet"
         deviceDetails.clientId = "clientA"
@@ -55,7 +52,6 @@ class PushAdmin : QuickSpec {
 
     private static var deviceDetails3ClientB: ARTDeviceDetails = {
         let deviceDetails = ARTDeviceDetails(id: "deviceDetails3ClientB")
-        deviceDetails.secret = ARTLocalDevice.generateSecret()
         deviceDetails.platform = "android"
         deviceDetails.formFactor = "tablet"
         deviceDetails.clientId = "clientB"


### PR DESCRIPTION
The deviceSecret should be in `ARTLocalDevice`, instead of `ARTDeviceDetails`. ARTLocalDevice inherits from ARTDeviceDetails, so not much is changing.

The feature spec was previously inconsistent, and there is a PR to fix this: https://github.com/ably/docs/pull/1141