### PR TITLE
Fix for potentially insecure usage of the NSURLSession API

### DIFF
--- a/SocketRocket/SocketRocket/Internal/Proxy/ARTSRProxyConnect.m
+++ b/SocketRocket/SocketRocket/Internal/Proxy/ARTSRProxyConnect.m
@@ -236,7 +236,13 @@
     }
     __weak typeof(self) wself = self;
     NSURLRequest *request = [NSURLRequest requestWithURL:PACurl];
-    NSURLSession *session = [NSURLSession sharedSession];
+    NSURLSessionConfiguration *config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+    if (@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)) {
+        config.TLSMinimumSupportedProtocolVersion = tls_protocol_version_TLSv12;
+    } else {
+        config.TLSMinimumSupportedProtocol = kTLSProtocol12;
+    }
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:config delegate:nil delegateQueue:nil];
     [[session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         __strong typeof(wself) sself = wself;
         if (!error) {


### PR DESCRIPTION
This finally fixes SocketRocket portion of NSURLSession API insecure usage, which was originally fixed here https://github.com/ably-forks/SocketRocket/issues/7, but then messed up with https://github.com/ably/ably-cocoa/pull/1090