### PR TITLE
Replaced bundleVersion to hardcoded ARTDefault_version

### DIFF
--- a/Source/ARTDefault.m
+++ b/Source/ARTDefault.m
@@ -181,7 +181,7 @@ static NSInteger _maxMessageSize = 65536;
 }
 
 + (NSString *)libraryAgent {
-    NSMutableString *agent = [NSMutableString stringWithFormat:@"%@/%@", ARTDefault_libraryName, [self bundleVersion]];
+    NSMutableString *agent = [NSMutableString stringWithFormat:@"%@/%@", ARTDefault_libraryName, ARTDefault_version];
     return agent;
 }
 


### PR DESCRIPTION
`[ARTDefault bundleVersion]` always used `CFBundleShortVersionString` for the version string, so when the framework is embed into the main executable, it takes main bundle version which is app version which is wrong. So I've replaced it with hardcoded version string. Bingo.