### PR TITLE
Make sure we all use the same version of Fastlane

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -55,7 +55,7 @@ jobs:
           make update_carthage_dependencies
 
       - name: Run Tests
-        run: fastlane ${{ matrix.lane }}
+        run: bundle exec fastlane ${{ matrix.lane }}
       
       # This is the script specified as the pod’s prepare_command in its Podspec.
       # It would be run automatically for a normal CocoaPods install, but it doesn’t

--- a/Makefile
+++ b/Makefile
@@ -67,15 +67,15 @@ submodules:
 
 ## [Tests] Run tests on iOS 12 using sandbox environment
 test_iOS:
-	ABLY_ENV="sandbox" NAME="ably-iOS" fastlane test_iOS12
+	ABLY_ENV="sandbox" NAME="ably-iOS" bundle exec fastlane test_iOS12
 
 ## [Tests] Run tests on tvOS 12 using sandbox environment
 test_tvOS:
-	ABLY_ENV="sandbox" NAME="ably-tvOS" fastlane test_tvOS12
+	ABLY_ENV="sandbox" NAME="ably-tvOS" bundle exec fastlane test_tvOS12
 
 ## [Tests] Run tests on macOS using sandbox environment
 test_macOS:
-	ABLY_ENV="sandbox" NAME="ably-macOS" fastlane test_macOS
+	ABLY_ENV="sandbox" NAME="ably-macOS" bundle exec fastlane test_macOS
 
 ## -- CocoaPods --
 

--- a/README.md
+++ b/README.md
@@ -715,7 +715,8 @@ You can also view the [community reported Github issues](https://github.com/ably
 In this repository the `main` branch contains the latest development version of the Ably SDK. All development (bug fixing, feature implementation, etc.) is done against the `main` branch, which you should branch from whenever you'd like to make modifications. Here's the steps to follow when contributing to this repository.
 
  - Fork it
- - Install carthage: `brew install carthage`
+ - Install Carthage: `brew install carthage`
+ - Install gems: `bundle install`
  - Setup or update your machine by running `make update`
  - Create your feature branch from `main` (`git checkout main && git checkout -b my-new-feature-branch`)
  - Commit your changes (`git commit -am 'Add some feature'`)
@@ -739,11 +740,9 @@ from the command line and then do a clean rebuild in Xcode.
 Changes made to dependencies in the [Cartfile](Cartfile) need to be reflected in
 [Ably.podspec](Ably.podspec) and vice-versa.
 
-## Running tests
+### Running tests
 
 To run tests use `make test_[iOS|tvOS|macOS]`.
-
-Note: [Fastlane](https://fastlane.tools) should be installed.
 
 ## Release Process
 


### PR DESCRIPTION
Switch to using `bundle exec` to run Fastlane. This means that the version of Fastlane used will always be the one specified in `Gemfile.lock`. This removes a potential inconsistency between different developers’ machines, and also between developers’ machines and CI.