### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @maratal @ben-xD @lukasz-szyszkowski @QuintinWillison @lawrence-forooghian


### PR DESCRIPTION
GitHub will automatically add the users listed here as reviewers on all pull requests in this repo. I think it’ll be helpful for contributors opening pull requests for the first time.

This list is the core development team for the repo; we can still add additional reviewers on an ad-hoc basis.

This is a quick example so we can test its utility. If we want to keep it, we might instead want to use a single codeowner which is a GitHub team.