### PR TITLE
Fix/1188 Added allowed class for NSKeyedUnarchiver

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		56190954238C3D3200A862A6 /* CryptoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 56190953238C3D3200A862A6 /* CryptoTest.m */; };
 		56190955238C3D3200A862A6 /* CryptoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 56190953238C3D3200A862A6 /* CryptoTest.m */; };
 		56190956238C3D3200A862A6 /* CryptoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 56190953238C3D3200A862A6 /* CryptoTest.m */; };
+		841134782722205400CFA837 /* ARTArchiveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 841134772722205400CFA837 /* ARTArchiveTests.m */; };
 		8412FDE72661AC37001FE9E6 /* AblyDeltaCodec.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDE12661AC37001FE9E6 /* AblyDeltaCodec.xcframework */; };
 		8412FDED2661AC37001FE9E6 /* msgpack.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDE32661AC37001FE9E6 /* msgpack.xcframework */; };
 		8412FDF52661AC7B001FE9E6 /* Aspects.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF12661AC7A001FE9E6 /* Aspects.xcframework */; };
@@ -1005,6 +1006,7 @@
 		217D182025421FED00DFF07E /* ARTSRSecurityPolicy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARTSRSecurityPolicy.h; sourceTree = "<group>"; };
 		560579D824AF1BA900A4D03D /* ARTDefaultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARTDefaultTests.swift; sourceTree = "<group>"; };
 		56190953238C3D3200A862A6 /* CryptoTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CryptoTest.m; sourceTree = "<group>"; };
+		841134772722205400CFA837 /* ARTArchiveTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTArchiveTests.m; sourceTree = "<group>"; };
 		8412FDE12661AC37001FE9E6 /* AblyDeltaCodec.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = AblyDeltaCodec.xcframework; path = Carthage/Build/AblyDeltaCodec.xcframework; sourceTree = "<group>"; };
 		8412FDE32661AC37001FE9E6 /* msgpack.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = msgpack.xcframework; path = Carthage/Build/msgpack.xcframework; sourceTree = "<group>"; };
 		8412FDF12661AC7A001FE9E6 /* Aspects.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Aspects.xcframework; path = Carthage/Build/Aspects.xcframework; sourceTree = "<group>"; };
@@ -1471,6 +1473,7 @@
 				856AAC9A1B6E326E00B07119 /* ably-common */,
 				856AAC951B6E30C800B07119 /* AblySpec-Bridging-Header.h */,
 				D780846C1C68B3E50083009D /* NSObject+TestSuite.h */,
+				841134772722205400CFA837 /* ARTArchiveTests.m */,
 				56190953238C3D3200A862A6 /* CryptoTest.m */,
 				848ED97226E50D0F0087E800 /* ObjcppTest.mm */,
 				D780846D1C68B3E50083009D /* NSObject+TestSuite.m */,
@@ -2641,6 +2644,7 @@
 				D798554823EB96C000946BE2 /* DeltaCodec.swift in Sources */,
 				D74CBC0B212EC22800D090E4 /* RestPaginated.swift in Sources */,
 				D72304701BB72CED00F1ABDA /* RealtimeClient.swift in Sources */,
+				841134782722205400CFA837 /* ARTArchiveTests.m in Sources */,
 				D74A17B81FA0D9A3006D27B5 /* PushAdmin.swift in Sources */,
 				EB7913A81C6E54C3000ABF9B /* Crypto.swift in Sources */,
 				D777EEE820650ADF002EBA03 /* PushChannel.swift in Sources */,

--- a/Source/ARTDeviceIdentityTokenDetails.m
+++ b/Source/ARTDeviceIdentityTokenDetails.m
@@ -69,7 +69,7 @@ NSString *const ARTCoderClientIdKey = @"clientId";
 }
 
 + (ARTDeviceIdentityTokenDetails *)unarchive:(NSData *)data {
-    return [NSObject art_unarchiveWithAllowedClass:[self class] fromData:data];
+    return [[self class] art_unarchiveFromData:data];
 }
 
 @end

--- a/Source/ARTDeviceIdentityTokenDetails.m
+++ b/Source/ARTDeviceIdentityTokenDetails.m
@@ -69,7 +69,7 @@ NSString *const ARTCoderClientIdKey = @"clientId";
 }
 
 + (ARTDeviceIdentityTokenDetails *)unarchive:(NSData *)data {
-    return [[self class] art_unarchiveFromData:data];
+    return [self art_unarchiveFromData:data];
 }
 
 @end

--- a/Source/ARTDeviceIdentityTokenDetails.m
+++ b/Source/ARTDeviceIdentityTokenDetails.m
@@ -69,7 +69,7 @@ NSString *const ARTCoderClientIdKey = @"clientId";
 }
 
 + (ARTDeviceIdentityTokenDetails *)unarchive:(NSData *)data {
-    return [NSObject art_unarchive:data];
+    return [NSObject art_unarchiveWithAllowedClass:[self class] fromData:data];
 }
 
 @end

--- a/Source/ARTPushActivationEvent.m
+++ b/Source/ARTPushActivationEvent.m
@@ -36,7 +36,7 @@ NSString *const ARTCoderIdentityTokenDetailsKey = @"identityTokenDetails";
 }
 
 + (ARTPushActivationEvent *)unarchive:(NSData *)data {
-    return [NSObject art_unarchive:data];
+    return [NSObject art_unarchiveWithAllowedClass:[self class] fromData:data];
 }
 
 @end

--- a/Source/ARTPushActivationEvent.m
+++ b/Source/ARTPushActivationEvent.m
@@ -36,7 +36,7 @@ NSString *const ARTCoderIdentityTokenDetailsKey = @"identityTokenDetails";
 }
 
 + (ARTPushActivationEvent *)unarchive:(NSData *)data {
-    return [[self class] art_unarchiveFromData:data];
+    return [self art_unarchiveFromData:data];
 }
 
 @end

--- a/Source/ARTPushActivationEvent.m
+++ b/Source/ARTPushActivationEvent.m
@@ -36,7 +36,7 @@ NSString *const ARTCoderIdentityTokenDetailsKey = @"identityTokenDetails";
 }
 
 + (ARTPushActivationEvent *)unarchive:(NSData *)data {
-    return [NSObject art_unarchiveWithAllowedClass:[self class] fromData:data];
+    return [[self class] art_unarchiveFromData:data];
 }
 
 @end

--- a/Source/ARTPushActivationState.m
+++ b/Source/ARTPushActivationState.m
@@ -60,7 +60,7 @@
 }
 
 + (ARTPushActivationState *)unarchive:(NSData *)data {
-    return [NSObject art_unarchive:data];
+    return [NSObject art_unarchiveWithAllowedClass:[self class] fromData:data];
 }
 
 @end

--- a/Source/ARTPushActivationState.m
+++ b/Source/ARTPushActivationState.m
@@ -60,7 +60,7 @@
 }
 
 + (ARTPushActivationState *)unarchive:(NSData *)data {
-    return [[self class] art_unarchiveFromData:data];
+    return [self art_unarchiveFromData:data];
 }
 
 @end

--- a/Source/ARTPushActivationState.m
+++ b/Source/ARTPushActivationState.m
@@ -60,7 +60,7 @@
 }
 
 + (ARTPushActivationState *)unarchive:(NSData *)data {
-    return [NSObject art_unarchiveWithAllowedClass:[self class] fromData:data];
+    return [[self class] art_unarchiveFromData:data];
 }
 
 @end

--- a/Source/ARTPushActivationStateMachine.m
+++ b/Source/ARTPushActivationStateMachine.m
@@ -35,7 +35,7 @@ NSString *const ARTPushActivationPendingEventsKey = @"ARTPushActivationPendingEv
         _userQueue = _rest.userQueue;
         // Unarchiving
         NSData *stateData = [rest.storage objectForKey:ARTPushActivationCurrentStateKey];
-        _current = [NSObject art_unarchive:stateData];
+        _current = [NSObject art_unarchiveWithAllowedClass:[ARTPushActivationState class] fromData:stateData];
         if (!_current) {
             _current = [[ARTPushActivationStateNotActivated alloc] initWithMachine:self];
         } else {
@@ -45,7 +45,7 @@ NSString *const ARTPushActivationPendingEventsKey = @"ARTPushActivationPendingEv
             _current.machine = self;
         }
         NSData *pendingEventsData = [rest.storage objectForKey:ARTPushActivationPendingEventsKey];
-        _pendingEvents = [NSObject art_unarchive:pendingEventsData];
+        _pendingEvents = [NSObject art_unarchiveWithAllowedClass:[ARTPushActivationEvent class] fromData:pendingEventsData];
         if (!_pendingEvents) {
             _pendingEvents = [NSMutableArray array];
         }

--- a/Source/ARTPushActivationStateMachine.m
+++ b/Source/ARTPushActivationStateMachine.m
@@ -35,7 +35,7 @@ NSString *const ARTPushActivationPendingEventsKey = @"ARTPushActivationPendingEv
         _userQueue = _rest.userQueue;
         // Unarchiving
         NSData *stateData = [rest.storage objectForKey:ARTPushActivationCurrentStateKey];
-        _current = [NSObject art_unarchiveWithAllowedClass:[ARTPushActivationState class] fromData:stateData];
+        _current = [ARTPushActivationState art_unarchiveFromData:stateData];
         if (!_current) {
             _current = [[ARTPushActivationStateNotActivated alloc] initWithMachine:self];
         } else {
@@ -45,7 +45,7 @@ NSString *const ARTPushActivationPendingEventsKey = @"ARTPushActivationPendingEv
             _current.machine = self;
         }
         NSData *pendingEventsData = [rest.storage objectForKey:ARTPushActivationPendingEventsKey];
-        _pendingEvents = [NSObject art_unarchiveWithAllowedClass:[ARTPushActivationEvent class] fromData:pendingEventsData];
+        _pendingEvents = [ARTPushActivationEvent art_unarchiveFromData:pendingEventsData];
         if (!_pendingEvents) {
             _pendingEvents = [NSMutableArray array];
         }

--- a/Source/ARTTypes.h
+++ b/Source/ARTTypes.h
@@ -241,7 +241,7 @@ NSString *generateNonce(void);
 
 @interface NSObject (ARTArchive)
 - (nullable NSData *)art_archive;
-+ (nullable id)art_unarchive:(NSData *)data;
++ (nullable id)art_unarchiveWithAllowedClass:(Class)cls fromData:(NSData *)data;
 @end
 
 @interface NSURLSessionTask (ARTCancellable) <ARTCancellable>

--- a/Source/ARTTypes.h
+++ b/Source/ARTTypes.h
@@ -241,7 +241,7 @@ NSString *generateNonce(void);
 
 @interface NSObject (ARTArchive)
 - (nullable NSData *)art_archive;
-+ (nullable id)art_unarchiveWithAllowedClass:(Class)cls fromData:(NSData *)data;
++ (nullable id)art_unarchiveFromData:(NSData *)data;
 @end
 
 @interface NSURLSessionTask (ARTCancellable) <ARTCancellable>

--- a/Source/ARTTypes.m
+++ b/Source/ARTTypes.m
@@ -388,7 +388,7 @@ NSString *ARTChannelEventToStr(ARTChannelEvent event) {
 }
 
 + (nullable id)art_unarchiveFromData:(NSData *)data {
-    NSSet* allowedTypes = [NSSet setWithArray:@[ [NSArray class], [NSDictionary class], [self class]]];
+    NSSet* allowedTypes = [NSSet setWithArray:@[ [NSArray class], [NSDictionary class], self]];
 #if TARGET_OS_MACCATALYST
     NSError *error;
     id result = [NSKeyedUnarchiver unarchivedObjectOfClasses:allowedTypes fromData:data error:&error];
@@ -401,7 +401,7 @@ NSString *ARTChannelEventToStr(ARTChannelEvent event) {
         NSError *error;
         id result = [NSKeyedUnarchiver unarchivedObjectOfClasses:allowedTypes fromData:data error:&error];
         if (error) {
-            NSLog(@"%@ unarchive failed: %@", [self class], error);
+            NSLog(@"%@ unarchive failed: %@", self, error);
         }
         return result;
     }

--- a/Source/ARTTypes.m
+++ b/Source/ARTTypes.m
@@ -387,20 +387,25 @@ NSString *ARTChannelEventToStr(ARTChannelEvent event) {
 #endif
 }
 
-+ (nullable id)art_unarchive:(NSData *)data {
++ (nullable id)art_unarchiveWithAllowedClass:(Class)cls fromData:(NSData *)data {
+    if (data == nil) {
+        NSLog(@"%@ unarchive abortion due to data is NULL", cls);
+        return nil;
+    }
+    NSSet* allowedTypes = [NSSet setWithArray:@[ [NSArray class], [NSDictionary class], cls]];
 #if TARGET_OS_MACCATALYST
     NSError *error;
-    id result = [NSKeyedUnarchiver unarchivedObjectOfClass:[self class] fromData:data error:&error];
+    id result = [NSKeyedUnarchiver unarchivedObjectOfClasses:allowedTypes fromData:data error:&error];
     if (error) {
-        NSLog(@"ARTDeviceIdentityTokenDetails Unarchive failed: %@", error);
+        NSLog(@"%@ unarchive failed: %@", cls, error);
     }
     return result;
 #else
     if (@available(macOS 10.13, iOS 11, tvOS 11, *)) {
         NSError *error;
-        id result = [NSKeyedUnarchiver unarchivedObjectOfClass:[self class] fromData:data error:&error];
+        id result = [NSKeyedUnarchiver unarchivedObjectOfClasses:allowedTypes fromData:data error:&error];
         if (error) {
-            NSLog(@"ARTDeviceIdentityTokenDetails Unarchive failed: %@", error);
+            NSLog(@"%@ unarchive failed: %@", cls, error);
         }
         return result;
     }

--- a/Source/ARTTypes.m
+++ b/Source/ARTTypes.m
@@ -393,7 +393,7 @@ NSString *ARTChannelEventToStr(ARTChannelEvent event) {
     NSError *error;
     id result = [NSKeyedUnarchiver unarchivedObjectOfClasses:allowedTypes fromData:data error:&error];
     if (error) {
-        NSLog(@"%@ unarchive failed: %@", cls, error);
+        NSLog(@"%@ unarchive failed: %@", self, error);
     }
     return result;
 #else

--- a/Source/ARTTypes.m
+++ b/Source/ARTTypes.m
@@ -388,10 +388,6 @@ NSString *ARTChannelEventToStr(ARTChannelEvent event) {
 }
 
 + (nullable id)art_unarchiveWithAllowedClass:(Class)cls fromData:(NSData *)data {
-    if (data == nil) {
-        NSLog(@"%@ unarchive abortion due to data is NULL", cls);
-        return nil;
-    }
     NSSet* allowedTypes = [NSSet setWithArray:@[ [NSArray class], [NSDictionary class], cls]];
 #if TARGET_OS_MACCATALYST
     NSError *error;

--- a/Source/ARTTypes.m
+++ b/Source/ARTTypes.m
@@ -387,8 +387,8 @@ NSString *ARTChannelEventToStr(ARTChannelEvent event) {
 #endif
 }
 
-+ (nullable id)art_unarchiveWithAllowedClass:(Class)cls fromData:(NSData *)data {
-    NSSet* allowedTypes = [NSSet setWithArray:@[ [NSArray class], [NSDictionary class], cls]];
++ (nullable id)art_unarchiveFromData:(NSData *)data {
+    NSSet* allowedTypes = [NSSet setWithArray:@[ [NSArray class], [NSDictionary class], [self class]]];
 #if TARGET_OS_MACCATALYST
     NSError *error;
     id result = [NSKeyedUnarchiver unarchivedObjectOfClasses:allowedTypes fromData:data error:&error];
@@ -401,7 +401,7 @@ NSString *ARTChannelEventToStr(ARTChannelEvent event) {
         NSError *error;
         id result = [NSKeyedUnarchiver unarchivedObjectOfClasses:allowedTypes fromData:data error:&error];
         if (error) {
-            NSLog(@"%@ unarchive failed: %@", cls, error);
+            NSLog(@"%@ unarchive failed: %@", [self class], error);
         }
         return result;
     }

--- a/Source/ARTTypes.m
+++ b/Source/ARTTypes.m
@@ -369,7 +369,7 @@ NSString *ARTChannelEventToStr(ARTChannelEvent event) {
     NSError *error;
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self requiringSecureCoding:false error:&error];
     if (error) {
-        NSLog(@"ARTDeviceIdentityTokenDetails Archive failed: %@", error);
+        NSLog(@"%@ archive failed: %@", [self class], error);
     }
     return data;
 #else
@@ -377,7 +377,7 @@ NSString *ARTChannelEventToStr(ARTChannelEvent event) {
         NSError *error;
         NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self requiringSecureCoding:false error:&error];
         if (error) {
-            NSLog(@"ARTDeviceIdentityTokenDetails Archive failed: %@", error);
+            NSLog(@"%@ archive failed: %@", [self class], error);
         }
         return data;
     }

--- a/Spec/ARTArchiveTests.m
+++ b/Spec/ARTArchiveTests.m
@@ -1,0 +1,37 @@
+@import XCTest;
+#import <Ably/Ably.h>
+
+@interface _StateMachineDelegate : NSObject <ARTPushRegistererDelegate>
+@end
+
+@implementation _StateMachineDelegate
+- (void)didActivateAblyPush:(nullable ARTErrorInfo *)error { }
+- (void)didDeactivateAblyPush:(nullable ARTErrorInfo *)error { }
+@end
+
+@interface ARTArchiveTests : XCTestCase
+@end
+
+@implementation ARTArchiveTests
+    
+- (void)test_art_unarchivedObjectOfClass_for_state_machine_states {
+    
+    ARTRest* rest = [[ARTRest alloc] initWithKey:@"xxxx:xxxx"];
+    ARTPushActivationStateMachine* stateMachine = [[ARTPushActivationStateMachine alloc] initWithRest:rest.internal delegate:[[_StateMachineDelegate alloc] init]];
+    
+    NSArray* initialStates = [NSMutableArray arrayWithArray:@[
+        [[ARTPushActivationStateNotActivated alloc] initWithMachine:stateMachine],
+        [[ARTPushActivationStateWaitingForPushDeviceDetails alloc] initWithMachine:stateMachine],
+        [[ARTPushActivationStateAfterRegistrationSyncFailed alloc] initWithMachine:stateMachine]
+    ]];
+    
+    NSData* data = [initialStates art_archive];
+    
+    NSArray* unarchivedStates = [NSObject art_unarchiveWithAllowedClass:[ARTPushActivationState class] fromData:data];
+    
+    XCTAssert([unarchivedStates[0] isKindOfClass:[ARTPushActivationStateNotActivated class]]);
+    XCTAssert([unarchivedStates[1] isKindOfClass:[ARTPushActivationStateWaitingForPushDeviceDetails class]]);
+    XCTAssert([unarchivedStates[2] isKindOfClass:[ARTPushActivationStateAfterRegistrationSyncFailed class]]);
+}
+
+@end

--- a/Spec/ARTArchiveTests.m
+++ b/Spec/ARTArchiveTests.m
@@ -13,7 +13,7 @@
 @end
 
 @implementation ARTArchiveTests
-    
+
 - (void)test_art_unarchivedObjectOfClass_for_state_machine_states {
     
     ARTRest* rest = [[ARTRest alloc] initWithKey:@"xxxx:xxxx"];
@@ -27,7 +27,7 @@
     
     NSData* data = [initialStates art_archive];
     
-    NSArray* unarchivedStates = [NSObject art_unarchiveWithAllowedClass:[ARTPushActivationState class] fromData:data];
+    NSArray* unarchivedStates = [ARTPushActivationState art_unarchiveFromData:data];
     
     XCTAssert([unarchivedStates[0] isKindOfClass:[ARTPushActivationStateNotActivated class]]);
     XCTAssert([unarchivedStates[1] isKindOfClass:[ARTPushActivationStateWaitingForPushDeviceDetails class]]);


### PR DESCRIPTION
`NSKeyedUnarchiver` becomes more tricky with new version of iOS SDK. So it took a little while to figure out how to use it properly. With iOS 11 it is not happy if you indirectly allow to parse any type within an archive, so now it requires to provide allowed classes list. So I did.

Also I've provided dedicated test for unarchiving function specifically in Objective-C so Swift wouldn't interfere with its under the hood collection types conversions.