### PR TITLE
Removed optional base64 auth header

### DIFF
--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -482,9 +482,8 @@
 }
 
 - (NSString *)prepareTokenAuthorisationHeader:(NSString *)token {
-    NSData *tokenData = [token dataUsingEncoding:NSUTF8StringEncoding];
-    NSString *tokenBase64 = [tokenData base64EncodedStringWithOptions:0];
-    return [NSString stringWithFormat:@"Bearer %@", tokenBase64];
+    // RSA3b: For REST requests, the token string is *optionally* Base64-encoded
+    return [NSString stringWithFormat:@"Bearer %@", token];
 }
 
 - (void)time:(ARTDateTimeCallback)callback {

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -135,7 +135,7 @@ class Auth : QuickSpec {
                         return
                     }
 
-                    let expectedAuthorization = "Bearer \(encodeBase64(currentToken))"
+                    let expectedAuthorization = "Bearer \(currentToken)"
                     
                     guard let request = testHTTPExecutor.requests.first else {
                         fail("No request found")


### PR DESCRIPTION
For Basic Auth:
[RSA11](https://docs.ably.io/client-lib-development-guide/features/#RSA11)

For REST requests:
[RSA3b](https://docs.ably.io/client-lib-development-guide/features/#RSA3b)