### PR TITLE
Example app: Use relative path of Ably Cocoa

### DIFF
--- a/Examples/SPM/Package.resolved
+++ b/Examples/SPM/Package.resolved
@@ -2,21 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "ably-cocoa",
-        "repositoryURL": "/Users/lukaszszyszkowski/@projekty_ios/ably-cocoa",
-        "state": {
-          "branch": null,
-          "revision": "23433617838d34ef8d963883b12c8a77f1a1b4bb",
-          "version": null
-        }
-      },
-      {
         "package": "AblyDeltaCodec",
         "repositoryURL": "https://github.com/ably/delta-codec-cocoa",
         "state": {
-          "branch": "main",
-          "revision": "d09d34a5489665a3c924a95791ce0a97ef26cc99",
-          "version": null
+          "branch": null,
+          "revision": "d3c6972b4e10ddd9bea1d26d2c1778c5cd3d0bac",
+          "version": "1.3.2"
         }
       },
       {

--- a/Examples/SPM/Package.swift
+++ b/Examples/SPM/Package.swift
@@ -4,24 +4,6 @@
 import PackageDescription
 import Darwin.C
 
-// Setup ENV variables when using with Xcode IDE
-//
-//setenv("PACKAGE_URL", "", 1)
-//setenv("PACKAGE_REVISION", "", 1)
-
-func env(_ name: String) -> String? {
-    if let envPointer = getenv(name) {
-        return String(cString: envPointer)
-    } else {
-        print("Can't find environment \(name)")
-        return nil
-    }
-}
-
-guard let packageURL = env("PACKAGE_URL"), let revision = env("PACKAGE_REVISION") else {
-    exit(0)
-}
-
 let package = Package(
     name: "SPMIntegration",
     platforms: [
@@ -29,7 +11,7 @@ let package = Package(
         .macOS(.v10_11)
     ],
     dependencies: [
-        .package(name:"ably-cocoa", url: packageURL, .revision(revision))
+        .package(path: "../../")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Our example app currently uses an environment variable to find the SDK (Ably Cocoa). It's simpler to use a relative path, resulting in smaller `Package.swift` and `Package.resolved` files.

You may notice that this example app uses AblyDeltaCodec v1.3.2. Even though Ably Cocoa has not been released to use AblyDeltaCodec, `1.3.2` this example app uses it because Ably Cocoa only specifies a **minimum** version of AblyDeltaCodec.