### PR TITLE
[Groundwork for #1201] Unroll test-defining loops in test files into `reusableTests` function calls

### DIFF
--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -3942,58 +3942,53 @@ class Auth : QuickSpec {
         describe("TokenRequest") {
             // TE6
             describe("fromJson") {
-                let cases = [
-                    "with TTL": (
-                        "{" +
-                        "    \"clientId\":\"myClientId\"," +
-                        "    \"mac\":\"4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4=\"," +
-                        "    \"capability\":\"{\\\"test\\\":[\\\"publish\\\"]}\"," +
-                        "    \"ttl\":42000," +
-                        "    \"timestamp\":1479087321934," +
-                        "    \"keyName\":\"xxxxxx.yyyyyy\"," +
-                        "    \"nonce\":\"7830658976108826\"" +
-                        "}",
-                        { (_ request: ARTTokenRequest) in
-                            expect(request.clientId).to(equal("myClientId"))
-                            expect(request.mac).to(equal("4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4="))
-                            expect(request.capability).to(equal("{\"test\":[\"publish\"]}"))
-                            expect(request.ttl as? TimeInterval).to(equal(TimeInterval(42)))
-                            expect(request.timestamp).to(equal(Date(timeIntervalSince1970: 1479087321.934)))
-                            expect(request.keyName).to(equal("xxxxxx.yyyyyy"))
-                            expect(request.nonce).to(equal("7830658976108826"))
-                        }
-                    ),
-                    "without TTL": (
-                        "{" +
-                        "    \"mac\":\"4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4=\"," +
-                        "    \"capability\":\"{\\\"test\\\":[\\\"publish\\\"]}\"," +
-                        "    \"timestamp\":1479087321934," +
-                        "    \"keyName\":\"xxxxxx.yyyyyy\"," +
-                        "    \"nonce\":\"7830658976108826\"" +
-                        "}",
-                        { (_ request: ARTTokenRequest) in
-                            expect(request.clientId).to(beNil())
-                            expect(request.mac).to(equal("4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4="))
-                            expect(request.capability).to(equal("{\"test\":[\"publish\"]}"))
-                            expect(request.ttl).to(beNil())
-                            expect(request.timestamp).to(equal(Date(timeIntervalSince1970: 1479087321.934)))
-                            expect(request.keyName).to(equal("xxxxxx.yyyyyy"))
-                            expect(request.nonce).to(equal("7830658976108826"))
-                        }
-                    )
-                ]
+                func reusableTestsTestTokenRequestFromJson(_ json: String, check: @escaping (_ request: ARTTokenRequest) -> Void) {
+                    it("accepts a string, which should be interpreted as JSON") {
+                        check(try! ARTTokenRequest.fromJson(json as ARTJsonCompatible))
+                    }
 
-                for (caseName, (json, check)) in cases {
-                    context(caseName) {
-                        it("accepts a string, which should be interpreted as JSON") {
-                            check(try! ARTTokenRequest.fromJson(json as ARTJsonCompatible))
-                        }
+                    it("accepts a NSDictionary") {
+                        let data = json.data(using: String.Encoding.utf8)!
+                        let dict = try! JSONSerialization.jsonObject(with: data, options: .mutableLeaves) as! NSDictionary
+                        check(try! ARTTokenRequest.fromJson(dict))
+                    }
+                }
 
-                        it("accepts a NSDictionary") {
-                            let data = json.data(using: String.Encoding.utf8)!
-                            let dict = try! JSONSerialization.jsonObject(with: data, options: .mutableLeaves) as! NSDictionary
-                            check(try! ARTTokenRequest.fromJson(dict))
-                        }
+                context("with TTL") {
+                    reusableTestsTestTokenRequestFromJson("{" +
+                                             "    \"clientId\":\"myClientId\"," +
+                                             "    \"mac\":\"4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4=\"," +
+                                             "    \"capability\":\"{\\\"test\\\":[\\\"publish\\\"]}\"," +
+                                             "    \"ttl\":42000," +
+                                             "    \"timestamp\":1479087321934," +
+                                             "    \"keyName\":\"xxxxxx.yyyyyy\"," +
+                                             "    \"nonce\":\"7830658976108826\"" +
+                                             "}") { request in
+                        expect(request.clientId).to(equal("myClientId"))
+                        expect(request.mac).to(equal("4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4="))
+                        expect(request.capability).to(equal("{\"test\":[\"publish\"]}"))
+                        expect(request.ttl as? TimeInterval).to(equal(TimeInterval(42)))
+                        expect(request.timestamp).to(equal(Date(timeIntervalSince1970: 1479087321.934)))
+                        expect(request.keyName).to(equal("xxxxxx.yyyyyy"))
+                        expect(request.nonce).to(equal("7830658976108826"))
+                    }
+                }
+                
+                context("without TTL") {
+                    reusableTestsTestTokenRequestFromJson("{" +
+                                             "    \"mac\":\"4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4=\"," +
+                                             "    \"capability\":\"{\\\"test\\\":[\\\"publish\\\"]}\"," +
+                                             "    \"timestamp\":1479087321934," +
+                                             "    \"keyName\":\"xxxxxx.yyyyyy\"," +
+                                             "    \"nonce\":\"7830658976108826\"" +
+                                             "}") { request in
+                        expect(request.clientId).to(beNil())
+                        expect(request.mac).to(equal("4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4="))
+                        expect(request.capability).to(equal("{\"test\":[\"publish\"]}"))
+                        expect(request.ttl).to(beNil())
+                        expect(request.timestamp).to(equal(Date(timeIntervalSince1970: 1479087321.934)))
+                        expect(request.keyName).to(equal("xxxxxx.yyyyyy"))
+                        expect(request.nonce).to(equal("7830658976108826"))
                     }
                 }
 

--- a/Spec/PushActivationStateMachine.swift
+++ b/Spec/PushActivationStateMachine.swift
@@ -540,104 +540,106 @@ class PushActivationStateMachine : QuickSpec {
             }
 
             // RSH3e
-            for fromEvent in [
-                ARTPushActivationEventCalledActivate(),
-                ARTPushActivationEventGotPushDeviceDetails()
-            ] {
-                context("State WaitingForRegistrationSync through \(fromEvent)") {
-
-                    beforeEach {
-                        storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForRegistrationSync(machine: initialStateMachine, from: fromEvent))
-                        rest.internal.storage = storage
-                        stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
-                        (stateMachine.current as! ARTPushActivationStateWaitingForRegistrationSync).fromEvent = fromEvent
+            func reusableTestsTestStateWaitingForRegistrationSyncThrough(_ fromEvent: ARTPushActivationEvent) {
+                beforeEach {
+                    storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForRegistrationSync(machine: initialStateMachine, from: fromEvent))
+                    rest.internal.storage = storage
+                    stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
+                    (stateMachine.current as! ARTPushActivationStateWaitingForRegistrationSync).fromEvent = fromEvent
+                }
+                
+                // RSH3e1
+                it("on Event CalledActivate") {
+                    var activatedCallbackCalled = false
+                    let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callActivatedCallback:")) {
+                        activatedCallbackCalled = true
                     }
-
-                    // RSH3e1
-                    it("on Event CalledActivate") {
-                        var activatedCallbackCalled = false
-                        let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callActivatedCallback:")) {
-                            activatedCallbackCalled = true
-                        }
-                        defer { hook.remove() }
-
-                        stateMachine.send(ARTPushActivationEventCalledActivate())
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForRegistrationSync.self))
-                        if (!fromEvent.isKind(of: ARTPushActivationEventCalledActivate.self)) {                        expect(activatedCallbackCalled).to(beTrue())
-                            expect(stateMachine.pendingEvents).to(haveCount(0))
-                        } else {
-                            expect(activatedCallbackCalled).to(beFalse())
-                            expect(stateMachine.pendingEvents).to(haveCount(1))
-                        }
-                    }
-
-                    // RSH3e2
-                    it("on Event RegistrationSynced") {
-                        var setAndPersistIdentityTokenDetailsCalled = false
-                        let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
-                            setAndPersistIdentityTokenDetailsCalled = true
-                        }
-                        defer { hookDevice.remove() }
-                        
-                        let delegate = StateMachineDelegate()
-                        stateMachine.delegate = delegate
-                        
-                        var activateCallbackCalled = false
-                        delegate.onDidActivateAblyPush = { error in
-                            expect(error).to(beNil())
-                            activateCallbackCalled = true
-                        }
-
-                        let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(
-                            token: "123456",
-                            issued: Date(),
-                            expires: Date.distantFuture,
-                            capability: "",
-                            clientId: ""
-                        )
-
-                        stateMachine.send(ARTPushActivationEventRegistrationSynced(identityTokenDetails: testIdentityTokenDetails))
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
-                        expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
-                        
-                        // RSH3e2b
-                        expect(activateCallbackCalled).toEventually(equal(fromEvent is ARTPushActivationEventCalledActivate), timeout: testTimeout)
-                    }
-
-                    // RSH3e3
-                    it("on Event SyncRegistrationFailed") {
-                        let expectedError = ARTErrorInfo(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
-
-                        var updateFailedCallbackCalled = false
-                        let hook = stateMachine.testSuite_getArgument(from: NSSelectorFromString("callUpdateFailedCallback:"), at: 0, callback: { arg0 in
-                            updateFailedCallbackCalled = true
-                            guard let error = arg0 as? ARTErrorInfo else {
-                                fail("Error is missing"); return
-                            }
-                            expect(error) == expectedError
-                        })
-                        defer { hook.remove() }
-                        
-                        let delegate = StateMachineDelegate()
-                        stateMachine.delegate = delegate
-                        
-                        var activateCallbackCalled = false
-                        delegate.onDidActivateAblyPush = { error in
-                            expect(error) == expectedError
-                            activateCallbackCalled = true
-                        }
-
-                        stateMachine.send(ARTPushActivationEventSyncRegistrationFailed(error: expectedError))
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateAfterRegistrationSyncFailed.self))
-                        
-                        // RSH3e3a
-                        expect(updateFailedCallbackCalled).toEventually(equal(!(fromEvent is ARTPushActivationEventCalledActivate)), timeout: testTimeout)
-                        // RSH3e3c
-                        expect(activateCallbackCalled).toEventually(equal(fromEvent is ARTPushActivationEventCalledActivate), timeout: testTimeout)
+                    defer { hook.remove() }
+                    
+                    stateMachine.send(ARTPushActivationEventCalledActivate())
+                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForRegistrationSync.self))
+                    if (!fromEvent.isKind(of: ARTPushActivationEventCalledActivate.self)) {                        expect(activatedCallbackCalled).to(beTrue())
+                        expect(stateMachine.pendingEvents).to(haveCount(0))
+                    } else {
+                        expect(activatedCallbackCalled).to(beFalse())
+                        expect(stateMachine.pendingEvents).to(haveCount(1))
                     }
                 }
+                
+                // RSH3e2
+                it("on Event RegistrationSynced") {
+                    var setAndPersistIdentityTokenDetailsCalled = false
+                    let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
+                        setAndPersistIdentityTokenDetailsCalled = true
+                    }
+                    defer { hookDevice.remove() }
+                    
+                    let delegate = StateMachineDelegate()
+                    stateMachine.delegate = delegate
+                    
+                    var activateCallbackCalled = false
+                    delegate.onDidActivateAblyPush = { error in
+                        expect(error).to(beNil())
+                        activateCallbackCalled = true
+                    }
+                    
+                    let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(
+                        token: "123456",
+                        issued: Date(),
+                        expires: Date.distantFuture,
+                        capability: "",
+                        clientId: ""
+                    )
+                    
+                    stateMachine.send(ARTPushActivationEventRegistrationSynced(identityTokenDetails: testIdentityTokenDetails))
+                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
+                    expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
+                    
+                    // RSH3e2b
+                    expect(activateCallbackCalled).toEventually(equal(fromEvent is ARTPushActivationEventCalledActivate), timeout: testTimeout)
+                }
+                
+                // RSH3e3
+                it("on Event SyncRegistrationFailed") {
+                    let expectedError = ARTErrorInfo(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
+                    
+                    var updateFailedCallbackCalled = false
+                    let hook = stateMachine.testSuite_getArgument(from: NSSelectorFromString("callUpdateFailedCallback:"), at: 0, callback: { arg0 in
+                        updateFailedCallbackCalled = true
+                        guard let error = arg0 as? ARTErrorInfo else {
+                            fail("Error is missing"); return
+                        }
+                        expect(error) == expectedError
+                    })
+                    defer { hook.remove() }
+                    
+                    let delegate = StateMachineDelegate()
+                    stateMachine.delegate = delegate
+                    
+                    var activateCallbackCalled = false
+                    delegate.onDidActivateAblyPush = { error in
+                        expect(error) == expectedError
+                        activateCallbackCalled = true
+                    }
+                    
+                    stateMachine.send(ARTPushActivationEventSyncRegistrationFailed(error: expectedError))
+                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateAfterRegistrationSyncFailed.self))
+                    
+                    // RSH3e3a
+                    expect(updateFailedCallbackCalled).toEventually(equal(!(fromEvent is ARTPushActivationEventCalledActivate)), timeout: testTimeout)
+                    // RSH3e3c
+                    expect(activateCallbackCalled).toEventually(equal(fromEvent is ARTPushActivationEventCalledActivate), timeout: testTimeout)
+                }
             }
-
+            
+            context("State WaitingForRegistrationSync through ARTPushActivationEventCalledActivate") {
+                reusableTestsTestStateWaitingForRegistrationSyncThrough(ARTPushActivationEventCalledActivate())
+            }
+            
+            context("State WaitingForRegistrationSync through ARTPushActivationEventGotPushDeviceDetails") {
+                reusableTestsTestStateWaitingForRegistrationSyncThrough(ARTPushActivationEventGotPushDeviceDetails())
+            }
+            
             // RSH3f
             context("State AfterRegistrationSyncFailed") {
 

--- a/Spec/Stats.swift
+++ b/Spec/Stats.swift
@@ -47,32 +47,38 @@ class Stats: QuickSpec {
             }
 
             // TS7
-            for direction in ["inbound", "outbound"] {
-                context(direction) {
-                    let data: JSON = [
-                        [ direction: [
-                            "realtime": [ "messages": [ "count": 5] ],
-                            "all": [ "messages": [ "count": 25 ], "presence": [ "data": 210 ] ]
-                        ] ]
-                    ]
-                    let rawData = try! data.rawData()
-                    let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
-                    let subject = stats?.value(forKey: direction) as? ARTStatsMessageTraffic
+            func reusableTestsTestDirection(_ direction: String) {
+                let data: JSON = [
+                    [ direction: [
+                        "realtime": [ "messages": [ "count": 5] ],
+                        "all": [ "messages": [ "count": 25 ], "presence": [ "data": 210 ] ]
+                    ] ]
+                ]
+                let rawData = try! data.rawData()
+                let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
+                let subject = stats?.value(forKey: direction) as? ARTStatsMessageTraffic
 
-                    it("should return a MessageTraffic object") {
-                        expect(subject).to(beAnInstanceOf(ARTStatsMessageTraffic.self))
-                    }
-
-                    // TS5
-                    it("should return value for realtime message counts") {
-                        expect(subject?.realtime.messages.count).to(equal(5))
-                    }
-
-                    // TS5
-                    it("should return value for all presence data") {
-                        expect(subject?.all.presence.data).to(equal(210))
-                    }
+                it("should return a MessageTraffic object") {
+                    expect(subject).to(beAnInstanceOf(ARTStatsMessageTraffic.self))
                 }
+
+                // TS5
+                it("should return value for realtime message counts") {
+                    expect(subject?.realtime.messages.count).to(equal(5))
+                }
+
+                // TS5
+                it("should return value for all presence data") {
+                    expect(subject?.all.presence.data).to(equal(210))
+                }
+            }
+        
+            context("inbound") {
+                reusableTestsTestDirection("inbound")
+            }
+            
+            context("outbound") {
+                reusableTestsTestDirection("outbound")
             }
 
             // TS4

--- a/Spec/Stats.swift
+++ b/Spec/Stats.swift
@@ -136,29 +136,35 @@ class Stats: QuickSpec {
             }
 
             // TS8
-            for requestType in ["apiRequests", "tokenRequests"] {
+            func reusableTestsTestRequestType(_ requestType: String) {
                 let data: JSON = [
                     [ requestType: [ "succeeded": 5, "failed": 10 ] ]
                 ]
                 let rawData = try! data.rawData()
                 let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
                 let subject = stats?.value(forKey: requestType) as? ARTStatsRequestCount
+                
+                it("should return a RequestCount object") {
+                    expect(subject).to(beAnInstanceOf(ARTStatsRequestCount.self))
+                }
 
-                context(requestType) {
-                    it("should return a RequestCount object") {
-                        expect(subject).to(beAnInstanceOf(ARTStatsRequestCount.self))
-                    }
+                it("should return value for succeeded") {
+                    expect(subject?.succeeded).to(equal(5))
+                }
 
-                    it("should return value for succeeded") {
-                        expect(subject?.succeeded).to(equal(5))
-                    }
-
-                    it("should return value for failed") {
-                        expect(subject?.failed).to(equal(10))
-                    }
+                it("should return value for failed") {
+                    expect(subject?.failed).to(equal(10))
                 }
             }
-
+            
+            context("apiRequests") {
+                reusableTestsTestRequestType("apiRequests")
+            }
+            
+            context("tokenRequests") {
+                reusableTestsTestRequestType("tokenRequests")
+            }
+            
             context("interval") {
                 let data: JSON = [
                     [ "intervalId": "2004-02-01:05:06" ]

--- a/Spec/Stats.swift
+++ b/Spec/Stats.swift
@@ -10,34 +10,40 @@ class Stats: QuickSpec {
             let encoder = ARTJsonLikeEncoder()
 
             // TS6
-            for attribute in ["all", "persisted"] {
-                context(attribute) {
-                    let data: JSON = [
-                        [ attribute: [ "messages": [ "count": 5], "all": [ "data": 10 ] ] ]
-                    ]
-                    let rawData = try! data.rawData()
-                    let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
-                    let subject = stats?.value(forKey: attribute) as? ARTStatsMessageTypes
+            func reusableTestsTestAttribute(_ attribute: String) {
+                let data: JSON = [
+                    [ attribute: [ "messages": [ "count": 5], "all": [ "data": 10 ] ] ]
+                ]
+                let rawData = try! data.rawData()
+                let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
+                let subject = stats?.value(forKey: attribute) as? ARTStatsMessageTypes
 
-                    it("should return a MessagesTypes object") {
-                        expect(subject).to(beAnInstanceOf(ARTStatsMessageTypes.self))
-                    }
-
-                    // TS5
-                    it("should return value for message counts") {
-                        expect(subject?.messages.count).to(equal(5))
-                    }
-
-                    // TS5
-                    it("should return value for all data transferred") {
-                        expect(subject?.all.data).to(equal(10))
-                    }
-
-                    // TS2
-                    it("should return zero for empty values") {
-                        expect(subject?.presence.count).to(equal(0))
-                    }
+                it("should return a MessagesTypes object") {
+                    expect(subject).to(beAnInstanceOf(ARTStatsMessageTypes.self))
                 }
+
+                // TS5
+                it("should return value for message counts") {
+                    expect(subject?.messages.count).to(equal(5))
+                }
+
+                // TS5
+                it("should return value for all data transferred") {
+                    expect(subject?.all.data).to(equal(10))
+                }
+
+                // TS2
+                it("should return zero for empty values") {
+                    expect(subject?.presence.count).to(equal(0))
+                }
+            }
+            
+            context("all") {
+                reusableTestsTestAttribute("all")
+            }
+            
+            context("persisted") {
+                reusableTestsTestAttribute("persisted")
             }
 
             // TS7

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -12,20 +12,6 @@ typealias HookToken = AspectToken
 
 let AblyTestsErrorDomain = "test.ably.io"
 
-class CryptoTest {
-    private static let aes128 = "cipher+aes-128-cbc";
-    private static let aes256 = "cipher+aes-256-cbc";
-
-    public static let fixtures: [(
-        fileName: String,
-        expectedEncryptedEncoding: String,
-        keyLength: UInt
-    )] = [
-        ("crypto-data-128", aes128, 128),
-        ("crypto-data-256", aes256, 256),
-    ];
-}
-
 class Configuration : QuickConfiguration {
     override class func configure(_ configuration: Quick.Configuration!) {
         configuration.beforeSuite {


### PR DESCRIPTION
## What does this do?

Unrolls some test-defining loops into individual calls to a reusable function. See first commit message for more details.

## Does it change the behaviour of the test suite?

No, it's just a refactor.

## Why are we doing this?

It’s groundwork for removing the Quick testing framework using an automated migrator tool (#1201). The
migrator that I’m writing won’t be able to handle arbitrary statements like `forEach` calls or loops, so we need to replace them with something it knows how to handle, namely a call to a function named with a special `reusableTests` prefix.