### PR TITLE
[Groundwork for #1201] Unroll simple test-defining loops in test files

### DIFF
--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -524,18 +524,19 @@ class Auth : QuickSpec {
                 // Cases:
                 //  - useTokenAuth is specified and thus a key is not provided
                 //  - authCallback and authUrl are both specified
-                let cases: [String: (ARTAuthOptions) -> ()] = [
-                    "useTokenAuth and no key":{ $0.useTokenAuth = true },
-                    "authCallback and authUrl":{ $0.authCallback = { params, callback in /*nothing*/ }; $0.authUrl = URL(string: "http://auth.ably.io") }
-                ]
+                func testStopsClientWithOptions(caseSetter: (ARTClientOptions) -> ()) {
+                    let options = ARTClientOptions()
+                    caseSetter(options)
+                    
+                    expect{ ARTRest(options: options) }.to(raiseException())
+                }
                 
-                for (caseName, caseSetter) in cases {
-                    it("should stop client when \(caseName) occurs") {
-                        let options = ARTClientOptions()
-                        caseSetter(options)
-                        
-                        expect{ ARTRest(options: options) }.to(raiseException())
-                    }
+                it("should stop client when useTokenAuth and no key occurs") {
+                    testStopsClientWithOptions { $0.useTokenAuth = true }
+                }
+                
+                it ("should stop client when authCallback and authUrl occurs") {
+                    testStopsClientWithOptions { $0.authCallback = { params, callback in /*nothing*/ }; $0.authUrl = URL(string: "http://auth.ably.io") }
                 }
 
                 // RSA4c

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -169,15 +169,37 @@ class Auth : QuickSpec {
 
             // RSA4
             context("authentication method") {
-                for (caseName, caseSetter) in AblyTests.authTokenCases {
-                    it("should be default auth method when \(caseName) is set") {
-                        let options = ARTClientOptions()
-                        caseSetter(options)
+                func testOptionsGiveDefaultAuthMethod(_ caseSetter: (ARTAuthOptions) -> Void) {
+                    let options = ARTClientOptions()
+                    caseSetter(options)
+                    
+                    let client = ARTRest(options: options)
+                    
+                    expect(client.auth.internal.method).to(equal(ARTAuthMethod.token))
+                }
+                
+                it("should be default auth method when options’ useTokenAuth is set") {
+                    testOptionsGiveDefaultAuthMethod { $0.useTokenAuth = true; $0.key = "fake:key" }
+                }
+                
+                it("should be default auth method when options’ authUrl is set") {
+                    testOptionsGiveDefaultAuthMethod { $0.authUrl = URL(string: "http://test.com") }
+                }
+                
+                it("should be default auth method when options’ authCallback is set") {
+                    testOptionsGiveDefaultAuthMethod { $0.authCallback = { _, _ in return } }
+                }
+                
+                it("should be default auth method when options’ tokenDetails is set") {
+                    testOptionsGiveDefaultAuthMethod { $0.tokenDetails = ARTTokenDetails(token: "token") }
+                }
 
-                        let client = ARTRest(options: options)
-
-                        expect(client.auth.internal.method).to(equal(ARTAuthMethod.token))
-                    }
+                it("should be default auth method when options’ token is set") {
+                    testOptionsGiveDefaultAuthMethod { $0.token = "token" }
+                }
+                
+                it("should be default auth method when options’ key is set") {
+                    testOptionsGiveDefaultAuthMethod { $0.tokenDetails = ARTTokenDetails(token: "token"); $0.key = "fake:key" }
                 }
 
                 // RSA4a

--- a/Spec/RestClient.swift
+++ b/Spec/RestClient.swift
@@ -1385,44 +1385,51 @@ class RestClient: QuickSpec {
                 // RSC15f
                 context("should store successful fallback host as default host") {
                     
-                    for caseTest: FakeNetworkResponse in [.hostUnreachable,
-                                                          .requestTimeout(timeout: 0.1),
-                                                          .hostInternalError(code: 501)] {
-                        it("\(caseTest)") {
-                            let options = ARTClientOptions(key: "xxxx:xxxx")
-                            let client = ARTRest(options: options)
-                            let mockHTTP = MockHTTP(logger: options.logHandler)
-                            testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                            client.internal.httpExecutor = testHTTPExecutor
-                            mockHTTP.setNetworkState(network: caseTest, resetAfter: 1)
-                            let channel = client.channels.get("test")
+                    func testStoresSuccessfulFallbackHostAsDefaultHost(_ caseTest: FakeNetworkResponse) {
+                        let options = ARTClientOptions(key: "xxxx:xxxx")
+                        let client = ARTRest(options: options)
+                        let mockHTTP = MockHTTP(logger: options.logHandler)
+                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+                        client.internal.httpExecutor = testHTTPExecutor
+                        mockHTTP.setNetworkState(network: caseTest, resetAfter: 1)
+                        let channel = client.channels.get("test")
 
-                            waitUntil(timeout: testTimeout) { done in
-                                channel.publish(nil, data: "nil") { _ in
-                                    done()
-                                }
+                        waitUntil(timeout: testTimeout) { done in
+                            channel.publish(nil, data: "nil") { _ in
+                                done()
                             }
-
-                            expect(testHTTPExecutor.requests).to(haveCount(2))
-                            expect(NSRegularExpression.match(testHTTPExecutor.requests[0].url!.host, pattern: "rest.ably.io")).to(beTrue())
-                            expect(NSRegularExpression.match(testHTTPExecutor.requests[1].url!.host, pattern: "[a-e].ably-realtime.com")).to(beTrue())
-                            
-                            //#1 Store fallback used to request
-                            let usedFallbackURL = testHTTPExecutor.requests[1].url!
-                            
-                            waitUntil(timeout: testTimeout) { done in
-                                channel.publish(nil, data: "nil") { _ in
-                                    done()
-                                }
-                            }
-                            
-                            let reusedURL = testHTTPExecutor.requests[2].url!
-                            
-                            // Reuse host has to be equal previous (stored #1) fallback host
-                            expect(testHTTPExecutor.requests).to(haveCount(3))
-                            expect(usedFallbackURL.host).to(equal(reusedURL.host))
-                            
                         }
+
+                        expect(testHTTPExecutor.requests).to(haveCount(2))
+                        expect(NSRegularExpression.match(testHTTPExecutor.requests[0].url!.host, pattern: "rest.ably.io")).to(beTrue())
+                        expect(NSRegularExpression.match(testHTTPExecutor.requests[1].url!.host, pattern: "[a-e].ably-realtime.com")).to(beTrue())
+                        
+                        //#1 Store fallback used to request
+                        let usedFallbackURL = testHTTPExecutor.requests[1].url!
+                        
+                        waitUntil(timeout: testTimeout) { done in
+                            channel.publish(nil, data: "nil") { _ in
+                                done()
+                            }
+                        }
+                        
+                        let reusedURL = testHTTPExecutor.requests[2].url!
+                        
+                        // Reuse host has to be equal previous (stored #1) fallback host
+                        expect(testHTTPExecutor.requests).to(haveCount(3))
+                        expect(usedFallbackURL.host).to(equal(reusedURL.host))
+                    }
+                    
+                    it(".hostUnreachable") {
+                        testStoresSuccessfulFallbackHostAsDefaultHost(.hostUnreachable)
+                    }
+                    
+                    it(".requestTimeout(timeout: 0.1)") {
+                        testStoresSuccessfulFallbackHostAsDefaultHost(.requestTimeout(timeout: 0.1))
+                    }
+                    
+                    it(".hostInternalError(code: 501)") {
+                        testStoresSuccessfulFallbackHostAsDefaultHost(.hostInternalError(code: 501))
                     }
                     
                     context("should restore default primary host after fallbackRetryTimeout expired") {

--- a/Spec/RestClient.swift
+++ b/Spec/RestClient.swift
@@ -492,20 +492,42 @@ class RestClient: QuickSpec {
 
                 // RSC14b
                 context("basic authentication flag") {
-                    it("should be true when key is set") {
+                    it("should be true when initialized with a key") {
                         let client = ARTRest(key: "key:secret")
                         expect(client.auth.internal.options.isBasicAuth()).to(beTrue())
                     }
+                    
+                    func testOptionsGiveBasicAuthFalse(_ caseSetter: (ARTAuthOptions) -> Void) {
+                        let options = ARTClientOptions()
+                        caseSetter(options)
+                        
+                        let client = ARTRest(options: options)
+                        
+                        expect(client.auth.internal.options.isBasicAuth()).to(beFalse())
+                    }
+                    
+                    it("should be false when options’ useTokenAuth is set") {
+                        testOptionsGiveBasicAuthFalse { $0.useTokenAuth = true; $0.key = "fake:key" }
+                    }
+                    
+                    it("should be false when options’ authUrl is set") {
+                        testOptionsGiveBasicAuthFalse { $0.authUrl = URL(string: "http://test.com") }
+                    }
+                    
+                    it("should be false when options’ authCallback is set") {
+                        testOptionsGiveBasicAuthFalse { $0.authCallback = { _, _ in return } }
+                    }
+                    
+                    it("should be false when options’ tokenDetails is set") {
+                        testOptionsGiveBasicAuthFalse { $0.tokenDetails = ARTTokenDetails(token: "token") }
+                    }
 
-                    for (caseName, caseSetter) in AblyTests.authTokenCases {
-                        it("should be false when \(caseName) is set") {
-                            let options = ARTClientOptions()
-                            caseSetter(options)
-
-                            let client = ARTRest(options: options)
-
-                            expect(client.auth.internal.options.isBasicAuth()).to(beFalse())
-                        }
+                    it("should be false when options’ token is set") {
+                        testOptionsGiveBasicAuthFalse { $0.token = "token" }
+                    }
+                    
+                    it("should be false when options’ key is set") {
+                        testOptionsGiveBasicAuthFalse { $0.tokenDetails = ARTTokenDetails(token: "token"); $0.key = "fake:key" }
                     }
                 }
 

--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -1337,60 +1337,65 @@ class RestClientChannel: QuickSpec {
             // RSL5b
             context("should support AES encryption") {
 
-                for encryptionKeyLength: UInt in [128, 256] {
-                    it("\(encryptionKeyLength) CBC mode") {
-                        let options = AblyTests.commonAppSetup()
-                        let client = ARTRest(options: options)
-                        client.internal.httpExecutor = testHTTPExecutor
-
-                        let params: ARTCipherParams = ARTCrypto.getDefaultParams([
-                            "key": ARTCrypto.generateRandomKey(encryptionKeyLength)
-                            ])
-                        expect(params.algorithm).to(equal("AES"))
-                        expect(params.keyLength).to(equal(encryptionKeyLength))
-                        expect(params.mode).to(equal("CBC"))
-
-                        let channelOptions = ARTChannelOptions(cipher: params)
-                        let channel = client.channels.get("test", options: channelOptions)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish("test", data: "message1") { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
+                func testSupportsAESEncryptionWithKeyLength(_ encryptionKeyLength: UInt) {
+                    let options = AblyTests.commonAppSetup()
+                    let client = ARTRest(options: options)
+                    client.internal.httpExecutor = testHTTPExecutor
+                    
+                    let params: ARTCipherParams = ARTCrypto.getDefaultParams([
+                        "key": ARTCrypto.generateRandomKey(encryptionKeyLength)
+                    ])
+                    expect(params.algorithm).to(equal("AES"))
+                    expect(params.keyLength).to(equal(encryptionKeyLength))
+                    expect(params.mode).to(equal("CBC"))
+                    
+                    let channelOptions = ARTChannelOptions(cipher: params)
+                    let channel = client.channels.get("test", options: channelOptions)
+                    
+                    waitUntil(timeout: testTimeout) { done in
+                        channel.publish("test", data: "message1") { error in
+                            expect(error).to(beNil())
+                            done()
                         }
-
-                        guard let httpBody = testHTTPExecutor.requests.last?.httpBody else {
-                            fail("HTTPBody is empty")
-                            return
-                        }
-                        let httpBodyAsJSON = AblyTests.msgpackToJSON(httpBody)
-                        expect(httpBodyAsJSON["encoding"].string).to(equal("utf-8/cipher+aes-\(encryptionKeyLength)-cbc/base64"))
-                        expect(httpBodyAsJSON["name"].string).to(equal("test"))
-                        expect(httpBodyAsJSON["data"].string).toNot(equal("message1"))
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.history { result, error in
-                                expect(error).to(beNil())
-                                guard let result = result else {
-                                    fail("PaginatedResult is empty"); done()
-                                    return
-                                }
-                                expect(result.hasNext).to(beFalse())
-                                expect(result.isLast).to(beTrue())
-                                let items = result.items
-                                if result.items.isEmpty {
-                                    fail("PaginatedResult has no items"); done()
-                                    return
-                                }
-                                expect(items[0].name).to(equal("test"))
-                                expect(items[0].data as? String).to(equal("message1"))
-                                done()
+                    }
+                    
+                    guard let httpBody = testHTTPExecutor.requests.last?.httpBody else {
+                        fail("HTTPBody is empty")
+                        return
+                    }
+                    let httpBodyAsJSON = AblyTests.msgpackToJSON(httpBody)
+                    expect(httpBodyAsJSON["encoding"].string).to(equal("utf-8/cipher+aes-\(encryptionKeyLength)-cbc/base64"))
+                    expect(httpBodyAsJSON["name"].string).to(equal("test"))
+                    expect(httpBodyAsJSON["data"].string).toNot(equal("message1"))
+                    
+                    waitUntil(timeout: testTimeout) { done in
+                        channel.history { result, error in
+                            expect(error).to(beNil())
+                            guard let result = result else {
+                                fail("PaginatedResult is empty"); done()
+                                return
                             }
+                            expect(result.hasNext).to(beFalse())
+                            expect(result.isLast).to(beTrue())
+                            let items = result.items
+                            if result.items.isEmpty {
+                                fail("PaginatedResult has no items"); done()
+                                return
+                            }
+                            expect(items[0].name).to(equal("test"))
+                            expect(items[0].data as? String).to(equal("message1"))
+                            done()
                         }
                     }
                 }
-
+                
+                it("128 CBC mode") {
+                    testSupportsAESEncryptionWithKeyLength(128)
+                }
+                
+                it("256 CBC mode") {
+                    testSupportsAESEncryptionWithKeyLength(256)
+                }
             }
 
         }

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -78,18 +78,6 @@ class AblyTests {
         }
     }
 
-    class var authTokenCases: [String: (ARTAuthOptions) -> Void] {
-        get { return [
-            "useTokenAuth": { $0.useTokenAuth = true; $0.key = "fake:key" },
-            "authUrl": { $0.authUrl = URL(string: "http://test.com") },
-            "authCallback": { $0.authCallback = { _, _ in return } },
-            "tokenDetails": { $0.tokenDetails = ARTTokenDetails(token: "token") },
-            "token": { $0.token = "token" },
-            "key": { $0.tokenDetails = ARTTokenDetails(token: "token"); $0.key = "fake:key" }
-            ]
-        }
-    }
-
     static var testApplication: JSON?
     static fileprivate var setupOptionsCounter = 0
 


### PR DESCRIPTION
## What does this do?

Unrolls some test-defining loops into individual calls to a reusable function. See first commit message for more details. Similar to #1225.

## Does it change the behaviour of the test suite?

No, it's just a refactor.

## Why are we doing this?

It’s groundwork for removing the Quick testing framework using an automated migrator tool (#1201). Same motivation as #1225 (but the solution is simpler here as it doesn’t need us to create a `reusableTests` function).