### PR TITLE
[Groundwork for #1201] Replace call to `pending` with `xit`

### DIFF
--- a/Spec/PushActivationStateMachine.swift
+++ b/Spec/PushActivationStateMachine.swift
@@ -180,7 +180,7 @@ class PushActivationStateMachine : QuickSpec {
                 context("on Event GotPushDeviceDetails") {
 
                     // TODO: The exception is raised but the `send:` method is doing an async call and the `expect` doesn't catch it
-                    pending("should raise exception if ARTPushRegistererDelegate is not implemented") {
+                    xit("should raise exception if ARTPushRegistererDelegate is not implemented") {
                         expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
                         expect {
                             stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())


### PR DESCRIPTION
## What does this do?

Replaces a call to `pending` in our tests (the only one in the codebase) with a call to `xit`.

## Does it change the behaviour of the test suite?

No, it's just a refactor.

## Why are we doing this?

It’s groundwork for removing the Quick testing framework using an automated migrator tool (#1201). The migrator won’t know what to do with a call to `pending` (see commit message for more details).