### PR TITLE
[Groundwork for #1201] Remove floating statements at `spec` / `describe` / `context` level

### DIFF
--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -4114,8 +4114,11 @@ class Auth : QuickSpec {
 
             // RSA8g RSA8c
             context("when using authUrl") {
-                let options = AblyTests.clientOptions()
-                options.authUrl = URL(string: echoServerAddress)!
+                let options: ARTClientOptions = {
+                    let options = AblyTests.clientOptions()
+                    options.authUrl = URL(string: echoServerAddress)!
+                    return options
+                }()
 
                 var keys: [String: String]!
 

--- a/Spec/Crypto.swift
+++ b/Spec/Crypto.swift
@@ -8,8 +8,7 @@ class Crypto : QuickSpec {
         describe("Crypto") {
             let key = "+/h4eHh4eHh4eHh4eHh4eA=="
             let binaryKey = Data(base64Encoded: key, options: .ignoreUnknownCharacters)!
-            let longKey = NSMutableData(data: binaryKey)
-            longKey.append(binaryKey)
+            let longKey = binaryKey + binaryKey
 
             // RSE1
             context("getDefaultParams") {

--- a/Spec/ObjectLifetimes.swift
+++ b/Spec/ObjectLifetimes.swift
@@ -5,8 +5,11 @@ import Nimble
 class ObjectLifetimes: QuickSpec {
     override func spec() {
         describe("ObjectLifetimes") {
-            let options = ARTClientOptions(key: "fake:key")
-            options.autoConnect = false
+            let options: ARTClientOptions = {
+                let options = ARTClientOptions(key: "fake:key")
+                options.autoConnect = false
+                return options
+            }()
             
             context("user code releases public object") {
                 it("the object's internal child's back-reference is released too") {

--- a/Spec/RealtimeClient.swift
+++ b/Spec/RealtimeClient.swift
@@ -274,8 +274,11 @@ class RealtimeClient: QuickSpec {
             }
 
             context("stats") {
-                let query = ARTStatsQuery()
-                query.unit = .minute
+                let query: ARTStatsQuery = {
+                    let query = ARTStatsQuery()
+                    query.unit = .minute
+                    return query
+                }()
 
                 // RTC5a
                 it("should present an async interface") {

--- a/Spec/RealtimeClientPresence.swift
+++ b/Spec/RealtimeClientPresence.swift
@@ -3370,8 +3370,11 @@ class RealtimeClientPresence: QuickSpec {
                     }
                     
                     context("if waitForSync is false") {
-                        let getParams = ARTRealtimePresenceQuery()
-                        getParams.waitForSync = false
+                        let getParams: ARTRealtimePresenceQuery = {
+                            let getParams = ARTRealtimePresenceQuery()
+                            getParams.waitForSync = false
+                            return getParams
+                        }()
                         
                         it("returns the members in the current PresenceMap") {
                             let (channel, client) = getSuspendedChannel()

--- a/Spec/RestClientStats.swift
+++ b/Spec/RestClientStats.swift
@@ -61,9 +61,12 @@ class RestClientStats: QuickSpec {
                         return dateComponents
                     }()
                     let date = calendar.date(from: dateComponents as DateComponents)!
-                    let dateFormatter = DateFormatter()
-                    dateFormatter.timeZone = NSTimeZone(name: "UTC") as TimeZone?
-                    dateFormatter.dateFormat = "YYYY-MM-dd:HH:mm"
+                    let dateFormatter: DateFormatter = {
+                        let dateFormatter = DateFormatter()
+                        dateFormatter.timeZone = NSTimeZone(name: "UTC") as TimeZone?
+                        dateFormatter.dateFormat = "YYYY-MM-dd:HH:mm"
+                        return dateFormatter
+                    }()
                     
                     let statsFixtures: JSON = [
                         [

--- a/Spec/RestClientStats.swift
+++ b/Spec/RestClientStats.swift
@@ -51,12 +51,15 @@ class RestClientStats: QuickSpec {
                 // RSC6a
                 context("result") {
                     let calendar = NSCalendar(identifier: NSCalendar.Identifier.gregorian)!
-                    let dateComponents = NSDateComponents()
-                    dateComponents.year = calendar.component(NSCalendar.Unit.year, from: NSDate() as Date) - 1
-                    dateComponents.month = 2
-                    dateComponents.day = 3
-                    dateComponents.hour = 16
-                    dateComponents.minute = 3
+                    let dateComponents: NSDateComponents = {
+                        let dateComponents = NSDateComponents()
+                        dateComponents.year = calendar.component(NSCalendar.Unit.year, from: NSDate() as Date) - 1
+                        dateComponents.month = 2
+                        dateComponents.day = 3
+                        dateComponents.hour = 16
+                        dateComponents.minute = 3
+                        return dateComponents
+                    }()
                     let date = calendar.date(from: dateComponents as DateComponents)!
                     let dateFormatter = DateFormatter()
                     dateFormatter.timeZone = NSTimeZone(name: "UTC") as TimeZone?


### PR DESCRIPTION
## What does this do?

Removes some arbitrary statements from `spec` / `describe` / `context` level, moving them into related variable declarations.

## Does it change the behaviour of the test suite?

No, it's just a refactor.

## Why are we doing this?

It’s groundwork for removing the Quick testing framework using an automated migrator tool (#1201). The migrator that I’m writing won’t be able to handle these statements, so I'm moving them inside statements that it knows how to handle. See the first commit message for more details.
