### PR TITLE
[Groundwork for #1201, but also a fix] Fix setting of fallback retry timeout in tests

### DIFF
--- a/Spec/RestClient.swift
+++ b/Spec/RestClient.swift
@@ -1456,7 +1456,9 @@ class RestClient: QuickSpec {
                     
                     context("should restore default primary host after fallbackRetryTimeout expired") {
                         
-                        ARTDefault.setFallbackRetryTimeout(1.0)
+                        beforeEach {
+                            ARTDefault.setFallbackRetryTimeout(1.0)
+                        }
                         
                         func testRestoresDefaultPrimaryHostAfterTimeoutExpires(_ caseTest: FakeNetworkResponse) {
                             let options = ARTClientOptions(key: "xxxx:xxxx")
@@ -1501,7 +1503,9 @@ class RestClient: QuickSpec {
                     
                     context("should use another fallback host if previous fallback request failed and store it as default if current fallback request succseeded") {
                             
-                        ARTDefault.setFallbackRetryTimeout(10)
+                        beforeEach {
+                            ARTDefault.setFallbackRetryTimeout(10)
+                        }
 
                         func testUsesAnotherFallbackHost(_ caseTest: FakeNetworkResponse) {
                             let options = ARTClientOptions(key: "xxxx:xxxx")


### PR DESCRIPTION
## What does this do?

Moves the setting of `ARTDefault.fallbackRetryTimeout` from the top level of `context` to inside `beforeEach` blocks. See commit message for explanation of why I think it was an error to put this code at `context` level.

## Does it change the behaviour of the test suite?

In theory, yes, although I think in practice it doesn’t since the existing code was accidentally working (see commit message).

## Why are we doing this?

Original motivation that caused me to notice this was #1232 (removing arbitrary statements at `context` level).