### PR TITLE
Add names to the various stages of the check-pod workflow

### DIFF
--- a/.github/workflows/check-pod.yml
+++ b/.github/workflows/check-pod.yml
@@ -12,15 +12,23 @@ jobs:
 
       # Run the steps we document in the Release Process.
       # unzip commands included as proof-of-life for the Carthage output.
-      - run: |
-          ruby --version
-          echo -n "carthage version: " && carthage version
-          echo -n "pod version: " && pod --version --verbose
-          make --version
-          make update
-          make carthage_package
+      - name: Check Ruby version
+        run: ruby --version
+      - name: Check Carthage version
+        run: 'echo -n "carthage version: " && carthage version'
+      - name: Check CocoaPods version
+        run: 'echo -n "pod version: " && pod --version --verbose'
+      - name: Check Make version
+        run: make --version
+      - name: Build Carthage dependencies
+        run: make update
+      - name: Build Ably framework
+        run: make carthage_package
+      - name: Check contents of generated ZIP file
+        run: |
           unzip -l Ably.framework.zip
           unzip -l Ably.framework.zip | grep 'Mac/Ably.framework'
           unzip -l Ably.framework.zip | grep 'tvOS/Ably.framework'
           unzip -l Ably.framework.zip | grep 'iOS/Ably.framework'
-          pod lib lint
+      - name: Validate pod
+        run: pod lib lint

--- a/Scripts/carthage-with-workaround-for-issue-3019.sh
+++ b/Scripts/carthage-with-workaround-for-issue-3019.sh
@@ -8,9 +8,10 @@ set -euo pipefail
 xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
 trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
 
-# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# For Xcode 12 and 13 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
 # the build will fail on lipo due to duplicate architectures.
 echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1300 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
 echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
 
 export XCODE_XCCONFIG_FILE="$xcconfig"


### PR DESCRIPTION
I’m investigating a failure and it’s not immediately obvious which of the commands have failed. Hopefully this will help.