### PR TITLE
[Groundwork for #1201] Rename or remove clashing variables

### DIFF
--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -4073,12 +4073,12 @@ class Auth : QuickSpec {
             let messageName = "message_JWT"
             
             context("client initialized with a JWT token in ClientOptions") {
-                let options = AblyTests.clientOptions()
+                let jwtTestsOptions = AblyTests.clientOptions()
 
                 context("with valid credentials") {
                     xit("pulls stats successfully") {
-                        options.token = getJWTToken()
-                        let client = AblyTests.newRealtime(options)
+                        jwtTestsOptions.token = getJWTToken()
+                        let client = AblyTests.newRealtime(jwtTestsOptions)
                         defer { client.dispose(); client.close() }
 
                         waitUntil(timeout: testTimeout) { done in
@@ -4092,9 +4092,9 @@ class Auth : QuickSpec {
 
                 context("with invalid credentials") {
                     it("fails to connect with reason 'invalid signature'") {
-                        options.token = getJWTToken(invalid: true)
-                        options.autoConnect = false
-                        let client = AblyTests.newRealtime(options)
+                        jwtTestsOptions.token = getJWTToken(invalid: true)
+                        jwtTestsOptions.autoConnect = false
+                        let client = AblyTests.newRealtime(jwtTestsOptions)
                         defer { client.dispose(); client.close() }
 
                         waitUntil(timeout: testTimeout) { done in
@@ -4114,7 +4114,7 @@ class Auth : QuickSpec {
 
             // RSA8g RSA8c
             context("when using authUrl") {
-                let options: ARTClientOptions = {
+                let authUrlTestsOptions: ARTClientOptions = {
                     let options = AblyTests.clientOptions()
                     options.authUrl = URL(string: echoServerAddress)!
                     return options
@@ -4132,10 +4132,10 @@ class Auth : QuickSpec {
                     it("fetches a channels and posts a message") {
                         setupDependencies()
 
-                        options.authParams = [URLQueryItem]()
-                        options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
-                        options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
-                        let client = ARTRealtime(options: options)
+                        authUrlTestsOptions.authParams = [URLQueryItem]()
+                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
+                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
+                        let client = ARTRealtime(options: authUrlTestsOptions)
                         defer { client.dispose(); client.close() }
 
                         waitUntil(timeout: testTimeout) { done in
@@ -4155,10 +4155,10 @@ class Auth : QuickSpec {
                     it("fails to connect with reason 'invalid signature'") {
                         setupDependencies()
 
-                        options.authParams = [URLQueryItem]()
-                        options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
-                        options.authParams?.append(URLQueryItem(name: "keySecret", value: "INVALID"))
-                        let client = ARTRealtime(options: options)
+                        authUrlTestsOptions.authParams = [URLQueryItem]()
+                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
+                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keySecret", value: "INVALID"))
+                        let client = ARTRealtime(options: authUrlTestsOptions)
                         defer { client.dispose(); client.close() }
 
                         waitUntil(timeout: testTimeout) { done in
@@ -4181,11 +4181,11 @@ class Auth : QuickSpec {
                         setupDependencies()
 
                         let tokenDuration = 5.0
-                        options.authParams = [URLQueryItem]()
-                        options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
-                        options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
-                        options.authParams?.append(URLQueryItem(name: "expiresIn", value: String(UInt(tokenDuration))))
-                        let client = ARTRealtime(options: options)
+                        authUrlTestsOptions.authParams = [URLQueryItem]()
+                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
+                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
+                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "expiresIn", value: String(UInt(tokenDuration))))
+                        let client = ARTRealtime(options: authUrlTestsOptions)
                         defer { client.dispose(); client.close() }
                         
                         waitUntil(timeout: testTimeout) { done in
@@ -4209,12 +4209,12 @@ class Auth : QuickSpec {
                         // The server sends an AUTH protocol message 30 seconds before a token expires
                         // We create a token that lasts 35 seconds, so there's room to receive the AUTH message
                         let tokenDuration = 35.0
-                        options.authParams = [URLQueryItem]()
-                        options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
-                        options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
-                        options.authParams?.append(URLQueryItem(name: "expiresIn", value: String(UInt(tokenDuration))))
-                        options.autoConnect = false // Prevent auto connection so we can set the transport proxy
-                        let client = ARTRealtime(options: options)
+                        authUrlTestsOptions.authParams = [URLQueryItem]()
+                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
+                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
+                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "expiresIn", value: String(UInt(tokenDuration))))
+                        authUrlTestsOptions.autoConnect = false // Prevent auto connection so we can set the transport proxy
+                        let client = ARTRealtime(options: authUrlTestsOptions)
                         client.internal.setTransport(TestProxyTransport.self)
                         defer { client.dispose(); client.close() }
                         
@@ -4237,15 +4237,15 @@ class Auth : QuickSpec {
 
             // RSA8g
             context("when using authCallback") {
-                let options = AblyTests.clientOptions()
+                let authCallbackTestsOptions = AblyTests.clientOptions()
 
                 context("with valid credentials") {
                     xit("pulls stats successfully") {
-                        options.authCallback = { tokenParams, completion in
+                        authCallbackTestsOptions.authCallback = { tokenParams, completion in
                             let token = ARTTokenDetails(token: getJWTToken()!)
                             completion(token, nil)
                         }
-                        let client = ARTRealtime(options: options)
+                        let client = ARTRealtime(options: authCallbackTestsOptions)
                         defer { client.dispose(); client.close() }
 
                         waitUntil(timeout: testTimeout) { done in
@@ -4259,11 +4259,11 @@ class Auth : QuickSpec {
 
                 context("with invalid credentials") {
                     it("fails to connect") {
-                        options.authCallback = { tokenParams, completion in
+                        authCallbackTestsOptions.authCallback = { tokenParams, completion in
                             let token = ARTTokenDetails(token: getJWTToken(invalid: true)!)
                             completion(token, nil)
                         }
-                        let client = ARTRealtime(options: options)
+                        let client = ARTRealtime(options: authCallbackTestsOptions)
                         defer { client.dispose(); client.close() }
 
                         waitUntil(timeout: testTimeout) { done in
@@ -4390,12 +4390,12 @@ class Auth : QuickSpec {
         
         // RSC1 RSC1a RSC1c RSA3d
         describe("JWT and rest") {
-            let options = AblyTests.clientOptions()
+            let jwtAndRestTestsOptions = AblyTests.clientOptions()
             
             context("when the JWT token embeds an Ably token") {
                 it ("pulls stats successfully") {
-                    options.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded")!)
-                    let client = ARTRest(options: options)
+                    jwtAndRestTestsOptions.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded")!)
+                    let client = ARTRest(options: jwtAndRestTestsOptions)
                     waitUntil(timeout: testTimeout) { done in
                         client.stats { stats, error in
                             expect(error).to(beNil())
@@ -4407,8 +4407,8 @@ class Auth : QuickSpec {
             
             context("when the JWT token embeds an Ably token and it is requested as encrypted") {
                 it ("pulls stats successfully") {
-                    options.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded", encrypted: 1)!)
-                    let client = ARTRest(options: options)
+                    jwtAndRestTestsOptions.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded", encrypted: 1)!)
+                    let client = ARTRest(options: jwtAndRestTestsOptions)
                     waitUntil(timeout: testTimeout) { done in
                         client.stats { stats, error in
                             expect(error).to(beNil())

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -1746,7 +1746,7 @@ class Auth : QuickSpec {
                 var options: ARTClientOptions!
                 var rest: ARTRest!
 
-                func setupDependencies() {
+                func tokenParamsTestsSetupDependencies() {
                     if (options == nil) {
                         options = AblyTests.commonAppSetup()
                         options.clientId = currentClientId
@@ -1755,7 +1755,7 @@ class Auth : QuickSpec {
                 }
 
                 it("using defaults") {
-                    setupDependencies()
+                    tokenParamsTestsSetupDependencies()
 
                     // Default values
                     let defaultTokenParams = ARTTokenParams(clientId: currentClientId)
@@ -1777,7 +1777,7 @@ class Auth : QuickSpec {
                 }
 
                 it("overriding defaults") {
-                    setupDependencies()
+                    tokenParamsTestsSetupDependencies()
 
                     // Custom values
                     let expectedTtl = 4800.0
@@ -4122,7 +4122,7 @@ class Auth : QuickSpec {
 
                 var keys: [String: String]!
 
-                func setupDependencies() {
+                func rsa8gTestsSetupDependencies() {
                     if (keys == nil) {
                         keys = getKeys()
                     }
@@ -4130,7 +4130,7 @@ class Auth : QuickSpec {
 
                 context("with valid credentials") {
                     it("fetches a channels and posts a message") {
-                        setupDependencies()
+                        rsa8gTestsSetupDependencies()
 
                         authUrlTestsOptions.authParams = [URLQueryItem]()
                         authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
@@ -4153,7 +4153,7 @@ class Auth : QuickSpec {
 
                 context("with wrong credentials") {
                     it("fails to connect with reason 'invalid signature'") {
-                        setupDependencies()
+                        rsa8gTestsSetupDependencies()
 
                         authUrlTestsOptions.authParams = [URLQueryItem]()
                         authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
@@ -4178,7 +4178,7 @@ class Auth : QuickSpec {
                 context("when token expires") {
 
                     it ("receives a 40142 error from the server") {
-                        setupDependencies()
+                        rsa8gTestsSetupDependencies()
 
                         let tokenDuration = 5.0
                         authUrlTestsOptions.authParams = [URLQueryItem]()
@@ -4204,7 +4204,7 @@ class Auth : QuickSpec {
                 // RTC8a4
                 context("when the server sends and AUTH protocol message") {
                     it("client reauths correctly without going through a disconnection") {
-                        setupDependencies()
+                        rsa8gTestsSetupDependencies()
                         
                         // The server sends an AUTH protocol message 30 seconds before a token expires
                         // We create a token that lasts 35 seconds, so there's room to receive the AUTH message
@@ -4422,7 +4422,7 @@ class Auth : QuickSpec {
             context("when the JWT token is returned with application/jwt content type") {
                 var client: ARTRest!
 
-                func setupDependencies() {
+                func jwtContentTypeTestsSetupDependencies() {
                     if (client == nil) {
                         let options = AblyTests.clientOptions()
                         let keys = getKeys()
@@ -4436,7 +4436,7 @@ class Auth : QuickSpec {
                 }
 
                 beforeEach {
-                    setupDependencies()
+                    jwtContentTypeTestsSetupDependencies()
                 }
                 
                 it("the client successfully connects and pulls stats") {

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -2183,7 +2183,7 @@ class RealtimeClientChannel: QuickSpec {
                         }
                         afterEach { rtl6c2TestsClient.close() }
 
-                        func publish(_ done: @escaping () -> ()) {
+                        func rtl16c2TestsPublish(_ done: @escaping () -> ()) {
                             rtl6c2TestsChannel.publish(nil, data: "message") { error in
                                 expect(error).to(beNil())
                                 expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.connected))
@@ -2195,7 +2195,7 @@ class RealtimeClientChannel: QuickSpec {
                             it("INITIALIZED") {
                                 waitUntil(timeout: testTimeout) { done in
                                     expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.initialized))
-                                    publish(done)
+                                    rtl16c2TestsPublish(done)
                                     rtl6c2TestsClient.connect()
                                     expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
                                 }
@@ -2205,7 +2205,7 @@ class RealtimeClientChannel: QuickSpec {
                                 waitUntil(timeout: testTimeout) { done in
                                     rtl6c2TestsClient.connect()
                                     expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.connecting))
-                                    publish(done)
+                                    rtl16c2TestsPublish(done)
                                     expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
                                 }
                             }
@@ -2217,7 +2217,7 @@ class RealtimeClientChannel: QuickSpec {
 
                                 waitUntil(timeout: testTimeout) { done in
                                     expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.disconnected))
-                                    publish(done)
+                                    rtl16c2TestsPublish(done)
                                     expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
                                 }
                             }
@@ -2231,7 +2231,7 @@ class RealtimeClientChannel: QuickSpec {
                                 expect(rtl6c2TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
 
                                 waitUntil(timeout: testTimeout) { done in
-                                    publish(done)
+                                    rtl16c2TestsPublish(done)
                                     expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(0))
                                     expect((rtl6c2TestsClient.internal.transport as! TestProxyTransport).protocolMessagesSent.filter({ $0.action == .message })).to(haveCount(1))
                                 }
@@ -2244,7 +2244,7 @@ class RealtimeClientChannel: QuickSpec {
                                 waitUntil(timeout: testTimeout) { done in
                                     rtl6c2TestsChannel.attach()
                                     expect(rtl6c2TestsChannel.state).to(equal(ARTRealtimeChannelState.attaching))
-                                    publish(done)
+                                    rtl16c2TestsPublish(done)
                                     expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(0))
                                     expect((rtl6c2TestsClient.internal.transport as! TestProxyTransport).protocolMessagesSent.filter({ $0.action == .message })).to(haveCount(1))
                                 }
@@ -2278,7 +2278,7 @@ class RealtimeClientChannel: QuickSpec {
                                 expect(rtl6c2TestsChannel.state).to(equal(ARTRealtimeChannelState.attached))
 
                                 waitUntil(timeout: testTimeout) { done in
-                                    publish(done)
+                                    rtl16c2TestsPublish(done)
                                     expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
                                 }
                             }
@@ -2312,7 +2312,7 @@ class RealtimeClientChannel: QuickSpec {
                             ARTDefault.setConnectionStateTtl(previousConnectionStateTtl)
                         }
 
-                        func publish(_ done: @escaping () -> ()) {
+                        func rtl6c4TestsPublish(_ done: @escaping () -> ()) {
                             rtl6c4TestsChannel.publish(nil, data: "message") { error in
                                 expect(error).toNot(beNil())
                                 done()
@@ -2325,7 +2325,7 @@ class RealtimeClientChannel: QuickSpec {
                             rtl6c4TestsClient.internal.onSuspended()
                             expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.suspended), timeout: testTimeout)
                             waitUntil(timeout: testTimeout) { done in
-                                publish(done)
+                                rtl6c4TestsPublish(done)
                             }
                         }
 
@@ -2335,7 +2335,7 @@ class RealtimeClientChannel: QuickSpec {
                             rtl6c4TestsClient.close()
                             expect(rtl6c4TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.closing))
                             waitUntil(timeout: testTimeout) { done in
-                                publish(done)
+                                rtl6c4TestsPublish(done)
                             }
                         }
 
@@ -2345,7 +2345,7 @@ class RealtimeClientChannel: QuickSpec {
                             rtl6c4TestsClient.close()
                             expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.closed), timeout: testTimeout)
                             waitUntil(timeout: testTimeout) { done in
-                                publish(done)
+                                rtl6c4TestsPublish(done)
                             }
                         }
 
@@ -2355,7 +2355,7 @@ class RealtimeClientChannel: QuickSpec {
                             rtl6c4TestsClient.internal.onError(AblyTests.newErrorProtocolMessage())
                             expect(rtl6c4TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.failed))
                             waitUntil(timeout: testTimeout) { done in
-                                publish(done)
+                                rtl6c4TestsPublish(done)
                             }
                         }
 
@@ -2366,7 +2366,7 @@ class RealtimeClientChannel: QuickSpec {
                             rtl6c4TestsChannel.internal.setSuspended(ARTStatus.state(.ok))
                             expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.suspended), timeout: testTimeout)
                             waitUntil(timeout: testTimeout) { done in
-                                publish(done)
+                                rtl6c4TestsPublish(done)
                             }
                         }
 
@@ -2378,7 +2378,7 @@ class RealtimeClientChannel: QuickSpec {
                             rtl6c4TestsChannel.internal.onError(protocolError)
                             expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.failed), timeout: testTimeout)
                             waitUntil(timeout: testTimeout) { done in
-                                publish(done)
+                                rtl6c4TestsPublish(done)
                             }
                         }
                     }

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -2170,23 +2170,23 @@ class RealtimeClientChannel: QuickSpec {
 
                     // RTL6c2
                     context("the message") {
-                        var client: ARTRealtime!
-                        var channel: ARTRealtimeChannel!
+                        var rtl6c2TestsClient: ARTRealtime!
+                        var rtl6c2TestsChannel: ARTRealtimeChannel!
 
                         beforeEach {
                             let options = AblyTests.commonAppSetup()
                             options.useTokenAuth = true
                             options.autoConnect = false
-                            client = AblyTests.newRealtime(options)
-                            channel = client.channels.get("test")
-                            expect(client.internal.options.queueMessages).to(beTrue())
+                            rtl6c2TestsClient = AblyTests.newRealtime(options)
+                            rtl6c2TestsChannel = rtl6c2TestsClient.channels.get("test")
+                            expect(rtl6c2TestsClient.internal.options.queueMessages).to(beTrue())
                         }
-                        afterEach { client.close() }
+                        afterEach { rtl6c2TestsClient.close() }
 
                         func publish(_ done: @escaping () -> ()) {
-                            channel.publish(nil, data: "message") { error in
+                            rtl6c2TestsChannel.publish(nil, data: "message") { error in
                                 expect(error).to(beNil())
-                                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+                                expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.connected))
                                 done()
                             }
                         }
@@ -2194,75 +2194,75 @@ class RealtimeClientChannel: QuickSpec {
                         context("should be queued and delivered as soon as the connection state returns to CONNECTED if the connection is") {
                             it("INITIALIZED") {
                                 waitUntil(timeout: testTimeout) { done in
-                                    expect(client.connection.state).to(equal(ARTRealtimeConnectionState.initialized))
+                                    expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.initialized))
                                     publish(done)
-                                    client.connect()
-                                    expect(client.internal.queuedMessages).to(haveCount(1))
+                                    rtl6c2TestsClient.connect()
+                                    expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
                                 }
                             }
 
                             it("CONNECTING") {
                                 waitUntil(timeout: testTimeout) { done in
-                                    client.connect()
-                                    expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connecting))
+                                    rtl6c2TestsClient.connect()
+                                    expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.connecting))
                                     publish(done)
-                                    expect(client.internal.queuedMessages).to(haveCount(1))
+                                    expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
                                 }
                             }
 
                             it("DISCONNECTED") {
-                                client.connect()
-                                expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                                client.internal.onDisconnected()
+                                rtl6c2TestsClient.connect()
+                                expect(rtl6c2TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+                                rtl6c2TestsClient.internal.onDisconnected()
 
                                 waitUntil(timeout: testTimeout) { done in
-                                    expect(client.connection.state).to(equal(ARTRealtimeConnectionState.disconnected))
+                                    expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.disconnected))
                                     publish(done)
-                                    expect(client.internal.queuedMessages).to(haveCount(1))
+                                    expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
                                 }
                             }
                         }
 
                         context("should NOT be queued instead it should be published if the channel is") {
                             it("INITIALIZED") {
-                                client.connect()
-                                expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
+                                rtl6c2TestsClient.connect()
+                                expect(rtl6c2TestsChannel.state).to(equal(ARTRealtimeChannelState.initialized))
 
-                                expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+                                expect(rtl6c2TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
 
                                 waitUntil(timeout: testTimeout) { done in
                                     publish(done)
-                                    expect(client.internal.queuedMessages).to(haveCount(0))
-                                    expect((client.internal.transport as! TestProxyTransport).protocolMessagesSent.filter({ $0.action == .message })).to(haveCount(1))
+                                    expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(0))
+                                    expect((rtl6c2TestsClient.internal.transport as! TestProxyTransport).protocolMessagesSent.filter({ $0.action == .message })).to(haveCount(1))
                                 }
                             }
 
                             it("ATTACHING") {
-                                client.connect()
-                                expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+                                rtl6c2TestsClient.connect()
+                                expect(rtl6c2TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
 
                                 waitUntil(timeout: testTimeout) { done in
-                                    channel.attach()
-                                    expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+                                    rtl6c2TestsChannel.attach()
+                                    expect(rtl6c2TestsChannel.state).to(equal(ARTRealtimeChannelState.attaching))
                                     publish(done)
-                                    expect(client.internal.queuedMessages).to(haveCount(0))
-                                    expect((client.internal.transport as! TestProxyTransport).protocolMessagesSent.filter({ $0.action == .message })).to(haveCount(1))
+                                    expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(0))
+                                    expect((rtl6c2TestsClient.internal.transport as! TestProxyTransport).protocolMessagesSent.filter({ $0.action == .message })).to(haveCount(1))
                                 }
                             }
 
                             it("ATTACHED") {
                                 waitUntil(timeout: testTimeout) { done in
-                                    channel.attach() { error in
+                                    rtl6c2TestsChannel.attach() { error in
                                         expect(error).to(beNil())
                                         done()
                                     }
-                                    client.connect()
+                                    rtl6c2TestsClient.connect()
                                 }
 
                                 waitUntil(timeout: testTimeout) { done in
                                     let tokenParams = ARTTokenParams()
                                     tokenParams.ttl = 5.0
-                                    client.auth.authorize(tokenParams, options: nil) { tokenDetails, error in
+                                    rtl6c2TestsClient.auth.authorize(tokenParams, options: nil) { tokenDetails, error in
                                         expect(error).to(beNil())
                                         expect(tokenDetails).toNot(beNil())
                                         done()
@@ -2270,16 +2270,16 @@ class RealtimeClientChannel: QuickSpec {
                                 }
 
                                 waitUntil(timeout: testTimeout) { done in
-                                    client.connection.once(.disconnected) { _ in
+                                    rtl6c2TestsClient.connection.once(.disconnected) { _ in
                                         done()
                                     }
                                 }
 
-                                expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+                                expect(rtl6c2TestsChannel.state).to(equal(ARTRealtimeChannelState.attached))
 
                                 waitUntil(timeout: testTimeout) { done in
                                     publish(done)
-                                    expect(client.internal.queuedMessages).to(haveCount(1))
+                                    expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
                                 }
                             }
                         }
@@ -2288,8 +2288,8 @@ class RealtimeClientChannel: QuickSpec {
                     // RTL6c4
                     context("will result in an error if the") {
                         var options: ARTClientOptions!
-                        var client: ARTRealtime!
-                        var channel: ARTRealtimeChannel!
+                        var rtl6c4TestsClient: ARTRealtime!
+                        var rtl6c4TestsChannel: ARTRealtimeChannel!
 
                         let previousConnectionStateTtl = ARTDefault.connectionStateTtl()
 
@@ -2304,79 +2304,79 @@ class RealtimeClientChannel: QuickSpec {
                         beforeEach {
                             setupDependencies()
                             ARTDefault.setConnectionStateTtl(0.3)
-                            client = AblyTests.newRealtime(options)
-                            channel = client.channels.get("test")
+                            rtl6c4TestsClient = AblyTests.newRealtime(options)
+                            rtl6c4TestsChannel = rtl6c4TestsClient.channels.get("test")
                         }
                         afterEach {
-                            client.close()
+                            rtl6c4TestsClient.close()
                             ARTDefault.setConnectionStateTtl(previousConnectionStateTtl)
                         }
 
                         func publish(_ done: @escaping () -> ()) {
-                            channel.publish(nil, data: "message") { error in
+                            rtl6c4TestsChannel.publish(nil, data: "message") { error in
                                 expect(error).toNot(beNil())
                                 done()
                             }
                         }
 
                         it("connection is SUSPENDED") {
-                            client.connect()
-                            expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                            client.internal.onSuspended()
-                            expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.suspended), timeout: testTimeout)
+                            rtl6c4TestsClient.connect()
+                            expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+                            rtl6c4TestsClient.internal.onSuspended()
+                            expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.suspended), timeout: testTimeout)
                             waitUntil(timeout: testTimeout) { done in
                                 publish(done)
                             }
                         }
 
                         it("connection is CLOSING") {
-                            client.connect()
-                            expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                            client.close()
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closing))
+                            rtl6c4TestsClient.connect()
+                            expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+                            rtl6c4TestsClient.close()
+                            expect(rtl6c4TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.closing))
                             waitUntil(timeout: testTimeout) { done in
                                 publish(done)
                             }
                         }
 
                         it("connection is CLOSED") {
-                            client.connect()
-                            expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                            client.close()
-                            expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.closed), timeout: testTimeout)
+                            rtl6c4TestsClient.connect()
+                            expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+                            rtl6c4TestsClient.close()
+                            expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.closed), timeout: testTimeout)
                             waitUntil(timeout: testTimeout) { done in
                                 publish(done)
                             }
                         }
 
                         it("connection is FAILED") {
-                            client.connect()
-                            expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                            client.internal.onError(AblyTests.newErrorProtocolMessage())
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.failed))
+                            rtl6c4TestsClient.connect()
+                            expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+                            rtl6c4TestsClient.internal.onError(AblyTests.newErrorProtocolMessage())
+                            expect(rtl6c4TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.failed))
                             waitUntil(timeout: testTimeout) { done in
                                 publish(done)
                             }
                         }
 
                         it("channel is SUSPENDED") {
-                            client.connect()
-                            channel.attach()
-                            expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-                            channel.internal.setSuspended(ARTStatus.state(.ok))
-                            expect(channel.state).toEventually(equal(ARTRealtimeChannelState.suspended), timeout: testTimeout)
+                            rtl6c4TestsClient.connect()
+                            rtl6c4TestsChannel.attach()
+                            expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+                            rtl6c4TestsChannel.internal.setSuspended(ARTStatus.state(.ok))
+                            expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.suspended), timeout: testTimeout)
                             waitUntil(timeout: testTimeout) { done in
                                 publish(done)
                             }
                         }
 
                         it("channel is FAILED") {
-                            client.connect()
-                            channel.attach()
-                            expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+                            rtl6c4TestsClient.connect()
+                            rtl6c4TestsChannel.attach()
+                            expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
                             let protocolError = AblyTests.newErrorProtocolMessage()
-                            channel.internal.onError(protocolError)
-                            expect(channel.state).toEventually(equal(ARTRealtimeChannelState.failed), timeout: testTimeout)
+                            rtl6c4TestsChannel.internal.onError(protocolError)
+                            expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.failed), timeout: testTimeout)
                             waitUntil(timeout: testTimeout) { done in
                                 publish(done)
                             }

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -2815,8 +2815,8 @@ class RealtimeClientConnection: QuickSpec {
                 
                 // RTN15g RTN15g1
                 context("when connection (ttl + idle interval) period has passed since last activity") {
-                    var client: ARTRealtime!
-                    var connectionId = ""
+                    var ttlAndIdleIntervalPassedTestsClient: ARTRealtime!
+                    var ttlAndIdleIntervalPassedTestsConnectionId = ""
                     let customTtlInterval: TimeInterval = 0.1
                     let customIdleInterval: TimeInterval = 0.1
                     
@@ -2824,31 +2824,31 @@ class RealtimeClientConnection: QuickSpec {
                         let options = AblyTests.commonAppSetup()
                         // We want this to be > than the sum of customTtlInterval and customIdleInterval
                         options.disconnectedRetryTimeout = 5.0 + customTtlInterval + customIdleInterval
-                        client = AblyTests.newRealtime(options)
-                        client.internal.shouldImmediatelyReconnect = false
-                        client.connect()
-                        defer { client.close() }
+                        ttlAndIdleIntervalPassedTestsClient = AblyTests.newRealtime(options)
+                        ttlAndIdleIntervalPassedTestsClient.internal.shouldImmediatelyReconnect = false
+                        ttlAndIdleIntervalPassedTestsClient.connect()
+                        defer { ttlAndIdleIntervalPassedTestsClient.close() }
                         
                         waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.connected) { _ in
-                                expect(client.connection.id).toNot(beNil())
-                                connectionId = client.connection.id!
-                                client.internal.connectionStateTtl = customTtlInterval
-                                client.internal.maxIdleInterval = customIdleInterval
-                                client.connection.once(.disconnected) { _ in
+                            ttlAndIdleIntervalPassedTestsClient.connection.once(.connected) { _ in
+                                expect(ttlAndIdleIntervalPassedTestsClient.connection.id).toNot(beNil())
+                                ttlAndIdleIntervalPassedTestsConnectionId = ttlAndIdleIntervalPassedTestsClient.connection.id!
+                                ttlAndIdleIntervalPassedTestsClient.internal.connectionStateTtl = customTtlInterval
+                                ttlAndIdleIntervalPassedTestsClient.internal.maxIdleInterval = customIdleInterval
+                                ttlAndIdleIntervalPassedTestsClient.connection.once(.disconnected) { _ in
                                     let disconnectedAt = Date()
-                                    expect(client.internal.connectionStateTtl).to(equal(customTtlInterval))
-                                    expect(client.internal.maxIdleInterval).to(equal(customIdleInterval))
-                                    client.connection.once(.connecting) { _ in
+                                    expect(ttlAndIdleIntervalPassedTestsClient.internal.connectionStateTtl).to(equal(customTtlInterval))
+                                    expect(ttlAndIdleIntervalPassedTestsClient.internal.maxIdleInterval).to(equal(customIdleInterval))
+                                    ttlAndIdleIntervalPassedTestsClient.connection.once(.connecting) { _ in
                                         let reconnectionInterval = Date().timeIntervalSince(disconnectedAt)
-                                        expect(reconnectionInterval).to(beGreaterThan(client.internal.connectionStateTtl + client.internal.maxIdleInterval))
-                                        client.connection.once(.connected) { _ in
-                                            expect(client.connection.id).toNot(equal(connectionId))
+                                        expect(reconnectionInterval).to(beGreaterThan(ttlAndIdleIntervalPassedTestsClient.internal.connectionStateTtl + ttlAndIdleIntervalPassedTestsClient.internal.maxIdleInterval))
+                                        ttlAndIdleIntervalPassedTestsClient.connection.once(.connected) { _ in
+                                            expect(ttlAndIdleIntervalPassedTestsClient.connection.id).toNot(equal(ttlAndIdleIntervalPassedTestsConnectionId))
                                             done()
                                         }
                                     }
                                 }
-                                client.internal.onDisconnected()
+                                ttlAndIdleIntervalPassedTestsClient.internal.onDisconnected()
                             }
                         }
                     }
@@ -2857,28 +2857,28 @@ class RealtimeClientConnection: QuickSpec {
                         let options = AblyTests.commonAppSetup()
                         // We want this to be > than the sum of customTtlInterval and customIdleInterval
                         options.disconnectedRetryTimeout = 5.0
-                        client = AblyTests.newRealtime(options)
-                        client.internal.shouldImmediatelyReconnect = false
-                        defer { client.close() }
+                        ttlAndIdleIntervalPassedTestsClient = AblyTests.newRealtime(options)
+                        ttlAndIdleIntervalPassedTestsClient.internal.shouldImmediatelyReconnect = false
+                        defer { ttlAndIdleIntervalPassedTestsClient.close() }
                         let channelName = "test-reattach-after-ttl"
-                        let channel = client.channels.get(channelName)
+                        let channel = ttlAndIdleIntervalPassedTestsClient.channels.get(channelName)
                         
                         waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.connected) { _ in
-                                connectionId = client.connection.id!
-                                client.internal.connectionStateTtl = customTtlInterval
-                                client.internal.maxIdleInterval = customIdleInterval
+                            ttlAndIdleIntervalPassedTestsClient.connection.once(.connected) { _ in
+                                ttlAndIdleIntervalPassedTestsConnectionId = ttlAndIdleIntervalPassedTestsClient.connection.id!
+                                ttlAndIdleIntervalPassedTestsClient.internal.connectionStateTtl = customTtlInterval
+                                ttlAndIdleIntervalPassedTestsClient.internal.maxIdleInterval = customIdleInterval
                                 channel.attach { error in
                                     if let error = error {
                                         fail(error.message)
                                     }
                                     expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
-                                    client.internal.onDisconnected()
+                                    ttlAndIdleIntervalPassedTestsClient.internal.onDisconnected()
                                 }
-                                client.connection.once(.disconnected) { _ in
-                                    client.connection.once(.connecting) { _ in
-                                        client.connection.once(.connected) { _ in
-                                            expect(client.connection.id).toNot(equal(connectionId))
+                                ttlAndIdleIntervalPassedTestsClient.connection.once(.disconnected) { _ in
+                                    ttlAndIdleIntervalPassedTestsClient.connection.once(.connecting) { _ in
+                                        ttlAndIdleIntervalPassedTestsClient.connection.once(.connected) { _ in
+                                            expect(ttlAndIdleIntervalPassedTestsClient.connection.id).toNot(equal(ttlAndIdleIntervalPassedTestsConnectionId))
                                             channel.once(.attached) { stateChange in
                                                 expect(stateChange.resumed).to(beFalse())
                                                 done()
@@ -2887,38 +2887,38 @@ class RealtimeClientConnection: QuickSpec {
                                     }
                                 }
                             }
-                            client.connect()
+                            ttlAndIdleIntervalPassedTestsClient.connect()
                         }
                     }
                 }
                 
                 // RTN15g2
                 context("when connection (ttl + idle interval) period has NOT passed since last activity") {
-                    var client: ARTRealtime!
-                    var connectionId = ""
+                    var ttlAndIdleIntervalNotPassedTestsClient: ARTRealtime!
+                    var ttlAndIdleIntervalNotPassedTestsConnectionId = ""
                     
                     it("uses the same connection") {
                         let options = AblyTests.commonAppSetup()
-                        client = AblyTests.newRealtime(options)
-                        client.connect()
-                        defer { client.close() }
+                        ttlAndIdleIntervalNotPassedTestsClient = AblyTests.newRealtime(options)
+                        ttlAndIdleIntervalNotPassedTestsClient.connect()
+                        defer { ttlAndIdleIntervalNotPassedTestsClient.close() }
                         
                         waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.connected) { _ in
-                                expect(client.connection.id).toNot(beNil())
-                                connectionId = client.connection.id!
-                                client.connection.once(.disconnected) { _ in
+                            ttlAndIdleIntervalNotPassedTestsClient.connection.once(.connected) { _ in
+                                expect(ttlAndIdleIntervalNotPassedTestsClient.connection.id).toNot(beNil())
+                                ttlAndIdleIntervalNotPassedTestsConnectionId = ttlAndIdleIntervalNotPassedTestsClient.connection.id!
+                                ttlAndIdleIntervalNotPassedTestsClient.connection.once(.disconnected) { _ in
                                     let disconnectedAt = Date()
-                                    client.connection.once(.connecting) { _ in
+                                    ttlAndIdleIntervalNotPassedTestsClient.connection.once(.connecting) { _ in
                                         let reconnectionInterval = Date().timeIntervalSince(disconnectedAt)
-                                        expect(reconnectionInterval).to(beLessThan(client.internal.connectionStateTtl + client.internal.maxIdleInterval))
-                                        client.connection.once(.connected) { _ in
-                                            expect(client.connection.id).to(equal(connectionId))
+                                        expect(reconnectionInterval).to(beLessThan(ttlAndIdleIntervalNotPassedTestsClient.internal.connectionStateTtl + ttlAndIdleIntervalNotPassedTestsClient.internal.maxIdleInterval))
+                                        ttlAndIdleIntervalNotPassedTestsClient.connection.once(.connected) { _ in
+                                            expect(ttlAndIdleIntervalNotPassedTestsClient.connection.id).to(equal(ttlAndIdleIntervalNotPassedTestsConnectionId))
                                             done()
                                         }
                                     }
                                 }
-                                client.internal.onDisconnected()
+                                ttlAndIdleIntervalNotPassedTestsClient.internal.onDisconnected()
                             }
                         }
                     }
@@ -4072,31 +4072,31 @@ class RealtimeClientConnection: QuickSpec {
 
                 // RTN20a
                 context("should immediately change the state to DISCONNECTED if the operating system indicates that the underlying internet connection is no longer available") {
-                    var client: ARTRealtime!
+                    var internetConnectionNotAvailableTestsClient: ARTRealtime!
 
                     beforeEach {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
-                        client = ARTRealtime(options: options)
-                        client.internal.setReachabilityClass(TestReachability.self)
+                        internetConnectionNotAvailableTestsClient = ARTRealtime(options: options)
+                        internetConnectionNotAvailableTestsClient.internal.setReachabilityClass(TestReachability.self)
                     }
 
                     afterEach {
-                        client.dispose()
-                        client.close()
+                        internetConnectionNotAvailableTestsClient.dispose()
+                        internetConnectionNotAvailableTestsClient.close()
                     }
 
                     it("when CONNECTING") {
                         waitUntil(timeout: testTimeout) { done in
-                            client.connection.on { stateChange in
+                            internetConnectionNotAvailableTestsClient.connection.on { stateChange in
                                 switch stateChange.current {
                                 case .connecting:
                                     expect(stateChange.reason).to(beNil())
-                                    guard let reachability = client.internal.reachability as? TestReachability else {
+                                    guard let reachability = internetConnectionNotAvailableTestsClient.internal.reachability as? TestReachability else {
                                         fail("expected test reachability")
                                         done(); return
                                     }
-                                    expect(reachability.host).to(equal(client.internal.options.realtimeHost))
+                                    expect(reachability.host).to(equal(internetConnectionNotAvailableTestsClient.internal.options.realtimeHost))
                                     reachability.simulate(false)
                                 case .disconnected:
                                     guard let reason = stateChange.reason else {
@@ -4109,21 +4109,21 @@ class RealtimeClientConnection: QuickSpec {
                                     break
                                 }
                             }
-                            client.connect()
+                            internetConnectionNotAvailableTestsClient.connect()
                         }
                     }
 
                     it("when CONNECTED") {
                         waitUntil(timeout: testTimeout) { done in
-                            client.connection.on { stateChange in
+                            internetConnectionNotAvailableTestsClient.connection.on { stateChange in
                                 switch stateChange.current {
                                 case .connected:
                                     expect(stateChange.reason).to(beNil())
-                                    guard let reachability = client.internal.reachability as? TestReachability else {
+                                    guard let reachability = internetConnectionNotAvailableTestsClient.internal.reachability as? TestReachability else {
                                         fail("expected test reachability")
                                         done(); return
                                     }
-                                    expect(reachability.host).to(equal(client.internal.options.realtimeHost))
+                                    expect(reachability.host).to(equal(internetConnectionNotAvailableTestsClient.internal.options.realtimeHost))
                                     reachability.simulate(false)
                                 case .disconnected:
                                     guard let reason = stateChange.reason else {
@@ -4136,7 +4136,7 @@ class RealtimeClientConnection: QuickSpec {
                                     break
                                 }
                             }
-                            client.connect()
+                            internetConnectionNotAvailableTestsClient.connect()
                         }
                     }
                 }

--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -19,8 +19,10 @@ class RestClientChannel: QuickSpec {
 
         // RSL1
         describe("publish") {
-            let name = "foo"
-            let data = "bar"
+            struct PublishArgs {
+                static let name = "foo"
+                static let data = "bar"
+            }
 
             // RSL1b
             context("with name and data arguments") {
@@ -28,7 +30,7 @@ class RestClientChannel: QuickSpec {
                     var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
                     var publishedMessage: ARTMessage?
 
-                    channel.publish(name, data: data) { error in
+                    channel.publish(PublishArgs.name, data: PublishArgs.data) { error in
                         publishError = error
                         channel.history { result, _ in
                             publishedMessage = result?.items.first
@@ -36,8 +38,8 @@ class RestClientChannel: QuickSpec {
                     }
 
                     expect(publishError).toEventually(beNil(), timeout: testTimeout)
-                    expect(publishedMessage?.name).toEventually(equal(name), timeout: testTimeout)
-                    expect(publishedMessage?.data as? String).toEventually(equal(data), timeout: testTimeout)
+                    expect(publishedMessage?.name).toEventually(equal(PublishArgs.name), timeout: testTimeout)
+                    expect(publishedMessage?.data as? String).toEventually(equal(PublishArgs.data), timeout: testTimeout)
                 }
             }
 
@@ -47,7 +49,7 @@ class RestClientChannel: QuickSpec {
                     var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "io.ably.XCTest", code: -1, userInfo: nil))
                     var publishedMessage: ARTMessage?
 
-                    channel.publish(name, data: nil) { error in
+                    channel.publish(PublishArgs.name, data: nil) { error in
                         publishError = error
                         channel.history { result, _ in
                             publishedMessage = result?.items.first
@@ -55,7 +57,7 @@ class RestClientChannel: QuickSpec {
                     }
 
                     expect(publishError).toEventually(beNil(), timeout: testTimeout)
-                    expect(publishedMessage?.name).toEventually(equal(name), timeout: testTimeout)
+                    expect(publishedMessage?.name).toEventually(equal(PublishArgs.name), timeout: testTimeout)
                     expect(publishedMessage?.data).toEventually(beNil(), timeout: testTimeout)
                 }
             }
@@ -66,7 +68,7 @@ class RestClientChannel: QuickSpec {
                     var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
                     var publishedMessage: ARTMessage?
 
-                    channel.publish(nil, data: data) { error in
+                    channel.publish(nil, data: PublishArgs.data) { error in
                         publishError = error
                         channel.history { result, _ in
                             publishedMessage = result?.items.first
@@ -75,7 +77,7 @@ class RestClientChannel: QuickSpec {
 
                     expect(publishError).toEventually(beNil(), timeout: testTimeout)
                     expect(publishedMessage?.name).toEventually(beNil(), timeout: testTimeout)
-                    expect(publishedMessage?.data as? String).toEventually(equal(data), timeout: testTimeout)
+                    expect(publishedMessage?.data as? String).toEventually(equal(PublishArgs.data), timeout: testTimeout)
                 }
             }
 
@@ -107,7 +109,7 @@ class RestClientChannel: QuickSpec {
                     var publishedMessage: ARTMessage?
 
                     waitUntil(timeout: testTimeout) { done in
-                        channel.publish([ARTMessage(name: name, data: data)]) { error in
+                        channel.publish([ARTMessage(name: PublishArgs.name, data: PublishArgs.data)]) { error in
                             publishError = error
                             channel.history { result, _ in
                                 publishedMessage = result?.items.first
@@ -117,8 +119,8 @@ class RestClientChannel: QuickSpec {
                     }
 
                     expect(publishError).to(beNil())
-                    expect(publishedMessage?.name).to(equal(name))
-                    expect(publishedMessage?.data as? String).to(equal(data))
+                    expect(publishedMessage?.name).to(equal(PublishArgs.name))
+                    expect(publishedMessage?.data as? String).to(equal(PublishArgs.data))
                 }
             }
 

--- a/Spec/Stats.swift
+++ b/Spec/Stats.swift
@@ -83,12 +83,14 @@ class Stats: QuickSpec {
 
             // TS4
             context("connections") {
-                let data: JSON = [
-                    [ "connections": [ "tls": [ "opened": 5], "all": [ "peak": 10 ] ] ]
-                ]
-                let rawData = try! data.rawData()
-                let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
-                let subject = stats?.connections
+                let subject: ARTStatsConnectionTypes? = {
+                    let data: JSON = [
+                        [ "connections": [ "tls": [ "opened": 5], "all": [ "peak": 10 ] ] ]
+                    ]
+                    let rawData = try! data.rawData()
+                    let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
+                    return stats?.connections
+                }()
 
                 it("should return a ConnectionTypes object") {
                     expect(subject).to(beAnInstanceOf(ARTStatsConnectionTypes.self))
@@ -110,12 +112,14 @@ class Stats: QuickSpec {
 
             // TS9
             context("channels") {
-                let data: JSON = [
-                    [ "channels": [ "opened": 5, "peak": 10 ] ]
-                ]
-                let rawData = try! data.rawData()
-                let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
-                let subject = stats?.channels
+                let subject: ARTStatsResourceCount? = {
+                    let data: JSON = [
+                        [ "channels": [ "opened": 5, "peak": 10 ] ]
+                    ]
+                    let rawData = try! data.rawData()
+                    let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
+                    return stats?.channels
+                }()
 
                 it("should return a ResourceCount object") {
                     expect(subject).to(beAnInstanceOf(ARTStatsResourceCount.self))
@@ -166,13 +170,13 @@ class Stats: QuickSpec {
             }
             
             context("interval") {
-                let data: JSON = [
-                    [ "intervalId": "2004-02-01:05:06" ]
-                ]
-                let rawData = try! data.rawData()
-                let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
-
                 it("should return a Date object representing the start of the interval") {
+                    let data: JSON = [
+                        [ "intervalId": "2004-02-01:05:06" ]
+                    ]
+                    let rawData = try! data.rawData()
+                    let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
+                    
                     let dateComponents = NSDateComponents()
                     dateComponents.year = 2004
                     dateComponents.month = 2
@@ -188,23 +192,25 @@ class Stats: QuickSpec {
             }
             
             context("push") {
-                let data: JSON = [
-                    [ "push":
-                        [
-                            "messages": 10,
-                            "notifications": [
-                                "invalid": 1,
-                                "attempted": 2,
-                                "successful": 3,
-                                "failed": 4
-                            ],
-                            "directPublishes": 5
+                let subject: ARTStatsPushCount? = {
+                    let data: JSON = [
+                        [ "push":
+                            [
+                                "messages": 10,
+                                "notifications": [
+                                    "invalid": 1,
+                                    "attempted": 2,
+                                    "successful": 3,
+                                    "failed": 4
+                                ],
+                                "directPublishes": 5
+                            ]
                         ]
                     ]
-                ]
-                let rawData = try! data.rawData()
-                let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
-                let subject = stats?.pushes
+                    let rawData = try! data.rawData()
+                    let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
+                    return stats?.pushes
+                }()
 
                 it("should return a ARTStatsPushCount object") {
                     expect(subject).to(beAnInstanceOf(ARTStatsPushCount.self))
@@ -236,11 +242,13 @@ class Stats: QuickSpec {
             }
 
             context("inProgress") {
-                let data: JSON = [
-                    [ "inProgress": "2004-02-01:05:06" ]
-                ]
-                let rawData = try! data.rawData()
-                let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
+                let stats: ARTStats? = {
+                    let data: JSON = [
+                        [ "inProgress": "2004-02-01:05:06" ]
+                    ]
+                    let rawData = try! data.rawData()
+                    return try! encoder.decodeStats(rawData)[0] as? ARTStats
+                }()
 
                 it("should return a Date object representing the last sub-interval included in this statistic") {
                     let dateComponents = NSDateComponents()
@@ -258,11 +266,13 @@ class Stats: QuickSpec {
             }
             
             context("count") {
-                let data: JSON = [
-                    [ "count": 55 ]
-                ]
-                let rawData = try! data.rawData()
-                let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
+                let stats: ARTStats? = {
+                    let data: JSON = [
+                        [ "count": 55 ]
+                    ]
+                    let rawData = try! data.rawData()
+                    return try! encoder.decodeStats(rawData)[0] as? ARTStats
+                }()
 
                 it("should return value for number of lower-level stats") {
                     expect(stats?.count).to(equal(55))

--- a/Spec/Stats.swift
+++ b/Spec/Stats.swift
@@ -112,7 +112,7 @@ class Stats: QuickSpec {
 
             // TS9
             context("channels") {
-                let subject: ARTStatsResourceCount? = {
+                let channelsTestsSubject: ARTStatsResourceCount? = {
                     let data: JSON = [
                         [ "channels": [ "opened": 5, "peak": 10 ] ]
                     ]
@@ -122,20 +122,20 @@ class Stats: QuickSpec {
                 }()
 
                 it("should return a ResourceCount object") {
-                    expect(subject).to(beAnInstanceOf(ARTStatsResourceCount.self))
+                    expect(channelsTestsSubject).to(beAnInstanceOf(ARTStatsResourceCount.self))
                 }
 
                 it("should return value for opened counts") {
-                    expect(subject?.opened).to(equal(5))
+                    expect(channelsTestsSubject?.opened).to(equal(5))
                 }
 
                 it("should return value for peak channels") {
-                    expect(subject?.peak).to(equal(10))
+                    expect(channelsTestsSubject?.peak).to(equal(10))
                 }
 
                 // TS2
                 it("should return zero for empty values") {
-                    expect(subject?.refused).to(equal(0))
+                    expect(channelsTestsSubject?.refused).to(equal(0))
                 }
             }
 
@@ -192,7 +192,7 @@ class Stats: QuickSpec {
             }
             
             context("push") {
-                let subject: ARTStatsPushCount? = {
+                let pushTestsSubject: ARTStatsPushCount? = {
                     let data: JSON = [
                         [ "push":
                             [
@@ -213,36 +213,36 @@ class Stats: QuickSpec {
                 }()
 
                 it("should return a ARTStatsPushCount object") {
-                    expect(subject).to(beAnInstanceOf(ARTStatsPushCount.self))
+                    expect(pushTestsSubject).to(beAnInstanceOf(ARTStatsPushCount.self))
                 }
 
                 it("should return value for messages count") {
-                    expect(subject?.messages).to(equal(10))
+                    expect(pushTestsSubject?.messages).to(equal(10))
                 }
 
                 it("should return value for invalid notifications") {
-                    expect(subject?.invalid).to(equal(1))
+                    expect(pushTestsSubject?.invalid).to(equal(1))
                 }
 
                 it("should return value for attempted notifications") {
-                    expect(subject?.attempted).to(equal(2))
+                    expect(pushTestsSubject?.attempted).to(equal(2))
                 }
 
                 it("should return value for successful notifications") {
-                    expect(subject?.succeeded).to(equal(3))
+                    expect(pushTestsSubject?.succeeded).to(equal(3))
                 }
 
                 it("should return value for failed notifications") {
-                    expect(subject?.failed).to(equal(4))
+                    expect(pushTestsSubject?.failed).to(equal(4))
                 }
 
                 it("should return value for directPublishes") {
-                    expect(subject?.direct).to(equal(5))
+                    expect(pushTestsSubject?.direct).to(equal(5))
                 }
             }
 
             context("inProgress") {
-                let stats: ARTStats? = {
+                let inProgressTestsStats: ARTStats? = {
                     let data: JSON = [
                         [ "inProgress": "2004-02-01:05:06" ]
                     ]
@@ -261,12 +261,12 @@ class Stats: QuickSpec {
 
                     let expected = NSCalendar(identifier: NSCalendar.Identifier.gregorian)?.date(from: dateComponents as DateComponents)
 
-                    expect(stats?.dateFromInProgress()).to(equal(expected))
+                    expect(inProgressTestsStats?.dateFromInProgress()).to(equal(expected))
                 }
             }
             
             context("count") {
-                let stats: ARTStats? = {
+                let countTestStats: ARTStats? = {
                     let data: JSON = [
                         [ "count": 55 ]
                     ]
@@ -275,7 +275,7 @@ class Stats: QuickSpec {
                 }()
 
                 it("should return value for number of lower-level stats") {
-                    expect(stats?.count).to(equal(55))
+                    expect(countTestStats?.count).to(equal(55))
                 }
             }
         }


### PR DESCRIPTION
## What does this do?

Removes or renames some variables at the `spec` / `describe` / `context` level.

## Does it change the behaviour of the test suite?

No, it's just a refactor (moving variable declarations inside other ones, or renaming variables).

## Why are we doing this?

It’s groundwork for removing the Quick testing framework using an automated migrator tool (#1201). The migrator that I’m writing will pull all `spec` / `describe` / `context` level variable and function declarations in a file into a flattened file-wide list of global declarations. This might lead to clashes if multiple contexts use the same variable name. So we rename / remove things to avoid these clashes.

## Note

I had hoped to avoid this step, by making the migrator automatically rename variables to avoid clashes. I had a solution _almost_ working with [`swift-refactor`](https://github.com/apple/swift/tree/main/tools/swift-refactor) but for some reason that tool wasn't correctly updating variable references inside helper function declarations. I decided not to investigate this further, since it would probably end up taking a lot of time for something that could be fixed relatively quickly by hand. It's a shame, though.