### PR TITLE
Remove the Quick testing framework

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -93,9 +93,6 @@
 		8412FDF82661AC7B001FE9E6 /* SwiftyJSON.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF22661AC7B001FE9E6 /* SwiftyJSON.xcframework */; };
 		8412FDF92661AC7B001FE9E6 /* SwiftyJSON.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF22661AC7B001FE9E6 /* SwiftyJSON.xcframework */; };
 		8412FDFA2661AC7B001FE9E6 /* SwiftyJSON.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF22661AC7B001FE9E6 /* SwiftyJSON.xcframework */; };
-		8412FDFB2661AC7B001FE9E6 /* Quick.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF32661AC7B001FE9E6 /* Quick.xcframework */; };
-		8412FDFC2661AC7B001FE9E6 /* Quick.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF32661AC7B001FE9E6 /* Quick.xcframework */; };
-		8412FDFD2661AC7B001FE9E6 /* Quick.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF32661AC7B001FE9E6 /* Quick.xcframework */; };
 		8412FDFE2661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF42661AC7B001FE9E6 /* Nimble.xcframework */; };
 		8412FDFF2661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF42661AC7B001FE9E6 /* Nimble.xcframework */; };
 		8412FE002661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF42661AC7B001FE9E6 /* Nimble.xcframework */; };
@@ -1008,7 +1005,6 @@
 		8412FDE32661AC37001FE9E6 /* msgpack.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = msgpack.xcframework; path = Carthage/Build/msgpack.xcframework; sourceTree = "<group>"; };
 		8412FDF12661AC7A001FE9E6 /* Aspects.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Aspects.xcframework; path = Carthage/Build/Aspects.xcframework; sourceTree = "<group>"; };
 		8412FDF22661AC7B001FE9E6 /* SwiftyJSON.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SwiftyJSON.xcframework; path = Carthage/Build/SwiftyJSON.xcframework; sourceTree = "<group>"; };
-		8412FDF32661AC7B001FE9E6 /* Quick.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Quick.xcframework; path = Carthage/Build/Quick.xcframework; sourceTree = "<group>"; };
 		8412FDF42661AC7B001FE9E6 /* Nimble.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Nimble.xcframework; path = Carthage/Build/Nimble.xcframework; sourceTree = "<group>"; };
 		84569FA226B46ADC00457CF5 /* ClientOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientOptions.swift; sourceTree = "<group>"; };
 		848ED97226E50D0F0087E800 /* ObjcppTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjcppTest.mm; sourceTree = "<group>"; };
@@ -1284,7 +1280,6 @@
 			files = (
 				8412FDF82661AC7B001FE9E6 /* SwiftyJSON.xcframework in Frameworks */,
 				8412FDFE2661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */,
-				8412FDFB2661AC7B001FE9E6 /* Quick.xcframework in Frameworks */,
 				D70F277D2261046A00956251 /* Ably.framework in Frameworks */,
 				8412FDF52661AC7B001FE9E6 /* Aspects.xcframework in Frameworks */,
 			);
@@ -1305,7 +1300,6 @@
 			files = (
 				8412FDF92661AC7B001FE9E6 /* SwiftyJSON.xcframework in Frameworks */,
 				8412FDFF2661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */,
-				8412FDFC2661AC7B001FE9E6 /* Quick.xcframework in Frameworks */,
 				D7093C0F219E2DB200723F17 /* Ably.framework in Frameworks */,
 				8412FDF62661AC7B001FE9E6 /* Aspects.xcframework in Frameworks */,
 			);
@@ -1317,7 +1311,6 @@
 			files = (
 				8412FDFA2661AC7B001FE9E6 /* SwiftyJSON.xcframework in Frameworks */,
 				8412FE002661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */,
-				8412FDFD2661AC7B001FE9E6 /* Quick.xcframework in Frameworks */,
 				D7093C65219EE1AE00723F17 /* Ably.framework in Frameworks */,
 				8412FDF72661AC7B001FE9E6 /* Aspects.xcframework in Frameworks */,
 			);
@@ -1879,7 +1872,6 @@
 				8412FDE32661AC37001FE9E6 /* msgpack.xcframework */,
 				8412FDF12661AC7A001FE9E6 /* Aspects.xcframework */,
 				8412FDF42661AC7B001FE9E6 /* Nimble.xcframework */,
-				8412FDF32661AC7B001FE9E6 /* Quick.xcframework */,
 				8412FDF22661AC7B001FE9E6 /* SwiftyJSON.xcframework */,
 			);
 			name = Frameworks;

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,4 +1,3 @@
-github "Quick/Quick" == 4.0.0
 github "Quick/Nimble" == 9.2.1
 github "whitesmith/Aspects" "1.4.2-ws1"
 github "SwiftyJSON/SwiftyJSON" == 4.3.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,4 @@
 github "Quick/Nimble" "v9.2.1"
-github "Quick/Quick" "v4.0.0"
 github "SwiftyJSON/SwiftyJSON" "4.3.0"
 github "ably/delta-codec-cocoa" "1.3.2"
 github "rvi/msgpack-objective-C" "0.4.0"

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -4,16 +4,114 @@ import Nimble
 import Quick
 import Aspects
 
+        
+        private var testHTTPExecutor: TestProxyHTTPExecutor!
+                private func testOptionsGiveDefaultAuthMethod(_ caseSetter: (ARTAuthOptions) -> Void) {
+                    let options = ARTClientOptions()
+                    caseSetter(options)
+                    
+                    let client = ARTRest(options: options)
+                    
+                    expect(client.auth.internal.method).to(equal(ARTAuthMethod.token))
+                }
+                // Cases:
+                //  - useTokenAuth is specified and thus a key is not provided
+                //  - authCallback and authUrl are both specified
+                private func testStopsClientWithOptions(caseSetter: (ARTClientOptions) -> ()) {
+                    let options = ARTClientOptions()
+                    caseSetter(options)
+                    
+                    expect{ ARTRest(options: options) }.to(raiseException())
+                }
+
+                private let currentClientId = "client_string"
+
+                private var options: ARTClientOptions!
+                private var rest: ARTRest!
+
+                private func tokenParamsTestsSetupDependencies() {
+                    if (options == nil) {
+                        options = AblyTests.commonAppSetup()
+                        options.clientId = currentClientId
+                        rest = ARTRest(options: options)
+                    }
+                }
+                private let json = "{" +
+                "    \"token\": \"xxxxxx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\"," +
+                "    \"issued\": 1479087321934," +
+                "    \"expires\": 1479087363934," +
+                "    \"capability\": \"{\\\"test\\\":[\\\"publish\\\"]}\"," +
+                "    \"clientId\": \"myClientId\"" +
+                "}"
+
+                private func check(_ details: ARTTokenDetails) {
+                    expect(details.token).to(equal("xxxxxx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"))
+                    expect(details.issued).to(equal(Date(timeIntervalSince1970: 1479087321.934)))
+                    expect(details.expires).to(equal(Date(timeIntervalSince1970: 1479087363.934)))
+                    expect(details.capability).to(equal("{\"test\":[\"publish\"]}"))
+                    expect(details.clientId).to(equal("myClientId"))
+                }
+            private let channelName = "test_JWT"
+            private let messageName = "message_JWT"
+                private let jwtTestsOptions = AblyTests.clientOptions()
+                private let authUrlTestsOptions: ARTClientOptions = {
+                    let options = AblyTests.clientOptions()
+                    options.authUrl = URL(string: echoServerAddress)!
+                    return options
+                }()
+
+                private var keys: [String: String]!
+
+                private func rsa8gTestsSetupDependencies() {
+                    if (keys == nil) {
+                        keys = getKeys()
+                    }
+                }
+                private let authCallbackTestsOptions = AblyTests.clientOptions()
+            private let jwtAndRestTestsOptions = AblyTests.clientOptions()
+                private var client: ARTRest!
+
+                private func jwtContentTypeTestsSetupDependencies() {
+                    if (client == nil) {
+                        let options = AblyTests.clientOptions()
+                        let keys = getKeys()
+                        options.authUrl = URL(string: echoServerAddress)!
+                        options.authParams = [URLQueryItem]()
+                        options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
+                        options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
+                        options.authParams?.append(URLQueryItem(name: "returnType", value: "jwt"))
+                        client = ARTRest(options: options)
+                    }
+                }
+
 class Auth : QuickSpec {
-    override func spec() {
+
+// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+override class var defaultTestSuite : XCTestSuite {
+    let _ = testHTTPExecutor
+    let _ = currentClientId
+    let _ = options
+    let _ = rest
+    let _ = json
+    let _ = channelName
+    let _ = messageName
+    let _ = jwtTestsOptions
+    let _ = authUrlTestsOptions
+    let _ = keys
+    let _ = authCallbackTestsOptions
+    let _ = jwtAndRestTestsOptions
+    let _ = client
+
+    return super.defaultTestSuite
+}
+
         
         struct ExpectedTokenParams {
             static let clientId = "client_from_params"
             static let ttl = 1.0
             static let capability = "{\"cansubscribe:*\":[\"subscribe\"]}"
         }
-        
-        var testHTTPExecutor: TestProxyHTTPExecutor!
+    override func spec() {
 
         describe("Basic") {
 
@@ -173,14 +271,6 @@ class Auth : QuickSpec {
 
             // RSA4
             context("authentication method") {
-                func testOptionsGiveDefaultAuthMethod(_ caseSetter: (ARTAuthOptions) -> Void) {
-                    let options = ARTClientOptions()
-                    caseSetter(options)
-                    
-                    let client = ARTRest(options: options)
-                    
-                    expect(client.auth.internal.method).to(equal(ARTAuthMethod.token))
-                }
                 
                 it("should be default auth method when options’ useTokenAuth is set") {
                     testOptionsGiveDefaultAuthMethod { $0.useTokenAuth = true; $0.key = "fake:key" }
@@ -525,15 +615,6 @@ class Auth : QuickSpec {
             
             // RSA14
             context("options") {
-                // Cases:
-                //  - useTokenAuth is specified and thus a key is not provided
-                //  - authCallback and authUrl are both specified
-                func testStopsClientWithOptions(caseSetter: (ARTClientOptions) -> ()) {
-                    let options = ARTClientOptions()
-                    caseSetter(options)
-                    
-                    expect{ ARTRest(options: options) }.to(raiseException())
-                }
                 
                 it("should stop client when useTokenAuth and no key occurs") {
                     testStopsClientWithOptions { $0.useTokenAuth = true }
@@ -1740,19 +1821,6 @@ class Auth : QuickSpec {
 
             // RSA8b
             context("should support all TokenParams") {
-
-                let currentClientId = "client_string"
-
-                var options: ARTClientOptions!
-                var rest: ARTRest!
-
-                func tokenParamsTestsSetupDependencies() {
-                    if (options == nil) {
-                        options = AblyTests.commonAppSetup()
-                        options.clientId = currentClientId
-                        rest = ARTRest(options: options)
-                    }
-                }
 
                 it("using defaults") {
                     tokenParamsTestsSetupDependencies()
@@ -4032,21 +4100,6 @@ class Auth : QuickSpec {
         describe("TokenDetails") {
             // TD7
             describe("fromJson") {
-                let json = "{" +
-                "    \"token\": \"xxxxxx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\"," +
-                "    \"issued\": 1479087321934," +
-                "    \"expires\": 1479087363934," +
-                "    \"capability\": \"{\\\"test\\\":[\\\"publish\\\"]}\"," +
-                "    \"clientId\": \"myClientId\"" +
-                "}"
-
-                func check(_ details: ARTTokenDetails) {
-                    expect(details.token).to(equal("xxxxxx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"))
-                    expect(details.issued).to(equal(Date(timeIntervalSince1970: 1479087321.934)))
-                    expect(details.expires).to(equal(Date(timeIntervalSince1970: 1479087363.934)))
-                    expect(details.capability).to(equal("{\"test\":[\"publish\"]}"))
-                    expect(details.clientId).to(equal("myClientId"))
-                }
 
                 it("accepts a string, which should be interpreted as JSON") {
                     check(try! ARTTokenDetails.fromJson(json as ARTJsonCompatible))
@@ -4069,11 +4122,8 @@ class Auth : QuickSpec {
         }
 
         describe("JWT and realtime") {
-            let channelName = "test_JWT"
-            let messageName = "message_JWT"
             
             context("client initialized with a JWT token in ClientOptions") {
-                let jwtTestsOptions = AblyTests.clientOptions()
 
                 context("with valid credentials") {
                     xit("pulls stats successfully") {
@@ -4114,19 +4164,6 @@ class Auth : QuickSpec {
 
             // RSA8g RSA8c
             context("when using authUrl") {
-                let authUrlTestsOptions: ARTClientOptions = {
-                    let options = AblyTests.clientOptions()
-                    options.authUrl = URL(string: echoServerAddress)!
-                    return options
-                }()
-
-                var keys: [String: String]!
-
-                func rsa8gTestsSetupDependencies() {
-                    if (keys == nil) {
-                        keys = getKeys()
-                    }
-                }
 
                 context("with valid credentials") {
                     it("fetches a channels and posts a message") {
@@ -4237,7 +4274,6 @@ class Auth : QuickSpec {
 
             // RSA8g
             context("when using authCallback") {
-                let authCallbackTestsOptions = AblyTests.clientOptions()
 
                 context("with valid credentials") {
                     xit("pulls stats successfully") {
@@ -4390,7 +4426,6 @@ class Auth : QuickSpec {
         
         // RSC1 RSC1a RSC1c RSA3d
         describe("JWT and rest") {
-            let jwtAndRestTestsOptions = AblyTests.clientOptions()
             
             context("when the JWT token embeds an Ably token") {
                 it ("pulls stats successfully") {
@@ -4420,20 +4455,6 @@ class Auth : QuickSpec {
             
             // RSA4f, RSA8c
             context("when the JWT token is returned with application/jwt content type") {
-                var client: ARTRest!
-
-                func jwtContentTypeTestsSetupDependencies() {
-                    if (client == nil) {
-                        let options = AblyTests.clientOptions()
-                        let keys = getKeys()
-                        options.authUrl = URL(string: echoServerAddress)!
-                        options.authParams = [URLQueryItem]()
-                        options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
-                        options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
-                        options.authParams?.append(URLQueryItem(name: "returnType", value: "jwt"))
-                        client = ARTRest(options: options)
-                    }
-                }
 
                 beforeEach {
                     jwtContentTypeTestsSetupDependencies()

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -1,4514 +1,4440 @@
 import Ably
 import Ably.Private
+import Aspects
 import Nimble
 import Quick
-import Aspects
 
-        
-        private var testHTTPExecutor: TestProxyHTTPExecutor!
-                private func testOptionsGiveDefaultAuthMethod(_ caseSetter: (ARTAuthOptions) -> Void) {
-                    let options = ARTClientOptions()
-                    caseSetter(options)
-                    
-                    let client = ARTRest(options: options)
-                    
-                    expect(client.auth.internal.method).to(equal(ARTAuthMethod.token))
-                }
-                // Cases:
-                //  - useTokenAuth is specified and thus a key is not provided
-                //  - authCallback and authUrl are both specified
-                private func testStopsClientWithOptions(caseSetter: (ARTClientOptions) -> ()) {
-                    let options = ARTClientOptions()
-                    caseSetter(options)
-                    
-                    expect{ ARTRest(options: options) }.to(raiseException())
-                }
+private var testHTTPExecutor: TestProxyHTTPExecutor!
+private func testOptionsGiveDefaultAuthMethod(_ caseSetter: (ARTAuthOptions) -> Void) {
+    let options = ARTClientOptions()
+    caseSetter(options)
 
-                private let currentClientId = "client_string"
+    let client = ARTRest(options: options)
 
-                private var options: ARTClientOptions!
-                private var rest: ARTRest!
-
-                private func tokenParamsTestsSetupDependencies() {
-                    if (options == nil) {
-                        options = AblyTests.commonAppSetup()
-                        options.clientId = currentClientId
-                        rest = ARTRest(options: options)
-                    }
-                }
-                private let json = "{" +
-                "    \"token\": \"xxxxxx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\"," +
-                "    \"issued\": 1479087321934," +
-                "    \"expires\": 1479087363934," +
-                "    \"capability\": \"{\\\"test\\\":[\\\"publish\\\"]}\"," +
-                "    \"clientId\": \"myClientId\"" +
-                "}"
-
-                private func check(_ details: ARTTokenDetails) {
-                    expect(details.token).to(equal("xxxxxx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"))
-                    expect(details.issued).to(equal(Date(timeIntervalSince1970: 1479087321.934)))
-                    expect(details.expires).to(equal(Date(timeIntervalSince1970: 1479087363.934)))
-                    expect(details.capability).to(equal("{\"test\":[\"publish\"]}"))
-                    expect(details.clientId).to(equal("myClientId"))
-                }
-            private let channelName = "test_JWT"
-            private let messageName = "message_JWT"
-                private let jwtTestsOptions = AblyTests.clientOptions()
-                private let authUrlTestsOptions: ARTClientOptions = {
-                    let options = AblyTests.clientOptions()
-                    options.authUrl = URL(string: echoServerAddress)!
-                    return options
-                }()
-
-                private var keys: [String: String]!
-
-                private func rsa8gTestsSetupDependencies() {
-                    if (keys == nil) {
-                        keys = getKeys()
-                    }
-                }
-                private let authCallbackTestsOptions = AblyTests.clientOptions()
-            private let jwtAndRestTestsOptions = AblyTests.clientOptions()
-                private var client: ARTRest!
-
-                private func jwtContentTypeTestsSetupDependencies() {
-                    if (client == nil) {
-                        let options = AblyTests.clientOptions()
-                        let keys = getKeys()
-                        options.authUrl = URL(string: echoServerAddress)!
-                        options.authParams = [URLQueryItem]()
-                        options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
-                        options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
-                        options.authParams?.append(URLQueryItem(name: "returnType", value: "jwt"))
-                        client = ARTRest(options: options)
-                    }
-                }
-
-class Auth : XCTestCase {
-
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = testHTTPExecutor
-    let _ = currentClientId
-    let _ = options
-    let _ = rest
-    let _ = json
-    let _ = channelName
-    let _ = messageName
-    let _ = jwtTestsOptions
-    let _ = authUrlTestsOptions
-    let _ = keys
-    let _ = authCallbackTestsOptions
-    let _ = jwtAndRestTestsOptions
-    let _ = client
-
-    return super.defaultTestSuite
+    expect(client.auth.internal.method).to(equal(ARTAuthMethod.token))
 }
 
-        
-        struct ExpectedTokenParams {
-            static let clientId = "client_from_params"
-            static let ttl = 1.0
-            static let capability = "{\"cansubscribe:*\":[\"subscribe\"]}"
+// Cases:
+//  - useTokenAuth is specified and thus a key is not provided
+//  - authCallback and authUrl are both specified
+private func testStopsClientWithOptions(caseSetter: (ARTClientOptions) -> Void) {
+    let options = ARTClientOptions()
+    caseSetter(options)
+
+    expect { ARTRest(options: options) }.to(raiseException())
+}
+
+private let currentClientId = "client_string"
+
+private var options: ARTClientOptions!
+private var rest: ARTRest!
+
+private func tokenParamsTestsSetupDependencies() {
+    if options == nil {
+        options = AblyTests.commonAppSetup()
+        options.clientId = currentClientId
+        rest = ARTRest(options: options)
+    }
+}
+
+private let json = "{" +
+    "    \"token\": \"xxxxxx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\"," +
+    "    \"issued\": 1479087321934," +
+    "    \"expires\": 1479087363934," +
+    "    \"capability\": \"{\\\"test\\\":[\\\"publish\\\"]}\"," +
+    "    \"clientId\": \"myClientId\"" +
+    "}"
+
+private func check(_ details: ARTTokenDetails) {
+    expect(details.token).to(equal("xxxxxx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"))
+    expect(details.issued).to(equal(Date(timeIntervalSince1970: 1_479_087_321.934)))
+    expect(details.expires).to(equal(Date(timeIntervalSince1970: 1_479_087_363.934)))
+    expect(details.capability).to(equal("{\"test\":[\"publish\"]}"))
+    expect(details.clientId).to(equal("myClientId"))
+}
+
+private let channelName = "test_JWT"
+private let messageName = "message_JWT"
+private let jwtTestsOptions = AblyTests.clientOptions()
+private let authUrlTestsOptions: ARTClientOptions = {
+    let options = AblyTests.clientOptions()
+    options.authUrl = URL(string: echoServerAddress)!
+    return options
+}()
+
+private var keys: [String: String]!
+
+private func rsa8gTestsSetupDependencies() {
+    if keys == nil {
+        keys = getKeys()
+    }
+}
+
+private let authCallbackTestsOptions = AblyTests.clientOptions()
+private let jwtAndRestTestsOptions = AblyTests.clientOptions()
+private var client: ARTRest!
+
+private func jwtContentTypeTestsSetupDependencies() {
+    if client == nil {
+        let options = AblyTests.clientOptions()
+        let keys = getKeys()
+        options.authUrl = URL(string: echoServerAddress)!
+        options.authParams = [URLQueryItem]()
+        options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
+        options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
+        options.authParams?.append(URLQueryItem(name: "returnType", value: "jwt"))
+        client = ARTRest(options: options)
+    }
+}
+
+class Auth: XCTestCase {
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = testHTTPExecutor
+        _ = currentClientId
+        _ = options
+        _ = rest
+        _ = json
+        _ = channelName
+        _ = messageName
+        _ = jwtTestsOptions
+        _ = authUrlTestsOptions
+        _ = keys
+        _ = authCallbackTestsOptions
+        _ = jwtAndRestTestsOptions
+        _ = client
+
+        return super.defaultTestSuite
+    }
+
+    enum ExpectedTokenParams {
+        static let clientId = "client_from_params"
+        static let ttl = 1.0
+        static let capability = "{\"cansubscribe:*\":[\"subscribe\"]}"
+    }
+
+    // RSA1
+    func test__003__Basic__should_work_over_HTTPS_only() {
+        let clientOptions = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        clientOptions.tls = false
+
+        expect { ARTRest(options: clientOptions) }.to(raiseException())
+    }
+
+    // RSA11
+    func test__004__Basic__should_send_the_API_key_in_the_Authorization_header() {
+        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            client.channels.get("test").publish(nil, data: "message") { _ in
+                done()
+            }
         }
 
-        
+        let key64 = "\(client.internal.options.key!)"
+            .data(using: .utf8)!
+            .base64EncodedString(options: Data.Base64EncodingOptions(rawValue: 0))
 
-            // RSA1
-            func test__003__Basic__should_work_over_HTTPS_only() {
-                let clientOptions = AblyTests.setupOptions(AblyTests.jsonRestOptions)
-                clientOptions.tls = false
+        let expectedAuthorization = "Basic \(key64)"
 
-                expect{ ARTRest(options: clientOptions) }.to(raiseException())
+        guard let request = testHTTPExecutor.requests.first else {
+            fail("No request found")
+            return
+        }
+
+        let authorization = request.allHTTPHeaderFields?["Authorization"]
+
+        expect(authorization).to(equal(expectedAuthorization))
+    }
+
+    // RSA2
+    func test__005__Basic__should_be_default_when_an_API_key_is_set() {
+        let client = ARTRest(options: ARTClientOptions(key: "fake:key"))
+
+        expect(client.auth.internal.method).to(equal(ARTAuthMethod.basic))
+    }
+
+    // RSA3
+
+    // RSA3a
+    func test__010__Token__token_auth__should_work_over_HTTP() {
+        let options = AblyTests.clientOptions(requestToken: true)
+        options.tls = false
+        let clientHTTP = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        clientHTTP.internal.httpExecutor = testHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            clientHTTP.channels.get("test").publish(nil, data: "message") { _ in
+                done()
             }
+        }
 
-            // RSA11
-            func test__004__Basic__should_send_the_API_key_in_the_Authorization_header() {
-                let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
-                let client = ARTRest(options: options)
-                testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                client.internal.httpExecutor = testHTTPExecutor
-                
-                waitUntil(timeout: testTimeout) { done in
-                    client.channels.get("test").publish(nil, data: "message") { error in
+        guard let request = testHTTPExecutor.requests.first else {
+            fail("No request found")
+            return
+        }
+        guard let url = request.url else {
+            fail("Request is invalid")
+            return
+        }
+        expect(url.scheme).to(equal("http"), description: "No HTTP support")
+    }
+
+    func test__011__Token__token_auth__should_work_over_HTTPS() {
+        let options = AblyTests.clientOptions(requestToken: true)
+        options.tls = true
+        let clientHTTPS = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        clientHTTPS.internal.httpExecutor = testHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            clientHTTPS.channels.get("test").publish(nil, data: "message") { _ in
+                done()
+            }
+        }
+
+        guard let request = testHTTPExecutor.requests.first else {
+            fail("No request found")
+            return
+        }
+        guard let url = request.url else {
+            fail("Request is invalid")
+            return
+        }
+        expect(url.scheme).to(equal("https"), description: "No HTTPS support")
+    }
+
+    // RSA3b
+
+    func test__012__Token__token_auth__for_REST_requests__should_send_the_token_in_the_Authorization_header() {
+        let options = AblyTests.clientOptions()
+        options.token = getTestToken()
+
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            client.channels.get("test").publish(nil, data: "message") { _ in
+                done()
+            }
+        }
+
+        guard let currentToken = client.internal.options.token else {
+            fail("No access token")
+            return
+        }
+
+        let expectedAuthorization = "Bearer \(currentToken)"
+
+        guard let request = testHTTPExecutor.requests.first else {
+            fail("No request found")
+            return
+        }
+
+        let authorization = request.allHTTPHeaderFields?["Authorization"]
+
+        expect(authorization).to(equal(expectedAuthorization))
+    }
+
+    // RSA3c
+
+    func test__013__Token__token_auth__for_Realtime_connections__should_send_the_token_in_the_querystring_as_a_param_named_accessToken() {
+        let options = AblyTests.clientOptions()
+        options.token = getTestToken()
+        options.autoConnect = false
+
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+
+        if let transport = client.internal.transport as? TestProxyTransport, let query = transport.lastUrl?.query {
+            expect(query).to(haveParam("accessToken", withValue: client.auth.tokenDetails?.token ?? ""))
+        } else {
+            XCTFail("MockTransport is not working")
+        }
+    }
+
+    // RSA4
+
+    func test__014__Token__authentication_method__should_be_default_auth_method_when_options__useTokenAuth_is_set() {
+        testOptionsGiveDefaultAuthMethod { $0.useTokenAuth = true; $0.key = "fake:key" }
+    }
+
+    func test__015__Token__authentication_method__should_be_default_auth_method_when_options__authUrl_is_set() {
+        testOptionsGiveDefaultAuthMethod { $0.authUrl = URL(string: "http://test.com") }
+    }
+
+    func test__016__Token__authentication_method__should_be_default_auth_method_when_options__authCallback_is_set() {
+        testOptionsGiveDefaultAuthMethod { $0.authCallback = { _, _ in } }
+    }
+
+    func test__017__Token__authentication_method__should_be_default_auth_method_when_options__tokenDetails_is_set() {
+        testOptionsGiveDefaultAuthMethod { $0.tokenDetails = ARTTokenDetails(token: "token") }
+    }
+
+    func test__018__Token__authentication_method__should_be_default_auth_method_when_options__token_is_set() {
+        testOptionsGiveDefaultAuthMethod { $0.token = "token" }
+    }
+
+    func test__019__Token__authentication_method__should_be_default_auth_method_when_options__key_is_set() {
+        testOptionsGiveDefaultAuthMethod { $0.tokenDetails = ARTTokenDetails(token: "token"); $0.key = "fake:key" }
+    }
+
+    // RSA4a
+    func test__020__Token__authentication_method__should_indicate_an_error_and_not_retry_the_request_when_the_server_responds_with_a_token_error_and_there_is_no_way_to_renew_the_token() {
+        let options = AblyTests.clientOptions()
+        options.token = getTestToken()
+
+        let rest = ARTRest(options: options)
+        // No means to renew the token is provided
+        expect(rest.internal.options.key).to(beNil())
+        expect(rest.internal.options.authCallback).to(beNil())
+        expect(rest.internal.options.authUrl).to(beNil())
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = testHTTPExecutor
+
+        let channel = rest.channels.get("test")
+
+        testHTTPExecutor.simulateIncomingServerErrorOnNextRequest(ARTErrorCode.tokenRevoked.intValue, description: "token revoked")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish("message", data: nil) { error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(UInt(error.code)).to(equal(ARTState.requestTokenFailed.rawValue))
+                done()
+            }
+        }
+    }
+
+    // RSA4a
+    func test__021__Token__authentication_method__should_transition_the_connection_to_the_FAILED_state_when_the_server_responds_with_a_token_error_and_there_is_no_way_to_renew_the_token() {
+        let options = AblyTests.clientOptions()
+        options.tokenDetails = getTestTokenDetails(ttl: 0.1)
+        options.autoConnect = false
+
+        // Token will expire, expecting 40142
+        waitUntil(timeout: testTimeout) { done in
+            delay(0.2) { done() }
+        }
+
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+        // No means to renew the token is provided
+        expect(realtime.internal.options.key).to(beNil())
+        expect(realtime.internal.options.authCallback).to(beNil())
+        expect(realtime.internal.options.authUrl).to(beNil())
+        realtime.internal.setTransport(TestProxyTransport.self)
+
+        let channel = realtime.channels.get("test")
+
+        waitUntil(timeout: testTimeout.multiplied(by: 2)) { done in
+            realtime.connect()
+            channel.publish("message", data: nil) { error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error.code).to(equal(ARTErrorCode.tokenExpired.intValue))
+                expect(realtime.connection.state).to(equal(ARTRealtimeConnectionState.failed))
+                done()
+            }
+        }
+    }
+
+    // RSA4b
+    func test__022__Token__authentication_method__on_token_error__reissues_token_and_retries_REST_requests() {
+        var authCallbackCalled = 0
+
+        let options = AblyTests.commonAppSetup()
+        options.authCallback = { _, callback in
+            authCallbackCalled += 1
+            getTestTokenDetails { token, err in
+                callback(token, err)
+            }
+        }
+
+        let rest = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = testHTTPExecutor
+
+        let channel = rest.channels.get("test")
+
+        testHTTPExecutor.simulateIncomingServerErrorOnNextRequest(ARTErrorCode.tokenRevoked.intValue, description: "token revoked")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish("message", data: nil) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        // First request and a second attempt
+        expect(testHTTPExecutor.requests).to(haveCount(2))
+
+        // First token issue, and then reissue on token error.
+        expect(authCallbackCalled).to(equal(2))
+    }
+
+    // RSA4b
+    func test__023__Token__authentication_method__in_REST__if_the_token_creation_failed_or_the_subsequent_request_with_the_new_token_failed_due_to_a_token_error__then_the_request_should_result_in_an_error() {
+        let options = AblyTests.commonAppSetup()
+        options.useTokenAuth = true
+
+        let rest = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = testHTTPExecutor
+
+        let channel = rest.channels.get("test")
+
+        testHTTPExecutor.setListenerAfterRequest { _ in
+            testHTTPExecutor.simulateIncomingServerErrorOnNextRequest(ARTErrorCode.tokenRevoked.intValue, description: "token revoked")
+        }
+
+        testHTTPExecutor.simulateIncomingServerErrorOnNextRequest(ARTErrorCode.tokenRevoked.intValue, description: "token revoked")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish("message", data: nil) { error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error.code).to(equal(ARTErrorCode.tokenRevoked.intValue))
+                done()
+            }
+        }
+
+        // First request and a second attempt
+        expect(testHTTPExecutor.requests).to(haveCount(2))
+    }
+
+    // RSA4b
+    func test__024__Token__authentication_method__in_Realtime__if_the_token_creation_failed_then_the_connection_should_move_to_the_DISCONNECTED_state_and_reports_the_error() {
+        let options = AblyTests.commonAppSetup()
+        options.authCallback = { _, completion in
+            completion(nil, NSError(domain: NSURLErrorDomain, code: -1003, userInfo: [NSLocalizedDescriptionKey: "A server with the specified hostname could not be found."]))
+        }
+        options.autoConnect = false
+
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.failed) { _ in
+                fail("Should not reach Failed state"); done()
+            }
+            realtime.connection.once(.disconnected) { stateChange in
+                guard let errorInfo = stateChange.reason else {
+                    fail("ErrorInfo is nil"); done(); return
+                }
+                expect(errorInfo.message).to(contain("server with the specified hostname could not be found"))
+                done()
+            }
+            realtime.connect()
+        }
+    }
+
+    // RSA4b
+    func test__025__Token__authentication_method__in_Realtime__if_the_connection_fails_due_to_a_terminal_token_error__then_the_connection_should_move_to_the_FAILED_state_and_reports_the_error() {
+        let options = AblyTests.commonAppSetup()
+        options.authCallback = { _, completion in
+            getTestToken { token in
+                let invalidToken = String(token.reversed())
+                completion(invalidToken as ARTTokenDetailsCompatible?, nil)
+            }
+        }
+        options.autoConnect = false
+
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.failed) { stateChange in
+                guard let errorInfo = stateChange.reason else {
+                    fail("ErrorInfo is nil"); done(); return
+                }
+                expect(errorInfo.message).to(contain("No application found with id"))
+                done()
+            }
+            realtime.connection.once(.disconnected) { _ in
+                fail("Should not reach Disconnected state"); done()
+            }
+            realtime.connect()
+        }
+    }
+
+    // RSA4b1
+
+    func test__028__Token__authentication_method__local_token_validity_check__should_be_done_if_queryTime_is_true_and_local_time_is_in_sync_with_server() {
+        let options = AblyTests.commonAppSetup()
+        let testKey = options.key!
+
+        let tokenDetails = getTestTokenDetails(key: testKey, ttl: 5.0, queryTime: true)
+
+        options.queryTime = true
+        options.tokenDetails = tokenDetails
+        options.key = nil
+
+        let rest = ARTRest(options: options)
+        let proxyHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+
+        // Sync server time offset
+        let authOptions = ARTAuthOptions(key: testKey)
+        authOptions.queryTime = true
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(nil, options: authOptions, callback: { tokenRequest, error in
+                expect(error).to(beNil())
+                expect(tokenRequest).toNot(beNil())
+                done()
+            })
+        }
+
+        // Let the token expire
+        waitUntil(timeout: testTimeout) { done in
+            delay(5.0) {
+                done()
+            }
+        }
+
+        expect(rest.auth.internal.timeOffset).toNot(beNil())
+
+        rest.internal.httpExecutor = proxyHTTPExecutor
+        waitUntil(timeout: testTimeout) { done in
+            rest.channels.get("foo").history { _, error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error.code).to(equal(Int(ARTState.requestTokenFailed.rawValue)))
+                expect(error.message).to(contain("no means to renew the token is provided"))
+
+                expect(proxyHTTPExecutor.requests.count).to(equal(0))
+                done()
+            }
+        }
+
+        expect(rest.auth.tokenDetails).toNot(beNil())
+    }
+
+    func test__029__Token__authentication_method__local_token_validity_check__should_NOT_be_done_if_queryTime_is_false_and_local_time_is_NOT_in_sync_with_server() {
+        let options = AblyTests.commonAppSetup()
+        let testKey = options.key!
+
+        let tokenDetails = getTestTokenDetails(key: testKey, ttl: 5.0, queryTime: true)
+
+        options.queryTime = false
+        options.tokenDetails = tokenDetails
+        options.key = nil
+
+        let rest = ARTRest(options: options)
+        let proxyHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = proxyHTTPExecutor
+
+        // No server time offset
+        rest.auth.internal.clearTimeOffset()
+
+        // Let the token expire
+        waitUntil(timeout: testTimeout) { done in
+            delay(5.0) {
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.channels.get("foo").history { _, error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error.code).to(equal(Int(ARTState.requestTokenFailed.rawValue)))
+                expect(error.message).to(contain("no means to renew the token is provided"))
+                expect(proxyHTTPExecutor.requests.count).to(equal(1))
+                expect(proxyHTTPExecutor.responses.count).to(equal(1))
+                guard let response = proxyHTTPExecutor.responses.first else {
+                    fail("Response is nil"); done(); return
+                }
+                expect(response.value(forHTTPHeaderField: "X-Ably-Errorcode")).to(equal("\(ARTErrorCode.tokenExpired.intValue)"))
+                done()
+            }
+        }
+    }
+
+    // RSA4d
+    func test__026__Token__authentication_method__if_a_request_by_a_realtime_client_to_an_authUrl_results_in_an_HTTP_403_the_client_library_should_transition_to_the_FAILED_state() {
+        let options = AblyTests.clientOptions()
+        options.autoConnect = false
+        options.authUrl = URL(string: "https://echo.ably.io/respondwith?status=403")!
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.failed) { stateChange in
+                expect(stateChange.reason?.code).to(equal(ARTErrorCode.authConfiguredProviderFailure.intValue))
+                expect(stateChange.reason?.statusCode).to(equal(403))
+                done()
+            }
+            realtime.connect()
+        }
+    }
+
+    // RSA4d
+    func test__027__Token__authentication_method__if_an_authCallback_results_in_an_HTTP_403_the_client_library_should_transition_to_the_FAILED_state() {
+        let options = AblyTests.clientOptions()
+        options.autoConnect = false
+        var authCallbackHasBeenInvoked = false
+        options.authCallback = { _, completion in
+            authCallbackHasBeenInvoked = true
+            completion(nil, ARTErrorInfo(domain: "io.ably.cocoa", code: ARTErrorCode.forbidden.intValue, userInfo: ["ARTErrorInfoStatusCode": 403]))
+        }
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.failed) { stateChange in
+                expect(authCallbackHasBeenInvoked).to(beTrue())
+                expect(stateChange.reason?.code).to(equal(ARTErrorCode.authConfiguredProviderFailure.intValue))
+                expect(stateChange.reason?.statusCode).to(equal(403))
+                done()
+            }
+            realtime.connect()
+        }
+    }
+
+    // RSA14
+
+    func test__030__Token__options__should_stop_client_when_useTokenAuth_and_no_key_occurs() {
+        testStopsClientWithOptions { $0.useTokenAuth = true }
+    }
+
+    func test__031__Token__options__should_stop_client_when_authCallback_and_authUrl_occurs() {
+        testStopsClientWithOptions { $0.authCallback = { _, _ in /* nothing */ }; $0.authUrl = URL(string: "http://auth.ably.io") }
+    }
+
+    // RSA4c
+
+    // RSA4c1 & RSA4c2
+    func test__032__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_request_to_authUrl_fails__if_the_connection_is_CONNECTING__then_the_connection_attempt_should_be_treated_as_unsuccessful() {
+        let options = AblyTests.clientOptions()
+        options.autoConnect = false
+        options.authUrl = URL(string: "http://echo.ably.io")!
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.disconnected) { stateChange in
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
+                guard let errorInfo = stateChange.reason else {
+                    fail("ErrorInfo is nil"); done(); return
+                }
+                expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
+                done()
+            }
+            realtime.connect()
+        }
+
+        guard let errorInfo = realtime.connection.errorReason else {
+            fail("ErrorInfo is empty"); return
+        }
+        expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
+        expect(errorInfo.message).to(contain("body param is required"))
+    }
+
+    // RSA4c3
+    func test__033__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_request_to_authUrl_fails__if_the_connection_is_CONNECTED__then_the_connection_should_remain_CONNECTED() {
+        let token = getTestToken()
+        let options = AblyTests.clientOptions()
+        options.authUrl = URL(string: "http://echo.ably.io")!
+        options.authParams = [URLQueryItem]()
+        options.authParams?.append(URLQueryItem(name: "type", value: "text"))
+        options.authParams?.append(URLQueryItem(name: "body", value: token))
+
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+        }
+
+        // Token reauth will fail
+        realtime.internal.options.authParams = [URLQueryItem]()
+
+        // Inject AUTH
+        let authMessage = ARTProtocolMessage()
+        authMessage.action = ARTProtocolMessageAction.auth
+        realtime.internal.transport?.receive(authMessage)
+
+        expect(realtime.connection.errorReason).toEventuallyNot(beNil(), timeout: testTimeout)
+        guard let errorInfo = realtime.connection.errorReason else {
+            fail("ErrorInfo is empty"); return
+        }
+        expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
+        expect(errorInfo.message).to(contain("body param is required"))
+
+        expect(realtime.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+    }
+
+    // RSA4c1 & RSA4c2
+    func test__034__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_request_to_authCallback_fails__if_the_connection_is_CONNECTING__then_the_connection_attempt_should_be_treated_as_unsuccessful() {
+        let options = AblyTests.clientOptions()
+        options.autoConnect = false
+        options.authCallback = { _, completion in
+            completion(nil, NSError(domain: NSURLErrorDomain, code: -1003, userInfo: [NSLocalizedDescriptionKey: "A server with the specified hostname could not be found."]))
+        }
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.disconnected) { stateChange in
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
+                guard let errorInfo = stateChange.reason else {
+                    fail("ErrorInfo is nil"); done(); return
+                }
+                expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
+                done()
+            }
+            realtime.connect()
+        }
+
+        expect(realtime.connection.state).toEventually(equal(ARTRealtimeConnectionState.disconnected), timeout: testTimeout)
+        guard let errorInfo = realtime.connection.errorReason else {
+            fail("ErrorInfo is empty"); return
+        }
+        expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
+        expect(errorInfo.message).to(contain("hostname could not be found"))
+    }
+
+    // RSA4c3
+    func test__035__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_request_to_authCallback_fails__if_the_connection_is_CONNECTED__then_the_connection_should_remain_CONNECTED() {
+        let options = AblyTests.clientOptions()
+        options.authCallback = { _, completion in
+            getTestTokenDetails(completion: completion)
+        }
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+        }
+
+        // Token should renew and fail
+        realtime.internal.options.authCallback = { _, completion in
+            completion(nil, NSError(domain: NSURLErrorDomain, code: -1003, userInfo: [NSLocalizedDescriptionKey: "A server with the specified hostname could not be found."]))
+        }
+
+        // Inject AUTH
+        let authMessage = ARTProtocolMessage()
+        authMessage.action = ARTProtocolMessageAction.auth
+        realtime.internal.transport?.receive(authMessage)
+
+        expect(realtime.connection.errorReason).toEventuallyNot(beNil(), timeout: testTimeout)
+        guard let errorInfo = realtime.connection.errorReason else {
+            fail("ErrorInfo is empty"); return
+        }
+        expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
+        expect(errorInfo.message).to(contain("hostname could not be found"))
+
+        expect(realtime.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+    }
+
+    // RSA4c1 & RSA4c2
+    func test__036__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_provided_token_is_in_an_invalid_format__if_the_connection_is_CONNECTING__then_the_connection_attempt_should_be_treated_as_unsuccessful() {
+        let options = AblyTests.clientOptions()
+        options.autoConnect = false
+        options.authUrl = URL(string: "http://echo.ably.io")!
+        options.authParams = [URLQueryItem]()
+        options.authParams?.append(URLQueryItem(name: "type", value: "json"))
+        let invalidTokenFormat = "{secret_token:xxx}"
+        options.authParams?.append(URLQueryItem(name: "body", value: invalidTokenFormat))
+
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.disconnected) { stateChange in
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
+                guard let errorInfo = stateChange.reason else {
+                    fail("ErrorInfo is nil"); done(); return
+                }
+                expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
+                done()
+            }
+            realtime.connect()
+        }
+
+        guard let errorInfo = realtime.connection.errorReason else {
+            fail("ErrorInfo is empty"); return
+        }
+        expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
+        expect(errorInfo.message).to(contain("content response cannot be used for token request"))
+
+        expect(realtime.connection.state).toEventually(equal(ARTRealtimeConnectionState.disconnected), timeout: testTimeout)
+    }
+
+    // RSA4c3
+    func test__037__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_provided_token_is_in_an_invalid_format__if_the_connection_is_CONNECTED__then_the_connection_should_remain_CONNECTED() {
+        let options = AblyTests.clientOptions()
+        options.authUrl = URL(string: "http://echo.ably.io")!
+        options.authParams = [URLQueryItem]()
+        options.authParams?.append(URLQueryItem(name: "type", value: "text"))
+
+        let token = getTestToken()
+        options.authParams?.append(URLQueryItem(name: "body", value: token))
+
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+        }
+
+        // Token should renew and fail
+        waitUntil(timeout: testTimeout) { done in
+            realtime.unwrapAsync { realtime in
+                realtime.options.authParams = [URLQueryItem]()
+                realtime.options.authParams?.append(URLQueryItem(name: "type", value: "json"))
+                let invalidTokenFormat = "{secret_token:xxx}"
+                realtime.options.authParams?.append(URLQueryItem(name: "body", value: invalidTokenFormat))
+                done()
+            }
+        }
+
+        realtime.connection.on { stateChange in
+            if stateChange.current != .connected {
+                fail("Connection should remain connected")
+            }
+        }
+
+        // Inject AUTH
+        let authMessage = ARTProtocolMessage()
+        authMessage.action = ARTProtocolMessageAction.auth
+        realtime.internal.transport?.receive(authMessage)
+
+        expect(realtime.connection.errorReason).toEventuallyNot(beNil(), timeout: testTimeout)
+        guard let errorInfo = realtime.connection.errorReason else {
+            fail("ErrorInfo is empty"); return
+        }
+        expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
+        expect(errorInfo.message).to(contain("content response cannot be used for token request"))
+
+        expect(realtime.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+    }
+
+    // RSA4c1 & RSA4c2
+    func test__038__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_attempt_times_out_after_realtimeRequestTimeout__if_the_connection_is_CONNECTING__then_the_connection_attempt_should_be_treated_as_unsuccessful() {
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(0.5)
+
+        let options = AblyTests.clientOptions()
+        options.autoConnect = false
+        options.authCallback = { _, _ in
+            // Ignore `completion` closure to force a time out
+        }
+
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.disconnected) { stateChange in
+                guard let errorInfo = stateChange.reason else {
+                    fail("ErrorInfo is nil"); done(); return
+                }
+                expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
+                done()
+            }
+            realtime.connect()
+        }
+
+        guard let errorInfo = realtime.connection.errorReason else {
+            fail("ErrorInfo is empty"); return
+        }
+        expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
+        expect(errorInfo.message).to(contain("timed out"))
+
+        expect(realtime.connection.state).toEventually(equal(ARTRealtimeConnectionState.disconnected), timeout: testTimeout)
+    }
+
+    // RSA4c3
+    func test__039__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_attempt_times_out_after_realtimeRequestTimeout__if_the_connection_is_CONNECTED__then_the_connection_should_remain_CONNECTED() {
+        let options = AblyTests.clientOptions()
+        options.autoConnect = false
+        options.authCallback = { _, completion in
+            getTestTokenDetails(completion: completion)
+        }
+
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            realtime.connect()
+        }
+
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(0.5)
+
+        // Token should renew and fail
+        realtime.internal.options.authCallback = { _, _ in
+            // Ignore `completion` closure to force a time out
+        }
+
+        // Inject AUTH
+        let authMessage = ARTProtocolMessage()
+        authMessage.action = ARTProtocolMessageAction.auth
+        waitUntil(timeout: testTimeout) { done in
+            realtime.unwrapAsync { realtime in
+                realtime.transport?.receive(authMessage)
+                done()
+            }
+        }
+
+        expect(realtime.connection.errorReason).toEventuallyNot(beNil(), timeout: testTimeout)
+        guard let errorInfo = realtime.connection.errorReason else {
+            fail("ErrorInfo is empty"); return
+        }
+        expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
+        expect(errorInfo.message).to(contain("timed out"))
+
+        expect(realtime.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+    }
+
+    // RSA15
+
+    // RSA15a
+
+    func test__041__Token__token_auth_and_clientId__should_check_clientId_consistency__on_rest() {
+        let expectedClientId = "client_string"
+        let options = AblyTests.commonAppSetup()
+        options.useTokenAuth = true
+        options.clientId = expectedClientId
+
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            // Token
+            client.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(client.auth.internal.method).to(equal(ARTAuthMethod.token))
+                guard let tokenDetails = tokenDetails else {
+                    fail("TokenDetails is nil"); done(); return
+                }
+                expect(tokenDetails.clientId).to(equal(expectedClientId))
+                done()
+            }
+        }
+
+        switch extractBodyAsMsgPack(testHTTPExecutor.requests.first) {
+        case let .failure(error):
+            XCTFail(error)
+        case let .success(httpBody):
+            guard let requestedClientId = httpBody.unbox["clientId"] as? String else { XCTFail("No clientId field in HTTPBody"); return }
+            expect(requestedClientId).to(equal(expectedClientId))
+        }
+    }
+
+    func test__042__Token__token_auth_and_clientId__should_check_clientId_consistency__on_realtime() {
+        let expectedClientId = "client_string"
+        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        options.clientId = expectedClientId
+        options.autoConnect = false
+
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let error = stateChange.reason
+                if state == .connected, error == nil {
+                    let currentChannel = client.channels.get("test")
+                    currentChannel.subscribe { _ in
                         done()
                     }
+                    currentChannel.publish(nil, data: "ping", callback: nil)
                 }
+            }
+        }
 
-                let key64 = "\(client.internal.options.key!)"
-                    .data(using: .utf8)!
-                    .base64EncodedString(options: Data.Base64EncodingOptions(rawValue: 0))
-                                
-                let expectedAuthorization = "Basic \(key64)"
-                
-                guard let request = testHTTPExecutor.requests.first else {
-                    fail("No request found")
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("Transport is nil"); return
+        }
+        guard let connectedMessage = transport.protocolMessagesReceived.filter({ $0.action == .connected }).last else {
+            XCTFail("No CONNECTED protocol action received"); return
+        }
+
+        // CONNECTED ProtocolMessage
+        expect(connectedMessage.connectionDetails!.clientId).to(equal(expectedClientId))
+    }
+
+    func test__043__Token__token_auth_and_clientId__should_check_clientId_consistency__with_wildcard() {
+        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        options.clientId = "*"
+        expect { ARTRest(options: options) }.to(raiseException())
+        expect { ARTRealtime(options: options) }.to(raiseException())
+    }
+
+    // RSA15b
+    func test__040__Token__token_auth_and_clientId__should_permit_to_be_unauthenticated() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = nil
+
+        let clientBasic = ARTRest(options: options)
+
+        waitUntil(timeout: testTimeout) { done in
+            // Basic
+            clientBasic.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(clientBasic.auth.clientId).to(beNil())
+                options.tokenDetails = tokenDetails
+                done()
+            }
+        }
+
+        let clientToken = ARTRest(options: options)
+
+        waitUntil(timeout: testTimeout) { done in
+            // Last TokenDetails
+            clientToken.auth.authorize(nil, options: nil) { _, error in
+                expect(error).to(beNil())
+                expect(clientToken.auth.clientId).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RSA15c
+
+    func test__044__Token__token_auth_and_clientId__Incompatible_client__with_Realtime__it_should_change_the_connection_state_to_FAILED_and_emit_an_error() {
+        let options = AblyTests.commonAppSetup()
+        let wrongTokenDetails = getTestTokenDetails(clientId: "wrong")
+
+        options.clientId = "john"
+        options.autoConnect = false
+        options.authCallback = { _, completion in
+            completion(wrongTokenDetails, nil)
+        }
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.failed) { stateChange in
+                expect(stateChange.reason?.code).to(equal(ARTErrorCode.invalidCredentials.intValue))
+                done()
+            }
+            realtime.connect()
+        }
+    }
+
+    func test__045__Token__token_auth_and_clientId__Incompatible_client__with_Rest__it_should_result_in_an_appropriate_error_response() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let rest = ARTRest(options: options)
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.requestToken(ARTTokenParams(clientId: "wrong"), with: nil) { tokenDetails, error in
+                let error = error as! ARTErrorInfo
+                expect(error.code).to(equal(ARTErrorCode.incompatibleCredentials.intValue))
+                expect(tokenDetails).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RSA5
+    func test__006__Token__TTL_should_default_to_be_omitted() {
+        let tokenParams = ARTTokenParams()
+        expect(tokenParams.ttl).to(beNil())
+    }
+
+    func test__007__Token__should_URL_query_be_correctly_encoded() {
+        let tokenParams = ARTTokenParams()
+        tokenParams.capability = "{\"*\":[\"*\"]}"
+
+        if #available(iOS 10.0, *) {
+            let dateFormatter = ISO8601DateFormatter()
+            tokenParams.timestamp = dateFormatter.date(from: "2016-10-08T22:31:00Z")
+        } else {
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy/MM/dd HH:mm zzz"
+            tokenParams.timestamp = dateFormatter.date(from: "2016/10/08 22:31 GMT")
+        }
+
+        let options = ARTClientOptions()
+        options.authUrl = URL(string: "https://ably-test-suite.io")
+        let rest = ARTRest(options: options)
+        let request = rest.auth.internal.buildRequest(options, with: tokenParams)
+
+        if let query = request.url?.query {
+            expect(query).to(haveParam("capability", withValue: "%7B%22*%22:%5B%22*%22%5D%7D"))
+            expect(query).to(haveParam("timestamp", withValue: "1475965860000"))
+        } else {
+            fail("URL is empty")
+        }
+    }
+
+    // RSA6
+    func test__008__Token__should_omit_capability_field_if_it_is_not_specified() {
+        let tokenParams = ARTTokenParams()
+        expect(tokenParams.capability).to(beNil())
+
+        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let rest = ARTRest(options: options)
+        let testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = testHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            // Token
+            rest.auth.requestToken(tokenParams, with: options) { tokenDetails, error in
+                if let e = error {
+                    fail(e.localizedDescription); done(); return
+                }
+                expect(tokenParams.capability).to(beNil())
+                expect(tokenDetails?.capability).to(equal("{\"*\":[\"*\"]}"))
+                done()
+            }
+        }
+
+        switch extractBodyAsMsgPack(testHTTPExecutor.requests.first) {
+        case let .failure(error):
+            fail(error)
+        case let .success(httpBody):
+            expect(httpBody.unbox["capability"]).to(beNil())
+        }
+    }
+
+    // RSA6
+    func test__009__Token__should_add_capability_field_if_the_user_specifies_it() {
+        let tokenParams = ARTTokenParams()
+        tokenParams.capability = "{\"*\":[\"*\"]}"
+
+        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let rest = ARTRest(options: options)
+        let testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = testHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            // Token
+            rest.auth.requestToken(tokenParams, with: options) { tokenDetails, error in
+                if let e = error {
+                    fail(e.localizedDescription); done(); return
+                }
+                expect(tokenDetails?.capability).to(equal(tokenParams.capability))
+                done()
+            }
+        }
+
+        switch extractBodyAsMsgPack(testHTTPExecutor.requests.first) {
+        case let .failure(error):
+            fail(error)
+        case let .success(httpBody):
+            expect(httpBody.unbox["capability"] as? String).to(equal("{\"*\":[\"*\"]}"))
+        }
+    }
+
+    // RSA7
+
+    // RSA7a1
+    func test__046__Token__clientId_and_authenticated_clients__should_not_pass_clientId_with_published_message() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "mary"
+        let rest = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = testHTTPExecutor
+        let channel = rest.channels.get("RSA7a1")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish("foo", data: nil) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+        switch extractBodyAsMsgPack(testHTTPExecutor.requests.last) {
+        case let .failure(error):
+            fail(error)
+        case let .success(httpBody):
+            let message = httpBody.unbox
+            expect(message["clientId"]).to(beNil())
+            expect(message["name"] as? String).to(equal("foo"))
+        }
+    }
+
+    // RSA7a2
+    func test__047__Token__clientId_and_authenticated_clients__should_obtain_a_token_if_clientId_is_assigned() {
+        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        options.clientId = "client_string"
+
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            client.channels.get("test").publish(nil, data: "message") { error in
+                if let e = error {
+                    XCTFail(e.localizedDescription)
+                }
+                done()
+            }
+        }
+
+        let authorization = testHTTPExecutor.requests.last?.allHTTPHeaderFields?["Authorization"] ?? ""
+
+        expect(authorization).toNot(equal(""))
+    }
+
+    // RSA7a3
+    func test__048__Token__clientId_and_authenticated_clients__should_convenience_clientId_return_a_string() {
+        let clientOptions = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        clientOptions.clientId = "String"
+
+        expect(ARTRest(options: clientOptions).internal.options.clientId).to(equal("String"))
+    }
+
+    // RSA7a4
+    func test__049__Token__clientId_and_authenticated_clients__ClientOptions_clientId_takes_precendence_when_a_clientId_value_is_provided_in_both_ClientOptions_clientId_and_ClientOptions_defaultTokenParams() {
+        let options = AblyTests.clientOptions()
+        options.clientId = "john"
+        options.authCallback = { tokenParams, completion in
+            expect(tokenParams.clientId).to(equal(options.clientId))
+            getTestToken(clientId: tokenParams.clientId) { token in
+                completion(token as ARTTokenDetailsCompatible?, nil)
+            }
+        }
+        options.defaultTokenParams = ARTTokenParams(clientId: "tester")
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("test")
+
+        expect(client.auth.clientId).to(equal("john"))
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { error in
+                expect(error).to(beNil())
+                channel.history { paginatedResult, _ in
+                    guard let result = paginatedResult else {
+                        fail("PaginatedResult is empty"); done(); return
+                    }
+                    guard let message = result.items.first else {
+                        fail("First message does not exist"); done(); return
+                    }
+                    expect(message.clientId).to(equal("john"))
+                    done()
+                }
+            }
+        }
+    }
+
+    // RSA12
+
+    // RSA12a
+    func test__051__Token__clientId_and_authenticated_clients__Auth_clientId_attribute_is_null__identity_should_be_anonymous_for_all_operations() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let realtime = AblyTests.newRealtime(options)
+        defer { realtime.dispose(); realtime.close() }
+        expect(realtime.auth.clientId).to(beNil())
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(realtime.auth.clientId).to(beNil())
+                done()
+            }
+            realtime.connect()
+
+            let transport = realtime.internal.transport as! TestProxyTransport
+            transport.setBeforeIncomingMessageModifier { message in
+                if message.action == .connected {
+                    if let details = message.connectionDetails {
+                        details.clientId = nil
+                    }
+                }
+                return message
+            }
+        }
+    }
+
+    // RSA12b
+    func test__052__Token__clientId_and_authenticated_clients__Auth_clientId_attribute_is_null__identity_may_change_and_become_identified() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.token = getTestToken(clientId: "tester")
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+        expect(realtime.auth.clientId).to(beNil())
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.connecting) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(realtime.auth.clientId).to(beNil())
+            }
+            realtime.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(realtime.auth.clientId).to(equal("tester"))
+                done()
+            }
+            realtime.connect()
+        }
+    }
+
+    // RSA7b
+
+    // RSA7b1
+    func test__053__Token__clientId_and_authenticated_clients__auth_clientId_not_null__when_clientId_attribute_is_assigned_on_client_options() {
+        let clientOptions = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        clientOptions.clientId = "Exist"
+
+        expect(ARTRest(options: clientOptions).auth.clientId).to(equal("Exist"))
+    }
+
+    // RSA7b2
+    func test__054__Token__clientId_and_authenticated_clients__auth_clientId_not_null__when_tokenRequest_or_tokenDetails_has_clientId_not_null_or_wildcard_string() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "client_string"
+        options.useTokenAuth = true
+
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+
+        // TokenDetails
+        waitUntil(timeout: testTimeout) { done in
+            // Token
+            client.auth.authorize(nil, options: nil) { _, error in
+                expect(error).to(beNil())
+                expect(client.auth.internal.method).to(equal(ARTAuthMethod.token))
+                expect(client.auth.clientId).to(equal(options.clientId))
+                done()
+            }
+        }
+
+        // TokenRequest
+        switch extractBodyAsMsgPack(testHTTPExecutor.requests.last) {
+        case let .failure(error):
+            XCTFail(error)
+        case let .success(httpBody):
+            guard let requestedClientId = httpBody.unbox["clientId"] as? String else { XCTFail("No clientId field in HTTPBody"); return }
+            expect(client.auth.clientId).to(equal(requestedClientId))
+        }
+    }
+
+    // RSA7b3
+    func test__055__Token__clientId_and_authenticated_clients__auth_clientId_not_null__should_CONNECTED_ProtocolMessages_contain_a_clientId() {
+        let options = AblyTests.clientOptions()
+        options.token = getTestToken(clientId: "john")
+        expect(options.clientId).to(beNil())
+        options.autoConnect = false
+        let realtime = AblyTests.newRealtime(options)
+        defer { realtime.dispose(); realtime.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(realtime.auth.clientId).to(equal("john"))
+
+                let transport = realtime.internal.transport as! TestProxyTransport
+                let connectedProtocolMessage = transport.protocolMessagesReceived.filter { $0.action == .connected }[0]
+                expect(connectedProtocolMessage.connectionDetails!.clientId).to(equal("john"))
+                done()
+            }
+            realtime.connect()
+        }
+    }
+
+    // RSA7b4
+    func test__056__Token__clientId_and_authenticated_clients__auth_clientId_not_null__client_does_not_have_an_identity_when_a_wildcard_string_____is_present() {
+        let options = AblyTests.clientOptions()
+        options.token = getTestToken(clientId: "*")
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.on(.connected) { _ in
+                expect(realtime.auth.clientId).to(equal("*"))
+                done()
+            }
+        }
+    }
+
+    // RSA7c
+    func test__050__Token__clientId_and_authenticated_clients__should_clientId_be_null_or_string() {
+        let clientOptions = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        clientOptions.clientId = "*"
+
+        expect { ARTRest(options: clientOptions) }.to(raiseException())
+    }
+
+    // RSA8
+
+    // RSA8e
+    func test__062__requestToken__arguments__should_not_merge_with_the_configured_params_and_options_but_instead_replace_all_corresponding_values__even_when__null_() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "сlientId"
+        let rest = ARTRest(options: options)
+
+        let tokenParams = ARTTokenParams()
+        tokenParams.ttl = 2000
+        tokenParams.capability = "{\"cansubscribe:*\":[\"subscribe\"]}"
+
+        let precedenceOptions = AblyTests.commonAppSetup()
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.requestToken(tokenParams, with: precedenceOptions) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+                expect(tokenDetails!.capability).to(equal("{\"cansubscribe:*\":[\"subscribe\"]}"))
+                expect(tokenDetails!.clientId).to(beNil())
+                expect(tokenDetails!.expires!.timeIntervalSince1970 - tokenDetails!.issued!.timeIntervalSince1970).to(equal(tokenParams.ttl as? Double))
+                done()
+            }
+        }
+
+        let options2 = AblyTests.commonAppSetup()
+        options2.clientId = nil
+        let rest2 = ARTRest(options: options2)
+
+        let precedenceOptions2 = AblyTests.commonAppSetup()
+        precedenceOptions2.clientId = nil
+
+        waitUntil(timeout: testTimeout) { done in
+            rest2.auth.requestToken(nil, with: precedenceOptions2) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    XCTFail("tokenDetails is nil"); done(); return
+                }
+                expect(tokenDetails.clientId).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RSA8e
+    func test__063__requestToken__arguments__should_use_configured_defaults_if_the_object_arguments_are_omitted() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "tester"
+        let rest = ARTRest(options: options)
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.requestToken(nil, with: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+                expect(tokenDetails!.capability).to(equal("{\"*\":[\"*\"]}"))
+                expect(tokenDetails!.clientId).to(equal("tester"))
+                done()
+            }
+        }
+
+        let tokenParams = ARTTokenParams()
+        tokenParams.ttl = 2000
+        tokenParams.capability = "{\"cansubscribe:*\":[\"subscribe\"]}"
+        tokenParams.clientId = nil
+
+        let authOptions = ARTAuthOptions()
+        authOptions.key = options.key
+
+        // Provide TokenParams and Options
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.requestToken(tokenParams, with: authOptions) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+                expect(tokenDetails!.capability).to(equal("{\"cansubscribe:*\":[\"subscribe\"]}"))
+                expect(tokenDetails!.clientId).to(beNil())
+                expect(tokenDetails!.expires!.timeIntervalSince1970 - tokenDetails!.issued!.timeIntervalSince1970).to(equal(tokenParams.ttl as? Double))
+                done()
+            }
+        }
+
+        // Provide TokenParams as null
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.requestToken(nil, with: authOptions) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+                expect(tokenDetails!.capability).to(equal("{\"*\":[\"*\"]}"))
+                expect(tokenDetails!.clientId).to(equal("tester"))
+                expect(tokenDetails!.expires!.timeIntervalSince1970 - tokenDetails!.issued!.timeIntervalSince1970).to(equal(ARTDefault.ttl()))
+                done()
+            }
+        }
+
+        // Omit arguments
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.requestToken { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+                expect(tokenDetails!.capability).to(equal("{\"*\":[\"*\"]}"))
+                expect(tokenDetails!.clientId).to(equal("tester"))
+                done()
+            }
+        }
+    }
+
+    // RSA8c
+
+    func test__064__requestToken__authUrl__query_will_provide_a_token_string() {
+        let testToken = getTestToken()
+
+        let options = AblyTests.clientOptions()
+        options.authUrl = URL(string: "http://echo.ably.io")
+        expect(options.authUrl).toNot(beNil())
+        // Plain text
+        options.authParams = [URLQueryItem]()
+        options.authParams!.append(URLQueryItem(name: "type", value: "text"))
+        options.authParams!.append(URLQueryItem(name: "body", value: testToken))
+
+        let rest = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = testHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.requestToken(nil, with: nil, callback: { tokenDetails, error in
+                expect(testHTTPExecutor.requests.last?.url?.host).to(equal("echo.ably.io"))
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+                expect(tokenDetails?.token).to(equal(testToken))
+                done()
+            })
+        }
+    }
+
+    func test__065__requestToken__authUrl__query_will_provide_a_TokenDetails() {
+        guard let testTokenDetails = getTestTokenDetails(clientId: "tester") else {
+            fail("TokenDetails is empty")
+            return
+        }
+
+        let encoder = ARTJsonLikeEncoder()
+        encoder.delegate = ARTJsonEncoder()
+        guard let jsonTokenDetails = try? encoder.encode(testTokenDetails) else {
+            fail("Invalid TokenDetails")
+            return
+        }
+
+        let options = ARTClientOptions()
+        options.authUrl = URL(string: "http://echo.ably.io")
+        expect(options.authUrl).toNot(beNil())
+        // JSON with TokenDetails
+        options.authParams = [URLQueryItem]()
+        options.authParams?.append(URLQueryItem(name: "type", value: "json"))
+        options.authParams?.append(URLQueryItem(name: "body", value: jsonTokenDetails.toUTF8String))
+
+        let rest = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = testHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.requestToken(nil, with: nil, callback: { tokenDetails, error in
+                expect(testHTTPExecutor.requests.last?.url?.host).to(equal("echo.ably.io"))
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+                expect(tokenDetails?.clientId) == testTokenDetails.clientId
+                expect(tokenDetails?.capability) == testTokenDetails.capability
+                expect(tokenDetails?.issued).toNot(beNil())
+                expect(tokenDetails?.expires).toNot(beNil())
+                if let issued = tokenDetails?.issued, let testIssued = testTokenDetails.issued {
+                    expect(issued.compare(testIssued)) == ComparisonResult.orderedSame
+                }
+                if let expires = tokenDetails?.expires, let testExpires = testTokenDetails.expires {
+                    expect(expires.compare(testExpires)) == ComparisonResult.orderedSame
+                }
+                done()
+            })
+        }
+    }
+
+    func test__066__requestToken__authUrl__query_will_provide_a_TokenRequest() {
+        let tokenParams = ARTTokenParams()
+        tokenParams.capability = "{\"test\":[\"subscribe\"]}"
+
+        let options = AblyTests.commonAppSetup()
+        options.authUrl = URL(string: "http://echo.ably.io")
+        expect(options.authUrl).toNot(beNil())
+
+        var rest = ARTRest(options: options)
+
+        var tokenRequest: ARTTokenRequest?
+        waitUntil(timeout: testTimeout) { done in
+            // Sandbox and valid TokenRequest
+            rest.auth.createTokenRequest(tokenParams, options: nil, callback: { newTokenRequest, error in
+                expect(error).to(beNil())
+                tokenRequest = newTokenRequest
+                done()
+            })
+        }
+
+        guard let testTokenRequest = tokenRequest else {
+            fail("TokenRequest is empty")
+            return
+        }
+
+        let encoder = ARTJsonLikeEncoder()
+        encoder.delegate = ARTJsonEncoder()
+        guard let jsonTokenRequest = try? encoder.encode(testTokenRequest) else {
+            fail("Invalid TokenRequest")
+            return
+        }
+
+        // JSON with TokenRequest
+        options.authParams = [URLQueryItem]()
+        options.authParams?.append(URLQueryItem(name: "type", value: "json"))
+        options.authParams?.append(URLQueryItem(name: "body", value: jsonTokenRequest.toUTF8String))
+
+        rest = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = testHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.requestToken(nil, with: nil, callback: { tokenDetails, error in
+                expect(testHTTPExecutor.requests.first?.url?.host).to(equal("echo.ably.io"))
+                expect(testHTTPExecutor.requests.last?.url?.host).toNot(equal("echo.ably.io"))
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    fail("TokenDetails is empty"); done()
                     return
                 }
-                
-                let authorization = request.allHTTPHeaderFields?["Authorization"]
-                
-                expect(authorization).to(equal(expectedAuthorization))
+                expect(tokenDetails.token).toNot(beNil())
+                expect(tokenDetails.capability) == tokenParams.capability
+                done()
+            })
+        }
+    }
+
+    // RSA8c1a
+    func test__069__requestToken__authUrl__parameters__should_be_added_to_the_URL_when_auth_method_is_GET() {
+        let clientOptions = ARTClientOptions()
+        clientOptions.authUrl = URL(string: "http://auth.ably.io")
+        var authParams = [
+            "param1": "value",
+            "param2": "value",
+            "clientId": "should not be overwritten",
+        ]
+        clientOptions.authParams = authParams.map {
+            URLQueryItem(name: $0, value: $1)
+        }
+        clientOptions.authHeaders = ["X-Header-1": "foo", "X-Header-2": "bar"]
+        let tokenParams = ARTTokenParams()
+        tokenParams.clientId = "test"
+
+        let rest = ARTRest(options: clientOptions)
+        let request = rest.auth.internal.buildRequest(clientOptions, with: tokenParams)
+
+        for (header, expectedValue) in clientOptions.authHeaders! {
+            if let value = request.allHTTPHeaderFields?[header] {
+                expect(value).to(equal(expectedValue))
+            } else {
+                fail("Missing header in request: \(header), expected: \(expectedValue)")
             }
+        }
 
-            // RSA2
-            func test__005__Basic__should_be_default_when_an_API_key_is_set() {
-                let client = ARTRest(options: ARTClientOptions(key: "fake:key"))
-
-                expect(client.auth.internal.method).to(equal(ARTAuthMethod.basic))
+        guard let url = request.url else {
+            fail("Request is invalid")
+            return
+        }
+        guard let urlComponents = NSURLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            fail("invalid URL: \(url)")
+            return
+        }
+        expect(urlComponents.scheme).to(equal("http"))
+        expect(urlComponents.host).to(equal("auth.ably.io"))
+        guard let queryItems = urlComponents.queryItems else {
+            fail("URL without query: \(url)")
+            return
+        }
+        for queryItem in queryItems {
+            if var expectedValue = authParams[queryItem.name] {
+                if queryItem.name == "clientId" {
+                    expectedValue = "test"
+                }
+                expect(queryItem.value!).to(equal(expectedValue))
+                authParams.removeValue(forKey: queryItem.name)
             }
-
-        
-            
-            // RSA3
-            
-                // RSA3a
-                func test__010__Token__token_auth__should_work_over_HTTP() {
-                    let options = AblyTests.clientOptions(requestToken: true)
-                    options.tls = false
-                    let clientHTTP = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    clientHTTP.internal.httpExecutor = testHTTPExecutor
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        clientHTTP.channels.get("test").publish(nil, data: "message") { error in
-                            done()
-                        }
-                    }
-
-                    guard let request = testHTTPExecutor.requests.first else {
-                        fail("No request found")
-                        return
-                    }
-                    guard let url = request.url else {
-                        fail("Request is invalid")
-                        return
-                    }
-                    expect(url.scheme).to(equal("http"), description: "No HTTP support")
-                }
-
-                func test__011__Token__token_auth__should_work_over_HTTPS() {
-                    let options = AblyTests.clientOptions(requestToken: true)
-                    options.tls = true
-                    let clientHTTPS = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    clientHTTPS.internal.httpExecutor = testHTTPExecutor
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        clientHTTPS.channels.get("test").publish(nil, data: "message") { error in
-                            done()
-                        }
-                    }
-
-                    guard let request = testHTTPExecutor.requests.first else {
-                        fail("No request found")
-                        return
-                    }
-                    guard let url = request.url else {
-                        fail("Request is invalid")
-                        return
-                    }
-                    expect(url.scheme).to(equal("https"), description: "No HTTPS support")
-                }
-
-                // RSA3b
-                
-                    func test__012__Token__token_auth__for_REST_requests__should_send_the_token_in_the_Authorization_header() {
-                        let options = AblyTests.clientOptions()
-                        options.token = getTestToken()
-                        
-                        let client = ARTRest(options: options)
-                        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        
-                        waitUntil(timeout: testTimeout) { done in
-                            client.channels.get("test").publish(nil, data: "message") { error in
-                                done()
-                            }
-                        }
-                        
-                        guard let currentToken = client.internal.options.token else {
-                            fail("No access token")
-                            return
-                        }
-                        
-                        let expectedAuthorization = "Bearer \(currentToken)"
-                        
-                        guard let request = testHTTPExecutor.requests.first else {
-                            fail("No request found")
-                            return
-                        }
-                        
-                        let authorization = request.allHTTPHeaderFields?["Authorization"]
-                        
-                        expect(authorization).to(equal(expectedAuthorization))
-                    }
-                
-                // RSA3c
-                
-                    func test__013__Token__token_auth__for_Realtime_connections__should_send_the_token_in_the_querystring_as_a_param_named_accessToken() {
-                        let options = AblyTests.clientOptions()
-                        options.token = getTestToken()
-                        options.autoConnect = false
-                        
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        
-                        if let transport = client.internal.transport as? TestProxyTransport, let query = transport.lastUrl?.query {
-                            expect(query).to(haveParam("accessToken", withValue: client.auth.tokenDetails?.token ?? ""))
-                        }
-                        else {
-                            XCTFail("MockTransport is not working")
-                        }
-                    }
-
-            // RSA4
-            
-                
-                func test__014__Token__authentication_method__should_be_default_auth_method_when_options__useTokenAuth_is_set() {
-                    testOptionsGiveDefaultAuthMethod { $0.useTokenAuth = true; $0.key = "fake:key" }
-                }
-                
-                func test__015__Token__authentication_method__should_be_default_auth_method_when_options__authUrl_is_set() {
-                    testOptionsGiveDefaultAuthMethod { $0.authUrl = URL(string: "http://test.com") }
-                }
-                
-                func test__016__Token__authentication_method__should_be_default_auth_method_when_options__authCallback_is_set() {
-                    testOptionsGiveDefaultAuthMethod { $0.authCallback = { _, _ in return } }
-                }
-                
-                func test__017__Token__authentication_method__should_be_default_auth_method_when_options__tokenDetails_is_set() {
-                    testOptionsGiveDefaultAuthMethod { $0.tokenDetails = ARTTokenDetails(token: "token") }
-                }
-
-                func test__018__Token__authentication_method__should_be_default_auth_method_when_options__token_is_set() {
-                    testOptionsGiveDefaultAuthMethod { $0.token = "token" }
-                }
-                
-                func test__019__Token__authentication_method__should_be_default_auth_method_when_options__key_is_set() {
-                    testOptionsGiveDefaultAuthMethod { $0.tokenDetails = ARTTokenDetails(token: "token"); $0.key = "fake:key" }
-                }
-
-                // RSA4a
-                func test__020__Token__authentication_method__should_indicate_an_error_and_not_retry_the_request_when_the_server_responds_with_a_token_error_and_there_is_no_way_to_renew_the_token() {
-                    let options = AblyTests.clientOptions()
-                    options.token = getTestToken()
-
-                    let rest = ARTRest(options: options)
-                    // No means to renew the token is provided
-                    expect(rest.internal.options.key).to(beNil())
-                    expect(rest.internal.options.authCallback).to(beNil())
-                    expect(rest.internal.options.authUrl).to(beNil())
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    rest.internal.httpExecutor = testHTTPExecutor
-
-                    let channel = rest.channels.get("test")
-
-                    testHTTPExecutor.simulateIncomingServerErrorOnNextRequest(ARTErrorCode.tokenRevoked.intValue, description: "token revoked")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish("message", data: nil) { error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(UInt(error.code)).to(equal(ARTState.requestTokenFailed.rawValue))
-                            done()
-                        }
-                    }
-                }
-
-                // RSA4a
-                func test__021__Token__authentication_method__should_transition_the_connection_to_the_FAILED_state_when_the_server_responds_with_a_token_error_and_there_is_no_way_to_renew_the_token() {
-                    let options = AblyTests.clientOptions()
-                    options.tokenDetails = getTestTokenDetails(ttl: 0.1)
-                    options.autoConnect = false
-
-                    // Token will expire, expecting 40142
-                    waitUntil(timeout: testTimeout) { done in
-                        delay(0.2) { done() }
-                    }
-
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.dispose(); realtime.close() }
-                    // No means to renew the token is provided
-                    expect(realtime.internal.options.key).to(beNil())
-                    expect(realtime.internal.options.authCallback).to(beNil())
-                    expect(realtime.internal.options.authUrl).to(beNil())
-                    realtime.internal.setTransport(TestProxyTransport.self)
-
-                    let channel = realtime.channels.get("test")
-
-                    waitUntil(timeout: testTimeout.multiplied(by: 2)) { done in
-                        realtime.connect()
-                        channel.publish("message", data: nil) { error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.code).to(equal(ARTErrorCode.tokenExpired.intValue))
-                            expect(realtime.connection.state).to(equal(ARTRealtimeConnectionState.failed))
-                            done()
-                        }
-                    }
-                }
-                
-                // RSA4b
-                func test__022__Token__authentication_method__on_token_error__reissues_token_and_retries_REST_requests() {
-                    var authCallbackCalled = 0
-
-                    let options = AblyTests.commonAppSetup()
-                    options.authCallback = { _, callback in
-                        authCallbackCalled += 1
-                        getTestTokenDetails { token, err in
-                            callback(token, err)
-                        }
-                    }
-
-                    let rest = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    rest.internal.httpExecutor = testHTTPExecutor
-
-                    let channel = rest.channels.get("test")
-
-                    testHTTPExecutor.simulateIncomingServerErrorOnNextRequest(ARTErrorCode.tokenRevoked.intValue, description: "token revoked")
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish("message", data: nil) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    // First request and a second attempt
-                    expect(testHTTPExecutor.requests).to(haveCount(2))
-                    
-                    // First token issue, and then reissue on token error.
-                    expect(authCallbackCalled).to(equal(2))
-                }
-
-                // RSA4b
-                func test__023__Token__authentication_method__in_REST__if_the_token_creation_failed_or_the_subsequent_request_with_the_new_token_failed_due_to_a_token_error__then_the_request_should_result_in_an_error() {
-                    let options = AblyTests.commonAppSetup()
-                    options.useTokenAuth = true
-
-                    let rest = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    rest.internal.httpExecutor = testHTTPExecutor
-
-                    let channel = rest.channels.get("test")
-
-                    testHTTPExecutor.setListenerAfterRequest({ _ in
-                        testHTTPExecutor.simulateIncomingServerErrorOnNextRequest(ARTErrorCode.tokenRevoked.intValue, description: "token revoked")
-                    })
-
-                    testHTTPExecutor.simulateIncomingServerErrorOnNextRequest(ARTErrorCode.tokenRevoked.intValue, description: "token revoked")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish("message", data: nil) { error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.code).to(equal(ARTErrorCode.tokenRevoked.intValue))
-                            done()
-                        }
-                    }
-
-                    // First request and a second attempt
-                    expect(testHTTPExecutor.requests).to(haveCount(2))
-                }
-
-                // RSA4b
-                func test__024__Token__authentication_method__in_Realtime__if_the_token_creation_failed_then_the_connection_should_move_to_the_DISCONNECTED_state_and_reports_the_error() {
-                    let options = AblyTests.commonAppSetup()
-                    options.authCallback = { tokenParams, completion in
-                        completion(nil, NSError(domain: NSURLErrorDomain, code: -1003, userInfo: [NSLocalizedDescriptionKey: "A server with the specified hostname could not be found."]))
-                    }
-                    options.autoConnect = false
-
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.dispose(); realtime.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.connection.once(.failed) { _ in
-                            fail("Should not reach Failed state"); done(); return
-                        }
-                        realtime.connection.once(.disconnected) { stateChange in
-                            guard let errorInfo = stateChange.reason else {
-                                fail("ErrorInfo is nil"); done(); return
-                            }
-                            expect(errorInfo.message).to(contain("server with the specified hostname could not be found"))
-                            done()
-                        }
-                        realtime.connect()
-                    }
-                }
-
-                // RSA4b
-                func test__025__Token__authentication_method__in_Realtime__if_the_connection_fails_due_to_a_terminal_token_error__then_the_connection_should_move_to_the_FAILED_state_and_reports_the_error() {
-                    let options = AblyTests.commonAppSetup()
-                    options.authCallback = { tokenParams, completion in
-                        getTestToken() { token in
-                            let invalidToken = String(token.reversed())
-                            completion(invalidToken as ARTTokenDetailsCompatible?, nil)
-                        }
-                    }
-                    options.autoConnect = false
-
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.dispose(); realtime.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.connection.once(.failed) { stateChange in
-                            guard let errorInfo = stateChange.reason else {
-                                fail("ErrorInfo is nil"); done(); return
-                            }
-                            expect(errorInfo.message).to(contain("No application found with id"))
-                            done()
-                        }
-                        realtime.connection.once(.disconnected) { _ in
-                            fail("Should not reach Disconnected state"); done(); return
-                        }
-                        realtime.connect()
-                    }
-                }
-
-                // RSA4b1
-                
-                    func test__028__Token__authentication_method__local_token_validity_check__should_be_done_if_queryTime_is_true_and_local_time_is_in_sync_with_server() {
-                        let options = AblyTests.commonAppSetup()
-                        let testKey = options.key!
-
-                        let tokenDetails = getTestTokenDetails(key: testKey, ttl: 5.0, queryTime: true)
-
-                        options.queryTime = true
-                        options.tokenDetails = tokenDetails
-                        options.key = nil
-
-                        let rest = ARTRest(options: options)
-                        let proxyHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-
-                        // Sync server time offset
-                        let authOptions = ARTAuthOptions(key: testKey)
-                        authOptions.queryTime = true
-                        waitUntil(timeout: testTimeout) { done in
-                            rest.auth.createTokenRequest(nil, options: authOptions, callback: { tokenRequest, error in
-                                expect(error).to(beNil())
-                                expect(tokenRequest).toNot(beNil())
-                                done()
-                            })
-                        }
-
-                        // Let the token expire
-                        waitUntil(timeout: testTimeout) { done in
-                            delay(5.0) {
-                                done()
-                            }
-                        }
-
-                        expect(rest.auth.internal.timeOffset).toNot(beNil())
-
-                        rest.internal.httpExecutor = proxyHTTPExecutor
-                        waitUntil(timeout: testTimeout) { done in
-                            rest.channels.get("foo").history { _, error in
-                                guard let error = error else {
-                                    fail("Error is nil"); done(); return
-                                }
-                                expect((error ).code).to(equal(Int(ARTState.requestTokenFailed.rawValue)))
-                                expect(error.message).to(contain("no means to renew the token is provided"))
-
-                                expect(proxyHTTPExecutor.requests.count).to(equal(0))
-                                done()
-                            }
-                        }
-
-                        expect(rest.auth.tokenDetails).toNot(beNil())
-                    }
-
-                    func test__029__Token__authentication_method__local_token_validity_check__should_NOT_be_done_if_queryTime_is_false_and_local_time_is_NOT_in_sync_with_server() {
-                        let options = AblyTests.commonAppSetup()
-                        let testKey = options.key!
-
-                        let tokenDetails = getTestTokenDetails(key: testKey, ttl: 5.0, queryTime: true)
-
-                        options.queryTime = false
-                        options.tokenDetails = tokenDetails
-                        options.key = nil
-
-                        let rest = ARTRest(options: options)
-                        let proxyHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                        rest.internal.httpExecutor = proxyHTTPExecutor
-
-                        // No server time offset
-                        rest.auth.internal.clearTimeOffset()
-
-                        // Let the token expire
-                        waitUntil(timeout: testTimeout) { done in
-                            delay(5.0) {
-                                done()
-                            }
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            rest.channels.get("foo").history { _, error in
-                                guard let error = error else {
-                                    fail("Error is nil"); done(); return
-                                }
-                                expect((error ).code).to(equal(Int(ARTState.requestTokenFailed.rawValue)))
-                                expect(error.message).to(contain("no means to renew the token is provided"))
-                                expect(proxyHTTPExecutor.requests.count).to(equal(1))
-                                expect(proxyHTTPExecutor.responses.count).to(equal(1))
-                                guard let response = proxyHTTPExecutor.responses.first else {
-                                    fail("Response is nil"); done(); return
-                                }
-                                expect(response.value(forHTTPHeaderField: "X-Ably-Errorcode")).to(equal("\(ARTErrorCode.tokenExpired.intValue)"))
-                                done()
-                            }
-                        }
-                    }
-
-                // RSA4d
-                func test__026__Token__authentication_method__if_a_request_by_a_realtime_client_to_an_authUrl_results_in_an_HTTP_403_the_client_library_should_transition_to_the_FAILED_state() {
-                    let options = AblyTests.clientOptions()
-                    options.autoConnect = false
-                    options.authUrl = URL(string: "https://echo.ably.io/respondwith?status=403")!
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.dispose(); realtime.close() }
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.connection.once(.failed) { stateChange in
-                            expect(stateChange.reason?.code).to(equal(ARTErrorCode.authConfiguredProviderFailure.intValue))
-                            expect(stateChange.reason?.statusCode).to(equal(403))
-                            done()
-                        }
-                        realtime.connect()
-                    }
-                }
-                
-                // RSA4d
-                func test__027__Token__authentication_method__if_an_authCallback_results_in_an_HTTP_403_the_client_library_should_transition_to_the_FAILED_state() {
-                    let options = AblyTests.clientOptions()
-                    options.autoConnect = false
-                    var authCallbackHasBeenInvoked = false
-                    options.authCallback = { tokenParams, completion in
-                        authCallbackHasBeenInvoked = true
-                        completion(nil, ARTErrorInfo(domain: "io.ably.cocoa", code: ARTErrorCode.forbidden.intValue, userInfo: ["ARTErrorInfoStatusCode": 403]))
-                    }
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.dispose(); realtime.close() }
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.connection.once(.failed) { stateChange in
-                            expect(authCallbackHasBeenInvoked).to(beTrue())
-                            expect(stateChange.reason?.code).to(equal(ARTErrorCode.authConfiguredProviderFailure.intValue))
-                            expect(stateChange.reason?.statusCode).to(equal(403))
-                            done()
-                        }
-                        realtime.connect()
-                    }
-                }
-            
-            // RSA14
-            
-                
-                func test__030__Token__options__should_stop_client_when_useTokenAuth_and_no_key_occurs() {
-                    testStopsClientWithOptions { $0.useTokenAuth = true }
-                }
-                
-                func test__031__Token__options__should_stop_client_when_authCallback_and_authUrl_occurs() {
-                    testStopsClientWithOptions { $0.authCallback = { params, callback in /*nothing*/ }; $0.authUrl = URL(string: "http://auth.ably.io") }
-                }
-
-                // RSA4c
-                
-
-                    
-
-                        // RSA4c1 & RSA4c2
-                        func test__032__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_request_to_authUrl_fails__if_the_connection_is_CONNECTING__then_the_connection_attempt_should_be_treated_as_unsuccessful() {
-                            let options = AblyTests.clientOptions()
-                            options.autoConnect = false
-                            options.authUrl = URL(string: "http://echo.ably.io")!
-                            let realtime = ARTRealtime(options: options)
-                            defer { realtime.dispose(); realtime.close() }
-
-                            waitUntil(timeout: testTimeout) { done in
-                                realtime.connection.once(.disconnected) { stateChange in
-                                    expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
-                                    guard let errorInfo = stateChange.reason else {
-                                        fail("ErrorInfo is nil"); done(); return
-                                    }
-                                    expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
-                                    done()
-                                }
-                                realtime.connect()
-                            }
-
-                            guard let errorInfo = realtime.connection.errorReason else {
-                                fail("ErrorInfo is empty"); return
-                            }
-                            expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
-                            expect(errorInfo.message).to(contain("body param is required"))
-                        }
-
-                        // RSA4c3
-                        func test__033__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_request_to_authUrl_fails__if_the_connection_is_CONNECTED__then_the_connection_should_remain_CONNECTED() {
-                            let token = getTestToken()
-                            let options = AblyTests.clientOptions()
-                            options.authUrl = URL(string: "http://echo.ably.io")!
-                            options.authParams = [URLQueryItem]()
-                            options.authParams?.append(URLQueryItem(name: "type", value: "text"))
-                            options.authParams?.append(URLQueryItem(name: "body", value: token))
-
-                            let realtime = ARTRealtime(options: options)
-                            defer { realtime.dispose(); realtime.close() }
-
-                            waitUntil(timeout: testTimeout) { done in
-                                realtime.connection.once(.connected) { stateChange in
-                                    expect(stateChange.reason).to(beNil())
-                                    done()
-                                }
-                            }
-
-                            // Token reauth will fail
-                            realtime.internal.options.authParams = [URLQueryItem]()
-
-                            // Inject AUTH
-                            let authMessage = ARTProtocolMessage()
-                            authMessage.action = ARTProtocolMessageAction.auth
-                            realtime.internal.transport?.receive(authMessage)
-
-                            expect(realtime.connection.errorReason).toEventuallyNot(beNil(), timeout: testTimeout)
-                            guard let errorInfo = realtime.connection.errorReason else {
-                                fail("ErrorInfo is empty"); return
-                            }
-                            expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
-                            expect(errorInfo.message).to(contain("body param is required"))
-
-                            expect(realtime.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                        }
-
-                    
-
-                        // RSA4c1 & RSA4c2
-                        func test__034__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_request_to_authCallback_fails__if_the_connection_is_CONNECTING__then_the_connection_attempt_should_be_treated_as_unsuccessful() {
-                            let options = AblyTests.clientOptions()
-                            options.autoConnect = false
-                            options.authCallback = { tokenParams, completion in
-                                completion(nil, NSError(domain: NSURLErrorDomain, code: -1003, userInfo: [NSLocalizedDescriptionKey: "A server with the specified hostname could not be found."]))
-                            }
-                            let realtime = ARTRealtime(options: options)
-                            defer { realtime.dispose(); realtime.close() }
-
-                            waitUntil(timeout: testTimeout) { done in
-                                realtime.connection.once(.disconnected) { stateChange in
-                                    expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
-                                    guard let errorInfo = stateChange.reason else {
-                                        fail("ErrorInfo is nil"); done(); return
-                                    }
-                                    expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
-                                    done()
-                                }
-                                realtime.connect()
-                            }
-
-                            expect(realtime.connection.state).toEventually(equal(ARTRealtimeConnectionState.disconnected), timeout: testTimeout)
-                            guard let errorInfo = realtime.connection.errorReason else {
-                                fail("ErrorInfo is empty"); return
-                            }
-                            expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
-                            expect(errorInfo.message).to(contain("hostname could not be found"))
-                        }
-
-                        // RSA4c3
-                        func test__035__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_request_to_authCallback_fails__if_the_connection_is_CONNECTED__then_the_connection_should_remain_CONNECTED() {
-                            let options = AblyTests.clientOptions()
-                            options.authCallback = { tokenParams, completion in
-                                getTestTokenDetails(completion: completion)
-                            }
-                            let realtime = ARTRealtime(options: options)
-                            defer { realtime.dispose(); realtime.close() }
-
-                            waitUntil(timeout: testTimeout) { done in
-                                realtime.connection.once(.connected) { stateChange in
-                                    expect(stateChange.reason).to(beNil())
-                                    done()
-                                }
-                            }
-
-                            // Token should renew and fail
-                            realtime.internal.options.authCallback = { tokenParams, completion in
-                                completion(nil, NSError(domain: NSURLErrorDomain, code: -1003, userInfo: [NSLocalizedDescriptionKey: "A server with the specified hostname could not be found."]))
-                            }
-
-                            // Inject AUTH
-                            let authMessage = ARTProtocolMessage()
-                            authMessage.action = ARTProtocolMessageAction.auth
-                            realtime.internal.transport?.receive(authMessage)
-
-                            expect(realtime.connection.errorReason).toEventuallyNot(beNil(), timeout: testTimeout)
-                            guard let errorInfo = realtime.connection.errorReason else {
-                                fail("ErrorInfo is empty"); return
-                            }
-                            expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
-                            expect(errorInfo.message).to(contain("hostname could not be found"))
-
-                            expect(realtime.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                        }
-
-                    
-
-                        // RSA4c1 & RSA4c2
-                        func test__036__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_provided_token_is_in_an_invalid_format__if_the_connection_is_CONNECTING__then_the_connection_attempt_should_be_treated_as_unsuccessful() {
-                            let options = AblyTests.clientOptions()
-                            options.autoConnect = false
-                            options.authUrl = URL(string: "http://echo.ably.io")!
-                            options.authParams = [URLQueryItem]()
-                            options.authParams?.append(URLQueryItem(name: "type", value: "json"))
-                            let invalidTokenFormat = "{secret_token:xxx}"
-                            options.authParams?.append(URLQueryItem(name: "body", value: invalidTokenFormat))
-
-                            let realtime = ARTRealtime(options: options)
-                            defer { realtime.dispose(); realtime.close() }
-
-                            waitUntil(timeout: testTimeout) { done in
-                                realtime.connection.once(.disconnected) { stateChange in
-                                    expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
-                                    guard let errorInfo = stateChange.reason else {
-                                        fail("ErrorInfo is nil"); done(); return
-                                    }
-                                    expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
-                                    done()
-                                }
-                                realtime.connect()
-                            }
-
-                            guard let errorInfo = realtime.connection.errorReason else {
-                                fail("ErrorInfo is empty"); return
-                            }
-                            expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
-                            expect(errorInfo.message).to(contain("content response cannot be used for token request"))
-
-                            expect(realtime.connection.state).toEventually(equal(ARTRealtimeConnectionState.disconnected), timeout: testTimeout)
-                        }
-
-                        // RSA4c3
-                        func test__037__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_provided_token_is_in_an_invalid_format__if_the_connection_is_CONNECTED__then_the_connection_should_remain_CONNECTED() {
-                            let options = AblyTests.clientOptions()
-                            options.authUrl = URL(string: "http://echo.ably.io")!
-                            options.authParams = [URLQueryItem]()
-                            options.authParams?.append(URLQueryItem(name: "type", value: "text"))
-
-                            let token = getTestToken()
-                            options.authParams?.append(URLQueryItem(name: "body", value: token))
-
-                            let realtime = ARTRealtime(options: options)
-                            defer { realtime.dispose(); realtime.close() }
-
-                            waitUntil(timeout: testTimeout) { done in
-                                realtime.connection.once(.connected) { stateChange in
-                                    expect(stateChange.reason).to(beNil())
-                                    done()
-                                }
-                            }
-
-                            // Token should renew and fail
-                            waitUntil(timeout: testTimeout) { done in
-                                realtime.unwrapAsync { realtime in
-                                    realtime.options.authParams = [URLQueryItem]()
-                                    realtime.options.authParams?.append(URLQueryItem(name: "type", value: "json"))
-                                    let invalidTokenFormat = "{secret_token:xxx}"
-                                    realtime.options.authParams?.append(URLQueryItem(name: "body", value: invalidTokenFormat))
-                                    done()
-                                }
-                            }
-
-                            realtime.connection.on() { stateChange in
-                                if stateChange.current != .connected {
-                                    fail("Connection should remain connected")
-                                }
-                            }
-
-                            // Inject AUTH
-                            let authMessage = ARTProtocolMessage()
-                            authMessage.action = ARTProtocolMessageAction.auth
-                            realtime.internal.transport?.receive(authMessage)
-
-                            expect(realtime.connection.errorReason).toEventuallyNot(beNil(), timeout: testTimeout)
-                            guard let errorInfo = realtime.connection.errorReason else {
-                                fail("ErrorInfo is empty"); return
-                            }
-                            expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
-                            expect(errorInfo.message).to(contain("content response cannot be used for token request"))
-
-                            expect(realtime.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                        }
-
-                    
-                        // RSA4c1 & RSA4c2
-                        func test__038__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_attempt_times_out_after_realtimeRequestTimeout__if_the_connection_is_CONNECTING__then_the_connection_attempt_should_be_treated_as_unsuccessful() {
-                            let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                            defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                            ARTDefault.setRealtimeRequestTimeout(0.5)
-
-                            let options = AblyTests.clientOptions()
-                            options.autoConnect = false
-                            options.authCallback = { tokenParams, completion in
-                                // Ignore `completion` closure to force a time out
-                            }
-
-                            let realtime = ARTRealtime(options: options)
-                            defer { realtime.dispose(); realtime.close() }
-
-                            waitUntil(timeout: testTimeout) { done in
-                                realtime.connection.once(.disconnected) { stateChange in
-                                    guard let errorInfo = stateChange.reason else {
-                                        fail("ErrorInfo is nil"); done(); return
-                                    }
-                                    expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
-                                    done()
-                                }
-                                realtime.connect()
-                            }
-
-                            guard let errorInfo = realtime.connection.errorReason else {
-                                fail("ErrorInfo is empty"); return
-                            }
-                            expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
-                            expect(errorInfo.message).to(contain("timed out"))
-
-                            expect(realtime.connection.state).toEventually(equal(ARTRealtimeConnectionState.disconnected), timeout: testTimeout)
-                        }
-
-                        // RSA4c3
-                        func test__039__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_attempt_times_out_after_realtimeRequestTimeout__if_the_connection_is_CONNECTED__then_the_connection_should_remain_CONNECTED() {
-                            let options = AblyTests.clientOptions()
-                            options.autoConnect = false
-                            options.authCallback = { tokenParams, completion in
-                                getTestTokenDetails(completion: completion)
-                            }
-
-                            let realtime = ARTRealtime(options: options)
-                            defer { realtime.dispose(); realtime.close() }
-
-                            waitUntil(timeout: testTimeout) { done in
-                                realtime.connection.once(.connected) { stateChange in
-                                    expect(stateChange.reason).to(beNil())
-                                    done()
-                                }
-                                realtime.connect()
-                            }
-
-                            let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                            defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                            ARTDefault.setRealtimeRequestTimeout(0.5)
-
-                            // Token should renew and fail
-                            realtime.internal.options.authCallback = { tokenParams, completion in
-                                // Ignore `completion` closure to force a time out
-                            }
-
-                            // Inject AUTH
-                            let authMessage = ARTProtocolMessage()
-                            authMessage.action = ARTProtocolMessageAction.auth
-                            waitUntil(timeout: testTimeout) { done in
-                                realtime.unwrapAsync { realtime in
-                                    realtime.transport?.receive(authMessage)
-                                    done()
-                                }
-                            }
-
-                            expect(realtime.connection.errorReason).toEventuallyNot(beNil(), timeout: testTimeout)
-                            guard let errorInfo = realtime.connection.errorReason else {
-                                fail("ErrorInfo is empty"); return
-                            }
-                            expect(errorInfo.code) == ARTErrorCode.authConfiguredProviderFailure.intValue
-                            expect(errorInfo.message).to(contain("timed out"))
-
-                            expect(realtime.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                        }
-
-            // RSA15
-            
-                // RSA15a
-                
-
-                    func test__041__Token__token_auth_and_clientId__should_check_clientId_consistency__on_rest() {
-                        let expectedClientId = "client_string"
-                        let options = AblyTests.commonAppSetup()
-                        options.useTokenAuth = true
-                        options.clientId = expectedClientId
-
-                        let client = ARTRest(options: options)
-                        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-
-                        waitUntil(timeout: testTimeout) { done in
-                            // Token
-                            client.auth.authorize(nil, options: nil) { tokenDetails, error in
-                                expect(error).to(beNil())
-                                expect(client.auth.internal.method).to(equal(ARTAuthMethod.token))
-                                guard let tokenDetails = tokenDetails else {
-                                    fail("TokenDetails is nil"); done(); return
-                                }
-                                expect(tokenDetails.clientId).to(equal(expectedClientId))
-                                done()
-                            }
-                        }
-
-                        switch extractBodyAsMsgPack(testHTTPExecutor.requests.first) {
-                        case .failure(let error):
-                            XCTFail(error)
-                        case .success(let httpBody):
-                            guard let requestedClientId = httpBody.unbox["clientId"] as? String else { XCTFail("No clientId field in HTTPBody"); return }
-                            expect(requestedClientId).to(equal(expectedClientId))
-                        }
-                    }
-
-                    func test__042__Token__token_auth_and_clientId__should_check_clientId_consistency__on_realtime() {
-                        let expectedClientId = "client_string"
-                        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
-                        options.clientId = expectedClientId
-                        options.autoConnect = false
-
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.on { stateChange in
-                                let state = stateChange.current
-                                let error = stateChange.reason
-                                if state == .connected && error == nil {
-                                    let currentChannel = client.channels.get("test")
-                                    currentChannel.subscribe({ message in
-                                        done()
-                                    })
-                                    currentChannel.publish(nil, data: "ping", callback:nil)
-                                }
-                            }
-                        }
-
-                        guard let transport = client.internal.transport as? TestProxyTransport else {
-                            fail("Transport is nil"); return
-                        }
-                        guard let connectedMessage = transport.protocolMessagesReceived.filter({ $0.action == .connected }).last else {
-                            XCTFail("No CONNECTED protocol action received"); return
-                        }
-
-                        // CONNECTED ProtocolMessage
-                        expect(connectedMessage.connectionDetails!.clientId).to(equal(expectedClientId))
-                    }
-
-                    func test__043__Token__token_auth_and_clientId__should_check_clientId_consistency__with_wildcard() {
-                        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
-                        options.clientId = "*"
-                        expect{ ARTRest(options: options) }.to(raiseException())
-                        expect{ ARTRealtime(options: options) }.to(raiseException())
-                    }
-                
-                // RSA15b
-                func test__040__Token__token_auth_and_clientId__should_permit_to_be_unauthenticated() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = nil
-                    
-                    let clientBasic = ARTRest(options: options)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        // Basic
-                        clientBasic.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(clientBasic.auth.clientId).to(beNil())
-                            options.tokenDetails = tokenDetails
-                            done()
-                        }
-                    }
-
-                    let clientToken = ARTRest(options: options)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        // Last TokenDetails
-                        clientToken.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(clientToken.auth.clientId).to(beNil())
-                            done()
-                        }
-                    }
-                }
-                
-                // RSA15c
-                
-
-                    func test__044__Token__token_auth_and_clientId__Incompatible_client__with_Realtime__it_should_change_the_connection_state_to_FAILED_and_emit_an_error() {
-                        let options = AblyTests.commonAppSetup()
-                        let wrongTokenDetails = getTestTokenDetails(clientId: "wrong")
-
-                        options.clientId = "john"
-                        options.autoConnect = false
-                        options.authCallback = { tokenParams, completion in
-                            completion(wrongTokenDetails, nil)
-                        }
-                        let realtime = ARTRealtime(options: options)
-                        defer { realtime.close() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            realtime.connection.once(.failed) { stateChange in
-                                expect(stateChange.reason?.code).to(equal(ARTErrorCode.invalidCredentials.intValue))
-                                done()
-                            }
-                            realtime.connect()
-                        }
-                    }
-
-                    func test__045__Token__token_auth_and_clientId__Incompatible_client__with_Rest__it_should_result_in_an_appropriate_error_response() {
-                        let options = AblyTests.commonAppSetup()
-                        options.clientId = "john"
-                        let rest = ARTRest(options: options)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            rest.auth.requestToken(ARTTokenParams(clientId: "wrong"), with: nil) { tokenDetails, error in
-                                let error = error as! ARTErrorInfo
-                                expect(error.code).to(equal(ARTErrorCode.incompatibleCredentials.intValue))
-                                expect(tokenDetails).to(beNil())
-                                done()
-                            }
-                        }
-                    }
-            
-            // RSA5
-            func test__006__Token__TTL_should_default_to_be_omitted() {
-                let tokenParams = ARTTokenParams()
-                expect(tokenParams.ttl).to(beNil())
+        }
+        expect(authParams).to(beEmpty())
+    }
+
+    // RSA8c1b
+    func test__070__requestToken__authUrl__parameters__should_added_on_the_body_request_when_auth_method_is_POST() {
+        let clientOptions = ARTClientOptions()
+        clientOptions.authUrl = URL(string: "http://auth.ably.io")
+        clientOptions.authParams = [
+            URLQueryItem(name: "identifier", value: "123"),
+        ]
+        clientOptions.authMethod = "POST"
+        clientOptions.authHeaders = ["X-Header-1": "foo", "X-Header-2": "bar"]
+        let tokenParams = ARTTokenParams()
+        tokenParams.ttl = 2000
+        tokenParams.capability = "{\"cansubscribe:*\":[\"subscribe\"]}"
+
+        let rest = ARTRest(options: clientOptions)
+
+        let request = rest.auth.internal.buildRequest(clientOptions, with: tokenParams)
+
+        guard let httpBodyData = request.httpBody else {
+            fail("Body is missing"); return
+        }
+        guard let httpBodyString = String(data: httpBodyData, encoding: .utf8) else {
+            fail("Body should be a string"); return
+        }
+
+        let expectedFormEncoding = "capability=%7B%22cansubscribe%3A%2A%22%3A%5B%22subscribe%22%5D%7D&identifier=123&ttl=2000"
+
+        expect(httpBodyString).to(equal(expectedFormEncoding))
+
+        expect(request.value(forHTTPHeaderField: "Content-Type")).to(equal("application/x-www-form-urlencoded"))
+
+        expect(request.value(forHTTPHeaderField: "Content-Length")).to(equal("89"))
+
+        for (header, expectedValue) in clientOptions.authHeaders! {
+            if let value = request.value(forHTTPHeaderField: header) {
+                expect(value).to(equal(expectedValue))
+            } else {
+                fail("Missing header in request: \(header), expected: \(expectedValue)")
             }
+        }
+    }
 
-            func test__007__Token__should_URL_query_be_correctly_encoded() {
-                let tokenParams = ARTTokenParams()
-                tokenParams.capability = "{\"*\":[\"*\"]}"
+    // RSA8c2
+    func test__067__requestToken__authUrl__TokenParams_should_take_precedence_over_any_configured_authParams_when_a_name_conflict_occurs() {
+        let options = ARTClientOptions()
+        options.clientId = "john"
+        options.authUrl = URL(string: "http://auth.ably.io")
+        options.authMethod = "GET"
+        options.authHeaders = ["X-Header-1": "foo1", "X-Header-2": "foo2"]
+        let authParams = [
+            "key": "secret",
+            "clientId": "should be overridden",
+        ]
+        options.authParams = authParams.map { URLQueryItem(name: $0, value: $1) }
 
-                if #available(iOS 10.0, *) {
-                    let dateFormatter = ISO8601DateFormatter()
-                    tokenParams.timestamp = dateFormatter.date(from: "2016-10-08T22:31:00Z")
-                }
-                else {
-                    let dateFormatter = DateFormatter()
-                    dateFormatter.dateFormat = "yyyy/MM/dd HH:mm zzz"
-                    tokenParams.timestamp = dateFormatter.date(from: "2016/10/08 22:31 GMT")
-                }
+        let tokenParams = ARTTokenParams()
+        tokenParams.clientId = "tester"
 
-                let options = ARTClientOptions()
-                options.authUrl = URL(string: "https://ably-test-suite.io")
-                let rest = ARTRest(options: options)
-                let request = rest.auth.internal.buildRequest(options, with: tokenParams)
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
 
-                if let query = request.url?.query {
-                    expect(query).to(haveParam("capability", withValue: "%7B%22*%22:%5B%22*%22%5D%7D"))
-                    expect(query).to(haveParam("timestamp", withValue: "1475965860000"))
-                }
-                else {
-                    fail("URL is empty")
-                }
+        waitUntil(timeout: testTimeout) { done in
+            client.auth.requestToken(tokenParams, with: nil) { _, _ in
+                let query = testHTTPExecutor.requests[0].url!.query
+                expect(query).to(haveParam("clientId", withValue: tokenParams.clientId!))
+                done()
             }
-            
-            // RSA6
-            func test__008__Token__should_omit_capability_field_if_it_is_not_specified() {
-                let tokenParams = ARTTokenParams()
-                expect(tokenParams.capability).to(beNil())
-                
-                let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
-                let rest = ARTRest(options: options)
-                let testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                rest.internal.httpExecutor = testHTTPExecutor
+        }
+    }
 
-                waitUntil(timeout: testTimeout) { done in
-                    // Token
-                    rest.auth.requestToken(tokenParams, with: options) { tokenDetails, error in
-                        if let e = error {
-                            fail(e.localizedDescription); done(); return
-                        }
-                        expect(tokenParams.capability).to(beNil())
-                        expect(tokenDetails?.capability).to(equal("{\"*\":[\"*\"]}"))
-                        done()
-                    }
+    // RSA8c3
+    func test__068__requestToken__authUrl__should_override_previously_configured_parameters() {
+        let clientOptions = ARTClientOptions()
+        clientOptions.authUrl = URL(string: "http://auth.ably.io")
+        let rest = ARTRest(options: clientOptions)
+
+        let authOptions = ARTAuthOptions()
+        authOptions.authUrl = URL(string: "http://auth.ably.io")
+        authOptions.authParams = [URLQueryItem(name: "ttl", value: "invalid")]
+        authOptions.authParams = [URLQueryItem(name: "test", value: "1")]
+        let url = rest.auth.internal.buildURL(authOptions, with: ARTTokenParams())
+        expect(url.absoluteString).to(contain(URL(string: "http://auth.ably.io")?.absoluteString ?? ""))
+    }
+
+    // RSA8a
+    func test__057__requestToken__implicitly_creates_a_TokenRequest_and_requests_a_token() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+
+        var createTokenRequestMethodWasCalled = false
+
+        // Adds a block of code after `createTokenRequest` is triggered
+        let token = rest.auth.internal.testSuite_injectIntoMethod(after: NSSelectorFromString("_createTokenRequest:options:callback:")) {
+            createTokenRequestMethodWasCalled = true
+        }
+        defer { token.remove() }
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.requestToken(nil, with: nil, callback: { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails?.token).toNot(beEmpty())
+                done()
+            })
+        }
+
+        expect(createTokenRequestMethodWasCalled).to(beTrue())
+    }
+
+    // RSA8b
+
+    func test__071__requestToken__should_support_all_TokenParams__using_defaults() {
+        tokenParamsTestsSetupDependencies()
+
+        // Default values
+        let defaultTokenParams = ARTTokenParams(clientId: currentClientId)
+        defaultTokenParams.ttl = ARTDefault.ttl() as NSNumber // Set by the server.
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.requestToken(nil, with: nil, callback: { tokenDetails, _ in
+                expect(tokenDetails?.clientId).to(equal(defaultTokenParams.clientId))
+                expect(defaultTokenParams.capability).to(beNil())
+                expect(tokenDetails?.capability).to(equal("{\"*\":[\"*\"]}")) // Ably supplied capabilities of the underlying key
+                expect(tokenDetails?.issued).toNot(beNil())
+                expect(tokenDetails?.expires).toNot(beNil())
+                if let issued = tokenDetails?.issued, let expires = tokenDetails?.expires {
+                    expect(expires.timeIntervalSince(issued)).to(equal(defaultTokenParams.ttl as? TimeInterval))
                 }
+                done()
+            })
+        }
+    }
 
-                switch extractBodyAsMsgPack(testHTTPExecutor.requests.first) {
-                case .failure(let error):
+    func test__072__requestToken__should_support_all_TokenParams__overriding_defaults() {
+        tokenParamsTestsSetupDependencies()
+
+        // Custom values
+        let expectedTtl = 4800.0
+        let expectedCapability = "{\"canpublish:*\":[\"publish\"]}"
+
+        let tokenParams = ARTTokenParams(clientId: currentClientId)
+        tokenParams.ttl = NSNumber(value: expectedTtl)
+        tokenParams.capability = expectedCapability
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.requestToken(tokenParams, with: nil, callback: { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails?.clientId).to(equal(options.clientId))
+                expect(tokenDetails?.capability).to(equal(expectedCapability))
+                expect(tokenDetails?.issued).toNot(beNil())
+                expect(tokenDetails?.expires).toNot(beNil())
+                if let issued = tokenDetails?.issued, let expires = tokenDetails?.expires {
+                    expect(expires.timeIntervalSince(issued)).to(equal(expectedTtl))
+                }
+                done()
+            })
+        }
+    }
+
+    // RSA8d
+
+    func test__073__requestToken__When_authCallback_option_is_set__it_will_invoke_the_callback__with_a_token_string() {
+        let options = AblyTests.clientOptions()
+        let expectedTokenParams = ARTTokenParams()
+
+        options.authCallback = { tokenParams, completion in
+            expect(tokenParams.clientId).to(beNil())
+            completion("token_string" as ARTTokenDetailsCompatible?, nil)
+        }
+        let rest = ARTRest(options: options)
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.requestToken(expectedTokenParams, with: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails!.token).to(equal("token_string"))
+                done()
+            }
+        }
+    }
+
+    func test__074__requestToken__When_authCallback_option_is_set__it_will_invoke_the_callback__with_a_TokenDetails() {
+        let expectedTokenParams = ARTTokenParams()
+
+        let options = AblyTests.clientOptions()
+        options.authCallback = { tokenParams, completion in
+            expect(tokenParams.clientId).to(beNil())
+            completion(ARTTokenDetails(token: "token_from_details"), nil)
+        }
+        let rest = ARTRest(options: options)
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.requestToken(expectedTokenParams, with: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails!.token).to(equal("token_from_details"))
+                done()
+            }
+        }
+    }
+
+    func test__075__requestToken__When_authCallback_option_is_set__it_will_invoke_the_callback__with_a_TokenRequest() {
+        let options = AblyTests.commonAppSetup()
+        let expectedTokenParams = ARTTokenParams()
+        expectedTokenParams.clientId = "foo"
+        var rest: ARTRest!
+
+        options.authCallback = { tokenParams, completion in
+            expect(tokenParams.clientId).to(beIdenticalTo(expectedTokenParams.clientId))
+            rest.auth.createTokenRequest(tokenParams, options: options) { tokenRequest, error in
+                completion(tokenRequest, error)
+            }
+        }
+
+        rest = ARTRest(options: options)
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.requestToken(expectedTokenParams, with: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    fail("tokenDetails is nil"); done(); return
+                }
+                expect(tokenDetails.clientId).to(equal(expectedTokenParams.clientId))
+                done()
+            }
+        }
+    }
+
+    // RSA8f1
+    func test__058__requestToken__ensure_the_message_published_does_not_have_a_clientId() {
+        let options = AblyTests.commonAppSetup()
+        options.token = getTestToken(clientId: nil)
+        let rest = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = testHTTPExecutor
+        let channel = rest.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            let message = ARTMessage(name: nil, data: "message without an explicit clientId")
+            expect(message.clientId).to(beNil())
+            channel.publish([message]) { error in
+                expect(error).to(beNil())
+                switch extractBodyAsMessages(testHTTPExecutor.requests.first) {
+                case let .failure(error):
                     fail(error)
-                case .success(let httpBody):
-                    expect(httpBody.unbox["capability"]).to(beNil())
+                case let .success(httpBody):
+                    expect(httpBody.unbox.first!["clientId"]).to(beNil())
+                }
+                channel.history { page, error in
+                    expect(error).to(beNil())
+                    guard let page = page else {
+                        fail("Result is empty"); done(); return
+                    }
+                    expect(page.items).to(haveCount(1))
+                    expect((page.items[0]).clientId).to(beNil())
+                    done()
                 }
             }
+        }
+        expect(rest.auth.clientId).to(beNil())
+    }
 
-            // RSA6
-            func test__009__Token__should_add_capability_field_if_the_user_specifies_it() {
-                let tokenParams = ARTTokenParams()
-                tokenParams.capability = "{\"*\":[\"*\"]}"
+    // RSA8f2
+    func test__059__requestToken__ensure_that_the_message_is_rejected() {
+        let options = AblyTests.commonAppSetup()
+        options.token = getTestToken(clientId: nil)
+        let rest = ARTRest(options: options)
+        let channel = rest.channels.get("test")
 
-                let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
-                let rest = ARTRest(options: options)
-                let testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                rest.internal.httpExecutor = testHTTPExecutor
-
-                waitUntil(timeout: testTimeout) { done in
-                    // Token
-                    rest.auth.requestToken(tokenParams, with: options) { tokenDetails, error in
-                        if let e = error {
-                            fail(e.localizedDescription); done(); return
-                        }
-                        expect(tokenDetails?.capability).to(equal(tokenParams.capability))
-                        done()
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            let message = ARTMessage(name: nil, data: "message with an explicit clientId", clientId: "john")
+            channel.publish([message]) { error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
                 }
+                expect(error.message).to(contain("mismatched clientId"))
+                done()
+            }
+        }
+        expect(rest.auth.clientId).to(beNil())
+    }
 
-                switch extractBodyAsMsgPack(testHTTPExecutor.requests.first) {
-                case .failure(let error):
+    // RSA8f3
+    func test__060__requestToken__ensure_the_message_published_with_a_wildcard_____does_not_have_a_clientId() {
+        let options = AblyTests.commonAppSetup()
+        let rest = ARTRest(options: options)
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(ARTTokenParams(clientId: "*"), options: nil) { _, error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = testHTTPExecutor
+        let channel = rest.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            let message = ARTMessage(name: nil, data: "no client")
+            expect(message.clientId).to(beNil())
+            channel.publish([message]) { error in
+                expect(error).to(beNil())
+                switch extractBodyAsMessages(testHTTPExecutor.requests.first) {
+                case let .failure(error):
                     fail(error)
-                case .success(let httpBody):
-                    expect(httpBody.unbox["capability"] as? String).to(equal("{\"*\":[\"*\"]}"))
+                case let .success(httpBody):
+                    expect(httpBody.unbox.first!["clientId"]).to(beNil())
+                }
+                channel.history { page, error in
+                    guard let page = page else {
+                        fail("Page is empty"); done(); return
+                    }
+                    expect(error).to(beNil())
+                    expect(page.items).to(haveCount(1))
+                    expect(page.items[0].clientId).to(beNil())
+                    done()
                 }
             }
-            
-            // RSA7
-            
+        }
+        expect(rest.auth.clientId).to(equal("*"))
+    }
 
-                // RSA7a1
-                func test__046__Token__clientId_and_authenticated_clients__should_not_pass_clientId_with_published_message() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "mary"
-                    let rest = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    rest.internal.httpExecutor = testHTTPExecutor
-                    let channel = rest.channels.get("RSA7a1")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish("foo", data: nil) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
+    // RSA8f4
+    func test__061__requestToken__ensure_the_message_published_with_a_wildcard_____has_the_provided_clientId() {
+        let options = AblyTests.commonAppSetup()
+        // Request a token with a wildcard '*' value clientId
+        options.token = getTestToken(clientId: "*")
+        let rest = ARTRest(options: options)
+        let channel = rest.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            let message = ARTMessage(name: nil, data: "message with an explicit clientId", clientId: "john")
+            channel.publish([message]) { error in
+                expect(error).to(beNil())
+                channel.history { page, error in
+                    expect(error).to(beNil())
+                    guard let page = page else {
+                        fail("Page is empty"); done(); return
                     }
-                    switch extractBodyAsMsgPack(testHTTPExecutor.requests.last) {
-                    case .failure(let error):
-                        fail(error)
-                    case .success(let httpBody):
-                        let message = httpBody.unbox
-                        expect(message["clientId"]).to(beNil())
-                        expect(message["name"] as? String).to(equal("foo"))
+                    guard let item = page.items.first else {
+                        fail("First item does not exist"); done(); return
                     }
-                }
-                
-                // RSA7a2
-                func test__047__Token__clientId_and_authenticated_clients__should_obtain_a_token_if_clientId_is_assigned() {
-                    let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
-                    options.clientId = "client_string"
-                    
-                    let client = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    client.internal.httpExecutor = testHTTPExecutor
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        client.channels.get("test").publish(nil, data: "message") { error in
-                            if let e = error {
-                                XCTFail((e ).localizedDescription)
-                            }
-                            done()
-                        }
-                    }
-                    
-                    let authorization = testHTTPExecutor.requests.last?.allHTTPHeaderFields?["Authorization"] ?? ""
-                    
-                    expect(authorization).toNot(equal(""))
-                }
-                
-                // RSA7a3
-                func test__048__Token__clientId_and_authenticated_clients__should_convenience_clientId_return_a_string() {
-                    let clientOptions = AblyTests.setupOptions(AblyTests.jsonRestOptions)
-                    clientOptions.clientId = "String"
-                    
-                    expect(ARTRest(options: clientOptions).internal.options.clientId).to(equal("String"))
-                }
-
-                // RSA7a4
-                func test__049__Token__clientId_and_authenticated_clients__ClientOptions_clientId_takes_precendence_when_a_clientId_value_is_provided_in_both_ClientOptions_clientId_and_ClientOptions_defaultTokenParams() {
-                    let options = AblyTests.clientOptions()
-                    options.clientId = "john"
-                    options.authCallback = { tokenParams, completion in
-                        expect(tokenParams.clientId).to(equal(options.clientId))
-                        getTestToken(clientId: tokenParams.clientId) { token in
-                            completion(token as ARTTokenDetailsCompatible?, nil)
-                        }
-                    }
-                    options.defaultTokenParams = ARTTokenParams(clientId: "tester")
-                    let client = ARTRest(options: options)
-                    let channel = client.channels.get("test")
-
-                    expect(client.auth.clientId).to(equal("john"))
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: "message") { error in
-                            expect(error).to(beNil())
-                            channel.history() { paginatedResult, error in
-                                guard let result = paginatedResult else {
-                                    fail("PaginatedResult is empty"); done(); return
-                                }
-                                guard let message = result.items.first else {
-                                    fail("First message does not exist"); done(); return
-                                }
-                                expect(message.clientId).to(equal("john"))
-                                done()
-                            }
-                        }
-                    }
-                }
-                
-                // RSA12
-                
-
-                    // RSA12a
-                    func test__051__Token__clientId_and_authenticated_clients__Auth_clientId_attribute_is_null__identity_should_be_anonymous_for_all_operations() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let realtime = AblyTests.newRealtime(options)
-                        defer { realtime.dispose(); realtime.close() }
-                        expect(realtime.auth.clientId).to(beNil())
-
-                        waitUntil(timeout: testTimeout) { done in
-                            realtime.connection.once(.connected) { stateChange in
-                                expect(stateChange.reason).to(beNil())
-                                expect(realtime.auth.clientId).to(beNil())
-                                done()
-                            }
-                            realtime.connect()
-                            
-                            let transport = realtime.internal.transport as! TestProxyTransport
-                            transport.setBeforeIncomingMessageModifier({ message in
-                                if message.action == .connected {
-                                    if let details = message.connectionDetails {
-                                        details.clientId = nil
-                                    }
-                                }
-                                return message
-                            })
-                        }
-                    }
-
-                    // RSA12b
-                    func test__052__Token__clientId_and_authenticated_clients__Auth_clientId_attribute_is_null__identity_may_change_and_become_identified() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        options.token = getTestToken(clientId: "tester")
-                        let realtime = ARTRealtime(options: options)
-                        defer { realtime.dispose(); realtime.close() }
-                        expect(realtime.auth.clientId).to(beNil())
-
-                        waitUntil(timeout: testTimeout) { done in
-                            realtime.connection.once(.connecting) { stateChange in
-                                expect(stateChange.reason).to(beNil())
-                                expect(realtime.auth.clientId).to(beNil())
-                            }
-                            realtime.connection.once(.connected) { stateChange in
-                                expect(stateChange.reason).to(beNil())
-                                expect(realtime.auth.clientId).to(equal("tester"))
-                                done()
-                            }
-                            realtime.connect()
-                        }
-                    }
-                
-                // RSA7b
-                
-                    // RSA7b1
-                    func test__053__Token__clientId_and_authenticated_clients__auth_clientId_not_null__when_clientId_attribute_is_assigned_on_client_options() {
-                        let clientOptions = AblyTests.setupOptions(AblyTests.jsonRestOptions)
-                        clientOptions.clientId = "Exist"
-                        
-                        expect(ARTRest(options: clientOptions).auth.clientId).to(equal("Exist"))
-                    }
-                    
-                    // RSA7b2
-                    func test__054__Token__clientId_and_authenticated_clients__auth_clientId_not_null__when_tokenRequest_or_tokenDetails_has_clientId_not_null_or_wildcard_string() {
-                        let options = AblyTests.commonAppSetup()
-                        options.clientId = "client_string"
-                        options.useTokenAuth = true
-                        
-                        let client = ARTRest(options: options)
-                        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        
-                        // TokenDetails
-                        waitUntil(timeout: testTimeout) { done in
-                            // Token
-                            client.auth.authorize(nil, options: nil) { token, error in
-                                expect(error).to(beNil())
-                                expect(client.auth.internal.method).to(equal(ARTAuthMethod.token))
-                                expect(client.auth.clientId).to(equal(options.clientId))
-                                done()
-                            }
-                        }
-                        
-                        // TokenRequest
-                        switch extractBodyAsMsgPack(testHTTPExecutor.requests.last) {
-                        case .failure(let error):
-                            XCTFail(error)
-                        case .success(let httpBody):
-                            guard let requestedClientId = httpBody.unbox["clientId"] as? String else { XCTFail("No clientId field in HTTPBody"); return }
-                            expect(client.auth.clientId).to(equal(requestedClientId))
-                        }
-                    }
-                    
-                    // RSA7b3
-                    func test__055__Token__clientId_and_authenticated_clients__auth_clientId_not_null__should_CONNECTED_ProtocolMessages_contain_a_clientId() {
-                        let options = AblyTests.clientOptions()
-                        options.token = getTestToken(clientId: "john")
-                        expect(options.clientId).to(beNil())
-                        options.autoConnect = false
-                        let realtime = AblyTests.newRealtime(options)
-                        defer { realtime.dispose(); realtime.close() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            realtime.connection.once(.connected) { stateChange in
-                                expect(stateChange.reason).to(beNil())
-                                expect(realtime.auth.clientId).to(equal("john"))
-
-                                let transport = realtime.internal.transport as! TestProxyTransport
-                                let connectedProtocolMessage = transport.protocolMessagesReceived.filter{ $0.action == .connected }[0]
-                                expect(connectedProtocolMessage.connectionDetails!.clientId).to(equal("john"))
-                                done()
-                            }
-                            realtime.connect()
-                        }
-                    }
-
-                    // RSA7b4
-                    func test__056__Token__clientId_and_authenticated_clients__auth_clientId_not_null__client_does_not_have_an_identity_when_a_wildcard_string_____is_present() {
-                        let options = AblyTests.clientOptions()
-                        options.token = getTestToken(clientId: "*")
-                        let realtime = ARTRealtime(options: options)
-                        defer { realtime.dispose(); realtime.close() }
-                        waitUntil(timeout: testTimeout) { done in
-                            realtime.connection.on(.connected) { _ in
-                                expect(realtime.auth.clientId).to(equal("*"))
-                                done()
-                            }
-                        }
-                    }
-                
-                // RSA7c
-                func test__050__Token__clientId_and_authenticated_clients__should_clientId_be_null_or_string() {
-                    let clientOptions = AblyTests.setupOptions(AblyTests.jsonRestOptions)
-                    clientOptions.clientId = "*"
-                    
-                    expect{ ARTRest(options: clientOptions) }.to(raiseException())
-                }
-        
-        // RSA8
-        
-            
-                // RSA8e
-                func test__062__requestToken__arguments__should_not_merge_with_the_configured_params_and_options_but_instead_replace_all_corresponding_values__even_when__null_() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "сlientId"
-                    let rest = ARTRest(options: options)
-
-                    let tokenParams = ARTTokenParams()
-                    tokenParams.ttl = 2000
-                    tokenParams.capability = "{\"cansubscribe:*\":[\"subscribe\"]}"
-
-                    let precedenceOptions = AblyTests.commonAppSetup()
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.requestToken(tokenParams, with: precedenceOptions) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails).toNot(beNil())
-                            expect(tokenDetails!.capability).to(equal("{\"cansubscribe:*\":[\"subscribe\"]}"))
-                            expect(tokenDetails!.clientId).to(beNil())
-                            expect(tokenDetails!.expires!.timeIntervalSince1970 - tokenDetails!.issued!.timeIntervalSince1970).to(equal(tokenParams.ttl as? Double))
-                            done()
-                        }
-                    }
-
-                    let options2 = AblyTests.commonAppSetup()
-                    options2.clientId = nil
-                    let rest2 = ARTRest(options: options2)
-
-                    let precedenceOptions2 = AblyTests.commonAppSetup()
-                    precedenceOptions2.clientId = nil
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest2.auth.requestToken(nil, with: precedenceOptions2) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                XCTFail("tokenDetails is nil"); done(); return
-                            }
-                            expect(tokenDetails.clientId).to(beNil())
-                            done()
-                        }
-                    }
-                }
-
-                // RSA8e
-                func test__063__requestToken__arguments__should_use_configured_defaults_if_the_object_arguments_are_omitted() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "tester"
-                    let rest = ARTRest(options: options)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.requestToken(nil, with: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails).toNot(beNil())
-                            expect(tokenDetails!.capability).to(equal("{\"*\":[\"*\"]}"))
-                            expect(tokenDetails!.clientId).to(equal("tester"))
-                            done()
-                        }
-                    }
-
-                    let tokenParams = ARTTokenParams()
-                    tokenParams.ttl = 2000
-                    tokenParams.capability = "{\"cansubscribe:*\":[\"subscribe\"]}"
-                    tokenParams.clientId = nil
-
-                    let authOptions = ARTAuthOptions()
-                    authOptions.key = options.key
-
-                    // Provide TokenParams and Options
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.requestToken(tokenParams, with: authOptions) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails).toNot(beNil())
-                            expect(tokenDetails!.capability).to(equal("{\"cansubscribe:*\":[\"subscribe\"]}"))
-                            expect(tokenDetails!.clientId).to(beNil())
-                            expect(tokenDetails!.expires!.timeIntervalSince1970 - tokenDetails!.issued!.timeIntervalSince1970).to(equal(tokenParams.ttl as? Double))
-                            done()
-                        }
-                    }
-
-                    // Provide TokenParams as null
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.requestToken(nil, with: authOptions) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails).toNot(beNil())
-                            expect(tokenDetails!.capability).to(equal("{\"*\":[\"*\"]}"))
-                            expect(tokenDetails!.clientId).to(equal("tester"))
-                            expect(tokenDetails!.expires!.timeIntervalSince1970 - tokenDetails!.issued!.timeIntervalSince1970).to(equal(ARTDefault.ttl()))
-                            done()
-                        }
-                    }
-
-                    // Omit arguments
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.requestToken { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails).toNot(beNil())
-                            expect(tokenDetails!.capability).to(equal("{\"*\":[\"*\"]}"))
-                            expect(tokenDetails!.clientId).to(equal("tester"))
-                            done()
-                        }
-                    }
-                }
-
-            // RSA8c
-            
-
-                func test__064__requestToken__authUrl__query_will_provide_a_token_string() {
-                    let testToken = getTestToken()
-
-                    let options = AblyTests.clientOptions()
-                    options.authUrl = URL(string: "http://echo.ably.io")
-                    expect(options.authUrl).toNot(beNil())
-                    // Plain text
-                    options.authParams = [URLQueryItem]()
-                    options.authParams!.append(URLQueryItem(name: "type", value: "text"))
-                    options.authParams!.append(URLQueryItem(name: "body", value: testToken))
-
-                    let rest = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    rest.internal.httpExecutor = testHTTPExecutor
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.requestToken(nil, with: nil, callback: { tokenDetails, error in
-                            expect(testHTTPExecutor.requests.last?.url?.host).to(equal("echo.ably.io"))
-                            expect(error).to(beNil())
-                            expect(tokenDetails).toNot(beNil())
-                            expect(tokenDetails?.token).to(equal(testToken))
-                            done()
-                        })
-                    }
-                }
-
-                func test__065__requestToken__authUrl__query_will_provide_a_TokenDetails() {
-                    guard let testTokenDetails = getTestTokenDetails(clientId: "tester") else {
-                        fail("TokenDetails is empty")
-                        return
-                    }
-
-                    let encoder = ARTJsonLikeEncoder()
-                    encoder.delegate = ARTJsonEncoder()
-                    guard let jsonTokenDetails = try? encoder.encode(testTokenDetails) else {
-                        fail("Invalid TokenDetails")
-                        return
-                    }
-
-                    let options = ARTClientOptions()
-                    options.authUrl = URL(string: "http://echo.ably.io")
-                    expect(options.authUrl).toNot(beNil())
-                    // JSON with TokenDetails
-                    options.authParams = [URLQueryItem]()
-                    options.authParams?.append(URLQueryItem(name: "type", value: "json"))
-                    options.authParams?.append(URLQueryItem(name: "body", value: jsonTokenDetails.toUTF8String))
-
-                    let rest = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    rest.internal.httpExecutor = testHTTPExecutor
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.requestToken(nil, with: nil, callback: { tokenDetails, error in
-                            expect(testHTTPExecutor.requests.last?.url?.host).to(equal("echo.ably.io"))
-                            expect(error).to(beNil())
-                            expect(tokenDetails).toNot(beNil())
-                            expect(tokenDetails?.clientId) == testTokenDetails.clientId
-                            expect(tokenDetails?.capability) == testTokenDetails.capability
-                            expect(tokenDetails?.issued).toNot(beNil())
-                            expect(tokenDetails?.expires).toNot(beNil())
-                            if let issued = tokenDetails?.issued, let testIssued = testTokenDetails.issued {
-                                expect(issued.compare(testIssued)) == ComparisonResult.orderedSame
-                            }
-                            if let expires = tokenDetails?.expires, let testExpires = testTokenDetails.expires {
-                                expect(expires.compare(testExpires)) == ComparisonResult.orderedSame
-                            }
-                            done()
-                        })
-                    }
-                }
-
-                func test__066__requestToken__authUrl__query_will_provide_a_TokenRequest() {
-                    let tokenParams = ARTTokenParams()
-                    tokenParams.capability = "{\"test\":[\"subscribe\"]}"
-
-                    let options = AblyTests.commonAppSetup()
-                    options.authUrl = URL(string: "http://echo.ably.io")
-                    expect(options.authUrl).toNot(beNil())
-
-                    var rest = ARTRest(options: options)
-
-                    var tokenRequest: ARTTokenRequest?
-                    waitUntil(timeout: testTimeout) { done in
-                        // Sandbox and valid TokenRequest
-                        rest.auth.createTokenRequest(tokenParams, options: nil, callback: { newTokenRequest, error in
-                            expect(error).to(beNil())
-                            tokenRequest = newTokenRequest
-                            done()
-                        })
-                    }
-
-                    guard let testTokenRequest = tokenRequest else {
-                        fail("TokenRequest is empty")
-                        return
-                    }
-
-                    let encoder = ARTJsonLikeEncoder()
-                    encoder.delegate = ARTJsonEncoder()
-                    guard let jsonTokenRequest = try? encoder.encode(testTokenRequest) else {
-                        fail("Invalid TokenRequest")
-                        return
-                    }
-
-                    // JSON with TokenRequest
-                    options.authParams = [URLQueryItem]()
-                    options.authParams?.append(URLQueryItem(name: "type", value: "json"))
-                    options.authParams?.append(URLQueryItem(name: "body", value: jsonTokenRequest.toUTF8String))
-
-                    rest = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    rest.internal.httpExecutor = testHTTPExecutor
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.requestToken(nil, with: nil, callback: { tokenDetails, error in
-                            expect(testHTTPExecutor.requests.first?.url?.host).to(equal("echo.ably.io"))
-                            expect(testHTTPExecutor.requests.last?.url?.host).toNot(equal("echo.ably.io"))
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                fail("TokenDetails is empty"); done()
-                                return
-                            }
-                            expect(tokenDetails.token).toNot(beNil())
-                            expect(tokenDetails.capability) == tokenParams.capability
-                            done()
-                        })
-                    }
-                }
-
-                
-                    // RSA8c1a
-                    func test__069__requestToken__authUrl__parameters__should_be_added_to_the_URL_when_auth_method_is_GET() {
-                        let clientOptions = ARTClientOptions()
-                        clientOptions.authUrl = URL(string: "http://auth.ably.io")
-                        var authParams = [
-                            "param1": "value",
-                            "param2": "value",
-                            "clientId": "should not be overwritten",
-                        ]
-                        clientOptions.authParams = authParams.map {
-                             URLQueryItem(name: $0, value: $1)
-                        }
-                        clientOptions.authHeaders = ["X-Header-1": "foo", "X-Header-2": "bar"]
-                        let tokenParams = ARTTokenParams()
-                        tokenParams.clientId = "test"
-
-                        let rest = ARTRest(options: clientOptions)
-                        let request = rest.auth.internal.buildRequest(clientOptions, with: tokenParams)
-
-                        for (header, expectedValue) in clientOptions.authHeaders! {
-                            if let value = request.allHTTPHeaderFields?[header] {
-                                expect(value).to(equal(expectedValue))
-                            } else {
-                                fail("Missing header in request: \(header), expected: \(expectedValue)")
-                            }
-                        }
-                        
-                        guard let url = request.url else {
-                            fail("Request is invalid")
-                            return
-                        }
-                        guard let urlComponents = NSURLComponents(url: url, resolvingAgainstBaseURL: false) else {
-                            fail("invalid URL: \(url)")
-                            return
-                        }
-                        expect(urlComponents.scheme).to(equal("http"))
-                        expect(urlComponents.host).to(equal("auth.ably.io"))
-                        guard let queryItems = urlComponents.queryItems else {
-                            fail("URL without query: \(url)")
-                            return
-                        }
-                        for queryItem in queryItems {
-                            if var expectedValue = authParams[queryItem.name] {
-                                if queryItem.name == "clientId" {
-                                    expectedValue = "test"
-                                }
-                                expect(queryItem.value!).to(equal(expectedValue))
-                                authParams.removeValue(forKey: queryItem.name)
-                            }
-                        }
-                        expect(authParams).to(beEmpty())
-                    }
-                    
-                    // RSA8c1b
-                    func test__070__requestToken__authUrl__parameters__should_added_on_the_body_request_when_auth_method_is_POST() {
-                        let clientOptions = ARTClientOptions()
-                        clientOptions.authUrl = URL(string: "http://auth.ably.io")
-                        clientOptions.authParams = [
-                            URLQueryItem(name: "identifier", value: "123")
-                        ]
-                        clientOptions.authMethod = "POST"
-                        clientOptions.authHeaders = ["X-Header-1": "foo", "X-Header-2": "bar"]
-                        let tokenParams = ARTTokenParams()
-                        tokenParams.ttl = 2000
-                        tokenParams.capability = "{\"cansubscribe:*\":[\"subscribe\"]}"
-                        
-                        let rest = ARTRest(options: clientOptions)
-                        
-                        let request = rest.auth.internal.buildRequest(clientOptions, with: tokenParams)
-
-                        guard let httpBodyData = request.httpBody else {
-                            fail("Body is missing"); return
-                        }
-                        guard let httpBodyString = String(data: httpBodyData, encoding: .utf8) else {
-                            fail("Body should be a string"); return
-                        }
-
-                        let expectedFormEncoding = "capability=%7B%22cansubscribe%3A%2A%22%3A%5B%22subscribe%22%5D%7D&identifier=123&ttl=2000"
-
-                        expect(httpBodyString).to(equal(expectedFormEncoding))
-
-                        expect(request.value(forHTTPHeaderField: "Content-Type")).to(equal("application/x-www-form-urlencoded"))
-
-                        expect(request.value(forHTTPHeaderField: "Content-Length")).to(equal("89"))
-
-                        for (header, expectedValue) in clientOptions.authHeaders! {
-                            if let value = request.value(forHTTPHeaderField: header) {
-                                expect(value).to(equal(expectedValue))
-                            } else {
-                                fail("Missing header in request: \(header), expected: \(expectedValue)")
-                            }
-                        }
-                    }
-
-                // RSA8c2
-                func test__067__requestToken__authUrl__TokenParams_should_take_precedence_over_any_configured_authParams_when_a_name_conflict_occurs() {
-                    let options = ARTClientOptions()
-                    options.clientId = "john"
-                    options.authUrl = URL(string: "http://auth.ably.io")
-                    options.authMethod = "GET"
-                    options.authHeaders = ["X-Header-1": "foo1", "X-Header-2": "foo2"]
-                    let authParams = [
-                        "key": "secret",
-                        "clientId": "should be overridden"
-                    ]
-                    options.authParams = authParams.map { URLQueryItem(name: $0, value: $1) }
-
-                    let tokenParams = ARTTokenParams()
-                    tokenParams.clientId = "tester"
-
-                    let client = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    client.internal.httpExecutor = testHTTPExecutor
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.auth.requestToken(tokenParams, with: nil) { tokenDetails, error in
-                            let query = testHTTPExecutor.requests[0].url!.query
-                            expect(query).to(haveParam("clientId", withValue: tokenParams.clientId!))
-                            done()
-                        }
-                    }
-                }
-                
-                // RSA8c3
-                func test__068__requestToken__authUrl__should_override_previously_configured_parameters() {
-                    let clientOptions = ARTClientOptions()
-                    clientOptions.authUrl = URL(string: "http://auth.ably.io")
-                    let rest = ARTRest(options: clientOptions)
-                    
-                    let authOptions = ARTAuthOptions()
-                    authOptions.authUrl = URL(string: "http://auth.ably.io")
-                    authOptions.authParams = [URLQueryItem(name: "ttl", value: "invalid")]
-                    authOptions.authParams = [URLQueryItem(name: "test", value: "1")]
-                    let url = rest.auth.internal.buildURL(authOptions, with: ARTTokenParams())
-                    expect(url.absoluteString).to(contain(URL(string: "http://auth.ably.io")?.absoluteString ?? ""))
-                }
-
-            // RSA8a
-            func test__057__requestToken__implicitly_creates_a_TokenRequest_and_requests_a_token() {
-                let rest = ARTRest(options: AblyTests.commonAppSetup())
-
-                var createTokenRequestMethodWasCalled = false
-
-                // Adds a block of code after `createTokenRequest` is triggered
-                let token = rest.auth.internal.testSuite_injectIntoMethod(after: NSSelectorFromString("_createTokenRequest:options:callback:")) {
-                    createTokenRequestMethodWasCalled = true
-                }
-                defer { token.remove() }
-
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.requestToken(nil, with: nil, callback: { tokenDetails, error in
-                        expect(error).to(beNil())
-                        expect(tokenDetails?.token).toNot(beEmpty())
-                        done()
-                    })
-                }
-
-                expect(createTokenRequestMethodWasCalled).to(beTrue())
-            }
-
-            // RSA8b
-            
-
-                func test__071__requestToken__should_support_all_TokenParams__using_defaults() {
-                    tokenParamsTestsSetupDependencies()
-
-                    // Default values
-                    let defaultTokenParams = ARTTokenParams(clientId: currentClientId)
-                    defaultTokenParams.ttl = ARTDefault.ttl() as NSNumber // Set by the server.
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.requestToken(nil, with: nil, callback: { tokenDetails, error in
-                            expect(tokenDetails?.clientId).to(equal(defaultTokenParams.clientId))
-                            expect(defaultTokenParams.capability).to(beNil())
-                            expect(tokenDetails?.capability).to(equal("{\"*\":[\"*\"]}")) //Ably supplied capabilities of the underlying key
-                            expect(tokenDetails?.issued).toNot(beNil())
-                            expect(tokenDetails?.expires).toNot(beNil())
-                            if let issued = tokenDetails?.issued, let expires = tokenDetails?.expires {
-                                expect(expires.timeIntervalSince(issued)).to(equal(defaultTokenParams.ttl as? TimeInterval))
-                            }
-                            done()
-                        })
-                    }
-                }
-
-                func test__072__requestToken__should_support_all_TokenParams__overriding_defaults() {
-                    tokenParamsTestsSetupDependencies()
-
-                    // Custom values
-                    let expectedTtl = 4800.0
-                    let expectedCapability = "{\"canpublish:*\":[\"publish\"]}"
-
-                    let tokenParams = ARTTokenParams(clientId: currentClientId)
-                    tokenParams.ttl = NSNumber(value: expectedTtl)
-                    tokenParams.capability = expectedCapability
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.requestToken(tokenParams, with: nil, callback: { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails?.clientId).to(equal(options.clientId))
-                            expect(tokenDetails?.capability).to(equal(expectedCapability))
-                            expect(tokenDetails?.issued).toNot(beNil())
-                            expect(tokenDetails?.expires).toNot(beNil())
-                            if let issued = tokenDetails?.issued, let expires = tokenDetails?.expires {
-                                expect(expires.timeIntervalSince(issued)).to(equal(expectedTtl))
-                            }
-                            done()
-                        })
-                    }
-                }
-
-            // RSA8d
-            
-
-                func test__073__requestToken__When_authCallback_option_is_set__it_will_invoke_the_callback__with_a_token_string() {
-                    let options = AblyTests.clientOptions()
-                    let expectedTokenParams = ARTTokenParams()
-
-                    options.authCallback = { tokenParams, completion in
-                        expect(tokenParams.clientId).to(beNil())
-                        completion("token_string" as ARTTokenDetailsCompatible?, nil)
-                    }
-                    let rest = ARTRest(options: options)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.requestToken(expectedTokenParams, with: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails!.token).to(equal("token_string"))
-                            done()
-                        }
-                    }
-                }
-
-                func test__074__requestToken__When_authCallback_option_is_set__it_will_invoke_the_callback__with_a_TokenDetails() {
-                    let expectedTokenParams = ARTTokenParams()
-
-                    let options = AblyTests.clientOptions()
-                    options.authCallback = { tokenParams, completion in
-                        expect(tokenParams.clientId).to(beNil())
-                        completion(ARTTokenDetails(token: "token_from_details"), nil)
-                    }
-                    let rest = ARTRest(options: options)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.requestToken(expectedTokenParams, with: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails!.token).to(equal("token_from_details"))
-                            done()
-                        }
-                    }
-                }
-
-                func test__075__requestToken__When_authCallback_option_is_set__it_will_invoke_the_callback__with_a_TokenRequest() {
-                    let options = AblyTests.commonAppSetup()
-                    let expectedTokenParams = ARTTokenParams()
-                    expectedTokenParams.clientId = "foo"
-                    var rest: ARTRest!
-
-                    options.authCallback = { tokenParams, completion in
-                        expect(tokenParams.clientId).to(beIdenticalTo(expectedTokenParams.clientId))
-                        rest.auth.createTokenRequest(tokenParams, options: options) { tokenRequest, error in
-                            completion(tokenRequest, error)
-                        }
-                    }
-
-                    rest = ARTRest(options: options)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.requestToken(expectedTokenParams, with: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                fail("tokenDetails is nil"); done(); return
-                            }
-                            expect(tokenDetails.clientId).to(equal(expectedTokenParams.clientId))
-                            done()
-                        }
-                    }
-                }
-
-            // RSA8f1
-            func test__058__requestToken__ensure_the_message_published_does_not_have_a_clientId() {
-                let options = AblyTests.commonAppSetup()
-                options.token = getTestToken(clientId: nil)
-                let rest = ARTRest(options: options)
-                testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                rest.internal.httpExecutor = testHTTPExecutor
-                let channel = rest.channels.get("test")
-
-                waitUntil(timeout: testTimeout) { done in
-                    let message = ARTMessage(name: nil, data: "message without an explicit clientId")
-                    expect(message.clientId).to(beNil())
-                    channel.publish([message]) { error in
-                        expect(error).to(beNil())
-                        switch extractBodyAsMessages(testHTTPExecutor.requests.first) {
-                        case .failure(let error):
-                            fail(error)
-                        case .success(let httpBody):
-                            expect(httpBody.unbox.first!["clientId"]).to(beNil())
-                        }
-                        channel.history { page, error in
-                            expect(error).to(beNil())
-                            guard let page = page else {
-                                fail("Result is empty"); done(); return
-                            }
-                            expect(page.items).to(haveCount(1))
-                            expect((page.items[0] ).clientId).to(beNil())
-                            done()
-                        }
-                    }
-                }
-                expect(rest.auth.clientId).to(beNil())
-            }
-
-            // RSA8f2
-            func test__059__requestToken__ensure_that_the_message_is_rejected() {
-                let options = AblyTests.commonAppSetup()
-                options.token = getTestToken(clientId: nil)
-                let rest = ARTRest(options: options)
-                let channel = rest.channels.get("test")
-
-                waitUntil(timeout: testTimeout) { done in
-                    let message = ARTMessage(name: nil, data: "message with an explicit clientId", clientId: "john")
-                    channel.publish([message]) { error in
-                        guard let error = error else {
-                            fail("Error is nil"); done(); return
-                        }
-                        expect(error.message).to(contain("mismatched clientId"))
-                        done()
-                    }
-                }
-                expect(rest.auth.clientId).to(beNil())
-            }
-
-            // RSA8f3
-            func test__060__requestToken__ensure_the_message_published_with_a_wildcard_____does_not_have_a_clientId() {
-                let options = AblyTests.commonAppSetup()
-                let rest = ARTRest(options: options)
-
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.authorize(ARTTokenParams(clientId: "*"), options: nil) { _, error in
-                        expect(error).to(beNil())
-                        done()
-                    }
-                }
-
-                testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                rest.internal.httpExecutor = testHTTPExecutor
-                let channel = rest.channels.get("test")
-
-                waitUntil(timeout: testTimeout) { done in
-                    let message = ARTMessage(name: nil, data: "no client")
-                    expect(message.clientId).to(beNil())
-                    channel.publish([message]) { error in
-                        expect(error).to(beNil())
-                        switch extractBodyAsMessages(testHTTPExecutor.requests.first) {
-                        case .failure(let error):
-                            fail(error)
-                        case .success(let httpBody):
-                            expect(httpBody.unbox.first!["clientId"]).to(beNil())
-                        }
-                        channel.history { page, error in
-                            guard let page = page else {
-                                fail("Page is empty"); done(); return
-                            }
-                            expect(error).to(beNil())
-                            expect(page.items).to(haveCount(1))
-                            expect(page.items[0].clientId).to(beNil())
-                            done()
-                        }
-                    }
-                }
-                expect(rest.auth.clientId).to(equal("*"))
-            }
-
-            // RSA8f4
-            func test__061__requestToken__ensure_the_message_published_with_a_wildcard_____has_the_provided_clientId() {
-                let options = AblyTests.commonAppSetup()
-                // Request a token with a wildcard '*' value clientId
-                options.token = getTestToken(clientId: "*")
-                let rest = ARTRest(options: options)
-                let channel = rest.channels.get("test")
-
-                waitUntil(timeout: testTimeout) { done in
-                    let message = ARTMessage(name: nil, data: "message with an explicit clientId", clientId: "john")
-                    channel.publish([message]) { error in
-                        expect(error).to(beNil())
-                        channel.history { page, error in
-                            expect(error).to(beNil())
-                            guard let page = page else {
-                                fail("Page is empty"); done(); return
-                            }
-                            guard let item = page.items.first else {
-                                fail("First item does not exist"); done(); return
-                            }
-                            expect(item.clientId).to(equal("john"))
-                            done()
-                        }
-                    }
-                }
-                expect(rest.auth.clientId).to(beNil())
-            }
-
-        // RSA9
-        
-
-            // RSA9h
-            func test__076__createTokenRequest__should_not_merge_with_the_configured_params_and_options_but_instead_replace_all_corresponding_values__even_when__null_() {
-                let options = AblyTests.commonAppSetup()
-                options.clientId = "client_string"
-                let rest = ARTRest(options: options)
-
-                let tokenParams = ARTTokenParams()
-                let defaultCapability = tokenParams.capability
-                expect(defaultCapability).to(beNil())
-
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.createTokenRequest(nil, options: nil) { tokenRequest, error in
-                        expect(error).to(beNil())
-                        guard let tokenRequest = tokenRequest else {
-                            XCTFail("tokenRequest is nil"); done(); return
-                        }
-                        expect(tokenRequest.clientId).to(equal(options.clientId))
-                        expect(tokenRequest.ttl).to(beNil())
-                        expect(tokenRequest.capability).to(beNil())
-                        done()
-                    }
-                }
-
-                tokenParams.ttl = NSNumber(value: ExpectedTokenParams.ttl)
-                tokenParams.capability = ExpectedTokenParams.capability
-                tokenParams.clientId = nil
-
-                let authOptions = ARTAuthOptions()
-                authOptions.queryTime = true
-                authOptions.key = options.key
-
-                let mockServerDate = Date().addingTimeInterval(120)
-                rest.auth.internal.testSuite_returnValue(for: NSSelectorFromString("handleServerTime:"), with: mockServerDate)
-
-                var serverTimeRequestCount = 0
-                let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
-                    serverTimeRequestCount += 1
-                }
-                defer { hook.remove() }
-
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.createTokenRequest(tokenParams, options: authOptions) { tokenRequest, error in
-                        expect(error).to(beNil())
-                        guard let tokenRequest = tokenRequest else {
-                            XCTFail("tokenRequest is nil"); done(); return
-                        }
-                        expect(tokenRequest.clientId).to(beNil())
-                        expect(tokenRequest.timestamp).to(beCloseTo(mockServerDate))
-                        expect(serverTimeRequestCount) == 1
-                        expect(tokenRequest.ttl).to(equal(ExpectedTokenParams.ttl as NSNumber))
-                        expect(tokenRequest.capability).to(equal(ExpectedTokenParams.capability))
-                        done()
-                    }
-                }
-
-                tokenParams.clientId = "newClientId"
-                tokenParams.ttl = 2000
-                tokenParams.capability = "{ \"test:*\":[\"test\"] }"
-
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.createTokenRequest(tokenParams, options: authOptions) { tokenRequest, error in
-                        expect(error).to(beNil())
-                        guard let tokenRequest = tokenRequest else {
-                            XCTFail("tokenRequest is nil"); done(); return
-                        }
-                        expect(tokenRequest.clientId).to(equal("newClientId"))
-                        expect(tokenRequest.ttl).to(equal(2000))
-                        expect(tokenRequest.capability).to(equal("{ \"test:*\":[\"test\"] }"))
-                        done()
-                    }
-                }
-
-                tokenParams.clientId = nil
-
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.createTokenRequest(tokenParams, options: authOptions) { tokenRequest, error in
-                        expect(error).to(beNil())
-                        guard let tokenRequest = tokenRequest else {
-                            XCTFail("tokenRequest is nil"); done(); return
-                        }
-                        expect(tokenRequest.clientId).to(beNil())
-                        done()
-                    }
+                    expect(item.clientId).to(equal("john"))
+                    done()
                 }
             }
+        }
+        expect(rest.auth.clientId).to(beNil())
+    }
 
-            func test__077__createTokenRequest__should_override_defaults_if_AuthOptions_provided() {
-                let defaultOptions = AblyTests.commonAppSetup()
-                defaultOptions.authCallback = { tokenParams, completion in
-                    fail("Should not be called")
+    // RSA9
+
+    // RSA9h
+    func test__076__createTokenRequest__should_not_merge_with_the_configured_params_and_options_but_instead_replace_all_corresponding_values__even_when__null_() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "client_string"
+        let rest = ARTRest(options: options)
+
+        let tokenParams = ARTTokenParams()
+        let defaultCapability = tokenParams.capability
+        expect(defaultCapability).to(beNil())
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(nil, options: nil) { tokenRequest, error in
+                expect(error).to(beNil())
+                guard let tokenRequest = tokenRequest else {
+                    XCTFail("tokenRequest is nil"); done(); return
                 }
-
-                var testTokenRequest: ARTTokenRequest?
-                let rest = ARTRest(options: defaultOptions)
-                rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, error in
-                    testTokenRequest = tokenRequest
-                })
-                expect(testTokenRequest).toEventuallyNot(beNil(), timeout: testTimeout)
-
-                var customCallbackCalled = false
-                let customOptions = ARTAuthOptions()
-                customOptions.authCallback = { tokenParams, completion in
-                    customCallbackCalled = true
-                    completion(testTokenRequest, nil)
-                }
-
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.authorize(nil, options: customOptions) { _, error in
-                        expect(error).to(beNil())
-                        done()
-                    }
-                }
-                expect(customCallbackCalled).to(beTrue())
+                expect(tokenRequest.clientId).to(equal(options.clientId))
+                expect(tokenRequest.ttl).to(beNil())
+                expect(tokenRequest.capability).to(beNil())
+                done()
             }
+        }
 
-            func test__078__createTokenRequest__should_use_defaults_if_no_AuthOptions_is_provided() {
-                var currentTokenRequest: ARTTokenRequest? = nil
-                var callbackCalled = false
+        tokenParams.ttl = NSNumber(value: ExpectedTokenParams.ttl)
+        tokenParams.capability = ExpectedTokenParams.capability
+        tokenParams.clientId = nil
 
-                let defaultOptions = AblyTests.commonAppSetup()
-                defaultOptions.authCallback = { tokenParams, completion in
-                    callbackCalled = true
-                    guard let tokenRequest = currentTokenRequest else {
-                        fail("tokenRequest is nil"); return
-                    }
-                    completion(tokenRequest, nil)
+        let authOptions = ARTAuthOptions()
+        authOptions.queryTime = true
+        authOptions.key = options.key
+
+        let mockServerDate = Date().addingTimeInterval(120)
+        rest.auth.internal.testSuite_returnValue(for: NSSelectorFromString("handleServerTime:"), with: mockServerDate)
+
+        var serverTimeRequestCount = 0
+        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
+            serverTimeRequestCount += 1
+        }
+        defer { hook.remove() }
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(tokenParams, options: authOptions) { tokenRequest, error in
+                expect(error).to(beNil())
+                guard let tokenRequest = tokenRequest else {
+                    XCTFail("tokenRequest is nil"); done(); return
                 }
-
-                let rest = ARTRest(options: defaultOptions)
-                rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, error in
-                    currentTokenRequest = tokenRequest
-                })
-                expect(currentTokenRequest).toEventuallyNot(beNil(), timeout: testTimeout)
-
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.authorize(nil, options: nil) { _, error in
-                        expect(error).to(beNil())
-                        done()
-                    }
-                }
-                expect(callbackCalled).to(beTrue())
-            }
-
-            func test__079__createTokenRequest__should_replace_defaults_if__nil__option_s_field_passed() {
-                let defaultOptions = AblyTests.commonAppSetup()
-                let rest = ARTRest(options: defaultOptions)
-
-                let customOptions = ARTAuthOptions()
-
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.createTokenRequest(nil, options: customOptions) { tokenRequest, error in
-                        guard let error = error else {
-                            fail("Error is nil"); done(); return
-                        }
-                        expect(error.localizedDescription).to(contain("no key provided for signing token requests"))
-                        done()
-                    }
-                }
-            }
-
-            // RSA9h
-            func test__080__createTokenRequest__should_use_configured_defaults_if_the_object_arguments_are_omitted() {
-                let options = AblyTests.commonAppSetup()
-                let rest = ARTRest(options: options)
-
-                let tokenParams = ARTTokenParams()
-                tokenParams.clientId = "tester"
-                tokenParams.ttl = 2000
-                tokenParams.capability = "{\"foo:*\":[\"publish\"]}"
-
-                let authOptions = ARTAuthOptions()
-                authOptions.queryTime = true
-                authOptions.key = options.key
-
-                var serverTimeRequestCount = 0
-                let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
-                    serverTimeRequestCount += 1
-                }
-                defer { hook.remove() }
-
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.createTokenRequest(tokenParams, options: authOptions) { tokenRequest, error in
-                        expect(error).to(beNil())
-                        guard let tokenRequest = tokenRequest else {
-                            XCTFail("TokenRequest is nil"); done(); return
-                        }
-                        expect(tokenRequest.clientId) == tokenParams.clientId
-                        expect(tokenRequest.ttl) == tokenParams.ttl
-                        expect(tokenRequest.capability) == tokenParams.capability
-                        done()
-                    }
-                }
-
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.createTokenRequest { tokenRequest, error in
-                        expect(error).to(beNil())
-                        guard let tokenRequest = tokenRequest else {
-                            XCTFail("TokenRequest is nil"); done(); return
-                        }
-                        expect(tokenRequest.clientId).to(beNil())
-                        expect(tokenRequest.ttl).to(beNil())
-                        expect(tokenRequest.capability).to(beNil())
-                        done()
-                    }
-                }
-
+                expect(tokenRequest.clientId).to(beNil())
+                expect(tokenRequest.timestamp).to(beCloseTo(mockServerDate))
                 expect(serverTimeRequestCount) == 1
+                expect(tokenRequest.ttl).to(equal(ExpectedTokenParams.ttl as NSNumber))
+                expect(tokenRequest.capability).to(equal(ExpectedTokenParams.capability))
+                done()
             }
+        }
 
-            // RSA9a
-            func test__081__createTokenRequest__should_create_and_sign_a_TokenRequest() {
-                let rest = ARTRest(options: AblyTests.commonAppSetup())
-                let expectedClientId = "client_string"
-                let tokenParams = ARTTokenParams(clientId: expectedClientId)
+        tokenParams.clientId = "newClientId"
+        tokenParams.ttl = 2000
+        tokenParams.capability = "{ \"test:*\":[\"test\"] }"
 
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
-                        defer { done() }
-                        expect(error).to(beNil())
-                        guard let tokenRequest = tokenRequest else {
-                            XCTFail("TokenRequest is nil"); return
-                        }
-                        expect(tokenRequest).to(beAnInstanceOf(ARTTokenRequest.self))
-                        expect(tokenRequest.clientId).to(equal(expectedClientId))
-                        expect(tokenRequest.mac).toNot(beNil())
-                        expect(tokenRequest.nonce).toNot(beNil())
-                    })
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(tokenParams, options: authOptions) { tokenRequest, error in
+                expect(error).to(beNil())
+                guard let tokenRequest = tokenRequest else {
+                    XCTFail("tokenRequest is nil"); done(); return
                 }
+                expect(tokenRequest.clientId).to(equal("newClientId"))
+                expect(tokenRequest.ttl).to(equal(2000))
+                expect(tokenRequest.capability).to(equal("{ \"test:*\":[\"test\"] }"))
+                done()
             }
+        }
 
-            // RSA9b
-            func test__082__createTokenRequest__should_support_AuthOptions() {
-                let rest = ARTRest(options: AblyTests.commonAppSetup())
-                let auth: ARTAuth = rest.auth
+        tokenParams.clientId = nil
 
-                let authOptions = ARTAuthOptions(key: "key:secret")
-
-                waitUntil(timeout: testTimeout) { done in
-                    auth.createTokenRequest(nil, options: authOptions, callback: { tokenRequest, error in
-                        defer { done() }
-                        expect(error).to(beNil())
-                        guard let tokenRequest = tokenRequest else {
-                            XCTFail("TokenRequest is nil"); return
-                        }
-                        expect(tokenRequest.keyName).to(equal("key"))
-                    })
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(tokenParams, options: authOptions) { tokenRequest, error in
+                expect(error).to(beNil())
+                guard let tokenRequest = tokenRequest else {
+                    XCTFail("tokenRequest is nil"); done(); return
                 }
+                expect(tokenRequest.clientId).to(beNil())
+                done()
             }
+        }
+    }
 
-            // RSA9c
-            func test__083__createTokenRequest__should_generate_a_unique_16_plus_character_nonce_if_none_is_provided() {
-                let rest = ARTRest(options: AblyTests.commonAppSetup())
+    func test__077__createTokenRequest__should_override_defaults_if_AuthOptions_provided() {
+        let defaultOptions = AblyTests.commonAppSetup()
+        defaultOptions.authCallback = { _, _ in
+            fail("Should not be called")
+        }
 
-                waitUntil(timeout: testTimeout) { done in
-                    // First
-                    rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, error in
-                        expect(error).to(beNil())
-                        guard let tokenRequest1 = tokenRequest else {
-                            XCTFail("TokenRequest1 is nil"); done(); return
-                        }
-                        expect(tokenRequest1.nonce).to(haveCount(16))
+        var testTokenRequest: ARTTokenRequest?
+        let rest = ARTRest(options: defaultOptions)
+        rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, _ in
+            testTokenRequest = tokenRequest
+        })
+        expect(testTokenRequest).toEventuallyNot(beNil(), timeout: testTimeout)
 
-                        // Second
-                        rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, error in
-                            expect(error).to(beNil())
-                            guard let tokenRequest2 = tokenRequest else {
-                                XCTFail("TokenRequest2 is nil"); done(); return
-                            }
-                            expect(tokenRequest2.nonce).to(haveCount(16))
+        var customCallbackCalled = false
+        let customOptions = ARTAuthOptions()
+        customOptions.authCallback = { _, completion in
+            customCallbackCalled = true
+            completion(testTokenRequest, nil)
+        }
 
-                            // Uniqueness
-                            expect(tokenRequest1.nonce).toNot(equal(tokenRequest2.nonce))
-                            done()
-                        })
-                    })
-                }
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: customOptions) { _, error in
+                expect(error).to(beNil())
+                done()
             }
+        }
+        expect(customCallbackCalled).to(beTrue())
+    }
 
-            // RSA9d
-            
+    func test__078__createTokenRequest__should_use_defaults_if_no_AuthOptions_is_provided() {
+        var currentTokenRequest: ARTTokenRequest?
+        var callbackCalled = false
 
-                func test__087__createTokenRequest__should_generate_a_timestamp__from_current_time_if_not_provided() {
-                    let rest = ARTRest(options: AblyTests.commonAppSetup())
+        let defaultOptions = AblyTests.commonAppSetup()
+        defaultOptions.authCallback = { _, completion in
+            callbackCalled = true
+            guard let tokenRequest = currentTokenRequest else {
+                fail("tokenRequest is nil"); return
+            }
+            completion(tokenRequest, nil)
+        }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, error in
-                            defer { done() }
-                            expect(error).to(beNil())
-                            guard let tokenRequest = tokenRequest else {
-                                XCTFail("TokenRequest is nil"); return
-                            }
-                            expect(tokenRequest.timestamp).to(beCloseTo(Date(), within: 1.0))
-                        })
-                    }
+        let rest = ARTRest(options: defaultOptions)
+        rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, _ in
+            currentTokenRequest = tokenRequest
+        })
+        expect(currentTokenRequest).toEventuallyNot(beNil(), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { _, error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+        expect(callbackCalled).to(beTrue())
+    }
+
+    func test__079__createTokenRequest__should_replace_defaults_if__nil__option_s_field_passed() {
+        let defaultOptions = AblyTests.commonAppSetup()
+        let rest = ARTRest(options: defaultOptions)
+
+        let customOptions = ARTAuthOptions()
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(nil, options: customOptions) { _, error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
                 }
+                expect(error.localizedDescription).to(contain("no key provided for signing token requests"))
+                done()
+            }
+        }
+    }
 
-                func test__088__createTokenRequest__should_generate_a_timestamp__will_retrieve_the_server_time_if_queryTime_is_true() {
-                    let rest = ARTRest(options: AblyTests.commonAppSetup())
+    // RSA9h
+    func test__080__createTokenRequest__should_use_configured_defaults_if_the_object_arguments_are_omitted() {
+        let options = AblyTests.commonAppSetup()
+        let rest = ARTRest(options: options)
 
-                    var serverTimeRequestWasMade = false
-                    let block: @convention(block) (AspectInfo) -> Void = { _ in
-                        serverTimeRequestWasMade = true
-                    }
+        let tokenParams = ARTTokenParams()
+        tokenParams.clientId = "tester"
+        tokenParams.ttl = 2000
+        tokenParams.capability = "{\"foo:*\":[\"publish\"]}"
 
-                    let hook = ARTRestInternal.aspect_hook(rest.internal)
-                    // Adds a block of code after `time` is triggered
-                    let _ = try? hook(#selector(ARTRestInternal._time(_:)), .positionBefore, unsafeBitCast(block, to: ARTRestInternal.self))
+        let authOptions = ARTAuthOptions()
+        authOptions.queryTime = true
+        authOptions.key = options.key
 
-                    let authOptions = ARTAuthOptions()
-                    authOptions.queryTime = true
-                    authOptions.key = AblyTests.commonAppSetup().key
+        var serverTimeRequestCount = 0
+        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
+            serverTimeRequestCount += 1
+        }
+        defer { hook.remove() }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.createTokenRequest(nil, options: authOptions, callback: { tokenRequest, error in
-                            expect(error).to(beNil())
-                            guard let tokenRequest = tokenRequest else {
-                                XCTFail("tokenRequest is nil"); done(); return
-                            }
-                            expect(tokenRequest.timestamp).toNot(beNil())
-                            expect(serverTimeRequestWasMade).to(beTrue())
-                            done()
-                        })
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(tokenParams, options: authOptions) { tokenRequest, error in
+                expect(error).to(beNil())
+                guard let tokenRequest = tokenRequest else {
+                    XCTFail("TokenRequest is nil"); done(); return
                 }
+                expect(tokenRequest.clientId) == tokenParams.clientId
+                expect(tokenRequest.ttl) == tokenParams.ttl
+                expect(tokenRequest.capability) == tokenParams.capability
+                done()
+            }
+        }
 
-            // RSA9e
-            
-
-                func test__089__createTokenRequest__TTL__should_be_optional() {
-                    let rest = ARTRest(options: AblyTests.commonAppSetup())
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, error in
-                            defer { done() }
-                            expect(error).to(beNil())
-                            guard let tokenRequest = tokenRequest else {
-                                XCTFail("TokenRequest is nil"); return
-                            }
-                            //In Seconds because TTL property is a NSTimeInterval but further it does the conversion to milliseconds
-                            expect(tokenRequest.ttl).to(beNil())
-                        })
-                    }
-
-                    let tokenParams = ARTTokenParams()
-                    expect(tokenParams.ttl).to(beNil())
-
-                    let expectedTtl = TimeInterval(10)
-                    tokenParams.ttl = NSNumber(value: expectedTtl)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
-                            defer { done() }
-                            expect(error).to(beNil())
-                            guard let tokenRequest = tokenRequest else {
-                                XCTFail("TokenRequest is nil"); return
-                            }
-                            expect(tokenRequest.ttl as? TimeInterval).to(equal(expectedTtl))
-                        })
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest { tokenRequest, error in
+                expect(error).to(beNil())
+                guard let tokenRequest = tokenRequest else {
+                    XCTFail("TokenRequest is nil"); done(); return
                 }
+                expect(tokenRequest.clientId).to(beNil())
+                expect(tokenRequest.ttl).to(beNil())
+                expect(tokenRequest.capability).to(beNil())
+                done()
+            }
+        }
 
-                func test__090__createTokenRequest__TTL__should_be_specified_in_milliseconds() {
-                    let rest = ARTRest(options: AblyTests.commonAppSetup())
+        expect(serverTimeRequestCount) == 1
+    }
 
-                    let params = ARTTokenParams()
-                    params.ttl = NSNumber(value: 42)
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.createTokenRequest(params, options: nil, callback: { tokenRequest, error in
-                            defer { done() }
-                            expect(error).to(beNil())
-                            guard let tokenRequest = tokenRequest else {
-                                XCTFail("TokenRequest is nil"); return
-                            }
-                            expect(tokenRequest.ttl as? TimeInterval).to(equal(42))
+    // RSA9a
+    func test__081__createTokenRequest__should_create_and_sign_a_TokenRequest() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+        let expectedClientId = "client_string"
+        let tokenParams = ARTTokenParams(clientId: expectedClientId)
 
-                            // Check if the encoder changes the TTL to milliseconds
-                            let encoder = rest.internal.defaultEncoder as! ARTJsonLikeEncoder
-                            let data = try! encoder.encode(tokenRequest)
-                            let jsonObject = (try! encoder.delegate!.decode(data)) as! NSDictionary
-                            let ttl = jsonObject["ttl"] as! NSNumber
-                            expect(ttl as? Int64).to(equal(42 * 1000))
-                            
-                            // Make sure it comes back the same.
-                            let decoded = try! encoder.decodeTokenRequest(data)
-                            expect(decoded.ttl as? TimeInterval).to(equal(42))
-                        })
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
+                defer { done() }
+                expect(error).to(beNil())
+                guard let tokenRequest = tokenRequest else {
+                    XCTFail("TokenRequest is nil"); return
+                }
+                expect(tokenRequest).to(beAnInstanceOf(ARTTokenRequest.self))
+                expect(tokenRequest.clientId).to(equal(expectedClientId))
+                expect(tokenRequest.mac).toNot(beNil())
+                expect(tokenRequest.nonce).toNot(beNil())
+            })
+        }
+    }
+
+    // RSA9b
+    func test__082__createTokenRequest__should_support_AuthOptions() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+        let auth: ARTAuth = rest.auth
+
+        let authOptions = ARTAuthOptions(key: "key:secret")
+
+        waitUntil(timeout: testTimeout) { done in
+            auth.createTokenRequest(nil, options: authOptions, callback: { tokenRequest, error in
+                defer { done() }
+                expect(error).to(beNil())
+                guard let tokenRequest = tokenRequest else {
+                    XCTFail("TokenRequest is nil"); return
+                }
+                expect(tokenRequest.keyName).to(equal("key"))
+            })
+        }
+    }
+
+    // RSA9c
+    func test__083__createTokenRequest__should_generate_a_unique_16_plus_character_nonce_if_none_is_provided() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+
+        waitUntil(timeout: testTimeout) { done in
+            // First
+            rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, error in
+                expect(error).to(beNil())
+                guard let tokenRequest1 = tokenRequest else {
+                    XCTFail("TokenRequest1 is nil"); done(); return
+                }
+                expect(tokenRequest1.nonce).to(haveCount(16))
+
+                // Second
+                rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, error in
+                    expect(error).to(beNil())
+                    guard let tokenRequest2 = tokenRequest else {
+                        XCTFail("TokenRequest2 is nil"); done(); return
                     }
+                    expect(tokenRequest2.nonce).to(haveCount(16))
+
+                    // Uniqueness
+                    expect(tokenRequest1.nonce).toNot(equal(tokenRequest2.nonce))
+                    done()
+                })
+            })
+        }
+    }
+
+    // RSA9d
+
+    func test__087__createTokenRequest__should_generate_a_timestamp__from_current_time_if_not_provided() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, error in
+                defer { done() }
+                expect(error).to(beNil())
+                guard let tokenRequest = tokenRequest else {
+                    XCTFail("TokenRequest is nil"); return
                 }
+                expect(tokenRequest.timestamp).to(beCloseTo(Date(), within: 1.0))
+            })
+        }
+    }
 
-                func test__091__createTokenRequest__TTL__should_be_valid_to_request_a_token_for_24_hours() {
-                    let rest = ARTRest(options: AblyTests.commonAppSetup())
-                    let tokenParams = ARTTokenParams()
-                    let dayInSeconds = TimeInterval(24 * 60 * 60)
-                    tokenParams.ttl = dayInSeconds as NSNumber
+    func test__088__createTokenRequest__should_generate_a_timestamp__will_retrieve_the_server_time_if_queryTime_is_true() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
 
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.requestToken(tokenParams, with: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                XCTFail("TokenDetails is nil"); done(); return
-                            }
-                            expect(tokenDetails.expires!.timeIntervalSince(tokenDetails.issued!)).to(beCloseTo(dayInSeconds))
-                            done()
-                        }
-                    }
+        var serverTimeRequestWasMade = false
+        let block: @convention(block) (AspectInfo) -> Void = { _ in
+            serverTimeRequestWasMade = true
+        }
+
+        let hook = ARTRestInternal.aspect_hook(rest.internal)
+        // Adds a block of code after `time` is triggered
+        _ = try? hook(#selector(ARTRestInternal._time(_:)), .positionBefore, unsafeBitCast(block, to: ARTRestInternal.self))
+
+        let authOptions = ARTAuthOptions()
+        authOptions.queryTime = true
+        authOptions.key = AblyTests.commonAppSetup().key
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(nil, options: authOptions, callback: { tokenRequest, error in
+                expect(error).to(beNil())
+                guard let tokenRequest = tokenRequest else {
+                    XCTFail("tokenRequest is nil"); done(); return
                 }
+                expect(tokenRequest.timestamp).toNot(beNil())
+                expect(serverTimeRequestWasMade).to(beTrue())
+                done()
+            })
+        }
+    }
 
-            // RSA9f
-            func test__084__createTokenRequest__should_provide_capability_has_json_text() {
-                let rest = ARTRest(options: AblyTests.commonAppSetup())
+    // RSA9e
 
-                let tokenParams = ARTTokenParams()
-                tokenParams.capability = "{ - }"
+    func test__089__createTokenRequest__TTL__should_be_optional() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
 
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
-                        defer { done() }
-                        guard let error = error else {
-                            XCTFail("Error is nil"); return
-                        }
-                        expect(error.localizedDescription).to(contain("Capability"))
-                        expect(tokenRequest?.capability).to(beNil())
-                    })
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, error in
+                defer { done() }
+                expect(error).to(beNil())
+                guard let tokenRequest = tokenRequest else {
+                    XCTFail("TokenRequest is nil"); return
                 }
+                // In Seconds because TTL property is a NSTimeInterval but further it does the conversion to milliseconds
+                expect(tokenRequest.ttl).to(beNil())
+            })
+        }
 
-                let expectedCapability = "{ \"cansubscribe:*\":[\"subscribe\"] }"
-                tokenParams.capability = expectedCapability
+        let tokenParams = ARTTokenParams()
+        expect(tokenParams.ttl).to(beNil())
+
+        let expectedTtl = TimeInterval(10)
+        tokenParams.ttl = NSNumber(value: expectedTtl)
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
+                defer { done() }
+                expect(error).to(beNil())
+                guard let tokenRequest = tokenRequest else {
+                    XCTFail("TokenRequest is nil"); return
+                }
+                expect(tokenRequest.ttl as? TimeInterval).to(equal(expectedTtl))
+            })
+        }
+    }
+
+    func test__090__createTokenRequest__TTL__should_be_specified_in_milliseconds() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+
+        let params = ARTTokenParams()
+        params.ttl = NSNumber(value: 42)
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(params, options: nil, callback: { tokenRequest, error in
+                defer { done() }
+                expect(error).to(beNil())
+                guard let tokenRequest = tokenRequest else {
+                    XCTFail("TokenRequest is nil"); return
+                }
+                expect(tokenRequest.ttl as? TimeInterval).to(equal(42))
+
+                // Check if the encoder changes the TTL to milliseconds
+                let encoder = rest.internal.defaultEncoder as! ARTJsonLikeEncoder
+                let data = try! encoder.encode(tokenRequest)
+                let jsonObject = (try! encoder.delegate!.decode(data)) as! NSDictionary
+                let ttl = jsonObject["ttl"] as! NSNumber
+                expect(ttl as? Int64).to(equal(42 * 1000))
+
+                // Make sure it comes back the same.
+                let decoded = try! encoder.decodeTokenRequest(data)
+                expect(decoded.ttl as? TimeInterval).to(equal(42))
+            })
+        }
+    }
+
+    func test__091__createTokenRequest__TTL__should_be_valid_to_request_a_token_for_24_hours() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+        let tokenParams = ARTTokenParams()
+        let dayInSeconds = TimeInterval(24 * 60 * 60)
+        tokenParams.ttl = dayInSeconds as NSNumber
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.requestToken(tokenParams, with: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    XCTFail("TokenDetails is nil"); done(); return
+                }
+                expect(tokenDetails.expires!.timeIntervalSince(tokenDetails.issued!)).to(beCloseTo(dayInSeconds))
+                done()
+            }
+        }
+    }
+
+    // RSA9f
+    func test__084__createTokenRequest__should_provide_capability_has_json_text() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+
+        let tokenParams = ARTTokenParams()
+        tokenParams.capability = "{ - }"
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
+                defer { done() }
+                guard let error = error else {
+                    XCTFail("Error is nil"); return
+                }
+                expect(error.localizedDescription).to(contain("Capability"))
+                expect(tokenRequest?.capability).to(beNil())
+            })
+        }
+
+        let expectedCapability = "{ \"cansubscribe:*\":[\"subscribe\"] }"
+        tokenParams.capability = expectedCapability
+
+        rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
+            expect(error).to(beNil())
+            guard let tokenRequest = tokenRequest else {
+                XCTFail("TokenRequest is nil"); return
+            }
+            expect(tokenRequest.capability).to(equal(expectedCapability))
+        })
+    }
+
+    // RSA9g
+    func test__085__createTokenRequest__should_generate_a_valid_HMAC() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+
+        let tokenParams = ARTTokenParams(clientId: "client_string")
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
+                expect(error).to(beNil())
+                guard let tokenRequest1 = tokenRequest else {
+                    XCTFail("TokenRequest is nil"); done(); return
+                }
+                let signed = tokenParams.sign(rest.internal.options.key!, withNonce: tokenRequest1.nonce)
+                expect(tokenRequest1.mac).to(equal(signed?.mac))
 
                 rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
                     expect(error).to(beNil())
-                    guard let tokenRequest = tokenRequest else {
-                        XCTFail("TokenRequest is nil"); return
+                    guard let tokenRequest2 = tokenRequest else {
+                        XCTFail("TokenRequest is nil"); done(); return
                     }
-                    expect(tokenRequest.capability).to(equal(expectedCapability))
+                    expect(tokenRequest2.nonce).toNot(equal(tokenRequest1.nonce))
+                    expect(tokenRequest2.mac).toNot(equal(tokenRequest1.mac))
+                    done()
                 })
+            })
+        }
+    }
+
+    // RSA9i
+    func test__086__createTokenRequest__should_respect_all_requirements() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+        let expectedClientId = "client_string"
+        let tokenParams = ARTTokenParams(clientId: expectedClientId)
+        let expectedTtl = 6.0
+        tokenParams.ttl = NSNumber(value: expectedTtl)
+        let expectedCapability = "{}"
+        tokenParams.capability = expectedCapability
+
+        let authOptions = ARTAuthOptions()
+        authOptions.queryTime = true
+        authOptions.key = AblyTests.commonAppSetup().key
+
+        var serverTime: Date?
+        waitUntil(timeout: testTimeout) { done in
+            rest.time { date, _ in
+                serverTime = date
+                done()
             }
+        }
+        expect(serverTime).toNot(beNil(), description: "Server time is nil")
 
-            // RSA9g
-            func test__085__createTokenRequest__should_generate_a_valid_HMAC() {
-                let rest = ARTRest(options: AblyTests.commonAppSetup())
-
-                let tokenParams = ARTTokenParams(clientId: "client_string")
-
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
-                        expect(error).to(beNil())
-                        guard let tokenRequest1 = tokenRequest else {
-                            XCTFail("TokenRequest is nil"); done(); return
-                        }
-                        let signed = tokenParams.sign(rest.internal.options.key!, withNonce: tokenRequest1.nonce)
-                        expect(tokenRequest1.mac).to(equal(signed?.mac))
-
-                        rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
-                            expect(error).to(beNil())
-                            guard let tokenRequest2 = tokenRequest else {
-                                XCTFail("TokenRequest is nil"); done(); return
-                            }
-                            expect(tokenRequest2.nonce).toNot(equal(tokenRequest1.nonce))
-                            expect(tokenRequest2.mac).toNot(equal(tokenRequest1.mac))
-                            done()
-                        })
-                    })
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(tokenParams, options: authOptions, callback: { tokenRequest, error in
+                defer { done() }
+                expect(error).to(beNil())
+                guard let tokenRequest = tokenRequest else {
+                    XCTFail("TokenRequest is nil"); return
                 }
+                expect(tokenRequest.clientId).to(equal(expectedClientId))
+                expect(tokenRequest.mac).toNot(beNil())
+                expect(tokenRequest.nonce).to(haveCount(16))
+                expect(tokenRequest.ttl as? TimeInterval).to(equal(expectedTtl))
+                expect(tokenRequest.capability).to(equal(expectedCapability))
+                expect(tokenRequest.timestamp).to(beCloseTo(serverTime!, within: 6.0))
+            })
+        }
+    }
+
+    // RSA10
+
+    // RSA10a
+    func test__092__authorize__should_always_create_a_token() {
+        let options = AblyTests.commonAppSetup()
+        options.useTokenAuth = true
+        let rest = ARTRest(options: options)
+        let channel = rest.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "first check") { error in
+                expect(error).to(beNil())
+                done()
             }
+        }
 
-            // RSA9i
-            func test__086__createTokenRequest__should_respect_all_requirements() {
-                let rest = ARTRest(options: AblyTests.commonAppSetup())
-                let expectedClientId = "client_string"
-                let tokenParams = ARTTokenParams(clientId: expectedClientId)
-                let expectedTtl = 6.0
-                tokenParams.ttl = NSNumber(value: expectedTtl)
-                let expectedCapability = "{}"
-                tokenParams.capability = expectedCapability
+        // Check that token exists
+        expect(rest.auth.internal.method).to(equal(ARTAuthMethod.token))
+        guard let firstTokenDetails = rest.auth.tokenDetails else {
+            fail("TokenDetails is nil"); return
+        }
+        expect(firstTokenDetails.token).toNot(beNil())
 
-                let authOptions = ARTAuthOptions()
-                authOptions.queryTime = true
-                authOptions.key = AblyTests.commonAppSetup().key
-
-                var serverTime: Date?
-                waitUntil(timeout: testTimeout) { done in
-                    rest.time({ date, error in
-                        serverTime = date
-                        done()
-                    })
-                }
-                expect(serverTime).toNot(beNil(), description: "Server time is nil")
-
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.createTokenRequest(tokenParams, options: authOptions, callback: { tokenRequest, error in
-                        defer { done() }
-                        expect(error).to(beNil())
-                        guard let tokenRequest = tokenRequest else {
-                            XCTFail("TokenRequest is nil"); return
-                        }
-                        expect(tokenRequest.clientId).to(equal(expectedClientId))
-                        expect(tokenRequest.mac).toNot(beNil())
-                        expect(tokenRequest.nonce).to(haveCount(16))
-                        expect(tokenRequest.ttl as? TimeInterval).to(equal(expectedTtl))
-                        expect(tokenRequest.capability).to(equal(expectedCapability))
-                        expect(tokenRequest.timestamp).to(beCloseTo(serverTime!, within: 6.0))
-                    })
-                }
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "second check") { error in
+                expect(error).to(beNil())
+                done()
             }
+        }
 
-        // RSA10
-        
+        // Check that token has not changed
+        expect(rest.auth.internal.method).to(equal(ARTAuthMethod.token))
+        guard let secondTokenDetails = rest.auth.tokenDetails else {
+            fail("TokenDetails is nil"); return
+        }
+        expect(firstTokenDetails).to(beIdenticalTo(secondTokenDetails))
 
-            // RSA10a
-            func test__092__authorize__should_always_create_a_token() {
-                let options = AblyTests.commonAppSetup()
-                options.useTokenAuth = true
-                let rest = ARTRest(options: options)
-                let channel = rest.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil, callback: { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    XCTFail("TokenDetails is nil"); done(); return
+                }
+                // Check that token has changed
+                expect(tokenDetails.token).toNot(equal(firstTokenDetails.token))
 
-                waitUntil(timeout: testTimeout) { done in
-                    channel.publish(nil, data: "first check") { error in
-                        expect(error).to(beNil())
-                        done()
+                channel.publish(nil, data: "third check") { error in
+                    expect(error).to(beNil())
+                    guard let thirdTokenDetails = rest.auth.tokenDetails else {
+                        fail("TokenDetails is nil"); return
                     }
+                    expect(thirdTokenDetails.token).to(equal(tokenDetails.token))
+                    done()
                 }
+            })
+        }
+    }
 
-                // Check that token exists
+    // RSA10a
+    func test__093__authorize__should_create_a_new_token_if_one_already_exist_and_ensure_Token_Auth_is_used_for_all_future_requests() {
+        let options = AblyTests.commonAppSetup()
+        let testToken = getTestToken()
+        options.token = testToken
+        let rest = ARTRest(options: options)
+
+        expect(rest.auth.tokenDetails?.token).toNot(beNil())
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil, callback: { tokenDetails, error in
+                guard let tokenDetails = tokenDetails else {
+                    XCTFail("TokenDetails is nil"); done(); return
+                }
+                expect(tokenDetails.token).toNot(equal(testToken))
                 expect(rest.auth.internal.method).to(equal(ARTAuthMethod.token))
-                guard let firstTokenDetails = rest.auth.tokenDetails else {
-                    fail("TokenDetails is nil"); return
-                }
-                expect(firstTokenDetails.token).toNot(beNil())
 
-                waitUntil(timeout: testTimeout) { done in
-                    channel.publish(nil, data: "second check") { error in
-                        expect(error).to(beNil())
-                        done()
-                    }
-                }
+                publishTestMessage(rest, completion: { error in
+                    expect(error).to(beNil())
+                    expect(rest.auth.internal.method).to(equal(ARTAuthMethod.token))
+                    expect(rest.auth.tokenDetails?.token).to(equal(tokenDetails.token))
+                    done()
+                })
+            })
+        }
+    }
 
-                // Check that token has not changed
+    // RSA10a
+    func test__094__authorize__should_create_a_token_immediately_and_ensures_Token_Auth_is_used_for_all_future_requests() {
+        let options = AblyTests.commonAppSetup()
+        let rest = ARTRest(options: options)
+
+        expect(rest.auth.tokenDetails?.token).to(beNil())
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil, callback: { tokenDetails, error in
+                guard let tokenDetails = tokenDetails else {
+                    XCTFail("TokenDetails is nil"); done(); return
+                }
+                expect(tokenDetails.token).toNot(beNil())
                 expect(rest.auth.internal.method).to(equal(ARTAuthMethod.token))
-                guard let secondTokenDetails = rest.auth.tokenDetails else {
-                    fail("TokenDetails is nil"); return
+
+                publishTestMessage(rest, completion: { error in
+                    expect(error).to(beNil())
+                    expect(rest.auth.internal.method).to(equal(ARTAuthMethod.token))
+                    expect(rest.auth.tokenDetails?.token).to(equal(tokenDetails.token))
+                    done()
+                })
+            })
+        }
+    }
+
+    // RSA10b
+    func test__095__authorize__should_supports_all_TokenParams_and_AuthOptions() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(ARTTokenParams(), options: ARTAuthOptions(), callback: { _, error in
+                guard let error = error as? ARTErrorInfo else {
+                    fail("Error is nil"); done(); return
                 }
-                expect(firstTokenDetails).to(beIdenticalTo(secondTokenDetails))
+                expect(error.localizedDescription).to(contain("no means to renew the token is provided"))
+                done()
+            })
+        }
+    }
 
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.authorize(nil, options: nil, callback: { tokenDetails, error in
-                        expect(error).to(beNil())
-                        guard let tokenDetails = tokenDetails else {
-                            XCTFail("TokenDetails is nil"); done(); return
-                        }
-                        // Check that token has changed
-                        expect(tokenDetails.token).toNot(equal(firstTokenDetails.token))
+    // RSA10e
+    func test__096__authorize__should_use_the_requestToken_implementation() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
 
-                        channel.publish(nil, data: "third check") { error in
-                            expect(error).to(beNil())
-                            guard let thirdTokenDetails = rest.auth.tokenDetails else {
-                                fail("TokenDetails is nil"); return
-                            }
-                            expect(thirdTokenDetails.token).to(equal(tokenDetails.token))
-                            done()
-                        }
-                    })
+        var requestMethodWasCalled = false
+        let block: @convention(block) (AspectInfo) -> Void = { _ in
+            requestMethodWasCalled = true
+        }
+
+        let hook = ARTAuthInternal.aspect_hook(rest.auth.internal)
+        // Adds a block of code after `requestToken` is triggered
+        let token = try? hook(#selector(ARTAuthInternal._requestToken(_:with:callback:)), [], unsafeBitCast(block, to: ARTAuthInternal.self))
+
+        expect(token).toNot(beNil())
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil, callback: { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    XCTFail("TokenDetails is nil"); done(); return
+                }
+                expect(tokenDetails.token).toNot(beEmpty())
+                done()
+            })
+        }
+
+        expect(requestMethodWasCalled).to(beTrue())
+    }
+
+    // RSA10f
+    func test__097__authorize__should_return_TokenDetails_with_valid_token_metadata() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "client_string"
+        let rest = ARTRest(options: options)
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    XCTFail("TokenDetails is nil"); done(); return
+                }
+                expect(tokenDetails).to(beAnInstanceOf(ARTTokenDetails.self))
+                expect(tokenDetails.token).toNot(beEmpty())
+                expect(tokenDetails.expires!.timeIntervalSinceNow).to(beGreaterThan(tokenDetails.issued!.timeIntervalSinceNow))
+                expect(tokenDetails.clientId).to(equal(options.clientId))
+                done()
+            }
+        }
+    }
+
+    // RSA10g
+
+    func test__099__authorize__on_subsequent_authorisations__should_store_the_AuthOptions_with_authUrl() {
+        let options = AblyTests.commonAppSetup()
+        let rest = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = testHTTPExecutor
+        let auth = rest.auth
+
+        let token = getTestToken()
+        let authOptions = ARTAuthOptions()
+        // Use authUrl for authentication with plain text token response
+        authOptions.authUrl = URL(string: "http://echo.ably.io")!
+        authOptions.authParams = [URLQueryItem]()
+        authOptions.authParams?.append(URLQueryItem(name: "type", value: "text"))
+        authOptions.authParams?.append(URLQueryItem(name: "body", value: token))
+        authOptions.authHeaders = ["X-Ably": "Test"]
+        authOptions.queryTime = true
+
+        waitUntil(timeout: testTimeout) { done in
+            auth.authorize(nil, options: authOptions) { tokenDetails, error in
+                expect(error).to(beNil())
+
+                guard let tokenDetails = tokenDetails else {
+                    XCTFail("TokenDetails is nil"); done(); return
+                }
+                expect(tokenDetails.token).to(equal(token))
+
+                auth.authorize(nil, options: nil) { tokenDetails, error in
+                    expect(error).to(beNil())
+
+                    guard let tokenDetails = tokenDetails else {
+                        XCTFail("TokenDetails is nil"); done(); return
+                    }
+                    expect(testHTTPExecutor.requests.last?.url?.host).to(equal("echo.ably.io"))
+                    expect(auth.internal.options.authUrl!.host).to(equal("echo.ably.io"))
+                    expect(auth.internal.options.authHeaders!["X-Ably"]).to(equal("Test"))
+                    expect(tokenDetails.token).to(equal(token))
+                    expect(auth.internal.options.queryTime).to(beFalse())
+                    done()
                 }
             }
+        }
+    }
 
-            // RSA10a
-            func test__093__authorize__should_create_a_new_token_if_one_already_exist_and_ensure_Token_Auth_is_used_for_all_future_requests() {
-                let options = AblyTests.commonAppSetup()
-                let testToken = getTestToken()
-                options.token = testToken
-                let rest = ARTRest(options: options)
+    func test__100__authorize__on_subsequent_authorisations__should_store_the_AuthOptions_with_authCallback() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+        let auth = rest.auth
 
-                expect(rest.auth.tokenDetails?.token).toNot(beNil())
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.authorize(nil, options: nil, callback: { tokenDetails, error in
-                        guard let tokenDetails = tokenDetails else {
-                            XCTFail("TokenDetails is nil"); done(); return
-                        }
-                        expect(tokenDetails.token).toNot(equal(testToken))
-                        expect(rest.auth.internal.method).to(equal(ARTAuthMethod.token))
+        var authCallbackHasBeenInvoked = false
 
-                        publishTestMessage(rest, completion: { error in
-                            expect(error).to(beNil())
-                            expect(rest.auth.internal.method).to(equal(ARTAuthMethod.token))
-                            expect(rest.auth.tokenDetails?.token).to(equal(tokenDetails.token))
-                            done()
-                        })
-                    })
+        let authOptions = ARTAuthOptions()
+        authOptions.authCallback = { _, completion in
+            authCallbackHasBeenInvoked = true
+            completion(ARTTokenDetails(token: "token"), nil)
+        }
+        authOptions.useTokenAuth = true
+        authOptions.queryTime = true
+
+        waitUntil(timeout: testTimeout) { done in
+            auth.authorize(nil, options: authOptions) { _, _ in
+                expect(authCallbackHasBeenInvoked).to(beTrue())
+
+                authCallbackHasBeenInvoked = false
+                let authOptions2 = ARTAuthOptions()
+
+                auth.internal.testSuite_forceTokenToExpire()
+
+                auth.authorize(nil, options: authOptions2) { _, _ in
+                    expect(authCallbackHasBeenInvoked).to(beFalse())
+                    expect(auth.internal.options.useTokenAuth).to(beFalse())
+                    expect(auth.internal.options.queryTime).to(beFalse())
+                    done()
                 }
             }
+        }
+    }
 
-            // RSA10a
-            func test__094__authorize__should_create_a_token_immediately_and_ensures_Token_Auth_is_used_for_all_future_requests() {
-                let options = AblyTests.commonAppSetup()
-                let rest = ARTRest(options: options)
+    func test__101__authorize__on_subsequent_authorisations__should_not_store_queryTime() {
+        let options = AblyTests.commonAppSetup()
+        let rest = ARTRest(options: options)
+        let authOptions = ARTAuthOptions()
+        authOptions.key = options.key
+        authOptions.queryTime = true
 
-                expect(rest.auth.tokenDetails?.token).to(beNil())
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.authorize(nil, options: nil, callback: { tokenDetails, error in
-                        guard let tokenDetails = tokenDetails else {
-                            XCTFail("TokenDetails is nil"); done(); return
-                        }
-                        expect(tokenDetails.token).toNot(beNil())
-                        expect(rest.auth.internal.method).to(equal(ARTAuthMethod.token))
+        var serverTimeRequestWasMade = false
+        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
+            serverTimeRequestWasMade = true
+        }
+        defer { hook.remove() }
 
-                        publishTestMessage(rest, completion: { error in
-                            expect(error).to(beNil())
-                            expect(rest.auth.internal.method).to(equal(ARTAuthMethod.token))
-                            expect(rest.auth.tokenDetails?.token).to(equal(tokenDetails.token))
-                            done()
-                        })
-                    })
+        waitUntil(timeout: testTimeout) { done in
+            // First time
+            rest.auth.authorize(nil, options: authOptions) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+                expect(serverTimeRequestWasMade).to(beTrue())
+                expect(rest.auth.internal.options.queryTime).to(beFalse())
+                serverTimeRequestWasMade = false
+
+                // Second time
+                rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                    expect(error).to(beNil())
+                    expect(tokenDetails).toNot(beNil())
+                    expect(serverTimeRequestWasMade).to(beFalse())
+                    expect(rest.auth.internal.options.queryTime).to(beFalse())
+                    done()
                 }
             }
+        }
+    }
 
-            // RSA10b
-            func test__095__authorize__should_supports_all_TokenParams_and_AuthOptions() {
-                let rest = ARTRest(options: AblyTests.commonAppSetup())
+    func test__102__authorize__on_subsequent_authorisations__should_store_the_TokenParams() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
 
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.authorize(ARTTokenParams(), options: ARTAuthOptions(), callback: { tokenDetails, error in
-                        guard let error = error as? ARTErrorInfo else {
-                            fail("Error is nil"); done(); return
-                        }
-                        expect(error.localizedDescription).to(contain("no means to renew the token is provided"))
-                        done()
-                    })
+        let tokenParams = ARTTokenParams()
+        tokenParams.clientId = ExpectedTokenParams.clientId
+        tokenParams.ttl = ExpectedTokenParams.ttl as NSNumber
+        tokenParams.capability = ExpectedTokenParams.capability
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(tokenParams, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            delay(tokenParams.ttl as! TimeInterval + 1.0) {
+                rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                    expect(error).to(beNil())
+                    guard let tokenDetails = tokenDetails else {
+                        XCTFail("TokenDetails is nil"); done(); return
+                    }
+                    expect(tokenDetails.clientId).to(equal(ExpectedTokenParams.clientId))
+                    expect(tokenDetails.issued!.addingTimeInterval(ExpectedTokenParams.ttl)).to(beCloseTo(tokenDetails.expires!))
+                    expect(tokenDetails.capability).to(equal(ExpectedTokenParams.capability))
+                    done()
                 }
             }
+        }
+    }
 
-            // RSA10e
-            func test__096__authorize__should_use_the_requestToken_implementation() {
-                let rest = ARTRest(options: AblyTests.commonAppSetup())
+    func test__103__authorize__on_subsequent_authorisations__should_use_configured_defaults_if_the_object_arguments_are_omitted() {
+        let options = AblyTests.commonAppSetup()
+        let rest = ARTRest(options: options)
 
-                var requestMethodWasCalled = false
-                let block: @convention(block) (AspectInfo) -> Void = { _ in
-                    requestMethodWasCalled = true
-                }
+        let tokenParams = ARTTokenParams()
+        tokenParams.clientId = ExpectedTokenParams.clientId
+        tokenParams.ttl = ExpectedTokenParams.ttl as NSNumber
+        tokenParams.capability = ExpectedTokenParams.capability
 
-                let hook = ARTAuthInternal.aspect_hook(rest.auth.internal)
-                // Adds a block of code after `requestToken` is triggered
-                let token = try? hook(#selector(ARTAuthInternal._requestToken(_:with:callback:)), [], unsafeBitCast(block, to: ARTAuthInternal.self))
+        let authOptions = ARTAuthOptions()
+        var authCallbackCalled = 0
+        authOptions.authCallback = { tokenParams, completion in
+            expect(tokenParams.clientId) == ExpectedTokenParams.clientId
+            expect(tokenParams.ttl as? TimeInterval) == ExpectedTokenParams.ttl
+            expect(tokenParams.capability) == ExpectedTokenParams.capability
+            authCallbackCalled += 1
+            getTestTokenDetails(key: options.key, completion: completion)
+        }
 
-                expect(token).toNot(beNil())
-
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.authorize(nil, options: nil, callback: { tokenDetails, error in
-                        expect(error).to(beNil())
-                        guard let tokenDetails = tokenDetails else {
-                            XCTFail("TokenDetails is nil"); done(); return
-                        }
-                        expect(tokenDetails.token).toNot(beEmpty())
-                        done()
-                    })
-                }
-
-                expect(requestMethodWasCalled).to(beTrue())
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(tokenParams, options: authOptions) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+                done()
             }
+        }
 
-            // RSA10f
-            func test__097__authorize__should_return_TokenDetails_with_valid_token_metadata() {
-                let options = AblyTests.commonAppSetup()
-                options.clientId = "client_string"
-                let rest = ARTRest(options: options)
-
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                        expect(error).to(beNil())
-                        guard let tokenDetails = tokenDetails else {
-                            XCTFail("TokenDetails is nil"); done(); return
-                        }
-                        expect(tokenDetails).to(beAnInstanceOf(ARTTokenDetails.self))
-                        expect(tokenDetails.token).toNot(beEmpty())
-                        expect(tokenDetails.expires!.timeIntervalSinceNow).to(beGreaterThan(tokenDetails.issued!.timeIntervalSinceNow))
-                        expect(tokenDetails.clientId).to(equal(options.clientId))
-                        done()
-                    }
-                }
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+                done()
             }
+        }
 
-            // RSA10g
-            
+        expect(authCallbackCalled) == 2
+    }
 
-                func test__099__authorize__on_subsequent_authorisations__should_store_the_AuthOptions_with_authUrl() {
-                    let options = AblyTests.commonAppSetup()
-                    let rest = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    rest.internal.httpExecutor = testHTTPExecutor
-                    let auth = rest.auth
+    // RSA10h
+    func test__098__authorize__should_use_the_configured_Auth_clientId__if_not_null__by_default() {
+        let options = AblyTests.commonAppSetup()
+        var rest = ARTRest(options: options)
 
-                    let token = getTestToken()
-                    let authOptions = ARTAuthOptions()
-                    // Use authUrl for authentication with plain text token response
-                    authOptions.authUrl = URL(string: "http://echo.ably.io")!
-                    authOptions.authParams = [URLQueryItem]()
-                    authOptions.authParams?.append(URLQueryItem(name: "type", value: "text"))
-                    authOptions.authParams?.append(URLQueryItem(name: "body", value: token))
-                    authOptions.authHeaders = ["X-Ably":"Test"]
-                    authOptions.queryTime = true
-
-                    waitUntil(timeout: testTimeout) { done in
-                        auth.authorize(nil, options: authOptions) { tokenDetails, error in
-                            expect(error).to(beNil())
-
-                            guard let tokenDetails = tokenDetails else {
-                                XCTFail("TokenDetails is nil"); done(); return
-                            }
-                            expect(tokenDetails.token).to(equal(token))
-                            
-                            auth.authorize(nil, options: nil) { tokenDetails, error in
-                                expect(error).to(beNil())
-
-                                guard let tokenDetails = tokenDetails else {
-                                    XCTFail("TokenDetails is nil"); done(); return
-                                }
-                                expect(testHTTPExecutor.requests.last?.url?.host).to(equal("echo.ably.io"))
-                                expect(auth.internal.options.authUrl!.host).to(equal("echo.ably.io"))
-                                expect(auth.internal.options.authHeaders!["X-Ably"]).to(equal("Test"))
-                                expect(tokenDetails.token).to(equal(token))
-                                expect(auth.internal.options.queryTime).to(beFalse())
-                                done()
-                            }
-                        }
-                    }
+        // ClientId null
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    XCTFail("TokenDetails is nil"); done(); return
                 }
-
-                func test__100__authorize__on_subsequent_authorisations__should_store_the_AuthOptions_with_authCallback() {
-                    let rest = ARTRest(options: AblyTests.commonAppSetup())
-                    let auth = rest.auth
-
-                    var authCallbackHasBeenInvoked = false
-
-                    let authOptions = ARTAuthOptions()
-                    authOptions.authCallback = { tokenParams, completion in
-                        authCallbackHasBeenInvoked = true
-                        completion(ARTTokenDetails(token: "token"), nil)
-                    }
-                    authOptions.useTokenAuth = true
-                    authOptions.queryTime = true
-
-                    waitUntil(timeout: testTimeout) { done in
-                        auth.authorize(nil, options: authOptions) { tokenDetails, error in
-                            expect(authCallbackHasBeenInvoked).to(beTrue())
-
-                            authCallbackHasBeenInvoked = false
-                            let authOptions2 = ARTAuthOptions()
-
-                            auth.internal.testSuite_forceTokenToExpire()
-
-                            auth.authorize(nil, options: authOptions2) { tokenDetails, error in
-                                expect(authCallbackHasBeenInvoked).to(beFalse())
-                                expect(auth.internal.options.useTokenAuth).to(beFalse())
-                                expect(auth.internal.options.queryTime).to(beFalse())
-                                done()
-                            }
-                        }
-                    }
-                }
-
-                func test__101__authorize__on_subsequent_authorisations__should_not_store_queryTime() {
-                    let options = AblyTests.commonAppSetup()
-                    let rest = ARTRest(options: options)
-                    let authOptions = ARTAuthOptions()
-                    authOptions.key = options.key
-                    authOptions.queryTime = true
-
-                    var serverTimeRequestWasMade = false
-                    let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
-                        serverTimeRequestWasMade = true
-                    }
-                    defer { hook.remove() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        // First time
-                        rest.auth.authorize(nil, options: authOptions) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails).toNot(beNil())
-                            expect(serverTimeRequestWasMade).to(beTrue())
-                            expect(rest.auth.internal.options.queryTime).to(beFalse())
-                            serverTimeRequestWasMade = false
-
-                            // Second time
-                            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                                expect(error).to(beNil())
-                                expect(tokenDetails).toNot(beNil())
-                                expect(serverTimeRequestWasMade).to(beFalse())
-                                expect(rest.auth.internal.options.queryTime).to(beFalse())
-                                done()
-                            }
-                        }
-                    }
-                }
-
-                func test__102__authorize__on_subsequent_authorisations__should_store_the_TokenParams() {
-                    let rest = ARTRest(options: AblyTests.commonAppSetup())
-
-                    let tokenParams = ARTTokenParams()
-                    tokenParams.clientId = ExpectedTokenParams.clientId
-                    tokenParams.ttl = ExpectedTokenParams.ttl as NSNumber
-                    tokenParams.capability = ExpectedTokenParams.capability
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(tokenParams, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails).toNot(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        delay(tokenParams.ttl as! TimeInterval + 1.0) {
-                            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                                expect(error).to(beNil())
-                                guard let tokenDetails = tokenDetails else {
-                                    XCTFail("TokenDetails is nil"); done(); return
-                                }
-                                expect(tokenDetails.clientId).to(equal(ExpectedTokenParams.clientId))
-                                expect(tokenDetails.issued!.addingTimeInterval(ExpectedTokenParams.ttl)).to(beCloseTo(tokenDetails.expires!))
-                                expect(tokenDetails.capability).to(equal(ExpectedTokenParams.capability))
-                                done()
-                            }
-                        }
-                    }
-                }
-
-                func test__103__authorize__on_subsequent_authorisations__should_use_configured_defaults_if_the_object_arguments_are_omitted() {
-                    let options = AblyTests.commonAppSetup()
-                    let rest = ARTRest(options: options)
-
-                    let tokenParams = ARTTokenParams()
-                    tokenParams.clientId = ExpectedTokenParams.clientId
-                    tokenParams.ttl = ExpectedTokenParams.ttl as NSNumber
-                    tokenParams.capability = ExpectedTokenParams.capability
-
-                    let authOptions = ARTAuthOptions()
-                    var authCallbackCalled = 0
-                    authOptions.authCallback = { tokenParams, completion in
-                        expect(tokenParams.clientId) == ExpectedTokenParams.clientId
-                        expect(tokenParams.ttl as? TimeInterval) == ExpectedTokenParams.ttl
-                        expect(tokenParams.capability) == ExpectedTokenParams.capability
-                        authCallbackCalled += 1
-                        getTestTokenDetails(key: options.key, completion: completion)
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(tokenParams, options: authOptions) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails).toNot(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails).toNot(beNil())
-                            done()
-                        }
-                    }
-
-                    expect(authCallbackCalled) == 2
-                }
-
-            // RSA10h
-            func test__098__authorize__should_use_the_configured_Auth_clientId__if_not_null__by_default() {
-                let options = AblyTests.commonAppSetup()
-                var rest = ARTRest(options: options)
-
-                // ClientId null
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                        expect(error).to(beNil())
-                        guard let tokenDetails = tokenDetails else {
-                            XCTFail("TokenDetails is nil"); done(); return
-                        }
-                        expect(tokenDetails.clientId).to(beNil())
-                        done()
-                    }
-                }
-
-                options.clientId = "client_string"
-                rest = ARTRest(options: options)
-
-                // ClientId not null
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                        expect(error).to(beNil())
-                        guard let tokenDetails = tokenDetails else {
-                            XCTFail("TokenDetails is nil"); done(); return
-                        }
-                        expect(tokenDetails.clientId).to(equal(options.clientId))
-                        done()
-                    }
-                }
+                expect(tokenDetails.clientId).to(beNil())
+                done()
             }
+        }
 
-            // RSA10i
-            
+        options.clientId = "client_string"
+        rest = ARTRest(options: options)
 
-                func test__104__authorize__should_adhere_to_all_requirements_relating_to__TokenParams() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "client_string"
-                    let rest = ARTRest(options: options)
-
-                    let tokenParams = ARTTokenParams()
-                    tokenParams.clientId = ExpectedTokenParams.clientId
-                    tokenParams.ttl = ExpectedTokenParams.ttl as NSNumber
-                    tokenParams.capability = ExpectedTokenParams.capability
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(tokenParams, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                XCTFail("TokenDetails is nil"); done(); return
-                            }
-                            expect(tokenDetails).to(beAnInstanceOf(ARTTokenDetails.self))
-                            expect(tokenDetails.token).toNot(beEmpty())
-                            expect(tokenDetails.clientId).to(equal(ExpectedTokenParams.clientId))
-                            expect(tokenDetails.issued!.addingTimeInterval(ExpectedTokenParams.ttl)).to(beCloseTo(tokenDetails.expires!))
-                            expect(tokenDetails.capability).to(equal(ExpectedTokenParams.capability))
-                            done()
-                        }
-                    }
+        // ClientId not null
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    XCTFail("TokenDetails is nil"); done(); return
                 }
+                expect(tokenDetails.clientId).to(equal(options.clientId))
+                done()
+            }
+        }
+    }
 
-                func test__105__authorize__should_adhere_to_all_requirements_relating_to__authCallback() {
-                    var currentTokenRequest: ARTTokenRequest? = nil
+    // RSA10i
 
-                    var rest = ARTRest(options: AblyTests.commonAppSetup())
-                    rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, error in
-                        currentTokenRequest = tokenRequest
-                    })
-                    expect(currentTokenRequest).toEventuallyNot(beNil(), timeout: testTimeout)
+    func test__104__authorize__should_adhere_to_all_requirements_relating_to__TokenParams() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "client_string"
+        let rest = ARTRest(options: options)
 
-                    if currentTokenRequest == nil {
-                        return
-                    }
+        let tokenParams = ARTTokenParams()
+        tokenParams.clientId = ExpectedTokenParams.clientId
+        tokenParams.ttl = ExpectedTokenParams.ttl as NSNumber
+        tokenParams.capability = ExpectedTokenParams.capability
 
-                    let options = AblyTests.clientOptions()
-                    options.authCallback = { tokenParams, completion in
-                        completion(currentTokenRequest!, nil)
-                    }
-
-                    rest = ARTRest(options: options)
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                XCTFail("TokenDetails is nil"); done(); return
-                            }
-                            expect(tokenDetails).to(beAnInstanceOf(ARTTokenDetails.self))
-                            expect(tokenDetails.token).toNot(beEmpty())
-                            expect(tokenDetails.expires!.timeIntervalSinceNow).to(beGreaterThan(tokenDetails.issued!.timeIntervalSinceNow))
-                            done()
-                        }
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(tokenParams, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    XCTFail("TokenDetails is nil"); done(); return
                 }
+                expect(tokenDetails).to(beAnInstanceOf(ARTTokenDetails.self))
+                expect(tokenDetails.token).toNot(beEmpty())
+                expect(tokenDetails.clientId).to(equal(ExpectedTokenParams.clientId))
+                expect(tokenDetails.issued!.addingTimeInterval(ExpectedTokenParams.ttl)).to(beCloseTo(tokenDetails.expires!))
+                expect(tokenDetails.capability).to(equal(ExpectedTokenParams.capability))
+                done()
+            }
+        }
+    }
 
-                func test__106__authorize__should_adhere_to_all_requirements_relating_to__authUrl() {
-                    let options = ARTClientOptions()
-                    options.authUrl = URL(string: "http://echo.ably.io")!
+    func test__105__authorize__should_adhere_to_all_requirements_relating_to__authCallback() {
+        var currentTokenRequest: ARTTokenRequest?
 
-                    let rest = ARTRest(options: options)
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            guard let error = error as? ARTErrorInfo else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.statusCode).to(equal(400)) //Bad request
-                            expect(tokenDetails).to(beNil())
-                            done()
-                        }
-                    }
+        var rest = ARTRest(options: AblyTests.commonAppSetup())
+        rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, _ in
+            currentTokenRequest = tokenRequest
+        })
+        expect(currentTokenRequest).toEventuallyNot(beNil(), timeout: testTimeout)
+
+        if currentTokenRequest == nil {
+            return
+        }
+
+        let options = AblyTests.clientOptions()
+        options.authCallback = { _, completion in
+            completion(currentTokenRequest!, nil)
+        }
+
+        rest = ARTRest(options: options)
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    XCTFail("TokenDetails is nil"); done(); return
                 }
+                expect(tokenDetails).to(beAnInstanceOf(ARTTokenDetails.self))
+                expect(tokenDetails.token).toNot(beEmpty())
+                expect(tokenDetails.expires!.timeIntervalSinceNow).to(beGreaterThan(tokenDetails.issued!.timeIntervalSinceNow))
+                done()
+            }
+        }
+    }
 
-                func test__107__authorize__should_adhere_to_all_requirements_relating_to__authUrl_with_json() {
-                    guard let tokenDetails = getTestTokenDetails() else {
-                        XCTFail("TokenDetails is empty")
-                        return
-                    }
+    func test__106__authorize__should_adhere_to_all_requirements_relating_to__authUrl() {
+        let options = ARTClientOptions()
+        options.authUrl = URL(string: "http://echo.ably.io")!
 
-                    let encoder = ARTJsonLikeEncoder()
-                    encoder.delegate = ARTJsonEncoder()
-                    guard let tokenDetailsJSON = String(data: try! encoder.encode(tokenDetails), encoding: .utf8) else {
-                        XCTFail("JSON TokenDetails is empty")
-                        return
-                    }
-
-                    let options = ARTClientOptions()
-                    // Use authUrl for authentication with JSON TokenDetails response
-                    options.authUrl = URL(string: "http://echo.ably.io")!
-                    options.authParams = [URLQueryItem]()
-                    options.authParams?.append(URLQueryItem(name: "type", value: "json"))
-                    options.authParams?.append(URLQueryItem(name: "body", value: "[]"))
-                    var rest = ARTRest(options: options)
-
-                    // Invalid TokenDetails
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect((error as! ARTErrorInfo).code).to(equal(Int(ARTState.authUrlIncompatibleContent.rawValue)))
-                            expect(tokenDetails).to(beNil())
-                            done()
-                        }
-                    }
-
-                    options.authParams?.removeLast()
-                    options.authParams?.append(URLQueryItem(name: "body", value: tokenDetailsJSON))
-                    rest = ARTRest(options: options)
-
-                    // Valid token
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails).toNot(beNil())
-                            done()
-                        }
-                    }
+        let rest = ARTRest(options: options)
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                guard let error = error as? ARTErrorInfo else {
+                    fail("Error is nil"); done(); return
                 }
+                expect(error.statusCode).to(equal(400)) // Bad request
+                expect(tokenDetails).to(beNil())
+                done()
+            }
+        }
+    }
 
-                // https://github.com/ably/ably-cocoa/issues/618
-                func test__108__authorize__should_adhere_to_all_requirements_relating_to__authUrl_returning_TokenRequest_decodes_TTL_as_expected() {
-                    let options = AblyTests.commonAppSetup()
+    func test__107__authorize__should_adhere_to_all_requirements_relating_to__authUrl_with_json() {
+        guard let tokenDetails = getTestTokenDetails() else {
+            XCTFail("TokenDetails is empty")
+            return
+        }
 
-                    var rest = ARTRest(options: options)
-                    var tokenRequest: ARTTokenRequest!
-                    waitUntil(timeout: testTimeout) { done in
-                        let params = ARTTokenParams(clientId: "myClientId", nonce: "12345")
-                        expect(params.ttl).to(beNil())
-                        rest.auth.createTokenRequest(params, options: nil) { req, _ in
-                            expect(req!.ttl).to(beNil())
-                            tokenRequest = req!
-                            done()
-                        }
-                    }
+        let encoder = ARTJsonLikeEncoder()
+        encoder.delegate = ARTJsonEncoder()
+        guard let tokenDetailsJSON = String(data: try! encoder.encode(tokenDetails), encoding: .utf8) else {
+            XCTFail("JSON TokenDetails is empty")
+            return
+        }
 
-                    let encoder = ARTJsonLikeEncoder()
-                    encoder.delegate = ARTJsonEncoder()
-                    let encodedTokenRequest: Data
-                    do {
-                        encodedTokenRequest = try encoder.encode(tokenRequest)
-                    }
-                    catch {
-                        fail("Encode failure: \(error)")
-                        return
-                    }
-                    guard let tokenRequestJSON = String(data: encodedTokenRequest, encoding: .utf8) else {
-                        XCTFail("JSON Token Request is empty")
-                        return
-                    }
+        let options = ARTClientOptions()
+        // Use authUrl for authentication with JSON TokenDetails response
+        options.authUrl = URL(string: "http://echo.ably.io")!
+        options.authParams = [URLQueryItem]()
+        options.authParams?.append(URLQueryItem(name: "type", value: "json"))
+        options.authParams?.append(URLQueryItem(name: "body", value: "[]"))
+        var rest = ARTRest(options: options)
 
-                    options.authUrl = URL(string: "http://echo.ably.io")!
-                    options.authParams = [URLQueryItem]()
-                    options.authParams?.append(URLQueryItem(name: "type", value: "json"))
-                    options.authParams?.append(URLQueryItem(name: "body", value: tokenRequestJSON))
-                    options.key = nil
-                    rest = ARTRest(options: options)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails).toNot(beNil())
-                            expect(tokenDetails?.clientId).to(equal("myClientId"))
-                            done()
-                        }
-                    }
+        // Invalid TokenDetails
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
                 }
+                expect((error as! ARTErrorInfo).code).to(equal(Int(ARTState.authUrlIncompatibleContent.rawValue)))
+                expect(tokenDetails).to(beNil())
+                done()
+            }
+        }
 
-                func test__109__authorize__should_adhere_to_all_requirements_relating_to__authUrl_with_plain_text() {
-                    let token = getTestToken()
-                    let options = ARTClientOptions()
-                    // Use authUrl for authentication with plain text token response
-                    options.authUrl = URL(string: "http://echo.ably.io")!
-                    options.authParams = [URLQueryItem]()
-                    options.authParams?.append(URLQueryItem(name: "type", value: "text"))
-                    options.authParams?.append(URLQueryItem(name: "body", value: ""))
-                    var rest = ARTRest(options: options)
+        options.authParams?.removeLast()
+        options.authParams?.append(URLQueryItem(name: "body", value: tokenDetailsJSON))
+        rest = ARTRest(options: options)
 
-                    // Invalid token
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).toNot(beNil())
-                            expect(tokenDetails).to(beNil())
-                            done()
-                        }
-                    }
+        // Valid token
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+                done()
+            }
+        }
+    }
 
-                    options.authParams?.removeLast()
-                    options.authParams?.append(URLQueryItem(name: "body", value: token))
-                    rest = ARTRest(options: options)
+    // https://github.com/ably/ably-cocoa/issues/618
+    func test__108__authorize__should_adhere_to_all_requirements_relating_to__authUrl_returning_TokenRequest_decodes_TTL_as_expected() {
+        let options = AblyTests.commonAppSetup()
 
-                    // Valid token
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails).toNot(beNil())
-                            done()
-                        }
-                    }
+        var rest = ARTRest(options: options)
+        var tokenRequest: ARTTokenRequest!
+        waitUntil(timeout: testTimeout) { done in
+            let params = ARTTokenParams(clientId: "myClientId", nonce: "12345")
+            expect(params.ttl).to(beNil())
+            rest.auth.createTokenRequest(params, options: nil) { req, _ in
+                expect(req!.ttl).to(beNil())
+                tokenRequest = req!
+                done()
+            }
+        }
+
+        let encoder = ARTJsonLikeEncoder()
+        encoder.delegate = ARTJsonEncoder()
+        let encodedTokenRequest: Data
+        do {
+            encodedTokenRequest = try encoder.encode(tokenRequest)
+        } catch {
+            fail("Encode failure: \(error)")
+            return
+        }
+        guard let tokenRequestJSON = String(data: encodedTokenRequest, encoding: .utf8) else {
+            XCTFail("JSON Token Request is empty")
+            return
+        }
+
+        options.authUrl = URL(string: "http://echo.ably.io")!
+        options.authParams = [URLQueryItem]()
+        options.authParams?.append(URLQueryItem(name: "type", value: "json"))
+        options.authParams?.append(URLQueryItem(name: "body", value: tokenRequestJSON))
+        options.key = nil
+        rest = ARTRest(options: options)
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+                expect(tokenDetails?.clientId).to(equal("myClientId"))
+                done()
+            }
+        }
+    }
+
+    func test__109__authorize__should_adhere_to_all_requirements_relating_to__authUrl_with_plain_text() {
+        let token = getTestToken()
+        let options = ARTClientOptions()
+        // Use authUrl for authentication with plain text token response
+        options.authUrl = URL(string: "http://echo.ably.io")!
+        options.authParams = [URLQueryItem]()
+        options.authParams?.append(URLQueryItem(name: "type", value: "text"))
+        options.authParams?.append(URLQueryItem(name: "body", value: ""))
+        var rest = ARTRest(options: options)
+
+        // Invalid token
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).toNot(beNil())
+                expect(tokenDetails).to(beNil())
+                done()
+            }
+        }
+
+        options.authParams?.removeLast()
+        options.authParams?.append(URLQueryItem(name: "body", value: token))
+        rest = ARTRest(options: options)
+
+        // Valid token
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+                done()
+            }
+        }
+    }
+
+    // RSA10j
+
+    func test__110__authorize__when_TokenParams_and_AuthOptions_are_provided__should_supersede_configured_AuthOptions__using_key__even_if_arguments_objects_are_empty() {
+        let defaultOptions = AblyTests.clientOptions() // sandbox
+        defaultOptions.key = "xxxx:xxxx"
+        let rest = ARTRest(options: defaultOptions)
+
+        let authOptions = ARTAuthOptions()
+        authOptions.key = AblyTests.commonAppSetup().key // valid key
+        let tokenParams = ARTTokenParams()
+        tokenParams.ttl = 1.0
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(tokenParams, options: authOptions) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let issued = tokenDetails?.issued else {
+                    fail("TokenDetails.issued is nil"); done(); return
                 }
-
-            // RSA10j
-            
-
-                func test__110__authorize__when_TokenParams_and_AuthOptions_are_provided__should_supersede_configured_AuthOptions__using_key__even_if_arguments_objects_are_empty() {
-                    let defaultOptions = AblyTests.clientOptions() //sandbox
-                    defaultOptions.key = "xxxx:xxxx"
-                    let rest = ARTRest(options: defaultOptions)
-
-                    let authOptions = ARTAuthOptions()
-                    authOptions.key = AblyTests.commonAppSetup().key //valid key
-                    let tokenParams = ARTTokenParams()
-                    tokenParams.ttl = 1.0
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(tokenParams, options: authOptions) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let issued = tokenDetails?.issued else {
-                                fail("TokenDetails.issued is nil"); done(); return
-                            }
-                            guard let expires = tokenDetails?.expires else {
-                                fail("TokenDetails.expires is nil"); done(); return
-                            }
-                            expect(issued).to(beCloseTo(expires, within: tokenParams.ttl as! TimeInterval + 0.1))
-                            delay(tokenParams.ttl as! TimeInterval + 0.1) {
-                                done()
-                            }
-                        }
-                    }
-
-                    authOptions.key = nil
-                    // First time
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: authOptions) { _, error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.localizedDescription).to(contain("no means to renew the token"))
-                            done()
-                        }
-                    }
-
-                    // Second time
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { _, error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.localizedDescription).to(contain("no means to renew the token"))
-                            done()
-                        }
-                    }
+                guard let expires = tokenDetails?.expires else {
+                    fail("TokenDetails.expires is nil"); done(); return
                 }
-
-                func test__111__authorize__when_TokenParams_and_AuthOptions_are_provided__should_supersede_configured_AuthOptions__using_authUrl__even_if_arguments_objects_are_empty() {
-                    let rest = ARTRest(options: AblyTests.commonAppSetup())
-
-                    let testTokenDetails = getTestTokenDetails(ttl: 0.1)
-                    let encoder = ARTJsonLikeEncoder()
-                    encoder.delegate = ARTJsonEncoder()
-                    guard let currentTokenDetails = testTokenDetails, let jsonTokenDetails = try? encoder.encode(currentTokenDetails) else {
-                        fail("Invalid TokenDetails")
-                        return
-                    }
-
-                    let authOptions = ARTAuthOptions()
-                    authOptions.authUrl = URL(string: "http://echo.ably.io")!
-                    authOptions.authParams = [URLQueryItem]()
-                    authOptions.authParams?.append(URLQueryItem(name: "type", value: "json"))
-                    authOptions.authParams?.append(URLQueryItem(name: "body", value: jsonTokenDetails.toUTF8String))
-                    authOptions.authHeaders = ["X-Ably":"Test"]
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: authOptions) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                XCTFail("TokenDetails is nil"); done(); return
-                            }
-                            expect(tokenDetails.token).to(equal(currentTokenDetails.token))
-                            expect(rest.auth.internal.options.authUrl).toNot(beNil())
-                            expect(rest.auth.internal.options.authParams).toNot(beNil())
-                            expect(rest.auth.internal.options.authHeaders).toNot(beNil())
-                            delay(0.1) { //force to use the authUrl again
-                                done()
-                            }
-                        }
-                    }
-
-                    authOptions.authParams = nil
-                    authOptions.authHeaders = nil
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: authOptions) { tokenDetails, error in
-                            guard let error = error as? ARTErrorInfo else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.statusCode).to(equal(400))
-                            expect(tokenDetails).to(beNil())
-                            expect(rest.auth.internal.options.authParams).to(beNil())
-                            expect(rest.auth.internal.options.authHeaders).to(beNil())
-                            done()
-                        }
-                    }
-
-                    // Repeat
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            guard let error = error as? ARTErrorInfo else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.statusCode).to(equal(400))
-                            expect(tokenDetails).to(beNil())
-                            expect(rest.auth.internal.options.authParams).to(beNil())
-                            expect(rest.auth.internal.options.authHeaders).to(beNil())
-                            done()
-                        }
-                    }
-
-                    authOptions.authUrl = nil
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: authOptions) { tokenDetails, error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(UInt((error as! ARTErrorInfo).code)).to(equal(ARTState.requestTokenFailed.rawValue))
-                            expect(tokenDetails).to(beNil())
-                            expect(rest.auth.internal.options.authUrl).to(beNil())
-                            expect(rest.auth.internal.options.authParams).to(beNil())
-                            expect(rest.auth.internal.options.authHeaders).to(beNil())
-                            done()
-                        }
-                    }
-
-                    // Repeat
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(UInt((error as! ARTErrorInfo).code)).to(equal(ARTState.requestTokenFailed.rawValue))
-                            expect(tokenDetails).to(beNil())
-                            expect(rest.auth.internal.options.authUrl).to(beNil())
-                            expect(rest.auth.internal.options.authParams).to(beNil())
-                            expect(rest.auth.internal.options.authHeaders).to(beNil())
-                            done()
-                        }
-                    }
-                }
-
-                func test__112__authorize__when_TokenParams_and_AuthOptions_are_provided__should_supersede_configured_AuthOptions__using_authCallback__even_if_arguments_objects_are_empty() {
-                    let rest = ARTRest(options: AblyTests.commonAppSetup())
-
-                    let testTokenDetails = ARTTokenDetails(token: "token", expires: Date(), issued: Date(), capability: nil, clientId: nil)
-                    var authCallbackHasBeenInvoked = false
-                    let authOptions = ARTAuthOptions()
-                    authOptions.authCallback = { tokenParams, completion in
-                        authCallbackHasBeenInvoked = true
-                        completion(testTokenDetails, nil)
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: authOptions) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails?.token).to(equal("token"))
-                            expect(authCallbackHasBeenInvoked).to(beTrue())
-                            expect(rest.auth.internal.options.authCallback).toNot(beNil())
-                            done()
-                        }
-                    }
-                    authCallbackHasBeenInvoked = false
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails?.token).to(equal("token"))
-                            expect(authCallbackHasBeenInvoked).to(beTrue())
-                            expect(rest.auth.internal.options.authCallback).toNot(beNil())
-                            done()
-                        }
-                    }
-                    authCallbackHasBeenInvoked = false
-
-                    authOptions.authCallback = nil
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: authOptions) { tokenDetails, error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(UInt((error as! ARTErrorInfo).code)).to(equal(ARTState.requestTokenFailed.rawValue))
-                            expect(tokenDetails).to(beNil())
-                            expect(authCallbackHasBeenInvoked).to(beFalse())
-                            expect(rest.auth.internal.options.authCallback).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(UInt((error as! ARTErrorInfo).code)).to(equal(ARTState.requestTokenFailed.rawValue))
-                            expect(tokenDetails).to(beNil())
-                            expect(authCallbackHasBeenInvoked).to(beFalse())
-                            expect(rest.auth.internal.options.authCallback).to(beNil())
-                            done()
-                        }
-                    }
-                }
-
-                func test__113__authorize__when_TokenParams_and_AuthOptions_are_provided__should_supersede_configured_params_and_options_even_if_arguments_objects_are_empty() {
-                    let options = AblyTests.clientOptions()
-                    options.key = "xxxx:xxxx"
-                    options.clientId = "client_string"
-                    let rest = ARTRest(options: options)
-
-                    let tokenParams = ARTTokenParams(clientId: options.clientId)
-
-                    // Defaults
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect((error as! ARTErrorInfo).code).to(equal(ARTErrorCode.notFound.intValue))
-                            expect(tokenDetails).to(beNil())
-                            done()
-                        }
-                    }
-
-                    // Custom
-                    tokenParams.ttl = ExpectedTokenParams.ttl as NSNumber
-                    tokenParams.capability = ExpectedTokenParams.capability
-                    tokenParams.clientId = nil
-
-                    let authOptions = ARTAuthOptions()
-                    authOptions.key = AblyTests.commonAppSetup().key
-                    authOptions.queryTime = true
-
-                    var serverTimeRequestCount = 0
-                    let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
-                        serverTimeRequestCount += 1
-                    }
-                    defer { hook.remove() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(tokenParams, options: authOptions) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                XCTFail("TokenDetails is nil"); done(); return
-                            }
-                            expect(tokenDetails.clientId).to(beNil())
-                            expect(tokenDetails.issued!.addingTimeInterval(ExpectedTokenParams.ttl)).to(beCloseTo(tokenDetails.expires!))
-                            expect(tokenDetails.capability).to(equal(ExpectedTokenParams.capability))
-                            expect(serverTimeRequestCount) == 1
-                            done()
-                        }
-                    }
-
-                    rest.auth.internal.testSuite_forceTokenToExpire()
-
-                    // Subsequent authorisations
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                fail("TokenDetails is nil"); done(); return
-                            }
-                            expect(tokenDetails.clientId).to(beNil())
-                            expect(tokenDetails.issued!.addingTimeInterval(ExpectedTokenParams.ttl)).to(beCloseTo(tokenDetails.expires!))
-                            expect(tokenDetails.capability).to(equal(ExpectedTokenParams.capability))
-                            expect(serverTimeRequestCount) == 1
-                            done()
-                        }
-                    }
-                }
-
-                func test__114__authorize__when_TokenParams_and_AuthOptions_are_provided__example__if_a_client_is_initialised_with_TokenParams_ttl_configured_with_a_custom_value__and_a_TokenParams_object_is_passed_in_as_an_argument_to__authorize_with_a_null_value_for_ttl__then_the_ttl_used_for_every_subsequent_authorization_will_be_null() {
-                    let options = AblyTests.commonAppSetup()
-                    options.defaultTokenParams = {
-                        $0.ttl = 0.1;
-                        $0.clientId = "tester";
-                        return $0
-                    }(ARTTokenParams())
-
-                    let rest = ARTRest(options: options)
-
-                    let testTokenParams = ARTTokenParams()
-                    testTokenParams.ttl = nil
-                    testTokenParams.clientId = nil
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(testTokenParams, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                fail("TokenDetails is nil"); done(); return
-                            }
-                            guard let issued = tokenDetails.issued else {
-                                fail("TokenDetails.issued is nil"); done(); return
-                            }
-                            guard let expires = tokenDetails.expires else {
-                                fail("TokenDetails.expires is nil"); done(); return
-                            }
-                            expect(tokenDetails.clientId).to(beNil())
-                            // `ttl` when omitted, the default value is applied
-                            expect(issued.addingTimeInterval(ARTDefault.ttl())).to(equal(expires))
-                            done()
-                        }
-                    }
-
-                    // Subsequent authorization
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                fail("TokenDetails is nil"); done(); return
-                            }
-                            guard let issued = tokenDetails.issued else {
-                                fail("TokenDetails.issued is nil"); done(); return
-                            }
-                            guard let expires = tokenDetails.expires else {
-                                fail("TokenDetails.expires is nil"); done(); return
-                            }
-                            expect(tokenDetails.clientId).to(beNil())
-                            expect(issued.addingTimeInterval(ARTDefault.ttl())).to(equal(expires))
-                            done()
-                        }
-                    }
-                }
-            
-            // RSA10k
-            
-
-                func skipped__test__115__authorize__server_time_offset__should_obtain_server_time_once_and_persist_the_offset_from_the_local_clock() {
-                    let options = AblyTests.commonAppSetup()
-                    let rest = ARTRest(options: options)
-
-                    let mockServerDate = Date().addingTimeInterval(120)
-                    rest.auth.internal.testSuite_returnValue(for: NSSelectorFromString("handleServerTime:"), with: mockServerDate)
-                    let currentDate = Date()
-
-                    var serverTimeRequestCount = 0
-                    let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
-                        serverTimeRequestCount += 1
-                    }
-                    defer { hook.remove() }
-
-                    let authOptions = ARTAuthOptions()
-                    authOptions.key = options.key
-                    authOptions.queryTime = true
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: authOptions, callback: { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard tokenDetails != nil else {
-                                fail("TokenDetails is nil"); done(); return
-                            }
-                            guard let timeOffset = rest.auth.internal.timeOffset?.doubleValue else {
-                                fail("Server Time Offset is nil"); done(); return
-                            }
-                            expect(timeOffset).toNot(equal(0))
-                            expect(rest.auth.internal.timeOffset).toNot(beNil())
-                            let calculatedServerDate = currentDate.addingTimeInterval(timeOffset)
-                            expect(calculatedServerDate).to(beCloseTo(mockServerDate, within: 0.9))
-                            expect(serverTimeRequestCount) == 1
-                            done()
-                        })
-                    }
-
-                    rest.auth.internal.testSuite_forceTokenToExpire()
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard tokenDetails != nil else {
-                                fail("TokenDetails is nil"); done(); return
-                            }
-                            guard let timeOffset = rest.auth.internal.timeOffset?.doubleValue else {
-                                fail("Server Time Offset is nil"); done(); return
-                            }
-                            expect(timeOffset).toNot(equal(0))
-                            let calculatedServerDate = currentDate.addingTimeInterval(timeOffset)
-                            expect(calculatedServerDate).to(beCloseTo(mockServerDate, within: 0.9))
-                            expect(serverTimeRequestCount) == 1
-                            done()
-                        }
-                    }
-                }
-
-                func test__116__authorize__server_time_offset__should_be_consistent_the_timestamp_request_with_the_server_time() {
-                    let options = AblyTests.commonAppSetup()
-                    let rest = ARTRest(options: options)
-
-                    let mockServerDate = Date().addingTimeInterval(120)
-                    rest.auth.internal.testSuite_returnValue(for: NSSelectorFromString("handleServerTime:"), with: mockServerDate)
-
-                    var serverTimeRequestCount = 0
-                    let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
-                        serverTimeRequestCount += 1
-                    }
-                    defer { hook.remove() }
-
-                    let authOptions = ARTAuthOptions()
-                    authOptions.key = options.key
-                    authOptions.queryTime = true
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.createTokenRequest(nil, options: authOptions) { tokenRequest, error in
-                            expect(error).to(beNil())
-                            guard let tokenRequest = tokenRequest else {
-                                fail("TokenRequest is nil"); done(); return
-                            }
-                            guard let timeOffset = rest.auth.internal.timeOffset?.doubleValue else {
-                                fail("Server Time Offset is nil"); done(); return
-                            }
-                            expect(timeOffset).toNot(equal(0))
-                            expect(mockServerDate.timeIntervalSinceNow).to(beCloseTo(timeOffset, within: 0.1))
-                            expect(tokenRequest.timestamp).to(beCloseTo(mockServerDate))
-                            expect(serverTimeRequestCount) == 1
-                            done()
-                        }
-                    }
-                }
-
-                func test__117__authorize__server_time_offset__should_be_possible_by_lib_Client_to_discard_the_cached_local_clock_offset() {
-                    let options = AblyTests.commonAppSetup()
-                    options.queryTime = true
-                    let rest = ARTRest(options: options)
-
-                    var serverTimeRequestCount = 0
-                    let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
-                        serverTimeRequestCount += 1
-                    }
-                    defer { hook.remove() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                fail("TokenDetails is nil"); done(); return
-                            }
-                            guard let timeOffset = rest.auth.internal.timeOffset?.doubleValue else {
-                                fail("Server Time Offset is nil"); done(); return
-                            }
-                            expect(timeOffset).toNot(beCloseTo(0))
-                            let calculatedServerDate = Date().addingTimeInterval(timeOffset)
-                            expect(tokenDetails.expires).to(beCloseTo(calculatedServerDate.addingTimeInterval(ARTDefault.ttl()), within: 1.0))
-                            expect(serverTimeRequestCount) == 1
-                            done()
-                        }
-                    }
-
-                    #if TARGET_OS_IPHONE
-                    NotificationCenter.default.post(name: UIApplication.significantTimeChangeNotification, object: nil)
-                    #else
-                    NotificationCenter.default.post(name: .NSSystemClockDidChange, object: nil)
-                    #endif
-
-                    rest.auth.internal.testSuite_forceTokenToExpire()
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard tokenDetails != nil else {
-                                fail("TokenDetails is nil"); done(); return
-                            }
-                            expect(rest.auth.internal.timeOffset).to(beNil())
-                            expect(serverTimeRequestCount) == 1
-                            done()
-                        }
-                    }
-                }
-
-                func test__118__authorize__server_time_offset__should_use_the_local_clock_offset_to_calculate_the_server_time() {
-                    let options = AblyTests.commonAppSetup()
-                    let rest = ARTRest(options: options)
-
-                    let authOptions = ARTAuthOptions()
-                    authOptions.key = options.key
-                    authOptions.queryTime = false
-
-                    let fakeOffset: TimeInterval = 60 //1 minute
-                    rest.auth.internal.setTimeOffset(fakeOffset)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.createTokenRequest(nil, options: authOptions) { tokenRequest, error in
-                            expect(error).to(beNil())
-                            guard let tokenRequest = tokenRequest else {
-                                fail("TokenRequest is nil"); done(); return
-                            }
-                            guard let timeOffset = rest.auth.internal.timeOffset?.doubleValue else {
-                                fail("Server Time Offset is nil"); done(); return
-                            }
-                            expect(timeOffset) == fakeOffset
-                            let calculatedServerDate = Date().addingTimeInterval(timeOffset)
-                            expect(tokenRequest.timestamp).to(beCloseTo(calculatedServerDate, within: 0.5))
-                            done()
-                        }
-                    }
-                }
-
-                func test__119__authorize__server_time_offset__should_request_server_time_when_queryTime_is_true_even_if_the_time_offset_is_assigned() {
-                    let options = AblyTests.commonAppSetup()
-                    let rest = ARTRest(options: options)
-
-                    var serverTimeRequestCount = 0
-                    let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time)) {
-                        serverTimeRequestCount += 1
-                    }
-                    defer { hook.remove() }
-
-                    let fakeOffset: TimeInterval = 60 //1 minute
-                    rest.auth.internal.setTimeOffset(fakeOffset)
-
-                    let authOptions = ARTAuthOptions()
-                    authOptions.key = options.key
-                    authOptions.queryTime = true
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.auth.authorize(nil, options: authOptions) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails).toNot(beNil())
-                            expect(serverTimeRequestCount) == 1
-                            guard let timeOffset = rest.auth.internal.timeOffset?.doubleValue else {
-                                fail("Server Time Offset is nil"); done(); return
-                            }
-                            expect(timeOffset).toNot(equal(fakeOffset))
-                            done()
-                        }
-                    }
-                }
-
-                func test__120__authorize__server_time_offset__should_discard_the_time_offset_in_situations_in_which_it_may_have_been_invalidated() {
-                    let rest = ARTRest(options: AblyTests.commonAppSetup())
-
-                    var discardTimeOffsetCallCount = 0
-                    let hook = rest.auth.internal.testSuite_injectIntoMethod(after: #selector(rest.auth.internal.discardTimeOffset)) {
-                        discardTimeOffsetCallCount += 1
-                    }
-                    defer { hook.remove() }
-
-                    #if TARGET_OS_IPHONE
-                    // Force notification
-                    NotificationCenter.default.post(name: UIApplication.significantTimeChangeNotification, object: nil)
-
-                    expect(discardTimeOffsetCallCount).toEventually(equal(1), timeout: testTimeout)
-
-                    // Force notification
-                    NotificationCenter.default.post(name: NSLocale.currentLocaleDidChangeNotification, object: nil)
-                    #else
-                    // Force notification
-                    NotificationCenter.default.post(name: NSNotification.Name.NSSystemClockDidChange, object: nil)
-
-                    expect(discardTimeOffsetCallCount).toEventually(equal(1), timeout: testTimeout)
-
-                    // Force notification
-                    NotificationCenter.default.post(name: NSLocale.currentLocaleDidChangeNotification, object: nil)
-                    #endif
-
-                    expect(discardTimeOffsetCallCount).toEventually(equal(2), timeout: testTimeout)
-                }
-
-            
-                func test__121__authorize__two_consecutive_authorizations__using_REST__should_call_each_authorize_callback() {
-                    let options = AblyTests.commonAppSetup()
-                    options.useTokenAuth = true
-                    let rest = ARTRest(options: options)
-
-                    var tokenDetailsFirst: ARTTokenDetails?
-                    var tokenDetailsLast: ARTTokenDetails?
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        rest.auth.authorize { tokenDetails, error in
-                            if let error = error {
-                                fail(error.localizedDescription); partialDone(); return
-                            }
-                            expect(tokenDetails).toNot(beNil())
-                            if tokenDetailsFirst == nil {
-                                tokenDetailsFirst = tokenDetails
-                            }
-                            else {
-                                tokenDetailsLast = tokenDetails
-                            }
-                            partialDone()
-                        }
-                        rest.auth.authorize { tokenDetails, error in
-                            if let error = error {
-                                fail(error.localizedDescription); partialDone(); return
-                            }
-                            expect(tokenDetails).toNot(beNil())
-                            if tokenDetailsFirst == nil {
-                                tokenDetailsFirst = tokenDetails
-                            }
-                            else {
-                                tokenDetailsLast = tokenDetails
-                            }
-                            partialDone()
-                        }
-                    }
-
-                    expect(tokenDetailsFirst?.token).toNot(equal(tokenDetailsLast?.token))
-                    expect(rest.auth.tokenDetails).to(beIdenticalTo(tokenDetailsLast))
-                    expect(rest.auth.tokenDetails?.token).to(equal(tokenDetailsLast?.token))
-                }
-                func test__122__authorize__two_consecutive_authorizations__using_Realtime_and_connection_is_CONNECTING__should_call_each_Realtime_authorize_callback() {
-                    let options = AblyTests.commonAppSetup()
-                    options.useTokenAuth = true
-                    let realtime = AblyTests.newRealtime(options)
-                    defer { realtime.close(); realtime.dispose() }
-
-                    var connectedStateCount = 0
-                    realtime.connection.on(.connected) { _ in
-                        connectedStateCount += 1
-                    }
-
-                    var tokenDetailsLast: ARTTokenDetails?
-                    var didCancelAuthorization = false
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        let callback: (ARTTokenDetails?, Error?) -> Void = { tokenDetails, error in
-                            if let error = error {
-                                if (error as NSError).code == URLError.cancelled.rawValue {
-                                    expect(tokenDetails).to(beNil())
-                                    didCancelAuthorization = true
-                                }
-                                else {
-                                    fail(error.localizedDescription); partialDone(); return
-                                }
-                            }
-                            else {
-                                expect(tokenDetails).toNot(beNil())
-                                tokenDetailsLast = tokenDetails
-                            }
-                            partialDone()
-                        }
-                        // One of them will be canceled by the connection:
-                        realtime.auth.authorize(callback)
-                        realtime.auth.authorize(callback)
-                    }
-
-                    expect(didCancelAuthorization).to(be(true))
-                    expect(realtime.auth.tokenDetails).to(beIdenticalTo(tokenDetailsLast))
-                    expect(realtime.auth.tokenDetails?.token).to(equal(tokenDetailsLast?.token))
-
-                    if let transport = realtime.internal.transport as? TestProxyTransport, let query = transport.lastUrl?.query {
-                        expect(query).to(haveParam("accessToken", withValue: realtime.auth.tokenDetails?.token ?? ""))
-                    }
-                    else {
-                        fail("MockTransport is not working")
-                    }
-
-                    expect(connectedStateCount) == 1
-                }
-                func test__123__authorize__two_consecutive_authorizations__using_Realtime_and_connection_is_CONNECTED__should_call_each_Realtime_authorize_callback() {
-                    let options = AblyTests.commonAppSetup()
-                    options.useTokenAuth = true
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.close(); realtime.dispose() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.connection.once(.connected) { state in
-                            done()
-                        }
-                    }
-
-                    var tokenDetailsFirst: ARTTokenDetails?
-                    var tokenDetailsLast: ARTTokenDetails?
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        realtime.auth.authorize { tokenDetails, error in
-                            if let error = error {
-                                fail(error.localizedDescription); partialDone(); return
-                            }
-                            expect(tokenDetails).toNot(beNil())
-                            if tokenDetailsFirst == nil {
-                                tokenDetailsFirst = tokenDetails
-                            }
-                            else {
-                                tokenDetailsLast = tokenDetails
-                            }
-                            partialDone()
-                        }
-                        realtime.auth.authorize { tokenDetails, error in
-                            if let error = error {
-                                fail(error.localizedDescription); partialDone(); return
-                            }
-                            expect(tokenDetails).toNot(beNil())
-                            if tokenDetailsFirst == nil {
-                                tokenDetailsFirst = tokenDetails
-                            }
-                            else {
-                                tokenDetailsLast = tokenDetails
-                            }
-                            partialDone()
-                        }
-                    }
-
-                    expect(tokenDetailsFirst?.token).toNot(equal(tokenDetailsLast?.token))
-                    expect(realtime.auth.tokenDetails).to(beIdenticalTo(tokenDetailsLast))
-                    expect(realtime.auth.tokenDetails?.token).to(equal(tokenDetailsLast?.token))
-                }
-
-        
-            
-                func test__124__TokenParams__timestamp__if_explicitly_set__should_be_returned_by_the_getter() {
-                    let params = ARTTokenParams()
-                    params.timestamp = Date(timeIntervalSince1970: 123)
-                    expect(params.timestamp).to(equal(Date(timeIntervalSince1970: 123)))
-                }
-
-                func test__125__TokenParams__timestamp__if_explicitly_set__the_value_should_stick() {
-                    let params = ARTTokenParams()
-                    params.timestamp = Date()
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let now = Double(NSDate().artToIntegerMs())
-                        guard let timestamp = params.timestamp else {
-                            fail("timestamp is nil"); done(); return
-                        }
-                        let firstParamsTimestamp = Double((timestamp as NSDate).artToIntegerMs())
-                        expect(firstParamsTimestamp).to(beCloseTo(now, within: 2.5))
-                        delay(0.25) {
-                            expect(Double((timestamp as NSDate).artToIntegerMs())).to(equal(firstParamsTimestamp))
-                            done()
-                        }
-                    }
-                }
-
-                // https://github.com/ably/ably-cocoa/pull/508#discussion_r82577728
-                func test__126__TokenParams__timestamp__object_has_no_timestamp_value_unless_explicitly_set() {
-                    let params = ARTTokenParams()
-                    expect(params.timestamp).to(beNil())
-                }
-
-        
-
-            // RTC8
-            func test__127__Reauth__should_use_authorize__force__true___to_reauth_with_a_token_with_a_different_set_of_capabilities() {
-                let options = AblyTests.commonAppSetup()
-                let initialToken = getTestToken(clientId: "tester", capability: "{\"restricted\":[\"*\"]}")
-                options.token = initialToken
-                let realtime = ARTRealtime(options: options)
-                defer { realtime.dispose(); realtime.close() }
-                let channel = realtime.channels.get("foo")
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.attach { error in
-                        guard let error = error else {
-                            fail("Error is nil"); done(); return
-                        }
-                        expect(error.code) == ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue
-                        done()
-                    }
-                }
-
-                let tokenParams = ARTTokenParams()
-                tokenParams.capability = "{\"\(channel.name)\":[\"*\"]}"
-                tokenParams.clientId = "tester"
-
-                waitUntil(timeout: testTimeout) { done in
-                    realtime.auth.authorize(tokenParams, options: nil) { tokenDetails, error in
-                        expect(error).to(beNil())
-                        expect(tokenDetails).toNot(beNil())
-                        done()
-                    }
-                }
-
-                expect(realtime.auth.tokenDetails?.token).toNot(equal(initialToken))
-                expect(realtime.auth.tokenDetails?.capability).to(equal(tokenParams.capability))
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.attach { error in
-                        expect(error).to(beNil())
-                        done()
-                    }
+                expect(issued).to(beCloseTo(expires, within: tokenParams.ttl as! TimeInterval + 0.1))
+                delay(tokenParams.ttl as! TimeInterval + 0.1) {
+                    done()
                 }
             }
+        }
 
-            // RTC8
-            func test__128__Reauth__for_a_token_change_that_fails_due_to_an_incompatible_token__which_should_result_in_the_connection_entering_the_FAILED_state() {
-                let options = AblyTests.commonAppSetup()
-                options.clientId = "tester"
-                options.useTokenAuth = true
-                let realtime = ARTRealtime(options: options)
-                defer { realtime.dispose(); realtime.close() }
-
-                waitUntil(timeout: testTimeout) { done in
-                    realtime.connection.on(.connected) { stateChange in
-                        expect(stateChange.reason).to(beNil())
-                        done()
-                    }
+        authOptions.key = nil
+        // First time
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: authOptions) { _, error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
                 }
+                expect(error.localizedDescription).to(contain("no means to renew the token"))
+                done()
+            }
+        }
 
-                guard let initialToken = realtime.auth.tokenDetails?.token else {
-                    fail("TokenDetails is nil"); return
+        // Second time
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { _, error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
                 }
+                expect(error.localizedDescription).to(contain("no means to renew the token"))
+                done()
+            }
+        }
+    }
 
-                let tokenParams = ARTTokenParams()
-                tokenParams.capability = "{\"restricted\":[\"*\"]}"
-                tokenParams.clientId = "secret"
+    func test__111__authorize__when_TokenParams_and_AuthOptions_are_provided__should_supersede_configured_AuthOptions__using_authUrl__even_if_arguments_objects_are_empty() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
 
-                waitUntil(timeout: testTimeout) { done in
-                    realtime.auth.authorize(tokenParams, options: nil) { tokenDetails, error in
-                        guard let error = error else {
-                            fail("Error is nil"); done(); return
-                        }
-                        expect((error as! ARTErrorInfo).code) == ARTErrorCode.incompatibleCredentials.intValue
+        let testTokenDetails = getTestTokenDetails(ttl: 0.1)
+        let encoder = ARTJsonLikeEncoder()
+        encoder.delegate = ARTJsonEncoder()
+        guard let currentTokenDetails = testTokenDetails, let jsonTokenDetails = try? encoder.encode(currentTokenDetails) else {
+            fail("Invalid TokenDetails")
+            return
+        }
+
+        let authOptions = ARTAuthOptions()
+        authOptions.authUrl = URL(string: "http://echo.ably.io")!
+        authOptions.authParams = [URLQueryItem]()
+        authOptions.authParams?.append(URLQueryItem(name: "type", value: "json"))
+        authOptions.authParams?.append(URLQueryItem(name: "body", value: jsonTokenDetails.toUTF8String))
+        authOptions.authHeaders = ["X-Ably": "Test"]
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: authOptions) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    XCTFail("TokenDetails is nil"); done(); return
+                }
+                expect(tokenDetails.token).to(equal(currentTokenDetails.token))
+                expect(rest.auth.internal.options.authUrl).toNot(beNil())
+                expect(rest.auth.internal.options.authParams).toNot(beNil())
+                expect(rest.auth.internal.options.authHeaders).toNot(beNil())
+                delay(0.1) { // force to use the authUrl again
+                    done()
+                }
+            }
+        }
+
+        authOptions.authParams = nil
+        authOptions.authHeaders = nil
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: authOptions) { tokenDetails, error in
+                guard let error = error as? ARTErrorInfo else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error.statusCode).to(equal(400))
+                expect(tokenDetails).to(beNil())
+                expect(rest.auth.internal.options.authParams).to(beNil())
+                expect(rest.auth.internal.options.authHeaders).to(beNil())
+                done()
+            }
+        }
+
+        // Repeat
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                guard let error = error as? ARTErrorInfo else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error.statusCode).to(equal(400))
+                expect(tokenDetails).to(beNil())
+                expect(rest.auth.internal.options.authParams).to(beNil())
+                expect(rest.auth.internal.options.authHeaders).to(beNil())
+                done()
+            }
+        }
+
+        authOptions.authUrl = nil
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: authOptions) { tokenDetails, error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(UInt((error as! ARTErrorInfo).code)).to(equal(ARTState.requestTokenFailed.rawValue))
+                expect(tokenDetails).to(beNil())
+                expect(rest.auth.internal.options.authUrl).to(beNil())
+                expect(rest.auth.internal.options.authParams).to(beNil())
+                expect(rest.auth.internal.options.authHeaders).to(beNil())
+                done()
+            }
+        }
+
+        // Repeat
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(UInt((error as! ARTErrorInfo).code)).to(equal(ARTState.requestTokenFailed.rawValue))
+                expect(tokenDetails).to(beNil())
+                expect(rest.auth.internal.options.authUrl).to(beNil())
+                expect(rest.auth.internal.options.authParams).to(beNil())
+                expect(rest.auth.internal.options.authHeaders).to(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__112__authorize__when_TokenParams_and_AuthOptions_are_provided__should_supersede_configured_AuthOptions__using_authCallback__even_if_arguments_objects_are_empty() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+
+        let testTokenDetails = ARTTokenDetails(token: "token", expires: Date(), issued: Date(), capability: nil, clientId: nil)
+        var authCallbackHasBeenInvoked = false
+        let authOptions = ARTAuthOptions()
+        authOptions.authCallback = { _, completion in
+            authCallbackHasBeenInvoked = true
+            completion(testTokenDetails, nil)
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: authOptions) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails?.token).to(equal("token"))
+                expect(authCallbackHasBeenInvoked).to(beTrue())
+                expect(rest.auth.internal.options.authCallback).toNot(beNil())
+                done()
+            }
+        }
+        authCallbackHasBeenInvoked = false
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails?.token).to(equal("token"))
+                expect(authCallbackHasBeenInvoked).to(beTrue())
+                expect(rest.auth.internal.options.authCallback).toNot(beNil())
+                done()
+            }
+        }
+        authCallbackHasBeenInvoked = false
+
+        authOptions.authCallback = nil
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: authOptions) { tokenDetails, error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(UInt((error as! ARTErrorInfo).code)).to(equal(ARTState.requestTokenFailed.rawValue))
+                expect(tokenDetails).to(beNil())
+                expect(authCallbackHasBeenInvoked).to(beFalse())
+                expect(rest.auth.internal.options.authCallback).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(UInt((error as! ARTErrorInfo).code)).to(equal(ARTState.requestTokenFailed.rawValue))
+                expect(tokenDetails).to(beNil())
+                expect(authCallbackHasBeenInvoked).to(beFalse())
+                expect(rest.auth.internal.options.authCallback).to(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__113__authorize__when_TokenParams_and_AuthOptions_are_provided__should_supersede_configured_params_and_options_even_if_arguments_objects_are_empty() {
+        let options = AblyTests.clientOptions()
+        options.key = "xxxx:xxxx"
+        options.clientId = "client_string"
+        let rest = ARTRest(options: options)
+
+        let tokenParams = ARTTokenParams(clientId: options.clientId)
+
+        // Defaults
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect((error as! ARTErrorInfo).code).to(equal(ARTErrorCode.notFound.intValue))
+                expect(tokenDetails).to(beNil())
+                done()
+            }
+        }
+
+        // Custom
+        tokenParams.ttl = ExpectedTokenParams.ttl as NSNumber
+        tokenParams.capability = ExpectedTokenParams.capability
+        tokenParams.clientId = nil
+
+        let authOptions = ARTAuthOptions()
+        authOptions.key = AblyTests.commonAppSetup().key
+        authOptions.queryTime = true
+
+        var serverTimeRequestCount = 0
+        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
+            serverTimeRequestCount += 1
+        }
+        defer { hook.remove() }
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(tokenParams, options: authOptions) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    XCTFail("TokenDetails is nil"); done(); return
+                }
+                expect(tokenDetails.clientId).to(beNil())
+                expect(tokenDetails.issued!.addingTimeInterval(ExpectedTokenParams.ttl)).to(beCloseTo(tokenDetails.expires!))
+                expect(tokenDetails.capability).to(equal(ExpectedTokenParams.capability))
+                expect(serverTimeRequestCount) == 1
+                done()
+            }
+        }
+
+        rest.auth.internal.testSuite_forceTokenToExpire()
+
+        // Subsequent authorisations
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    fail("TokenDetails is nil"); done(); return
+                }
+                expect(tokenDetails.clientId).to(beNil())
+                expect(tokenDetails.issued!.addingTimeInterval(ExpectedTokenParams.ttl)).to(beCloseTo(tokenDetails.expires!))
+                expect(tokenDetails.capability).to(equal(ExpectedTokenParams.capability))
+                expect(serverTimeRequestCount) == 1
+                done()
+            }
+        }
+    }
+
+    func test__114__authorize__when_TokenParams_and_AuthOptions_are_provided__example__if_a_client_is_initialised_with_TokenParams_ttl_configured_with_a_custom_value__and_a_TokenParams_object_is_passed_in_as_an_argument_to__authorize_with_a_null_value_for_ttl__then_the_ttl_used_for_every_subsequent_authorization_will_be_null() {
+        let options = AblyTests.commonAppSetup()
+        options.defaultTokenParams = {
+            $0.ttl = 0.1
+            $0.clientId = "tester"
+            return $0
+        }(ARTTokenParams())
+
+        let rest = ARTRest(options: options)
+
+        let testTokenParams = ARTTokenParams()
+        testTokenParams.ttl = nil
+        testTokenParams.clientId = nil
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(testTokenParams, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    fail("TokenDetails is nil"); done(); return
+                }
+                guard let issued = tokenDetails.issued else {
+                    fail("TokenDetails.issued is nil"); done(); return
+                }
+                guard let expires = tokenDetails.expires else {
+                    fail("TokenDetails.expires is nil"); done(); return
+                }
+                expect(tokenDetails.clientId).to(beNil())
+                // `ttl` when omitted, the default value is applied
+                expect(issued.addingTimeInterval(ARTDefault.ttl())).to(equal(expires))
+                done()
+            }
+        }
+
+        // Subsequent authorization
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    fail("TokenDetails is nil"); done(); return
+                }
+                guard let issued = tokenDetails.issued else {
+                    fail("TokenDetails.issued is nil"); done(); return
+                }
+                guard let expires = tokenDetails.expires else {
+                    fail("TokenDetails.expires is nil"); done(); return
+                }
+                expect(tokenDetails.clientId).to(beNil())
+                expect(issued.addingTimeInterval(ARTDefault.ttl())).to(equal(expires))
+                done()
+            }
+        }
+    }
+
+    // RSA10k
+
+    func skipped__test__115__authorize__server_time_offset__should_obtain_server_time_once_and_persist_the_offset_from_the_local_clock() {
+        let options = AblyTests.commonAppSetup()
+        let rest = ARTRest(options: options)
+
+        let mockServerDate = Date().addingTimeInterval(120)
+        rest.auth.internal.testSuite_returnValue(for: NSSelectorFromString("handleServerTime:"), with: mockServerDate)
+        let currentDate = Date()
+
+        var serverTimeRequestCount = 0
+        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
+            serverTimeRequestCount += 1
+        }
+        defer { hook.remove() }
+
+        let authOptions = ARTAuthOptions()
+        authOptions.key = options.key
+        authOptions.queryTime = true
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: authOptions, callback: { tokenDetails, error in
+                expect(error).to(beNil())
+                guard tokenDetails != nil else {
+                    fail("TokenDetails is nil"); done(); return
+                }
+                guard let timeOffset = rest.auth.internal.timeOffset?.doubleValue else {
+                    fail("Server Time Offset is nil"); done(); return
+                }
+                expect(timeOffset).toNot(equal(0))
+                expect(rest.auth.internal.timeOffset).toNot(beNil())
+                let calculatedServerDate = currentDate.addingTimeInterval(timeOffset)
+                expect(calculatedServerDate).to(beCloseTo(mockServerDate, within: 0.9))
+                expect(serverTimeRequestCount) == 1
+                done()
+            })
+        }
+
+        rest.auth.internal.testSuite_forceTokenToExpire()
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard tokenDetails != nil else {
+                    fail("TokenDetails is nil"); done(); return
+                }
+                guard let timeOffset = rest.auth.internal.timeOffset?.doubleValue else {
+                    fail("Server Time Offset is nil"); done(); return
+                }
+                expect(timeOffset).toNot(equal(0))
+                let calculatedServerDate = currentDate.addingTimeInterval(timeOffset)
+                expect(calculatedServerDate).to(beCloseTo(mockServerDate, within: 0.9))
+                expect(serverTimeRequestCount) == 1
+                done()
+            }
+        }
+    }
+
+    func test__116__authorize__server_time_offset__should_be_consistent_the_timestamp_request_with_the_server_time() {
+        let options = AblyTests.commonAppSetup()
+        let rest = ARTRest(options: options)
+
+        let mockServerDate = Date().addingTimeInterval(120)
+        rest.auth.internal.testSuite_returnValue(for: NSSelectorFromString("handleServerTime:"), with: mockServerDate)
+
+        var serverTimeRequestCount = 0
+        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
+            serverTimeRequestCount += 1
+        }
+        defer { hook.remove() }
+
+        let authOptions = ARTAuthOptions()
+        authOptions.key = options.key
+        authOptions.queryTime = true
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(nil, options: authOptions) { tokenRequest, error in
+                expect(error).to(beNil())
+                guard let tokenRequest = tokenRequest else {
+                    fail("TokenRequest is nil"); done(); return
+                }
+                guard let timeOffset = rest.auth.internal.timeOffset?.doubleValue else {
+                    fail("Server Time Offset is nil"); done(); return
+                }
+                expect(timeOffset).toNot(equal(0))
+                expect(mockServerDate.timeIntervalSinceNow).to(beCloseTo(timeOffset, within: 0.1))
+                expect(tokenRequest.timestamp).to(beCloseTo(mockServerDate))
+                expect(serverTimeRequestCount) == 1
+                done()
+            }
+        }
+    }
+
+    func test__117__authorize__server_time_offset__should_be_possible_by_lib_Client_to_discard_the_cached_local_clock_offset() {
+        let options = AblyTests.commonAppSetup()
+        options.queryTime = true
+        let rest = ARTRest(options: options)
+
+        var serverTimeRequestCount = 0
+        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
+            serverTimeRequestCount += 1
+        }
+        defer { hook.remove() }
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    fail("TokenDetails is nil"); done(); return
+                }
+                guard let timeOffset = rest.auth.internal.timeOffset?.doubleValue else {
+                    fail("Server Time Offset is nil"); done(); return
+                }
+                expect(timeOffset).toNot(beCloseTo(0))
+                let calculatedServerDate = Date().addingTimeInterval(timeOffset)
+                expect(tokenDetails.expires).to(beCloseTo(calculatedServerDate.addingTimeInterval(ARTDefault.ttl()), within: 1.0))
+                expect(serverTimeRequestCount) == 1
+                done()
+            }
+        }
+
+        #if TARGET_OS_IPHONE
+            NotificationCenter.default.post(name: UIApplication.significantTimeChangeNotification, object: nil)
+        #else
+            NotificationCenter.default.post(name: .NSSystemClockDidChange, object: nil)
+        #endif
+
+        rest.auth.internal.testSuite_forceTokenToExpire()
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard tokenDetails != nil else {
+                    fail("TokenDetails is nil"); done(); return
+                }
+                expect(rest.auth.internal.timeOffset).to(beNil())
+                expect(serverTimeRequestCount) == 1
+                done()
+            }
+        }
+    }
+
+    func test__118__authorize__server_time_offset__should_use_the_local_clock_offset_to_calculate_the_server_time() {
+        let options = AblyTests.commonAppSetup()
+        let rest = ARTRest(options: options)
+
+        let authOptions = ARTAuthOptions()
+        authOptions.key = options.key
+        authOptions.queryTime = false
+
+        let fakeOffset: TimeInterval = 60 // 1 minute
+        rest.auth.internal.setTimeOffset(fakeOffset)
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.createTokenRequest(nil, options: authOptions) { tokenRequest, error in
+                expect(error).to(beNil())
+                guard let tokenRequest = tokenRequest else {
+                    fail("TokenRequest is nil"); done(); return
+                }
+                guard let timeOffset = rest.auth.internal.timeOffset?.doubleValue else {
+                    fail("Server Time Offset is nil"); done(); return
+                }
+                expect(timeOffset) == fakeOffset
+                let calculatedServerDate = Date().addingTimeInterval(timeOffset)
+                expect(tokenRequest.timestamp).to(beCloseTo(calculatedServerDate, within: 0.5))
+                done()
+            }
+        }
+    }
+
+    func test__119__authorize__server_time_offset__should_request_server_time_when_queryTime_is_true_even_if_the_time_offset_is_assigned() {
+        let options = AblyTests.commonAppSetup()
+        let rest = ARTRest(options: options)
+
+        var serverTimeRequestCount = 0
+        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time)) {
+            serverTimeRequestCount += 1
+        }
+        defer { hook.remove() }
+
+        let fakeOffset: TimeInterval = 60 // 1 minute
+        rest.auth.internal.setTimeOffset(fakeOffset)
+
+        let authOptions = ARTAuthOptions()
+        authOptions.key = options.key
+        authOptions.queryTime = true
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: authOptions) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+                expect(serverTimeRequestCount) == 1
+                guard let timeOffset = rest.auth.internal.timeOffset?.doubleValue else {
+                    fail("Server Time Offset is nil"); done(); return
+                }
+                expect(timeOffset).toNot(equal(fakeOffset))
+                done()
+            }
+        }
+    }
+
+    func test__120__authorize__server_time_offset__should_discard_the_time_offset_in_situations_in_which_it_may_have_been_invalidated() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+
+        var discardTimeOffsetCallCount = 0
+        let hook = rest.auth.internal.testSuite_injectIntoMethod(after: #selector(rest.auth.internal.discardTimeOffset)) {
+            discardTimeOffsetCallCount += 1
+        }
+        defer { hook.remove() }
+
+        #if TARGET_OS_IPHONE
+            // Force notification
+            NotificationCenter.default.post(name: UIApplication.significantTimeChangeNotification, object: nil)
+
+            expect(discardTimeOffsetCallCount).toEventually(equal(1), timeout: testTimeout)
+
+            // Force notification
+            NotificationCenter.default.post(name: NSLocale.currentLocaleDidChangeNotification, object: nil)
+        #else
+            // Force notification
+            NotificationCenter.default.post(name: NSNotification.Name.NSSystemClockDidChange, object: nil)
+
+            expect(discardTimeOffsetCallCount).toEventually(equal(1), timeout: testTimeout)
+
+            // Force notification
+            NotificationCenter.default.post(name: NSLocale.currentLocaleDidChangeNotification, object: nil)
+        #endif
+
+        expect(discardTimeOffsetCallCount).toEventually(equal(2), timeout: testTimeout)
+    }
+
+    func test__121__authorize__two_consecutive_authorizations__using_REST__should_call_each_authorize_callback() {
+        let options = AblyTests.commonAppSetup()
+        options.useTokenAuth = true
+        let rest = ARTRest(options: options)
+
+        var tokenDetailsFirst: ARTTokenDetails?
+        var tokenDetailsLast: ARTTokenDetails?
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            rest.auth.authorize { tokenDetails, error in
+                if let error = error {
+                    fail(error.localizedDescription); partialDone(); return
+                }
+                expect(tokenDetails).toNot(beNil())
+                if tokenDetailsFirst == nil {
+                    tokenDetailsFirst = tokenDetails
+                } else {
+                    tokenDetailsLast = tokenDetails
+                }
+                partialDone()
+            }
+            rest.auth.authorize { tokenDetails, error in
+                if let error = error {
+                    fail(error.localizedDescription); partialDone(); return
+                }
+                expect(tokenDetails).toNot(beNil())
+                if tokenDetailsFirst == nil {
+                    tokenDetailsFirst = tokenDetails
+                } else {
+                    tokenDetailsLast = tokenDetails
+                }
+                partialDone()
+            }
+        }
+
+        expect(tokenDetailsFirst?.token).toNot(equal(tokenDetailsLast?.token))
+        expect(rest.auth.tokenDetails).to(beIdenticalTo(tokenDetailsLast))
+        expect(rest.auth.tokenDetails?.token).to(equal(tokenDetailsLast?.token))
+    }
+
+    func test__122__authorize__two_consecutive_authorizations__using_Realtime_and_connection_is_CONNECTING__should_call_each_Realtime_authorize_callback() {
+        let options = AblyTests.commonAppSetup()
+        options.useTokenAuth = true
+        let realtime = AblyTests.newRealtime(options)
+        defer { realtime.close(); realtime.dispose() }
+
+        var connectedStateCount = 0
+        realtime.connection.on(.connected) { _ in
+            connectedStateCount += 1
+        }
+
+        var tokenDetailsLast: ARTTokenDetails?
+        var didCancelAuthorization = false
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            let callback: (ARTTokenDetails?, Error?) -> Void = { tokenDetails, error in
+                if let error = error {
+                    if (error as NSError).code == URLError.cancelled.rawValue {
                         expect(tokenDetails).to(beNil())
-                        done()
+                        didCancelAuthorization = true
+                    } else {
+                        fail(error.localizedDescription); partialDone(); return
                     }
+                } else {
+                    expect(tokenDetails).toNot(beNil())
+                    tokenDetailsLast = tokenDetails
                 }
-
-                expect(realtime.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                expect(realtime.auth.tokenDetails?.token).to(equal(initialToken))
-                expect(realtime.auth.tokenDetails?.capability).toNot(equal(tokenParams.capability))
+                partialDone()
             }
-
-        
-            // TK2d
-            func test__129__TokenParams__timestamp_should_not_be_a_member_of_any_default_token_params() {
-                let rest = ARTRest(options: AblyTests.commonAppSetup())
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.authorize(nil, options: nil) { _, error in
-                        expect(error).to(beNil())
-                        guard let defaultTokenParams = rest.auth.internal.options.defaultTokenParams else {
-                            fail("DefaultTokenParams is nil"); done(); return
-                        }
-                        expect(defaultTokenParams.timestamp).to(beNil())
-
-                        var defaultTokenParamsCallCount = 0
-                        let hook = rest.auth.internal.options.testSuite_injectIntoMethod(after: NSSelectorFromString("defaultTokenParams")) {
-                            defaultTokenParamsCallCount += 1
-                        }
-                        defer { hook.remove() }
-
-                        let newTokenParams = ARTTokenParams(options: rest.auth.internal.options)
-                        expect(defaultTokenParamsCallCount) > 0
-
-                        newTokenParams.timestamp = Date()
-                        expect(newTokenParams.timestamp).toNot(beNil())
-                        expect(defaultTokenParams.timestamp).to(beNil()) //remain nil
-                        done()
-                    }
-                }
-            }
-
-        
-            // TE6
-            
-enum TestCase_ReusableTestsTestTokenRequestFromJson {
-case accepts_a_string__which_should_be_interpreted_as_JSON
-case accepts_a_NSDictionary
-}
-
-                func reusableTestsTestTokenRequestFromJson(_ json: String, testCase: TestCase_ReusableTestsTestTokenRequestFromJson, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil, check: @escaping (_ request: ARTTokenRequest) -> Void) {
-                    func test__accepts_a_string__which_should_be_interpreted_as_JSON() {
-contextBeforeEach?()
-
-                        check(try! ARTTokenRequest.fromJson(json as ARTJsonCompatible))
-
-contextAfterEach?()
-
-                    }
-
-                    func test__accepts_a_NSDictionary() {
-contextBeforeEach?()
-
-                        let data = json.data(using: String.Encoding.utf8)!
-                        let dict = try! JSONSerialization.jsonObject(with: data, options: .mutableLeaves) as! NSDictionary
-                        check(try! ARTTokenRequest.fromJson(dict))
-
-contextAfterEach?()
-
-                    }
-
-switch testCase  {
-case .accepts_a_string__which_should_be_interpreted_as_JSON:
-    test__accepts_a_string__which_should_be_interpreted_as_JSON()
-case .accepts_a_NSDictionary:
-    test__accepts_a_NSDictionary()
-}
-
-                }
-
-                
-                    func reusableTestsWrapper__TokenRequest__fromJson__with_TTL__reusableTestsTestTokenRequestFromJson(testCase: TestCase_ReusableTestsTestTokenRequestFromJson) {
-                    reusableTestsTestTokenRequestFromJson("{" +
-                                             "    \"clientId\":\"myClientId\"," +
-                                             "    \"mac\":\"4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4=\"," +
-                                             "    \"capability\":\"{\\\"test\\\":[\\\"publish\\\"]}\"," +
-                                             "    \"ttl\":42000," +
-                                             "    \"timestamp\":1479087321934," +
-                                             "    \"keyName\":\"xxxxxx.yyyyyy\"," +
-                                             "    \"nonce\":\"7830658976108826\"" +
-                                             "}", testCase: testCase) { request in
-                        expect(request.clientId).to(equal("myClientId"))
-                        expect(request.mac).to(equal("4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4="))
-                        expect(request.capability).to(equal("{\"test\":[\"publish\"]}"))
-                        expect(request.ttl as? TimeInterval).to(equal(TimeInterval(42)))
-                        expect(request.timestamp).to(equal(Date(timeIntervalSince1970: 1479087321.934)))
-                        expect(request.keyName).to(equal("xxxxxx.yyyyyy"))
-                        expect(request.nonce).to(equal("7830658976108826"))
-                    }}
-func test__132__TokenRequest__fromJson__with_TTL__accepts_a_string__which_should_be_interpreted_as_JSON() {
-reusableTestsWrapper__TokenRequest__fromJson__with_TTL__reusableTestsTestTokenRequestFromJson(testCase: .accepts_a_string__which_should_be_interpreted_as_JSON)
-}
-
-func test__133__TokenRequest__fromJson__with_TTL__accepts_a_NSDictionary() {
-reusableTestsWrapper__TokenRequest__fromJson__with_TTL__reusableTestsTestTokenRequestFromJson(testCase: .accepts_a_NSDictionary)
-}
-
-                
-                
-                    func reusableTestsWrapper__TokenRequest__fromJson__without_TTL__reusableTestsTestTokenRequestFromJson(testCase: TestCase_ReusableTestsTestTokenRequestFromJson) {
-                    reusableTestsTestTokenRequestFromJson("{" +
-                                             "    \"mac\":\"4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4=\"," +
-                                             "    \"capability\":\"{\\\"test\\\":[\\\"publish\\\"]}\"," +
-                                             "    \"timestamp\":1479087321934," +
-                                             "    \"keyName\":\"xxxxxx.yyyyyy\"," +
-                                             "    \"nonce\":\"7830658976108826\"" +
-                                             "}", testCase: testCase) { request in
-                        expect(request.clientId).to(beNil())
-                        expect(request.mac).to(equal("4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4="))
-                        expect(request.capability).to(equal("{\"test\":[\"publish\"]}"))
-                        expect(request.ttl).to(beNil())
-                        expect(request.timestamp).to(equal(Date(timeIntervalSince1970: 1479087321.934)))
-                        expect(request.keyName).to(equal("xxxxxx.yyyyyy"))
-                        expect(request.nonce).to(equal("7830658976108826"))
-                    }}
-func test__134__TokenRequest__fromJson__without_TTL__accepts_a_string__which_should_be_interpreted_as_JSON() {
-reusableTestsWrapper__TokenRequest__fromJson__without_TTL__reusableTestsTestTokenRequestFromJson(testCase: .accepts_a_string__which_should_be_interpreted_as_JSON)
-}
-
-func test__135__TokenRequest__fromJson__without_TTL__accepts_a_NSDictionary() {
-reusableTestsWrapper__TokenRequest__fromJson__without_TTL__reusableTestsTestTokenRequestFromJson(testCase: .accepts_a_NSDictionary)
-}
-
-
-                func test__130__TokenRequest__fromJson__rejects_invalid_JSON() {
-                    expect{try ARTTokenRequest.fromJson("not JSON" as ARTJsonCompatible)}.to(throwError())
-                }
-
-                func test__131__TokenRequest__fromJson__rejects_non_object_JSON() {
-                    expect{try ARTTokenRequest.fromJson("[]" as ARTJsonCompatible)}.to(throwError())
-                }
-
-        
-            // TD7
-            
-
-                func test__136__TokenDetails__fromJson__accepts_a_string__which_should_be_interpreted_as_JSON() {
-                    check(try! ARTTokenDetails.fromJson(json as ARTJsonCompatible))
-                }
-
-                func test__137__TokenDetails__fromJson__accepts_a_NSDictionary() {
-                    let data = json.data(using: String.Encoding.utf8)!
-                    let dict = try! JSONSerialization.jsonObject(with: data, options: .mutableLeaves) as! NSDictionary
-                    check(try! ARTTokenDetails.fromJson(dict))
-                }
-
-                func test__138__TokenDetails__fromJson__rejects_invalid_JSON() {
-                    expect{try ARTTokenDetails.fromJson("not JSON" as ARTJsonCompatible)}.to(throwError())
-                }
-
-                func test__139__TokenDetails__fromJson__rejects_non_object_JSON() {
-                    expect{try ARTTokenDetails.fromJson("[]" as ARTJsonCompatible)}.to(throwError())
-                }
-
-        
-            
-            
-
-                
-                    func skipped__test__140__JWT_and_realtime__client_initialized_with_a_JWT_token_in_ClientOptions__with_valid_credentials__pulls_stats_successfully() {
-                        jwtTestsOptions.token = getJWTToken()
-                        let client = AblyTests.newRealtime(jwtTestsOptions)
-                        defer { client.dispose(); client.close() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.stats { stats, error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-                    }
-
-                
-                    func test__141__JWT_and_realtime__client_initialized_with_a_JWT_token_in_ClientOptions__with_invalid_credentials__fails_to_connect_with_reason__invalid_signature_() {
-                        jwtTestsOptions.token = getJWTToken(invalid: true)
-                        jwtTestsOptions.autoConnect = false
-                        let client = AblyTests.newRealtime(jwtTestsOptions)
-                        defer { client.dispose(); client.close() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.failed) { stateChange in
-                                guard let reason = stateChange.reason else {
-                                    fail("Reason error is nil"); done(); return
-                                }
-                                expect(reason.code).to(equal(ARTErrorCode.invalidJwtFormat.intValue))
-                                expect(reason.description).to(satisfyAnyOf(contain("invalid signature"), contain("signature verification failed")))
-                                done()
-                            }
-                            client.connect()
-                        }
-                    }
-
-            // RSA8g RSA8c
-            
-
-                
-                    func test__142__JWT_and_realtime__when_using_authUrl__with_valid_credentials__fetches_a_channels_and_posts_a_message() {
-                        rsa8gTestsSetupDependencies()
-
-                        authUrlTestsOptions.authParams = [URLQueryItem]()
-                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
-                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
-                        let client = ARTRealtime(options: authUrlTestsOptions)
-                        defer { client.dispose(); client.close() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.connected, callback: { _ in
-                                let channel = client.channels.get(channelName)
-                                channel.publish(messageName, data: nil, callback: { error in
-                                    expect(error).to(beNil())
-                                    done()
-                                })
-                            })
-                            client.connect()
-                        }
-                    }
-
-                
-                    func test__143__JWT_and_realtime__when_using_authUrl__with_wrong_credentials__fails_to_connect_with_reason__invalid_signature_() {
-                        rsa8gTestsSetupDependencies()
-
-                        authUrlTestsOptions.authParams = [URLQueryItem]()
-                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
-                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keySecret", value: "INVALID"))
-                        let client = ARTRealtime(options: authUrlTestsOptions)
-                        defer { client.dispose(); client.close() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.disconnected) { stateChange in
-                                guard let reason = stateChange.reason else {
-                                    fail("Reason error is nil"); done(); return
-                                }
-                                expect(reason.code).to(equal(ARTErrorCode.invalidJwtFormat.intValue))
-                                expect(reason.description).to(satisfyAnyOf(contain("invalid signature"), contain("signature verification failed")))
-                                done()
-                            }
-                            client.connect()
-                        }
-                    }
-
-                
-
-                    func test__144__JWT_and_realtime__when_using_authUrl__when_token_expires__receives_a_40142_error_from_the_server() {
-                        rsa8gTestsSetupDependencies()
-
-                        let tokenDuration = 5.0
-                        authUrlTestsOptions.authParams = [URLQueryItem]()
-                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
-                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
-                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "expiresIn", value: String(UInt(tokenDuration))))
-                        let client = ARTRealtime(options: authUrlTestsOptions)
-                        defer { client.dispose(); client.close() }
-                        
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.connected) { stateChange in
-                                client.connection.once(.disconnected) { stateChange in
-                                    expect(stateChange.reason?.code).to(equal(ARTErrorCode.tokenExpired.intValue))
-                                    expect(stateChange.reason?.description).to(contain("Key/token status changed (expire)"))
-                                    done()
-                                }
-                            }
-                            client.connect()
-                        }
-                    }
-                
-                // RTC8a4
-                
-                    func test__145__JWT_and_realtime__when_using_authUrl__when_the_server_sends_and_AUTH_protocol_message__client_reauths_correctly_without_going_through_a_disconnection() {
-                        rsa8gTestsSetupDependencies()
-                        
-                        // The server sends an AUTH protocol message 30 seconds before a token expires
-                        // We create a token that lasts 35 seconds, so there's room to receive the AUTH message
-                        let tokenDuration = 35.0
-                        authUrlTestsOptions.authParams = [URLQueryItem]()
-                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
-                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
-                        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "expiresIn", value: String(UInt(tokenDuration))))
-                        authUrlTestsOptions.autoConnect = false // Prevent auto connection so we can set the transport proxy
-                        let client = ARTRealtime(options: authUrlTestsOptions)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        defer { client.dispose(); client.close() }
-                        
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.connected) { stateChange in
-                                let originalToken = client.auth.tokenDetails?.token
-                                let transport = client.internal.transport as! TestProxyTransport
-                                
-                                client.connection.once(.update) { stateChange in
-                                    expect(transport.protocolMessagesReceived.filter({ $0.action == .auth })).to(haveCount(1))
-                                    expect(originalToken).toNot(equal(client.auth.tokenDetails?.token))
-                                    done()
-                                }
-                            }
-                            client.connect()
-                        }
-                    }
-
-            // RSA8g
-            
-
-                
-                    func skipped__test__146__JWT_and_realtime__when_using_authCallback__with_valid_credentials__pulls_stats_successfully() {
-                        authCallbackTestsOptions.authCallback = { tokenParams, completion in
-                            let token = ARTTokenDetails(token: getJWTToken()!)
-                            completion(token, nil)
-                        }
-                        let client = ARTRealtime(options: authCallbackTestsOptions)
-                        defer { client.dispose(); client.close() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.stats { stats, error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-                    }
-
-                
-                    func test__147__JWT_and_realtime__when_using_authCallback__with_invalid_credentials__fails_to_connect() {
-                        authCallbackTestsOptions.authCallback = { tokenParams, completion in
-                            let token = ARTTokenDetails(token: getJWTToken(invalid: true)!)
-                            completion(token, nil)
-                        }
-                        let client = ARTRealtime(options: authCallbackTestsOptions)
-                        defer { client.dispose(); client.close() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.disconnected) { stateChange in
-                                guard let reason = stateChange.reason else {
-                                    fail("Reason error is nil"); done(); return
-                                }
-                                expect(reason.code).to(equal(ARTErrorCode.invalidJwtFormat.intValue))
-                                expect(reason.description).to(satisfyAnyOf(contain("invalid signature"), contain("signature verification failed")))
-                                done()
-                            }
-                            client.connect()
-                        }
-                    }
-
-            
-
-                func test__148__JWT_and_realtime__when_token_expires_and_has_a_means_to_renew__reconnects_using_authCallback_and_obtains_a_new_token() {
-                    let tokenDuration = 3.0
-                    let options = AblyTests.clientOptions()
-                    options.useTokenAuth = true
-                    options.autoConnect = false
-                    options.authCallback = { tokenParams, completion in
-                        let token = ARTTokenDetails(token: getJWTToken(expiresIn: Int(tokenDuration))!)
-                        completion(token, nil)
-                    }
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    var originalToken = ""
-                    var originalConnectionID = ""
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { _ in
-                            originalToken = client.auth.tokenDetails!.token
-                            originalConnectionID = client.connection.id!
-
-                            client.connection.once(.disconnected) { stateChange in
-                                expect(stateChange.reason?.code).to(equal(ARTErrorCode.tokenExpired.intValue))
-
-                                client.connection.once(.connected) { _ in
-                                    expect(client.connection.id).to(equal(originalConnectionID))
-                                    expect(client.auth.tokenDetails!.token).toNot(equal(originalToken))
-                                    done()
-                                }
-                            }
-                        }
-                        client.connect()
-                    }
-                }
-            
-            
-                func test__149__JWT_and_realtime__when_the_token_request_includes_a_clientId__the_clientId_is_the_same_specified_in_the_JWT_token_request() {
-                    let clientId = "JWTClientId"
-                    let options = AblyTests.clientOptions()
-                    options.tokenDetails = ARTTokenDetails(token: getJWTToken(clientId: clientId)!)
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { _ in
-                            expect(client.auth.clientId).to(equal(clientId))
-                            done()
-                        }
-                        client.connect()
-                    }
-                }
-            
-            
-                func test__150__JWT_and_realtime__when_the_token_request_includes_subscribe_only_capabilities__fails_to_publish_to_a_channel_with_subscribe_only_capability() {
-                    let capability = "{\"\(channelName)\":[\"subscribe\"]}"
-                    let options = AblyTests.clientOptions()
-                    options.tokenDetails = ARTTokenDetails(token: getJWTToken(capability: capability)!)
-                    // Prevent channel name to be prefixed by test-*
-                    options.channelNamePrefix = nil
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.channels.get(channelName).publish(messageName, data: nil, callback: { error in
-                            expect(error?.code).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
-                            expect(error?.message).to(contain("permission denied"))
-                            done()
-                        })
-                    }
-                }
-
-        // RSA11
-        
-
-            // RSA11b
-            func test__151__currentTokenDetails__should_hold_a__TokenDetails__instance_in_which_only_the__token__attribute_is_populated_with_that_token_string() {
-                let token = getTestToken()
-                let rest = ARTRest(token: token)
-                expect(rest.auth.tokenDetails?.token).to(equal(token))
-            }
-
-            // RSA11c
-            func test__152__currentTokenDetails__should_be_set_with_the_current_token__if_applicable__on_instantiation_and_each_time_it_is_replaced() {
-                let rest = ARTRest(options: AblyTests.commonAppSetup())
-                expect(rest.auth.tokenDetails).to(beNil())
-                var authenticatedTokenDetails: ARTTokenDetails?
-                waitUntil(timeout: testTimeout) { done in
-                    rest.auth.authorize { tokenDetails, error in
-                        expect(error).to(beNil())
-                        authenticatedTokenDetails = tokenDetails
-                        done()
-                    }
-                }
-                expect(rest.auth.tokenDetails).to(equal(authenticatedTokenDetails))
-            }
-
-            // RSA11d
-            func test__153__currentTokenDetails__should_be_empty_if_there_is_no_current_token() {
-                let rest = ARTRest(options: AblyTests.commonAppSetup())
-                expect(rest.auth.tokenDetails).to(beNil())
-            }
-        
-        // RSC1 RSC1a RSC1c RSA3d
-        
-            
-            
-                func test__154__JWT_and_rest__when_the_JWT_token_embeds_an_Ably_token__pulls_stats_successfully() {
-                    jwtAndRestTestsOptions.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded")!)
-                    let client = ARTRest(options: jwtAndRestTestsOptions)
-                    waitUntil(timeout: testTimeout) { done in
-                        client.stats { stats, error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
-            
-            
-                func test__155__JWT_and_rest__when_the_JWT_token_embeds_an_Ably_token_and_it_is_requested_as_encrypted__pulls_stats_successfully() {
-                    jwtAndRestTestsOptions.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded", encrypted: 1)!)
-                    let client = ARTRest(options: jwtAndRestTestsOptions)
-                    waitUntil(timeout: testTimeout) { done in
-                        client.stats { stats, error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
-            
-            // RSA4f, RSA8c
-            
-
-                func beforeEach__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type() {
-                    jwtContentTypeTestsSetupDependencies()
-                }
-                
-                func test__156__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type__the_client_successfully_connects_and_pulls_stats() {
-beforeEach__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type()
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.stats { stats, error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
-                
-                func test__157__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type__the_client_can_request_a_new_token_to_initilize_another_client_that_connects_and_pulls_stats() {
-beforeEach__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type()
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.auth.requestToken(nil, with: nil, callback: { tokenDetails, error in
-                            let newClientOptions = AblyTests.clientOptions()
-                            newClientOptions.token = tokenDetails!.token
-                            let newClient = ARTRest(options: newClientOptions)
-                            newClient.stats { stats, error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        })
-                    }
-                }
-
-        // https://github.com/ably/ably-cocoa/issues/849
-        func test__001__should_not_force_token_auth_when_clientId_is_set() {
-            let options = AblyTests.commonAppSetup()
-            options.clientId = "foo"
-            expect(options.isBasicAuth()).to(beTrue())
+            // One of them will be canceled by the connection:
+            realtime.auth.authorize(callback)
+            realtime.auth.authorize(callback)
         }
 
-        // https://github.com/ably/ably-cocoa/issues/1093
-        func test__002__should_accept_authURL_response_with_timestamp_argument_as_string() {
-            var originalTokenRequest: ARTTokenRequest!
-            let tmpRest = ARTRest(options: AblyTests.commonAppSetup())
-            waitUntil(timeout: testTimeout) { done in
-                let tokenParams = ARTTokenParams()
-                tokenParams.clientId = "john"
-                tokenParams.capability = """
-                {"chat:*":["publish","subscribe","presence","history"]}
-                """
-                tokenParams.ttl = 43200
-                tmpRest.auth.createTokenRequest(tokenParams, options: nil) { tokenRequest, error in
+        expect(didCancelAuthorization).to(be(true))
+        expect(realtime.auth.tokenDetails).to(beIdenticalTo(tokenDetailsLast))
+        expect(realtime.auth.tokenDetails?.token).to(equal(tokenDetailsLast?.token))
+
+        if let transport = realtime.internal.transport as? TestProxyTransport, let query = transport.lastUrl?.query {
+            expect(query).to(haveParam("accessToken", withValue: realtime.auth.tokenDetails?.token ?? ""))
+        } else {
+            fail("MockTransport is not working")
+        }
+
+        expect(connectedStateCount) == 1
+    }
+
+    func test__123__authorize__two_consecutive_authorizations__using_Realtime_and_connection_is_CONNECTED__should_call_each_Realtime_authorize_callback() {
+        let options = AblyTests.commonAppSetup()
+        options.useTokenAuth = true
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.close(); realtime.dispose() }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.connected) { _ in
+                done()
+            }
+        }
+
+        var tokenDetailsFirst: ARTTokenDetails?
+        var tokenDetailsLast: ARTTokenDetails?
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            realtime.auth.authorize { tokenDetails, error in
+                if let error = error {
+                    fail(error.localizedDescription); partialDone(); return
+                }
+                expect(tokenDetails).toNot(beNil())
+                if tokenDetailsFirst == nil {
+                    tokenDetailsFirst = tokenDetails
+                } else {
+                    tokenDetailsLast = tokenDetails
+                }
+                partialDone()
+            }
+            realtime.auth.authorize { tokenDetails, error in
+                if let error = error {
+                    fail(error.localizedDescription); partialDone(); return
+                }
+                expect(tokenDetails).toNot(beNil())
+                if tokenDetailsFirst == nil {
+                    tokenDetailsFirst = tokenDetails
+                } else {
+                    tokenDetailsLast = tokenDetails
+                }
+                partialDone()
+            }
+        }
+
+        expect(tokenDetailsFirst?.token).toNot(equal(tokenDetailsLast?.token))
+        expect(realtime.auth.tokenDetails).to(beIdenticalTo(tokenDetailsLast))
+        expect(realtime.auth.tokenDetails?.token).to(equal(tokenDetailsLast?.token))
+    }
+
+    func test__124__TokenParams__timestamp__if_explicitly_set__should_be_returned_by_the_getter() {
+        let params = ARTTokenParams()
+        params.timestamp = Date(timeIntervalSince1970: 123)
+        expect(params.timestamp).to(equal(Date(timeIntervalSince1970: 123)))
+    }
+
+    func test__125__TokenParams__timestamp__if_explicitly_set__the_value_should_stick() {
+        let params = ARTTokenParams()
+        params.timestamp = Date()
+
+        waitUntil(timeout: testTimeout) { done in
+            let now = Double(NSDate().artToIntegerMs())
+            guard let timestamp = params.timestamp else {
+                fail("timestamp is nil"); done(); return
+            }
+            let firstParamsTimestamp = Double((timestamp as NSDate).artToIntegerMs())
+            expect(firstParamsTimestamp).to(beCloseTo(now, within: 2.5))
+            delay(0.25) {
+                expect(Double((timestamp as NSDate).artToIntegerMs())).to(equal(firstParamsTimestamp))
+                done()
+            }
+        }
+    }
+
+    // https://github.com/ably/ably-cocoa/pull/508#discussion_r82577728
+    func test__126__TokenParams__timestamp__object_has_no_timestamp_value_unless_explicitly_set() {
+        let params = ARTTokenParams()
+        expect(params.timestamp).to(beNil())
+    }
+
+    // RTC8
+    func test__127__Reauth__should_use_authorize__force__true___to_reauth_with_a_token_with_a_different_set_of_capabilities() {
+        let options = AblyTests.commonAppSetup()
+        let initialToken = getTestToken(clientId: "tester", capability: "{\"restricted\":[\"*\"]}")
+        options.token = initialToken
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+        let channel = realtime.channels.get("foo")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error.code) == ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue
+                done()
+            }
+        }
+
+        let tokenParams = ARTTokenParams()
+        tokenParams.capability = "{\"\(channel.name)\":[\"*\"]}"
+        tokenParams.clientId = "tester"
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.auth.authorize(tokenParams, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+                done()
+            }
+        }
+
+        expect(realtime.auth.tokenDetails?.token).toNot(equal(initialToken))
+        expect(realtime.auth.tokenDetails?.capability).to(equal(tokenParams.capability))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RTC8
+    func test__128__Reauth__for_a_token_change_that_fails_due_to_an_incompatible_token__which_should_result_in_the_connection_entering_the_FAILED_state() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "tester"
+        options.useTokenAuth = true
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.on(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+        }
+
+        guard let initialToken = realtime.auth.tokenDetails?.token else {
+            fail("TokenDetails is nil"); return
+        }
+
+        let tokenParams = ARTTokenParams()
+        tokenParams.capability = "{\"restricted\":[\"*\"]}"
+        tokenParams.clientId = "secret"
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.auth.authorize(tokenParams, options: nil) { tokenDetails, error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect((error as! ARTErrorInfo).code) == ARTErrorCode.incompatibleCredentials.intValue
+                expect(tokenDetails).to(beNil())
+                done()
+            }
+        }
+
+        expect(realtime.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        expect(realtime.auth.tokenDetails?.token).to(equal(initialToken))
+        expect(realtime.auth.tokenDetails?.capability).toNot(equal(tokenParams.capability))
+    }
+
+    // TK2d
+    func test__129__TokenParams__timestamp_should_not_be_a_member_of_any_default_token_params() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize(nil, options: nil) { _, error in
+                expect(error).to(beNil())
+                guard let defaultTokenParams = rest.auth.internal.options.defaultTokenParams else {
+                    fail("DefaultTokenParams is nil"); done(); return
+                }
+                expect(defaultTokenParams.timestamp).to(beNil())
+
+                var defaultTokenParamsCallCount = 0
+                let hook = rest.auth.internal.options.testSuite_injectIntoMethod(after: NSSelectorFromString("defaultTokenParams")) {
+                    defaultTokenParamsCallCount += 1
+                }
+                defer { hook.remove() }
+
+                let newTokenParams = ARTTokenParams(options: rest.auth.internal.options)
+                expect(defaultTokenParamsCallCount) > 0
+
+                newTokenParams.timestamp = Date()
+                expect(newTokenParams.timestamp).toNot(beNil())
+                expect(defaultTokenParams.timestamp).to(beNil()) // remain nil
+                done()
+            }
+        }
+    }
+
+    // TE6
+
+    enum TestCase_ReusableTestsTestTokenRequestFromJson {
+        case accepts_a_string__which_should_be_interpreted_as_JSON
+        case accepts_a_NSDictionary
+    }
+
+    func reusableTestsTestTokenRequestFromJson(_ json: String, testCase: TestCase_ReusableTestsTestTokenRequestFromJson, beforeEach contextBeforeEach: (() -> Void)? = nil, afterEach contextAfterEach: (() -> Void)? = nil, check: @escaping (_ request: ARTTokenRequest) -> Void) {
+        func test__accepts_a_string__which_should_be_interpreted_as_JSON() {
+            contextBeforeEach?()
+
+            check(try! ARTTokenRequest.fromJson(json as ARTJsonCompatible))
+
+            contextAfterEach?()
+        }
+
+        func test__accepts_a_NSDictionary() {
+            contextBeforeEach?()
+
+            let data = json.data(using: String.Encoding.utf8)!
+            let dict = try! JSONSerialization.jsonObject(with: data, options: .mutableLeaves) as! NSDictionary
+            check(try! ARTTokenRequest.fromJson(dict))
+
+            contextAfterEach?()
+        }
+
+        switch testCase {
+        case .accepts_a_string__which_should_be_interpreted_as_JSON:
+            test__accepts_a_string__which_should_be_interpreted_as_JSON()
+        case .accepts_a_NSDictionary:
+            test__accepts_a_NSDictionary()
+        }
+    }
+
+    func reusableTestsWrapper__TokenRequest__fromJson__with_TTL__reusableTestsTestTokenRequestFromJson(testCase: TestCase_ReusableTestsTestTokenRequestFromJson) {
+        reusableTestsTestTokenRequestFromJson("{" +
+            "    \"clientId\":\"myClientId\"," +
+            "    \"mac\":\"4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4=\"," +
+            "    \"capability\":\"{\\\"test\\\":[\\\"publish\\\"]}\"," +
+            "    \"ttl\":42000," +
+            "    \"timestamp\":1479087321934," +
+            "    \"keyName\":\"xxxxxx.yyyyyy\"," +
+            "    \"nonce\":\"7830658976108826\"" +
+            "}", testCase: testCase) { request in
+                expect(request.clientId).to(equal("myClientId"))
+                expect(request.mac).to(equal("4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4="))
+                expect(request.capability).to(equal("{\"test\":[\"publish\"]}"))
+                expect(request.ttl as? TimeInterval).to(equal(TimeInterval(42)))
+                expect(request.timestamp).to(equal(Date(timeIntervalSince1970: 1_479_087_321.934)))
+                expect(request.keyName).to(equal("xxxxxx.yyyyyy"))
+                expect(request.nonce).to(equal("7830658976108826"))
+            }
+    }
+
+    func test__132__TokenRequest__fromJson__with_TTL__accepts_a_string__which_should_be_interpreted_as_JSON() {
+        reusableTestsWrapper__TokenRequest__fromJson__with_TTL__reusableTestsTestTokenRequestFromJson(testCase: .accepts_a_string__which_should_be_interpreted_as_JSON)
+    }
+
+    func test__133__TokenRequest__fromJson__with_TTL__accepts_a_NSDictionary() {
+        reusableTestsWrapper__TokenRequest__fromJson__with_TTL__reusableTestsTestTokenRequestFromJson(testCase: .accepts_a_NSDictionary)
+    }
+
+    func reusableTestsWrapper__TokenRequest__fromJson__without_TTL__reusableTestsTestTokenRequestFromJson(testCase: TestCase_ReusableTestsTestTokenRequestFromJson) {
+        reusableTestsTestTokenRequestFromJson("{" +
+            "    \"mac\":\"4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4=\"," +
+            "    \"capability\":\"{\\\"test\\\":[\\\"publish\\\"]}\"," +
+            "    \"timestamp\":1479087321934," +
+            "    \"keyName\":\"xxxxxx.yyyyyy\"," +
+            "    \"nonce\":\"7830658976108826\"" +
+            "}", testCase: testCase) { request in
+                expect(request.clientId).to(beNil())
+                expect(request.mac).to(equal("4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4="))
+                expect(request.capability).to(equal("{\"test\":[\"publish\"]}"))
+                expect(request.ttl).to(beNil())
+                expect(request.timestamp).to(equal(Date(timeIntervalSince1970: 1_479_087_321.934)))
+                expect(request.keyName).to(equal("xxxxxx.yyyyyy"))
+                expect(request.nonce).to(equal("7830658976108826"))
+            }
+    }
+
+    func test__134__TokenRequest__fromJson__without_TTL__accepts_a_string__which_should_be_interpreted_as_JSON() {
+        reusableTestsWrapper__TokenRequest__fromJson__without_TTL__reusableTestsTestTokenRequestFromJson(testCase: .accepts_a_string__which_should_be_interpreted_as_JSON)
+    }
+
+    func test__135__TokenRequest__fromJson__without_TTL__accepts_a_NSDictionary() {
+        reusableTestsWrapper__TokenRequest__fromJson__without_TTL__reusableTestsTestTokenRequestFromJson(testCase: .accepts_a_NSDictionary)
+    }
+
+    func test__130__TokenRequest__fromJson__rejects_invalid_JSON() {
+        expect { try ARTTokenRequest.fromJson("not JSON" as ARTJsonCompatible) }.to(throwError())
+    }
+
+    func test__131__TokenRequest__fromJson__rejects_non_object_JSON() {
+        expect { try ARTTokenRequest.fromJson("[]" as ARTJsonCompatible) }.to(throwError())
+    }
+
+    // TD7
+
+    func test__136__TokenDetails__fromJson__accepts_a_string__which_should_be_interpreted_as_JSON() {
+        check(try! ARTTokenDetails.fromJson(json as ARTJsonCompatible))
+    }
+
+    func test__137__TokenDetails__fromJson__accepts_a_NSDictionary() {
+        let data = json.data(using: String.Encoding.utf8)!
+        let dict = try! JSONSerialization.jsonObject(with: data, options: .mutableLeaves) as! NSDictionary
+        check(try! ARTTokenDetails.fromJson(dict))
+    }
+
+    func test__138__TokenDetails__fromJson__rejects_invalid_JSON() {
+        expect { try ARTTokenDetails.fromJson("not JSON" as ARTJsonCompatible) }.to(throwError())
+    }
+
+    func test__139__TokenDetails__fromJson__rejects_non_object_JSON() {
+        expect { try ARTTokenDetails.fromJson("[]" as ARTJsonCompatible) }.to(throwError())
+    }
+
+    func skipped__test__140__JWT_and_realtime__client_initialized_with_a_JWT_token_in_ClientOptions__with_valid_credentials__pulls_stats_successfully() {
+        jwtTestsOptions.token = getJWTToken()
+        let client = AblyTests.newRealtime(jwtTestsOptions)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.stats { _, error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__141__JWT_and_realtime__client_initialized_with_a_JWT_token_in_ClientOptions__with_invalid_credentials__fails_to_connect_with_reason__invalid_signature_() {
+        jwtTestsOptions.token = getJWTToken(invalid: true)
+        jwtTestsOptions.autoConnect = false
+        let client = AblyTests.newRealtime(jwtTestsOptions)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.failed) { stateChange in
+                guard let reason = stateChange.reason else {
+                    fail("Reason error is nil"); done(); return
+                }
+                expect(reason.code).to(equal(ARTErrorCode.invalidJwtFormat.intValue))
+                expect(reason.description).to(satisfyAnyOf(contain("invalid signature"), contain("signature verification failed")))
+                done()
+            }
+            client.connect()
+        }
+    }
+
+    // RSA8g RSA8c
+
+    func test__142__JWT_and_realtime__when_using_authUrl__with_valid_credentials__fetches_a_channels_and_posts_a_message() {
+        rsa8gTestsSetupDependencies()
+
+        authUrlTestsOptions.authParams = [URLQueryItem]()
+        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
+        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
+        let client = ARTRealtime(options: authUrlTestsOptions)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected, callback: { _ in
+                let channel = client.channels.get(channelName)
+                channel.publish(messageName, data: nil, callback: { error in
                     expect(error).to(beNil())
-                    originalTokenRequest = try! XCTUnwrap(tokenRequest)
+                    done()
+                })
+            })
+            client.connect()
+        }
+    }
+
+    func test__143__JWT_and_realtime__when_using_authUrl__with_wrong_credentials__fails_to_connect_with_reason__invalid_signature_() {
+        rsa8gTestsSetupDependencies()
+
+        authUrlTestsOptions.authParams = [URLQueryItem]()
+        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
+        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keySecret", value: "INVALID"))
+        let client = ARTRealtime(options: authUrlTestsOptions)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.disconnected) { stateChange in
+                guard let reason = stateChange.reason else {
+                    fail("Reason error is nil"); done(); return
+                }
+                expect(reason.code).to(equal(ARTErrorCode.invalidJwtFormat.intValue))
+                expect(reason.description).to(satisfyAnyOf(contain("invalid signature"), contain("signature verification failed")))
+                done()
+            }
+            client.connect()
+        }
+    }
+
+    func test__144__JWT_and_realtime__when_using_authUrl__when_token_expires__receives_a_40142_error_from_the_server() {
+        rsa8gTestsSetupDependencies()
+
+        let tokenDuration = 5.0
+        authUrlTestsOptions.authParams = [URLQueryItem]()
+        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
+        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
+        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "expiresIn", value: String(UInt(tokenDuration))))
+        let client = ARTRealtime(options: authUrlTestsOptions)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                client.connection.once(.disconnected) { stateChange in
+                    expect(stateChange.reason?.code).to(equal(ARTErrorCode.tokenExpired.intValue))
+                    expect(stateChange.reason?.description).to(contain("Key/token status changed (expire)"))
                     done()
                 }
             }
-            // "timestamp" as String
-            let tokenRequestJsonString = """
-                {"keyName":"\(originalTokenRequest.keyName)","timestamp":"\(String(dateToMilliseconds(originalTokenRequest.timestamp))))","clientId":"\(originalTokenRequest.clientId!)","nonce":"\(originalTokenRequest.nonce)","mac":"\(originalTokenRequest.mac)","ttl":"\(String(originalTokenRequest.ttl!.intValue * 1000)))","capability":"\(originalTokenRequest.capability!.replace("\"", withString: "\\\""))"}
-                """
+            client.connect()
+        }
+    }
 
-            let options = AblyTests.clientOptions()
-            options.authUrl = URL(string: "http://auth-test.ably.cocoa")
+    // RTC8a4
 
-            let rest = ARTRest(options: options)
-            expect(rest.auth.clientId).to(beNil())
-            #if TARGET_OS_IOS
+    func test__145__JWT_and_realtime__when_using_authUrl__when_the_server_sends_and_AUTH_protocol_message__client_reauths_correctly_without_going_through_a_disconnection() {
+        rsa8gTestsSetupDependencies()
+
+        // The server sends an AUTH protocol message 30 seconds before a token expires
+        // We create a token that lasts 35 seconds, so there's room to receive the AUTH message
+        let tokenDuration = 35.0
+        authUrlTestsOptions.authParams = [URLQueryItem]()
+        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
+        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
+        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "expiresIn", value: String(UInt(tokenDuration))))
+        authUrlTestsOptions.autoConnect = false // Prevent auto connection so we can set the transport proxy
+        let client = ARTRealtime(options: authUrlTestsOptions)
+        client.internal.setTransport(TestProxyTransport.self)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                let originalToken = client.auth.tokenDetails?.token
+                let transport = client.internal.transport as! TestProxyTransport
+
+                client.connection.once(.update) { _ in
+                    expect(transport.protocolMessagesReceived.filter { $0.action == .auth }).to(haveCount(1))
+                    expect(originalToken).toNot(equal(client.auth.tokenDetails?.token))
+                    done()
+                }
+            }
+            client.connect()
+        }
+    }
+
+    // RSA8g
+
+    func skipped__test__146__JWT_and_realtime__when_using_authCallback__with_valid_credentials__pulls_stats_successfully() {
+        authCallbackTestsOptions.authCallback = { _, completion in
+            let token = ARTTokenDetails(token: getJWTToken()!)
+            completion(token, nil)
+        }
+        let client = ARTRealtime(options: authCallbackTestsOptions)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.stats { _, error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__147__JWT_and_realtime__when_using_authCallback__with_invalid_credentials__fails_to_connect() {
+        authCallbackTestsOptions.authCallback = { _, completion in
+            let token = ARTTokenDetails(token: getJWTToken(invalid: true)!)
+            completion(token, nil)
+        }
+        let client = ARTRealtime(options: authCallbackTestsOptions)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.disconnected) { stateChange in
+                guard let reason = stateChange.reason else {
+                    fail("Reason error is nil"); done(); return
+                }
+                expect(reason.code).to(equal(ARTErrorCode.invalidJwtFormat.intValue))
+                expect(reason.description).to(satisfyAnyOf(contain("invalid signature"), contain("signature verification failed")))
+                done()
+            }
+            client.connect()
+        }
+    }
+
+    func test__148__JWT_and_realtime__when_token_expires_and_has_a_means_to_renew__reconnects_using_authCallback_and_obtains_a_new_token() {
+        let tokenDuration = 3.0
+        let options = AblyTests.clientOptions()
+        options.useTokenAuth = true
+        options.autoConnect = false
+        options.authCallback = { _, completion in
+            let token = ARTTokenDetails(token: getJWTToken(expiresIn: Int(tokenDuration))!)
+            completion(token, nil)
+        }
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        var originalToken = ""
+        var originalConnectionID = ""
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                originalToken = client.auth.tokenDetails!.token
+                originalConnectionID = client.connection.id!
+
+                client.connection.once(.disconnected) { stateChange in
+                    expect(stateChange.reason?.code).to(equal(ARTErrorCode.tokenExpired.intValue))
+
+                    client.connection.once(.connected) { _ in
+                        expect(client.connection.id).to(equal(originalConnectionID))
+                        expect(client.auth.tokenDetails!.token).toNot(equal(originalToken))
+                        done()
+                    }
+                }
+            }
+            client.connect()
+        }
+    }
+
+    func test__149__JWT_and_realtime__when_the_token_request_includes_a_clientId__the_clientId_is_the_same_specified_in_the_JWT_token_request() {
+        let clientId = "JWTClientId"
+        let options = AblyTests.clientOptions()
+        options.tokenDetails = ARTTokenDetails(token: getJWTToken(clientId: clientId)!)
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                expect(client.auth.clientId).to(equal(clientId))
+                done()
+            }
+            client.connect()
+        }
+    }
+
+    func test__150__JWT_and_realtime__when_the_token_request_includes_subscribe_only_capabilities__fails_to_publish_to_a_channel_with_subscribe_only_capability() {
+        let capability = "{\"\(channelName)\":[\"subscribe\"]}"
+        let options = AblyTests.clientOptions()
+        options.tokenDetails = ARTTokenDetails(token: getJWTToken(capability: capability)!)
+        // Prevent channel name to be prefixed by test-*
+        options.channelNamePrefix = nil
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.channels.get(channelName).publish(messageName, data: nil, callback: { error in
+                expect(error?.code).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
+                expect(error?.message).to(contain("permission denied"))
+                done()
+            })
+        }
+    }
+
+    // RSA11
+
+    // RSA11b
+    func test__151__currentTokenDetails__should_hold_a__TokenDetails__instance_in_which_only_the__token__attribute_is_populated_with_that_token_string() {
+        let token = getTestToken()
+        let rest = ARTRest(token: token)
+        expect(rest.auth.tokenDetails?.token).to(equal(token))
+    }
+
+    // RSA11c
+    func test__152__currentTokenDetails__should_be_set_with_the_current_token__if_applicable__on_instantiation_and_each_time_it_is_replaced() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+        expect(rest.auth.tokenDetails).to(beNil())
+        var authenticatedTokenDetails: ARTTokenDetails?
+        waitUntil(timeout: testTimeout) { done in
+            rest.auth.authorize { tokenDetails, error in
+                expect(error).to(beNil())
+                authenticatedTokenDetails = tokenDetails
+                done()
+            }
+        }
+        expect(rest.auth.tokenDetails).to(equal(authenticatedTokenDetails))
+    }
+
+    // RSA11d
+    func test__153__currentTokenDetails__should_be_empty_if_there_is_no_current_token() {
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+        expect(rest.auth.tokenDetails).to(beNil())
+    }
+
+    // RSC1 RSC1a RSC1c RSA3d
+
+    func test__154__JWT_and_rest__when_the_JWT_token_embeds_an_Ably_token__pulls_stats_successfully() {
+        jwtAndRestTestsOptions.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded")!)
+        let client = ARTRest(options: jwtAndRestTestsOptions)
+        waitUntil(timeout: testTimeout) { done in
+            client.stats { _, error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__155__JWT_and_rest__when_the_JWT_token_embeds_an_Ably_token_and_it_is_requested_as_encrypted__pulls_stats_successfully() {
+        jwtAndRestTestsOptions.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded", encrypted: 1)!)
+        let client = ARTRest(options: jwtAndRestTestsOptions)
+        waitUntil(timeout: testTimeout) { done in
+            client.stats { _, error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RSA4f, RSA8c
+
+    func beforeEach__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type() {
+        jwtContentTypeTestsSetupDependencies()
+    }
+
+    func test__156__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type__the_client_successfully_connects_and_pulls_stats() {
+        beforeEach__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type()
+
+        waitUntil(timeout: testTimeout) { done in
+            client.stats { _, error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__157__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type__the_client_can_request_a_new_token_to_initilize_another_client_that_connects_and_pulls_stats() {
+        beforeEach__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type()
+
+        waitUntil(timeout: testTimeout) { done in
+            client.auth.requestToken(nil, with: nil, callback: { tokenDetails, error in
+                let newClientOptions = AblyTests.clientOptions()
+                newClientOptions.token = tokenDetails!.token
+                let newClient = ARTRest(options: newClientOptions)
+                newClient.stats { _, error in
+                    expect(error).to(beNil())
+                    done()
+                }
+            })
+        }
+    }
+
+    // https://github.com/ably/ably-cocoa/issues/849
+    func test__001__should_not_force_token_auth_when_clientId_is_set() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "foo"
+        expect(options.isBasicAuth()).to(beTrue())
+    }
+
+    // https://github.com/ably/ably-cocoa/issues/1093
+    func test__002__should_accept_authURL_response_with_timestamp_argument_as_string() {
+        var originalTokenRequest: ARTTokenRequest!
+        let tmpRest = ARTRest(options: AblyTests.commonAppSetup())
+        waitUntil(timeout: testTimeout) { done in
+            let tokenParams = ARTTokenParams()
+            tokenParams.clientId = "john"
+            tokenParams.capability = """
+            {"chat:*":["publish","subscribe","presence","history"]}
+            """
+            tokenParams.ttl = 43200
+            tmpRest.auth.createTokenRequest(tokenParams, options: nil) { tokenRequest, error in
+                expect(error).to(beNil())
+                originalTokenRequest = try! XCTUnwrap(tokenRequest)
+                done()
+            }
+        }
+        // "timestamp" as String
+        let tokenRequestJsonString = """
+        {"keyName":"\(originalTokenRequest.keyName)","timestamp":"\(String(dateToMilliseconds(originalTokenRequest.timestamp))))","clientId":"\(originalTokenRequest.clientId!)","nonce":"\(originalTokenRequest.nonce)","mac":"\(originalTokenRequest.mac)","ttl":"\(String(originalTokenRequest.ttl!.intValue * 1000)))","capability":"\(originalTokenRequest.capability!.replace("\"", withString: "\\\""))"}
+        """
+
+        let options = AblyTests.clientOptions()
+        options.authUrl = URL(string: "http://auth-test.ably.cocoa")
+
+        let rest = ARTRest(options: options)
+        expect(rest.auth.clientId).to(beNil())
+        #if TARGET_OS_IOS
             expect(rest.device.clientId).to(beNil())
-            #endif
-            let testHttpExecutor = TestProxyHTTPExecutor(options.logHandler)
-            rest.internal.httpExecutor = testHttpExecutor
-            let channel = rest.channels.get("chat:one")
+        #endif
+        let testHttpExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = testHttpExecutor
+        let channel = rest.channels.get("chat:one")
 
-            testHttpExecutor.simulateIncomingPayloadOnNextRequest(tokenRequestJsonString.data(using: .utf8)!)
+        testHttpExecutor.simulateIncomingPayloadOnNextRequest(tokenRequestJsonString.data(using: .utf8)!)
 
-            waitUntil(timeout: testTimeout) { done in
-                channel.publish("foo", data: nil) { error in
-                    expect(error).to(beNil())
-                    done()
-                }
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish("foo", data: nil) { error in
+                expect(error).to(beNil())
+                done()
             }
-
-            expect(testHttpExecutor.requests.at(0)?.url?.host).to(equal("auth-test.ably.cocoa"))
-            guard let tokenDetails = rest.internal.auth.tokenDetails else {
-                fail("Should have token details"); return
-            }
-            expect(tokenDetails.clientId).to(equal(originalTokenRequest.clientId))
-            expect(tokenDetails.token).toNot(beNil())
         }
+
+        expect(testHttpExecutor.requests.at(0)?.url?.host).to(equal("auth-test.ably.cocoa"))
+        guard let tokenDetails = rest.internal.auth.tokenDetails else {
+            fail("Should have token details"); return
+        }
+        expect(tokenDetails.clientId).to(equal(originalTokenRequest.clientId))
+        expect(tokenDetails.token).toNot(beNil())
+    }
 }

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -2,7 +2,7 @@ import Ably
 import Ably.Private
 import Aspects
 import Nimble
-import Quick
+import XCTest
 
 private var testHTTPExecutor: TestProxyHTTPExecutor!
 private func testOptionsGiveDefaultAuthMethod(_ caseSetter: (ARTAuthOptions) -> Void) {

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -84,7 +84,7 @@ import Aspects
                     }
                 }
 
-class Auth : QuickSpec {
+class Auth : XCTestCase {
 
 // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
 override class var defaultTestSuite : XCTestSuite {
@@ -111,12 +111,11 @@ override class var defaultTestSuite : XCTestSuite {
             static let ttl = 1.0
             static let capability = "{\"cansubscribe:*\":[\"subscribe\"]}"
         }
-    override func spec() {
 
-        describe("Basic") {
+        
 
             // RSA1
-            it("should work over HTTPS only") {
+            func test__003__Basic__should_work_over_HTTPS_only() {
                 let clientOptions = AblyTests.setupOptions(AblyTests.jsonRestOptions)
                 clientOptions.tls = false
 
@@ -124,7 +123,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA11
-            it("should send the API key in the Authorization header") {
+            func test__004__Basic__should_send_the_API_key_in_the_Authorization_header() {
                 let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
                 let client = ARTRest(options: options)
                 testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
@@ -153,19 +152,18 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA2
-            it("should be default when an API key is set") {
+            func test__005__Basic__should_be_default_when_an_API_key_is_set() {
                 let client = ARTRest(options: ARTClientOptions(key: "fake:key"))
 
                 expect(client.auth.internal.method).to(equal(ARTAuthMethod.basic))
             }
-        }
 
-        describe("Token") {
+        
             
             // RSA3
-            context("token auth") {
+            
                 // RSA3a
-                it("should work over HTTP") {
+                func test__010__Token__token_auth__should_work_over_HTTP() {
                     let options = AblyTests.clientOptions(requestToken: true)
                     options.tls = false
                     let clientHTTP = ARTRest(options: options)
@@ -189,7 +187,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(url.scheme).to(equal("http"), description: "No HTTP support")
                 }
 
-                it("should work over HTTPS") {
+                func test__011__Token__token_auth__should_work_over_HTTPS() {
                     let options = AblyTests.clientOptions(requestToken: true)
                     options.tls = true
                     let clientHTTPS = ARTRest(options: options)
@@ -214,8 +212,8 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSA3b
-                context("for REST requests") {
-                    it("should send the token in the Authorization header") {
+                
+                    func test__012__Token__token_auth__for_REST_requests__should_send_the_token_in_the_Authorization_header() {
                         let options = AblyTests.clientOptions()
                         options.token = getTestToken()
                         
@@ -245,11 +243,10 @@ override class var defaultTestSuite : XCTestSuite {
                         
                         expect(authorization).to(equal(expectedAuthorization))
                     }
-                }
                 
                 // RSA3c
-                context("for Realtime connections") {
-                    it("should send the token in the querystring as a param named accessToken") {
+                
+                    func test__013__Token__token_auth__for_Realtime_connections__should_send_the_token_in_the_querystring_as_a_param_named_accessToken() {
                         let options = AblyTests.clientOptions()
                         options.token = getTestToken()
                         options.autoConnect = false
@@ -266,38 +263,36 @@ override class var defaultTestSuite : XCTestSuite {
                             XCTFail("MockTransport is not working")
                         }
                     }
-                }
-            }
 
             // RSA4
-            context("authentication method") {
+            
                 
-                it("should be default auth method when options’ useTokenAuth is set") {
+                func test__014__Token__authentication_method__should_be_default_auth_method_when_options__useTokenAuth_is_set() {
                     testOptionsGiveDefaultAuthMethod { $0.useTokenAuth = true; $0.key = "fake:key" }
                 }
                 
-                it("should be default auth method when options’ authUrl is set") {
+                func test__015__Token__authentication_method__should_be_default_auth_method_when_options__authUrl_is_set() {
                     testOptionsGiveDefaultAuthMethod { $0.authUrl = URL(string: "http://test.com") }
                 }
                 
-                it("should be default auth method when options’ authCallback is set") {
+                func test__016__Token__authentication_method__should_be_default_auth_method_when_options__authCallback_is_set() {
                     testOptionsGiveDefaultAuthMethod { $0.authCallback = { _, _ in return } }
                 }
                 
-                it("should be default auth method when options’ tokenDetails is set") {
+                func test__017__Token__authentication_method__should_be_default_auth_method_when_options__tokenDetails_is_set() {
                     testOptionsGiveDefaultAuthMethod { $0.tokenDetails = ARTTokenDetails(token: "token") }
                 }
 
-                it("should be default auth method when options’ token is set") {
+                func test__018__Token__authentication_method__should_be_default_auth_method_when_options__token_is_set() {
                     testOptionsGiveDefaultAuthMethod { $0.token = "token" }
                 }
                 
-                it("should be default auth method when options’ key is set") {
+                func test__019__Token__authentication_method__should_be_default_auth_method_when_options__key_is_set() {
                     testOptionsGiveDefaultAuthMethod { $0.tokenDetails = ARTTokenDetails(token: "token"); $0.key = "fake:key" }
                 }
 
                 // RSA4a
-                it("should indicate an error and not retry the request when the server responds with a token error and there is no way to renew the token") {
+                func test__020__Token__authentication_method__should_indicate_an_error_and_not_retry_the_request_when_the_server_responds_with_a_token_error_and_there_is_no_way_to_renew_the_token() {
                     let options = AblyTests.clientOptions()
                     options.token = getTestToken()
 
@@ -324,7 +319,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSA4a
-                it("should transition the connection to the FAILED state when the server responds with a token error and there is no way to renew the token") {
+                func test__021__Token__authentication_method__should_transition_the_connection_to_the_FAILED_state_when_the_server_responds_with_a_token_error_and_there_is_no_way_to_renew_the_token() {
                     let options = AblyTests.clientOptions()
                     options.tokenDetails = getTestTokenDetails(ttl: 0.1)
                     options.autoConnect = false
@@ -358,7 +353,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 
                 // RSA4b
-                it("on token error, reissues token and retries REST requests") {
+                func test__022__Token__authentication_method__on_token_error__reissues_token_and_retries_REST_requests() {
                     var authCallbackCalled = 0
 
                     let options = AblyTests.commonAppSetup()
@@ -392,7 +387,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSA4b
-                it("in REST, if the token creation failed or the subsequent request with the new token failed due to a token error, then the request should result in an error") {
+                func test__023__Token__authentication_method__in_REST__if_the_token_creation_failed_or_the_subsequent_request_with_the_new_token_failed_due_to_a_token_error__then_the_request_should_result_in_an_error() {
                     let options = AblyTests.commonAppSetup()
                     options.useTokenAuth = true
 
@@ -422,7 +417,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSA4b
-                it("in Realtime, if the token creation failed then the connection should move to the DISCONNECTED state and reports the error") {
+                func test__024__Token__authentication_method__in_Realtime__if_the_token_creation_failed_then_the_connection_should_move_to_the_DISCONNECTED_state_and_reports_the_error() {
                     let options = AblyTests.commonAppSetup()
                     options.authCallback = { tokenParams, completion in
                         completion(nil, NSError(domain: NSURLErrorDomain, code: -1003, userInfo: [NSLocalizedDescriptionKey: "A server with the specified hostname could not be found."]))
@@ -448,7 +443,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSA4b
-                it("in Realtime, if the connection fails due to a terminal token error, then the connection should move to the FAILED state and reports the error") {
+                func test__025__Token__authentication_method__in_Realtime__if_the_connection_fails_due_to_a_terminal_token_error__then_the_connection_should_move_to_the_FAILED_state_and_reports_the_error() {
                     let options = AblyTests.commonAppSetup()
                     options.authCallback = { tokenParams, completion in
                         getTestToken() { token in
@@ -477,8 +472,8 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSA4b1
-                context("local token validity check") {
-                    it("should be done if queryTime is true and local time is in sync with server") {
+                
+                    func test__028__Token__authentication_method__local_token_validity_check__should_be_done_if_queryTime_is_true_and_local_time_is_in_sync_with_server() {
                         let options = AblyTests.commonAppSetup()
                         let testKey = options.key!
 
@@ -528,7 +523,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(rest.auth.tokenDetails).toNot(beNil())
                     }
 
-                    it("should NOT be done if queryTime is false and local time is NOT in sync with server") {
+                    func test__029__Token__authentication_method__local_token_validity_check__should_NOT_be_done_if_queryTime_is_false_and_local_time_is_NOT_in_sync_with_server() {
                         let options = AblyTests.commonAppSetup()
                         let testKey = options.key!
 
@@ -569,10 +564,9 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                         }
                     }
-                }
 
                 // RSA4d
-                it("if a request by a realtime client to an authUrl results in an HTTP 403 the client library should transition to the FAILED state") {
+                func test__026__Token__authentication_method__if_a_request_by_a_realtime_client_to_an_authUrl_results_in_an_HTTP_403_the_client_library_should_transition_to_the_FAILED_state() {
                     let options = AblyTests.clientOptions()
                     options.autoConnect = false
                     options.authUrl = URL(string: "https://echo.ably.io/respondwith?status=403")!
@@ -590,7 +584,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 
                 // RSA4d
-                it("if an authCallback results in an HTTP 403 the client library should transition to the FAILED state") {
+                func test__027__Token__authentication_method__if_an_authCallback_results_in_an_HTTP_403_the_client_library_should_transition_to_the_FAILED_state() {
                     let options = AblyTests.clientOptions()
                     options.autoConnect = false
                     var authCallbackHasBeenInvoked = false
@@ -611,26 +605,25 @@ override class var defaultTestSuite : XCTestSuite {
                         realtime.connect()
                     }
                 }
-            }
             
             // RSA14
-            context("options") {
+            
                 
-                it("should stop client when useTokenAuth and no key occurs") {
+                func test__030__Token__options__should_stop_client_when_useTokenAuth_and_no_key_occurs() {
                     testStopsClientWithOptions { $0.useTokenAuth = true }
                 }
                 
-                it ("should stop client when authCallback and authUrl occurs") {
+                func test__031__Token__options__should_stop_client_when_authCallback_and_authUrl_occurs() {
                     testStopsClientWithOptions { $0.authCallback = { params, callback in /*nothing*/ }; $0.authUrl = URL(string: "http://auth.ably.io") }
                 }
 
                 // RSA4c
-                context("if an attempt by the realtime client library to authenticate is made using the authUrl or authCallback") {
+                
 
-                    context("the request to authUrl fails") {
+                    
 
                         // RSA4c1 & RSA4c2
-                        it("if the connection is CONNECTING, then the connection attempt should be treated as unsuccessful") {
+                        func test__032__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_request_to_authUrl_fails__if_the_connection_is_CONNECTING__then_the_connection_attempt_should_be_treated_as_unsuccessful() {
                             let options = AblyTests.clientOptions()
                             options.autoConnect = false
                             options.authUrl = URL(string: "http://echo.ably.io")!
@@ -657,7 +650,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
 
                         // RSA4c3
-                        it("if the connection is CONNECTED, then the connection should remain CONNECTED") {
+                        func test__033__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_request_to_authUrl_fails__if_the_connection_is_CONNECTED__then_the_connection_should_remain_CONNECTED() {
                             let token = getTestToken()
                             let options = AblyTests.clientOptions()
                             options.authUrl = URL(string: "http://echo.ably.io")!
@@ -692,12 +685,11 @@ override class var defaultTestSuite : XCTestSuite {
 
                             expect(realtime.connection.state).to(equal(ARTRealtimeConnectionState.connected))
                         }
-                    }
 
-                    context("the request to authCallback fails") {
+                    
 
                         // RSA4c1 & RSA4c2
-                        it("if the connection is CONNECTING, then the connection attempt should be treated as unsuccessful") {
+                        func test__034__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_request_to_authCallback_fails__if_the_connection_is_CONNECTING__then_the_connection_attempt_should_be_treated_as_unsuccessful() {
                             let options = AblyTests.clientOptions()
                             options.autoConnect = false
                             options.authCallback = { tokenParams, completion in
@@ -727,7 +719,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
 
                         // RSA4c3
-                        it("if the connection is CONNECTED, then the connection should remain CONNECTED") {
+                        func test__035__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_request_to_authCallback_fails__if_the_connection_is_CONNECTED__then_the_connection_should_remain_CONNECTED() {
                             let options = AblyTests.clientOptions()
                             options.authCallback = { tokenParams, completion in
                                 getTestTokenDetails(completion: completion)
@@ -761,12 +753,11 @@ override class var defaultTestSuite : XCTestSuite {
 
                             expect(realtime.connection.state).to(equal(ARTRealtimeConnectionState.connected))
                         }
-                    }
 
-                    context("the provided token is in an invalid format") {
+                    
 
                         // RSA4c1 & RSA4c2
-                        it("if the connection is CONNECTING, then the connection attempt should be treated as unsuccessful") {
+                        func test__036__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_provided_token_is_in_an_invalid_format__if_the_connection_is_CONNECTING__then_the_connection_attempt_should_be_treated_as_unsuccessful() {
                             let options = AblyTests.clientOptions()
                             options.autoConnect = false
                             options.authUrl = URL(string: "http://echo.ably.io")!
@@ -800,7 +791,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
 
                         // RSA4c3
-                        it("if the connection is CONNECTED, then the connection should remain CONNECTED") {
+                        func test__037__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_provided_token_is_in_an_invalid_format__if_the_connection_is_CONNECTED__then_the_connection_should_remain_CONNECTED() {
                             let options = AblyTests.clientOptions()
                             options.authUrl = URL(string: "http://echo.ably.io")!
                             options.authParams = [URLQueryItem]()
@@ -850,11 +841,10 @@ override class var defaultTestSuite : XCTestSuite {
 
                             expect(realtime.connection.state).to(equal(ARTRealtimeConnectionState.connected))
                         }
-                    }
 
-                    context("the attempt times out after realtimeRequestTimeout") {
+                    
                         // RSA4c1 & RSA4c2
-                        it("if the connection is CONNECTING, then the connection attempt should be treated as unsuccessful") {
+                        func test__038__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_attempt_times_out_after_realtimeRequestTimeout__if_the_connection_is_CONNECTING__then_the_connection_attempt_should_be_treated_as_unsuccessful() {
                             let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
                             defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
                             ARTDefault.setRealtimeRequestTimeout(0.5)
@@ -889,7 +879,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
 
                         // RSA4c3
-                        it("if the connection is CONNECTED, then the connection should remain CONNECTED") {
+                        func test__039__Token__options__if_an_attempt_by_the_realtime_client_library_to_authenticate_is_made_using_the_authUrl_or_authCallback__the_attempt_times_out_after_realtimeRequestTimeout__if_the_connection_is_CONNECTED__then_the_connection_should_remain_CONNECTED() {
                             let options = AblyTests.clientOptions()
                             options.autoConnect = false
                             options.authCallback = { tokenParams, completion in
@@ -935,16 +925,13 @@ override class var defaultTestSuite : XCTestSuite {
 
                             expect(realtime.connection.state).to(equal(ARTRealtimeConnectionState.connected))
                         }
-                    }
-                }
-            }
 
             // RSA15
-            context("token auth and clientId") {
+            
                 // RSA15a
-                context("should check clientId consistency") {
+                
 
-                    it("on rest") {
+                    func test__041__Token__token_auth_and_clientId__should_check_clientId_consistency__on_rest() {
                         let expectedClientId = "client_string"
                         let options = AblyTests.commonAppSetup()
                         options.useTokenAuth = true
@@ -976,7 +963,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("on realtime") {
+                    func test__042__Token__token_auth_and_clientId__should_check_clientId_consistency__on_realtime() {
                         let expectedClientId = "client_string"
                         let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
                         options.clientId = expectedClientId
@@ -1012,16 +999,15 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(connectedMessage.connectionDetails!.clientId).to(equal(expectedClientId))
                     }
 
-                    it("with wildcard") {
+                    func test__043__Token__token_auth_and_clientId__should_check_clientId_consistency__with_wildcard() {
                         let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
                         options.clientId = "*"
                         expect{ ARTRest(options: options) }.to(raiseException())
                         expect{ ARTRealtime(options: options) }.to(raiseException())
                     }
-                }
                 
                 // RSA15b
-                it("should permit to be unauthenticated") {
+                func test__040__Token__token_auth_and_clientId__should_permit_to_be_unauthenticated() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = nil
                     
@@ -1050,9 +1036,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 
                 // RSA15c
-                context("Incompatible client") {
+                
 
-                    it("with Realtime, it should change the connection state to FAILED and emit an error") {
+                    func test__044__Token__token_auth_and_clientId__Incompatible_client__with_Realtime__it_should_change_the_connection_state_to_FAILED_and_emit_an_error() {
                         let options = AblyTests.commonAppSetup()
                         let wrongTokenDetails = getTestTokenDetails(clientId: "wrong")
 
@@ -1073,7 +1059,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("with Rest, it should result in an appropriate error response") {
+                    func test__045__Token__token_auth_and_clientId__Incompatible_client__with_Rest__it_should_result_in_an_appropriate_error_response() {
                         let options = AblyTests.commonAppSetup()
                         options.clientId = "john"
                         let rest = ARTRest(options: options)
@@ -1087,16 +1073,14 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                         }
                     }
-                }
-            }
             
             // RSA5
-            it("TTL should default to be omitted") {
+            func test__006__Token__TTL_should_default_to_be_omitted() {
                 let tokenParams = ARTTokenParams()
                 expect(tokenParams.ttl).to(beNil())
             }
 
-            it("should URL query be correctly encoded") {
+            func test__007__Token__should_URL_query_be_correctly_encoded() {
                 let tokenParams = ARTTokenParams()
                 tokenParams.capability = "{\"*\":[\"*\"]}"
 
@@ -1125,7 +1109,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
             
             // RSA6
-            it("should omit capability field if it is not specified") {
+            func test__008__Token__should_omit_capability_field_if_it_is_not_specified() {
                 let tokenParams = ARTTokenParams()
                 expect(tokenParams.capability).to(beNil())
                 
@@ -1155,7 +1139,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA6
-            it("should add capability field if the user specifies it") {
+            func test__009__Token__should_add_capability_field_if_the_user_specifies_it() {
                 let tokenParams = ARTTokenParams()
                 tokenParams.capability = "{\"*\":[\"*\"]}"
 
@@ -1184,10 +1168,10 @@ override class var defaultTestSuite : XCTestSuite {
             }
             
             // RSA7
-            context("clientId and authenticated clients") {
+            
 
                 // RSA7a1
-                it("should not pass clientId with published message") {
+                func test__046__Token__clientId_and_authenticated_clients__should_not_pass_clientId_with_published_message() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "mary"
                     let rest = ARTRest(options: options)
@@ -1211,7 +1195,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 
                 // RSA7a2
-                it("should obtain a token if clientId is assigned") {
+                func test__047__Token__clientId_and_authenticated_clients__should_obtain_a_token_if_clientId_is_assigned() {
                     let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
                     options.clientId = "client_string"
                     
@@ -1234,7 +1218,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 
                 // RSA7a3
-                it("should convenience clientId return a string") {
+                func test__048__Token__clientId_and_authenticated_clients__should_convenience_clientId_return_a_string() {
                     let clientOptions = AblyTests.setupOptions(AblyTests.jsonRestOptions)
                     clientOptions.clientId = "String"
                     
@@ -1242,7 +1226,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSA7a4
-                it("ClientOptions#clientId takes precendence when a clientId value is provided in both ClientOptions#clientId and ClientOptions#defaultTokenParams") {
+                func test__049__Token__clientId_and_authenticated_clients__ClientOptions_clientId_takes_precendence_when_a_clientId_value_is_provided_in_both_ClientOptions_clientId_and_ClientOptions_defaultTokenParams() {
                     let options = AblyTests.clientOptions()
                     options.clientId = "john"
                     options.authCallback = { tokenParams, completion in
@@ -1274,10 +1258,10 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 
                 // RSA12
-                context("Auth#clientId attribute is null") {
+                
 
                     // RSA12a
-                    it("identity should be anonymous for all operations") {
+                    func test__051__Token__clientId_and_authenticated_clients__Auth_clientId_attribute_is_null__identity_should_be_anonymous_for_all_operations() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let realtime = AblyTests.newRealtime(options)
@@ -1305,7 +1289,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSA12b
-                    it("identity may change and become identified") {
+                    func test__052__Token__clientId_and_authenticated_clients__Auth_clientId_attribute_is_null__identity_may_change_and_become_identified() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         options.token = getTestToken(clientId: "tester")
@@ -1326,13 +1310,11 @@ override class var defaultTestSuite : XCTestSuite {
                             realtime.connect()
                         }
                     }
-
-                }
                 
                 // RSA7b
-                context("auth.clientId not null") {
+                
                     // RSA7b1
-                    it("when clientId attribute is assigned on client options") {
+                    func test__053__Token__clientId_and_authenticated_clients__auth_clientId_not_null__when_clientId_attribute_is_assigned_on_client_options() {
                         let clientOptions = AblyTests.setupOptions(AblyTests.jsonRestOptions)
                         clientOptions.clientId = "Exist"
                         
@@ -1340,7 +1322,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                     
                     // RSA7b2
-                    it("when tokenRequest or tokenDetails has clientId not null or wildcard string") {
+                    func test__054__Token__clientId_and_authenticated_clients__auth_clientId_not_null__when_tokenRequest_or_tokenDetails_has_clientId_not_null_or_wildcard_string() {
                         let options = AblyTests.commonAppSetup()
                         options.clientId = "client_string"
                         options.useTokenAuth = true
@@ -1371,7 +1353,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                     
                     // RSA7b3
-                    it("should CONNECTED ProtocolMessages contain a clientId") {
+                    func test__055__Token__clientId_and_authenticated_clients__auth_clientId_not_null__should_CONNECTED_ProtocolMessages_contain_a_clientId() {
                         let options = AblyTests.clientOptions()
                         options.token = getTestToken(clientId: "john")
                         expect(options.clientId).to(beNil())
@@ -1394,7 +1376,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSA7b4
-                    it("client does not have an identity when a wildcard string '*' is present") {
+                    func test__056__Token__clientId_and_authenticated_clients__auth_clientId_not_null__client_does_not_have_an_identity_when_a_wildcard_string_____is_present() {
                         let options = AblyTests.clientOptions()
                         options.token = getTestToken(clientId: "*")
                         let realtime = ARTRealtime(options: options)
@@ -1406,24 +1388,20 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                         }
                     }
-
-                }
                 
                 // RSA7c
-                it("should clientId be null or string") {
+                func test__050__Token__clientId_and_authenticated_clients__should_clientId_be_null_or_string() {
                     let clientOptions = AblyTests.setupOptions(AblyTests.jsonRestOptions)
                     clientOptions.clientId = "*"
                     
                     expect{ ARTRest(options: clientOptions) }.to(raiseException())
                 }
-            }
-        }
         
         // RSA8
-        describe("requestToken") {
-            context("arguments") {
+        
+            
                 // RSA8e
-                it("should not merge with the configured params and options but instead replace all corresponding values, even when @null@") {
+                func test__062__requestToken__arguments__should_not_merge_with_the_configured_params_and_options_but_instead_replace_all_corresponding_values__even_when__null_() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "сlientId"
                     let rest = ARTRest(options: options)
@@ -1465,7 +1443,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSA8e
-                it("should use configured defaults if the object arguments are omitted") {
+                func test__063__requestToken__arguments__should_use_configured_defaults_if_the_object_arguments_are_omitted() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "tester"
                     let rest = ARTRest(options: options)
@@ -1523,12 +1501,11 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
             // RSA8c
-            context("authUrl") {
+            
 
-                it("query will provide a token string") {
+                func test__064__requestToken__authUrl__query_will_provide_a_token_string() {
                     let testToken = getTestToken()
 
                     let options = AblyTests.clientOptions()
@@ -1554,7 +1531,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("query will provide a TokenDetails") {
+                func test__065__requestToken__authUrl__query_will_provide_a_TokenDetails() {
                     guard let testTokenDetails = getTestTokenDetails(clientId: "tester") else {
                         fail("TokenDetails is empty")
                         return
@@ -1599,7 +1576,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("query will provide a TokenRequest") {
+                func test__066__requestToken__authUrl__query_will_provide_a_TokenRequest() {
                     let tokenParams = ARTTokenParams()
                     tokenParams.capability = "{\"test\":[\"subscribe\"]}"
 
@@ -1656,9 +1633,9 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                context("parameters") {
+                
                     // RSA8c1a
-                    it("should be added to the URL when auth method is GET") {
+                    func test__069__requestToken__authUrl__parameters__should_be_added_to_the_URL_when_auth_method_is_GET() {
                         let clientOptions = ARTClientOptions()
                         clientOptions.authUrl = URL(string: "http://auth.ably.io")
                         var authParams = [
@@ -1711,7 +1688,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                     
                     // RSA8c1b
-                    it("should added on the body request when auth method is POST") {
+                    func test__070__requestToken__authUrl__parameters__should_added_on_the_body_request_when_auth_method_is_POST() {
                         let clientOptions = ARTClientOptions()
                         clientOptions.authUrl = URL(string: "http://auth.ably.io")
                         clientOptions.authParams = [
@@ -1750,10 +1727,9 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                         }
                     }
-                }
 
                 // RSA8c2
-                it("TokenParams should take precedence over any configured authParams when a name conflict occurs") {
+                func test__067__requestToken__authUrl__TokenParams_should_take_precedence_over_any_configured_authParams_when_a_name_conflict_occurs() {
                     let options = ARTClientOptions()
                     options.clientId = "john"
                     options.authUrl = URL(string: "http://auth.ably.io")
@@ -1782,7 +1758,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 
                 // RSA8c3
-                it("should override previously configured parameters") {
+                func test__068__requestToken__authUrl__should_override_previously_configured_parameters() {
                     let clientOptions = ARTClientOptions()
                     clientOptions.authUrl = URL(string: "http://auth.ably.io")
                     let rest = ARTRest(options: clientOptions)
@@ -1794,10 +1770,9 @@ override class var defaultTestSuite : XCTestSuite {
                     let url = rest.auth.internal.buildURL(authOptions, with: ARTTokenParams())
                     expect(url.absoluteString).to(contain(URL(string: "http://auth.ably.io")?.absoluteString ?? ""))
                 }
-            }
 
             // RSA8a
-            it("implicitly creates a TokenRequest and requests a token") {
+            func test__057__requestToken__implicitly_creates_a_TokenRequest_and_requests_a_token() {
                 let rest = ARTRest(options: AblyTests.commonAppSetup())
 
                 var createTokenRequestMethodWasCalled = false
@@ -1820,9 +1795,9 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA8b
-            context("should support all TokenParams") {
+            
 
-                it("using defaults") {
+                func test__071__requestToken__should_support_all_TokenParams__using_defaults() {
                     tokenParamsTestsSetupDependencies()
 
                     // Default values
@@ -1844,7 +1819,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("overriding defaults") {
+                func test__072__requestToken__should_support_all_TokenParams__overriding_defaults() {
                     tokenParamsTestsSetupDependencies()
 
                     // Custom values
@@ -1869,12 +1844,11 @@ override class var defaultTestSuite : XCTestSuite {
                         })
                     }
                 }
-            }
 
             // RSA8d
-            context("When authCallback option is set, it will invoke the callback") {
+            
 
-                it("with a token string") {
+                func test__073__requestToken__When_authCallback_option_is_set__it_will_invoke_the_callback__with_a_token_string() {
                     let options = AblyTests.clientOptions()
                     let expectedTokenParams = ARTTokenParams()
 
@@ -1893,7 +1867,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("with a TokenDetails") {
+                func test__074__requestToken__When_authCallback_option_is_set__it_will_invoke_the_callback__with_a_TokenDetails() {
                     let expectedTokenParams = ARTTokenParams()
 
                     let options = AblyTests.clientOptions()
@@ -1912,7 +1886,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("with a TokenRequest") {
+                func test__075__requestToken__When_authCallback_option_is_set__it_will_invoke_the_callback__with_a_TokenRequest() {
                     let options = AblyTests.commonAppSetup()
                     let expectedTokenParams = ARTTokenParams()
                     expectedTokenParams.clientId = "foo"
@@ -1938,10 +1912,9 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
             // RSA8f1
-            it("ensure the message published does not have a clientId") {
+            func test__058__requestToken__ensure_the_message_published_does_not_have_a_clientId() {
                 let options = AblyTests.commonAppSetup()
                 options.token = getTestToken(clientId: nil)
                 let rest = ARTRest(options: options)
@@ -1975,7 +1948,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA8f2
-            it("ensure that the message is rejected") {
+            func test__059__requestToken__ensure_that_the_message_is_rejected() {
                 let options = AblyTests.commonAppSetup()
                 options.token = getTestToken(clientId: nil)
                 let rest = ARTRest(options: options)
@@ -1995,7 +1968,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA8f3
-            it("ensure the message published with a wildcard '*' does not have a clientId") {
+            func test__060__requestToken__ensure_the_message_published_with_a_wildcard_____does_not_have_a_clientId() {
                 let options = AblyTests.commonAppSetup()
                 let rest = ARTRest(options: options)
 
@@ -2036,7 +2009,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA8f4
-            it("ensure the message published with a wildcard '*' has the provided clientId") {
+            func test__061__requestToken__ensure_the_message_published_with_a_wildcard_____has_the_provided_clientId() {
                 let options = AblyTests.commonAppSetup()
                 // Request a token with a wildcard '*' value clientId
                 options.token = getTestToken(clientId: "*")
@@ -2062,13 +2035,12 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 expect(rest.auth.clientId).to(beNil())
             }
-        }
 
         // RSA9
-        describe("createTokenRequest") {
+        
 
             // RSA9h
-            it("should not merge with the configured params and options but instead replace all corresponding values, even when @null@") {
+            func test__076__createTokenRequest__should_not_merge_with_the_configured_params_and_options_but_instead_replace_all_corresponding_values__even_when__null_() {
                 let options = AblyTests.commonAppSetup()
                 options.clientId = "client_string"
                 let rest = ARTRest(options: options)
@@ -2153,7 +2125,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
             }
 
-            it("should override defaults if AuthOptions provided") {
+            func test__077__createTokenRequest__should_override_defaults_if_AuthOptions_provided() {
                 let defaultOptions = AblyTests.commonAppSetup()
                 defaultOptions.authCallback = { tokenParams, completion in
                     fail("Should not be called")
@@ -2182,7 +2154,7 @@ override class var defaultTestSuite : XCTestSuite {
                 expect(customCallbackCalled).to(beTrue())
             }
 
-            it("should use defaults if no AuthOptions is provided") {
+            func test__078__createTokenRequest__should_use_defaults_if_no_AuthOptions_is_provided() {
                 var currentTokenRequest: ARTTokenRequest? = nil
                 var callbackCalled = false
 
@@ -2210,7 +2182,7 @@ override class var defaultTestSuite : XCTestSuite {
                 expect(callbackCalled).to(beTrue())
             }
 
-            it("should replace defaults if `nil` option's field passed") {
+            func test__079__createTokenRequest__should_replace_defaults_if__nil__option_s_field_passed() {
                 let defaultOptions = AblyTests.commonAppSetup()
                 let rest = ARTRest(options: defaultOptions)
 
@@ -2228,7 +2200,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA9h
-            it("should use configured defaults if the object arguments are omitted") {
+            func test__080__createTokenRequest__should_use_configured_defaults_if_the_object_arguments_are_omitted() {
                 let options = AblyTests.commonAppSetup()
                 let rest = ARTRest(options: options)
 
@@ -2277,7 +2249,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA9a
-            it("should create and sign a TokenRequest") {
+            func test__081__createTokenRequest__should_create_and_sign_a_TokenRequest() {
                 let rest = ARTRest(options: AblyTests.commonAppSetup())
                 let expectedClientId = "client_string"
                 let tokenParams = ARTTokenParams(clientId: expectedClientId)
@@ -2298,7 +2270,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA9b
-            it("should support AuthOptions") {
+            func test__082__createTokenRequest__should_support_AuthOptions() {
                 let rest = ARTRest(options: AblyTests.commonAppSetup())
                 let auth: ARTAuth = rest.auth
 
@@ -2317,7 +2289,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA9c
-            it("should generate a unique 16 plus character nonce if none is provided") {
+            func test__083__createTokenRequest__should_generate_a_unique_16_plus_character_nonce_if_none_is_provided() {
                 let rest = ARTRest(options: AblyTests.commonAppSetup())
 
                 waitUntil(timeout: testTimeout) { done in
@@ -2346,9 +2318,9 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA9d
-            context("should generate a timestamp") {
+            
 
-                it("from current time if not provided") {
+                func test__087__createTokenRequest__should_generate_a_timestamp__from_current_time_if_not_provided() {
                     let rest = ARTRest(options: AblyTests.commonAppSetup())
 
                     waitUntil(timeout: testTimeout) { done in
@@ -2363,7 +2335,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("will retrieve the server time if queryTime is true") {
+                func test__088__createTokenRequest__should_generate_a_timestamp__will_retrieve_the_server_time_if_queryTime_is_true() {
                     let rest = ARTRest(options: AblyTests.commonAppSetup())
 
                     var serverTimeRequestWasMade = false
@@ -2391,12 +2363,11 @@ override class var defaultTestSuite : XCTestSuite {
                         })
                     }
                 }
-            }
 
             // RSA9e
-            context("TTL") {
+            
 
-                it("should be optional") {
+                func test__089__createTokenRequest__TTL__should_be_optional() {
                     let rest = ARTRest(options: AblyTests.commonAppSetup())
 
                     waitUntil(timeout: testTimeout) { done in
@@ -2429,7 +2400,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should be specified in milliseconds") {
+                func test__090__createTokenRequest__TTL__should_be_specified_in_milliseconds() {
                     let rest = ARTRest(options: AblyTests.commonAppSetup())
 
                     let params = ARTTokenParams()
@@ -2457,7 +2428,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should be valid to request a token for 24 hours") {
+                func test__091__createTokenRequest__TTL__should_be_valid_to_request_a_token_for_24_hours() {
                     let rest = ARTRest(options: AblyTests.commonAppSetup())
                     let tokenParams = ARTTokenParams()
                     let dayInSeconds = TimeInterval(24 * 60 * 60)
@@ -2475,10 +2446,8 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RSA9f
-            it("should provide capability has json text") {
+            func test__084__createTokenRequest__should_provide_capability_has_json_text() {
                 let rest = ARTRest(options: AblyTests.commonAppSetup())
 
                 let tokenParams = ARTTokenParams()
@@ -2508,7 +2477,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA9g
-            it("should generate a valid HMAC") {
+            func test__085__createTokenRequest__should_generate_a_valid_HMAC() {
                 let rest = ARTRest(options: AblyTests.commonAppSetup())
 
                 let tokenParams = ARTTokenParams(clientId: "client_string")
@@ -2536,7 +2505,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA9i
-            it("should respect all requirements") {
+            func test__086__createTokenRequest__should_respect_all_requirements() {
                 let rest = ARTRest(options: AblyTests.commonAppSetup())
                 let expectedClientId = "client_string"
                 let tokenParams = ARTTokenParams(clientId: expectedClientId)
@@ -2575,13 +2544,11 @@ override class var defaultTestSuite : XCTestSuite {
                 }
             }
 
-        }
-
         // RSA10
-        describe("authorize") {
+        
 
             // RSA10a
-            it("should always create a token") {
+            func test__092__authorize__should_always_create_a_token() {
                 let options = AblyTests.commonAppSetup()
                 options.useTokenAuth = true
                 let rest = ARTRest(options: options)
@@ -2637,7 +2604,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA10a
-            it("should create a new token if one already exist and ensure Token Auth is used for all future requests") {
+            func test__093__authorize__should_create_a_new_token_if_one_already_exist_and_ensure_Token_Auth_is_used_for_all_future_requests() {
                 let options = AblyTests.commonAppSetup()
                 let testToken = getTestToken()
                 options.token = testToken
@@ -2663,7 +2630,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA10a
-            it("should create a token immediately and ensures Token Auth is used for all future requests") {
+            func test__094__authorize__should_create_a_token_immediately_and_ensures_Token_Auth_is_used_for_all_future_requests() {
                 let options = AblyTests.commonAppSetup()
                 let rest = ARTRest(options: options)
 
@@ -2687,7 +2654,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA10b
-            it("should supports all TokenParams and AuthOptions") {
+            func test__095__authorize__should_supports_all_TokenParams_and_AuthOptions() {
                 let rest = ARTRest(options: AblyTests.commonAppSetup())
 
                 waitUntil(timeout: testTimeout) { done in
@@ -2702,7 +2669,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA10e
-            it("should use the requestToken implementation") {
+            func test__096__authorize__should_use_the_requestToken_implementation() {
                 let rest = ARTRest(options: AblyTests.commonAppSetup())
 
                 var requestMethodWasCalled = false
@@ -2731,7 +2698,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA10f
-            it("should return TokenDetails with valid token metadata") {
+            func test__097__authorize__should_return_TokenDetails_with_valid_token_metadata() {
                 let options = AblyTests.commonAppSetup()
                 options.clientId = "client_string"
                 let rest = ARTRest(options: options)
@@ -2752,9 +2719,9 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA10g
-            context("on subsequent authorisations") {
+            
 
-                it("should store the AuthOptions with authUrl") {
+                func test__099__authorize__on_subsequent_authorisations__should_store_the_AuthOptions_with_authUrl() {
                     let options = AblyTests.commonAppSetup()
                     let rest = ARTRest(options: options)
                     testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
@@ -2797,7 +2764,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should store the AuthOptions with authCallback") {
+                func test__100__authorize__on_subsequent_authorisations__should_store_the_AuthOptions_with_authCallback() {
                     let rest = ARTRest(options: AblyTests.commonAppSetup())
                     let auth = rest.auth
 
@@ -2830,7 +2797,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should not store queryTime") {
+                func test__101__authorize__on_subsequent_authorisations__should_not_store_queryTime() {
                     let options = AblyTests.commonAppSetup()
                     let rest = ARTRest(options: options)
                     let authOptions = ARTAuthOptions()
@@ -2864,7 +2831,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should store the TokenParams") {
+                func test__102__authorize__on_subsequent_authorisations__should_store_the_TokenParams() {
                     let rest = ARTRest(options: AblyTests.commonAppSetup())
 
                     let tokenParams = ARTTokenParams()
@@ -2896,7 +2863,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should use configured defaults if the object arguments are omitted") {
+                func test__103__authorize__on_subsequent_authorisations__should_use_configured_defaults_if_the_object_arguments_are_omitted() {
                     let options = AblyTests.commonAppSetup()
                     let rest = ARTRest(options: options)
 
@@ -2934,10 +2901,8 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(authCallbackCalled) == 2
                 }
 
-            }
-
             // RSA10h
-            it("should use the configured Auth#clientId, if not null, by default") {
+            func test__098__authorize__should_use_the_configured_Auth_clientId__if_not_null__by_default() {
                 let options = AblyTests.commonAppSetup()
                 var rest = ARTRest(options: options)
 
@@ -2970,9 +2935,9 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA10i
-            context("should adhere to all requirements relating to") {
+            
 
-                it("TokenParams") {
+                func test__104__authorize__should_adhere_to_all_requirements_relating_to__TokenParams() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "client_string"
                     let rest = ARTRest(options: options)
@@ -2998,7 +2963,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("authCallback") {
+                func test__105__authorize__should_adhere_to_all_requirements_relating_to__authCallback() {
                     var currentTokenRequest: ARTTokenRequest? = nil
 
                     var rest = ARTRest(options: AblyTests.commonAppSetup())
@@ -3031,7 +2996,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("authUrl") {
+                func test__106__authorize__should_adhere_to_all_requirements_relating_to__authUrl() {
                     let options = ARTClientOptions()
                     options.authUrl = URL(string: "http://echo.ably.io")!
 
@@ -3048,7 +3013,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("authUrl with json") {
+                func test__107__authorize__should_adhere_to_all_requirements_relating_to__authUrl_with_json() {
                     guard let tokenDetails = getTestTokenDetails() else {
                         XCTFail("TokenDetails is empty")
                         return
@@ -3096,7 +3061,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // https://github.com/ably/ably-cocoa/issues/618
-                it("authUrl returning TokenRequest decodes TTL as expected") {
+                func test__108__authorize__should_adhere_to_all_requirements_relating_to__authUrl_returning_TokenRequest_decodes_TTL_as_expected() {
                     let options = AblyTests.commonAppSetup()
 
                     var rest = ARTRest(options: options)
@@ -3143,7 +3108,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("authUrl with plain text") {
+                func test__109__authorize__should_adhere_to_all_requirements_relating_to__authUrl_with_plain_text() {
                     let token = getTestToken()
                     let options = ARTClientOptions()
                     // Use authUrl for authentication with plain text token response
@@ -3175,13 +3140,11 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-                
-            }
 
             // RSA10j
-            context("when TokenParams and AuthOptions are provided") {
+            
 
-                it("should supersede configured AuthOptions (using key) even if arguments objects are empty") {
+                func test__110__authorize__when_TokenParams_and_AuthOptions_are_provided__should_supersede_configured_AuthOptions__using_key__even_if_arguments_objects_are_empty() {
                     let defaultOptions = AblyTests.clientOptions() //sandbox
                     defaultOptions.key = "xxxx:xxxx"
                     let rest = ARTRest(options: defaultOptions)
@@ -3231,7 +3194,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should supersede configured AuthOptions (using authUrl) even if arguments objects are empty") {
+                func test__111__authorize__when_TokenParams_and_AuthOptions_are_provided__should_supersede_configured_AuthOptions__using_authUrl__even_if_arguments_objects_are_empty() {
                     let rest = ARTRest(options: AblyTests.commonAppSetup())
 
                     let testTokenDetails = getTestTokenDetails(ttl: 0.1)
@@ -3325,7 +3288,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should supersede configured AuthOptions (using authCallback) even if arguments objects are empty") {
+                func test__112__authorize__when_TokenParams_and_AuthOptions_are_provided__should_supersede_configured_AuthOptions__using_authCallback__even_if_arguments_objects_are_empty() {
                     let rest = ARTRest(options: AblyTests.commonAppSetup())
 
                     let testTokenDetails = ARTTokenDetails(token: "token", expires: Date(), issued: Date(), capability: nil, clientId: nil)
@@ -3386,7 +3349,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should supersede configured params and options even if arguments objects are empty") {
+                func test__113__authorize__when_TokenParams_and_AuthOptions_are_provided__should_supersede_configured_params_and_options_even_if_arguments_objects_are_empty() {
                     let options = AblyTests.clientOptions()
                     options.key = "xxxx:xxxx"
                     options.clientId = "client_string"
@@ -3453,7 +3416,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("example: if a client is initialised with TokenParams#ttl configured with a custom value, and a TokenParams object is passed in as an argument to #authorize with a null value for ttl, then the ttl used for every subsequent authorization will be null") {
+                func test__114__authorize__when_TokenParams_and_AuthOptions_are_provided__example__if_a_client_is_initialised_with_TokenParams_ttl_configured_with_a_custom_value__and_a_TokenParams_object_is_passed_in_as_an_argument_to__authorize_with_a_null_value_for_ttl__then_the_ttl_used_for_every_subsequent_authorization_will_be_null() {
                     let options = AblyTests.commonAppSetup()
                     options.defaultTokenParams = {
                         $0.ttl = 0.1;
@@ -3505,13 +3468,11 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-
-            }
             
             // RSA10k
-            context("server time offset") {
+            
 
-                xit("should obtain server time once and persist the offset from the local clock") {
+                func skipped__test__115__authorize__server_time_offset__should_obtain_server_time_once_and_persist_the_offset_from_the_local_clock() {
                     let options = AblyTests.commonAppSetup()
                     let rest = ARTRest(options: options)
 
@@ -3567,7 +3528,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should be consistent the timestamp request with the server time") {
+                func test__116__authorize__server_time_offset__should_be_consistent_the_timestamp_request_with_the_server_time() {
                     let options = AblyTests.commonAppSetup()
                     let rest = ARTRest(options: options)
 
@@ -3602,7 +3563,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should be possible by lib Client to discard the cached local clock offset") {
+                func test__117__authorize__server_time_offset__should_be_possible_by_lib_Client_to_discard_the_cached_local_clock_offset() {
                     let options = AblyTests.commonAppSetup()
                     options.queryTime = true
                     let rest = ARTRest(options: options)
@@ -3651,7 +3612,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should use the local clock offset to calculate the server time") {
+                func test__118__authorize__server_time_offset__should_use_the_local_clock_offset_to_calculate_the_server_time() {
                     let options = AblyTests.commonAppSetup()
                     let rest = ARTRest(options: options)
 
@@ -3679,7 +3640,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should request server time when queryTime is true even if the time offset is assigned") {
+                func test__119__authorize__server_time_offset__should_request_server_time_when_queryTime_is_true_even_if_the_time_offset_is_assigned() {
                     let options = AblyTests.commonAppSetup()
                     let rest = ARTRest(options: options)
 
@@ -3710,7 +3671,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should discard the time offset in situations in which it may have been invalidated") {
+                func test__120__authorize__server_time_offset__should_discard_the_time_offset_in_situations_in_which_it_may_have_been_invalidated() {
                     let rest = ARTRest(options: AblyTests.commonAppSetup())
 
                     var discardTimeOffsetCallCount = 0
@@ -3740,10 +3701,8 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(discardTimeOffsetCallCount).toEventually(equal(2), timeout: testTimeout)
                 }
 
-            }
-
-            context("two consecutive authorizations") {
-                it("using REST, should call each authorize callback") {
+            
+                func test__121__authorize__two_consecutive_authorizations__using_REST__should_call_each_authorize_callback() {
                     let options = AblyTests.commonAppSetup()
                     options.useTokenAuth = true
                     let rest = ARTRest(options: options)
@@ -3784,7 +3743,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(rest.auth.tokenDetails).to(beIdenticalTo(tokenDetailsLast))
                     expect(rest.auth.tokenDetails?.token).to(equal(tokenDetailsLast?.token))
                 }
-                it("using Realtime and connection is CONNECTING, should call each Realtime authorize callback") {
+                func test__122__authorize__two_consecutive_authorizations__using_Realtime_and_connection_is_CONNECTING__should_call_each_Realtime_authorize_callback() {
                     let options = AblyTests.commonAppSetup()
                     options.useTokenAuth = true
                     let realtime = AblyTests.newRealtime(options)
@@ -3833,7 +3792,7 @@ override class var defaultTestSuite : XCTestSuite {
 
                     expect(connectedStateCount) == 1
                 }
-                it("using Realtime and connection is CONNECTED, should call each Realtime authorize callback") {
+                func test__123__authorize__two_consecutive_authorizations__using_Realtime_and_connection_is_CONNECTED__should_call_each_Realtime_authorize_callback() {
                     let options = AblyTests.commonAppSetup()
                     options.useTokenAuth = true
                     let realtime = ARTRealtime(options: options)
@@ -3881,19 +3840,16 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(realtime.auth.tokenDetails).to(beIdenticalTo(tokenDetailsLast))
                     expect(realtime.auth.tokenDetails?.token).to(equal(tokenDetailsLast?.token))
                 }
-            }
 
-        }
-
-        describe("TokenParams") {
-            context("timestamp") {
-                it("if explicitly set, should be returned by the getter") {
+        
+            
+                func test__124__TokenParams__timestamp__if_explicitly_set__should_be_returned_by_the_getter() {
                     let params = ARTTokenParams()
                     params.timestamp = Date(timeIntervalSince1970: 123)
                     expect(params.timestamp).to(equal(Date(timeIntervalSince1970: 123)))
                 }
 
-                it("if explicitly set, the value should stick") {
+                func test__125__TokenParams__timestamp__if_explicitly_set__the_value_should_stick() {
                     let params = ARTTokenParams()
                     params.timestamp = Date()
 
@@ -3912,17 +3868,15 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // https://github.com/ably/ably-cocoa/pull/508#discussion_r82577728
-                it("object has no timestamp value unless explicitly set") {
+                func test__126__TokenParams__timestamp__object_has_no_timestamp_value_unless_explicitly_set() {
                     let params = ARTTokenParams()
                     expect(params.timestamp).to(beNil())
                 }
-            }
-        }
 
-        describe("Reauth") {
+        
 
             // RTC8
-            it("should use authorize({force: true}) to reauth with a token with a different set of capabilities") {
+            func test__127__Reauth__should_use_authorize__force__true___to_reauth_with_a_token_with_a_different_set_of_capabilities() {
                 let options = AblyTests.commonAppSetup()
                 let initialToken = getTestToken(clientId: "tester", capability: "{\"restricted\":[\"*\"]}")
                 options.token = initialToken
@@ -3964,7 +3918,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTC8
-            it("for a token change that fails due to an incompatible token, which should result in the connection entering the FAILED state") {
+            func test__128__Reauth__for_a_token_change_that_fails_due_to_an_incompatible_token__which_should_result_in_the_connection_entering_the_FAILED_state() {
                 let options = AblyTests.commonAppSetup()
                 options.clientId = "tester"
                 options.useTokenAuth = true
@@ -4002,11 +3956,9 @@ override class var defaultTestSuite : XCTestSuite {
                 expect(realtime.auth.tokenDetails?.capability).toNot(equal(tokenParams.capability))
             }
 
-        }
-
-        describe("TokenParams") {
+        
             // TK2d
-            it("timestamp should not be a member of any default token params") {
+            func test__129__TokenParams__timestamp_should_not_be_a_member_of_any_default_token_params() {
                 let rest = ARTRest(options: AblyTests.commonAppSetup())
                 waitUntil(timeout: testTimeout) { done in
                     rest.auth.authorize(nil, options: nil) { _, error in
@@ -4032,24 +3984,47 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
             }
-        }
 
-        describe("TokenRequest") {
+        
             // TE6
-            describe("fromJson") {
-                func reusableTestsTestTokenRequestFromJson(_ json: String, check: @escaping (_ request: ARTTokenRequest) -> Void) {
-                    it("accepts a string, which should be interpreted as JSON") {
+            
+enum TestCase_ReusableTestsTestTokenRequestFromJson {
+case accepts_a_string__which_should_be_interpreted_as_JSON
+case accepts_a_NSDictionary
+}
+
+                func reusableTestsTestTokenRequestFromJson(_ json: String, testCase: TestCase_ReusableTestsTestTokenRequestFromJson, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil, check: @escaping (_ request: ARTTokenRequest) -> Void) {
+                    func test__accepts_a_string__which_should_be_interpreted_as_JSON() {
+contextBeforeEach?()
+
                         check(try! ARTTokenRequest.fromJson(json as ARTJsonCompatible))
+
+contextAfterEach?()
+
                     }
 
-                    it("accepts a NSDictionary") {
+                    func test__accepts_a_NSDictionary() {
+contextBeforeEach?()
+
                         let data = json.data(using: String.Encoding.utf8)!
                         let dict = try! JSONSerialization.jsonObject(with: data, options: .mutableLeaves) as! NSDictionary
                         check(try! ARTTokenRequest.fromJson(dict))
+
+contextAfterEach?()
+
                     }
+
+switch testCase  {
+case .accepts_a_string__which_should_be_interpreted_as_JSON:
+    test__accepts_a_string__which_should_be_interpreted_as_JSON()
+case .accepts_a_NSDictionary:
+    test__accepts_a_NSDictionary()
+}
+
                 }
 
-                context("with TTL") {
+                
+                    func reusableTestsWrapper__TokenRequest__fromJson__with_TTL__reusableTestsTestTokenRequestFromJson(testCase: TestCase_ReusableTestsTestTokenRequestFromJson) {
                     reusableTestsTestTokenRequestFromJson("{" +
                                              "    \"clientId\":\"myClientId\"," +
                                              "    \"mac\":\"4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4=\"," +
@@ -4058,7 +4033,7 @@ override class var defaultTestSuite : XCTestSuite {
                                              "    \"timestamp\":1479087321934," +
                                              "    \"keyName\":\"xxxxxx.yyyyyy\"," +
                                              "    \"nonce\":\"7830658976108826\"" +
-                                             "}") { request in
+                                             "}", testCase: testCase) { request in
                         expect(request.clientId).to(equal("myClientId"))
                         expect(request.mac).to(equal("4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4="))
                         expect(request.capability).to(equal("{\"test\":[\"publish\"]}"))
@@ -4066,17 +4041,25 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(request.timestamp).to(equal(Date(timeIntervalSince1970: 1479087321.934)))
                         expect(request.keyName).to(equal("xxxxxx.yyyyyy"))
                         expect(request.nonce).to(equal("7830658976108826"))
-                    }
-                }
+                    }}
+func test__132__TokenRequest__fromJson__with_TTL__accepts_a_string__which_should_be_interpreted_as_JSON() {
+reusableTestsWrapper__TokenRequest__fromJson__with_TTL__reusableTestsTestTokenRequestFromJson(testCase: .accepts_a_string__which_should_be_interpreted_as_JSON)
+}
+
+func test__133__TokenRequest__fromJson__with_TTL__accepts_a_NSDictionary() {
+reusableTestsWrapper__TokenRequest__fromJson__with_TTL__reusableTestsTestTokenRequestFromJson(testCase: .accepts_a_NSDictionary)
+}
+
                 
-                context("without TTL") {
+                
+                    func reusableTestsWrapper__TokenRequest__fromJson__without_TTL__reusableTestsTestTokenRequestFromJson(testCase: TestCase_ReusableTestsTestTokenRequestFromJson) {
                     reusableTestsTestTokenRequestFromJson("{" +
                                              "    \"mac\":\"4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4=\"," +
                                              "    \"capability\":\"{\\\"test\\\":[\\\"publish\\\"]}\"," +
                                              "    \"timestamp\":1479087321934," +
                                              "    \"keyName\":\"xxxxxx.yyyyyy\"," +
                                              "    \"nonce\":\"7830658976108826\"" +
-                                             "}") { request in
+                                             "}", testCase: testCase) { request in
                         expect(request.clientId).to(beNil())
                         expect(request.mac).to(equal("4rr4J+JzjiCL1DoS8wq7k11Z4oTGCb1PoeN+yGjkaH4="))
                         expect(request.capability).to(equal("{\"test\":[\"publish\"]}"))
@@ -4084,49 +4067,52 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(request.timestamp).to(equal(Date(timeIntervalSince1970: 1479087321.934)))
                         expect(request.keyName).to(equal("xxxxxx.yyyyyy"))
                         expect(request.nonce).to(equal("7830658976108826"))
-                    }
-                }
+                    }}
+func test__134__TokenRequest__fromJson__without_TTL__accepts_a_string__which_should_be_interpreted_as_JSON() {
+reusableTestsWrapper__TokenRequest__fromJson__without_TTL__reusableTestsTestTokenRequestFromJson(testCase: .accepts_a_string__which_should_be_interpreted_as_JSON)
+}
 
-                it("rejects invalid JSON") {
+func test__135__TokenRequest__fromJson__without_TTL__accepts_a_NSDictionary() {
+reusableTestsWrapper__TokenRequest__fromJson__without_TTL__reusableTestsTestTokenRequestFromJson(testCase: .accepts_a_NSDictionary)
+}
+
+
+                func test__130__TokenRequest__fromJson__rejects_invalid_JSON() {
                     expect{try ARTTokenRequest.fromJson("not JSON" as ARTJsonCompatible)}.to(throwError())
                 }
 
-                it("rejects non-object JSON") {
+                func test__131__TokenRequest__fromJson__rejects_non_object_JSON() {
                     expect{try ARTTokenRequest.fromJson("[]" as ARTJsonCompatible)}.to(throwError())
                 }
-            }
-        }
 
-        describe("TokenDetails") {
+        
             // TD7
-            describe("fromJson") {
+            
 
-                it("accepts a string, which should be interpreted as JSON") {
+                func test__136__TokenDetails__fromJson__accepts_a_string__which_should_be_interpreted_as_JSON() {
                     check(try! ARTTokenDetails.fromJson(json as ARTJsonCompatible))
                 }
 
-                it("accepts a NSDictionary") {
+                func test__137__TokenDetails__fromJson__accepts_a_NSDictionary() {
                     let data = json.data(using: String.Encoding.utf8)!
                     let dict = try! JSONSerialization.jsonObject(with: data, options: .mutableLeaves) as! NSDictionary
                     check(try! ARTTokenDetails.fromJson(dict))
                 }
 
-                it("rejects invalid JSON") {
+                func test__138__TokenDetails__fromJson__rejects_invalid_JSON() {
                     expect{try ARTTokenDetails.fromJson("not JSON" as ARTJsonCompatible)}.to(throwError())
                 }
 
-                it("rejects non-object JSON") {
+                func test__139__TokenDetails__fromJson__rejects_non_object_JSON() {
                     expect{try ARTTokenDetails.fromJson("[]" as ARTJsonCompatible)}.to(throwError())
                 }
-            }
-        }
 
-        describe("JWT and realtime") {
+        
             
-            context("client initialized with a JWT token in ClientOptions") {
+            
 
-                context("with valid credentials") {
-                    xit("pulls stats successfully") {
+                
+                    func skipped__test__140__JWT_and_realtime__client_initialized_with_a_JWT_token_in_ClientOptions__with_valid_credentials__pulls_stats_successfully() {
                         jwtTestsOptions.token = getJWTToken()
                         let client = AblyTests.newRealtime(jwtTestsOptions)
                         defer { client.dispose(); client.close() }
@@ -4138,10 +4124,9 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                         }
                     }
-                }
 
-                context("with invalid credentials") {
-                    it("fails to connect with reason 'invalid signature'") {
+                
+                    func test__141__JWT_and_realtime__client_initialized_with_a_JWT_token_in_ClientOptions__with_invalid_credentials__fails_to_connect_with_reason__invalid_signature_() {
                         jwtTestsOptions.token = getJWTToken(invalid: true)
                         jwtTestsOptions.autoConnect = false
                         let client = AblyTests.newRealtime(jwtTestsOptions)
@@ -4159,14 +4144,12 @@ override class var defaultTestSuite : XCTestSuite {
                             client.connect()
                         }
                     }
-                }
-            }
 
             // RSA8g RSA8c
-            context("when using authUrl") {
+            
 
-                context("with valid credentials") {
-                    it("fetches a channels and posts a message") {
+                
+                    func test__142__JWT_and_realtime__when_using_authUrl__with_valid_credentials__fetches_a_channels_and_posts_a_message() {
                         rsa8gTestsSetupDependencies()
 
                         authUrlTestsOptions.authParams = [URLQueryItem]()
@@ -4186,10 +4169,9 @@ override class var defaultTestSuite : XCTestSuite {
                             client.connect()
                         }
                     }
-                }
 
-                context("with wrong credentials") {
-                    it("fails to connect with reason 'invalid signature'") {
+                
+                    func test__143__JWT_and_realtime__when_using_authUrl__with_wrong_credentials__fails_to_connect_with_reason__invalid_signature_() {
                         rsa8gTestsSetupDependencies()
 
                         authUrlTestsOptions.authParams = [URLQueryItem]()
@@ -4210,11 +4192,10 @@ override class var defaultTestSuite : XCTestSuite {
                             client.connect()
                         }
                     }
-                }
 
-                context("when token expires") {
+                
 
-                    it ("receives a 40142 error from the server") {
+                    func test__144__JWT_and_realtime__when_using_authUrl__when_token_expires__receives_a_40142_error_from_the_server() {
                         rsa8gTestsSetupDependencies()
 
                         let tokenDuration = 5.0
@@ -4236,11 +4217,10 @@ override class var defaultTestSuite : XCTestSuite {
                             client.connect()
                         }
                     }
-                }
                 
                 // RTC8a4
-                context("when the server sends and AUTH protocol message") {
-                    it("client reauths correctly without going through a disconnection") {
+                
+                    func test__145__JWT_and_realtime__when_using_authUrl__when_the_server_sends_and_AUTH_protocol_message__client_reauths_correctly_without_going_through_a_disconnection() {
                         rsa8gTestsSetupDependencies()
                         
                         // The server sends an AUTH protocol message 30 seconds before a token expires
@@ -4269,14 +4249,12 @@ override class var defaultTestSuite : XCTestSuite {
                             client.connect()
                         }
                     }
-                }
-            }
 
             // RSA8g
-            context("when using authCallback") {
+            
 
-                context("with valid credentials") {
-                    xit("pulls stats successfully") {
+                
+                    func skipped__test__146__JWT_and_realtime__when_using_authCallback__with_valid_credentials__pulls_stats_successfully() {
                         authCallbackTestsOptions.authCallback = { tokenParams, completion in
                             let token = ARTTokenDetails(token: getJWTToken()!)
                             completion(token, nil)
@@ -4291,10 +4269,9 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                         }
                     }
-                }
 
-                context("with invalid credentials") {
-                    it("fails to connect") {
+                
+                    func test__147__JWT_and_realtime__when_using_authCallback__with_invalid_credentials__fails_to_connect() {
                         authCallbackTestsOptions.authCallback = { tokenParams, completion in
                             let token = ARTTokenDetails(token: getJWTToken(invalid: true)!)
                             completion(token, nil)
@@ -4314,12 +4291,10 @@ override class var defaultTestSuite : XCTestSuite {
                             client.connect()
                         }
                     }
-                }
-            }
 
-            context("when token expires and has a means to renew") {
+            
 
-                it("reconnects using authCallback and obtains a new token") {
+                func test__148__JWT_and_realtime__when_token_expires_and_has_a_means_to_renew__reconnects_using_authCallback_and_obtains_a_new_token() {
                     let tokenDuration = 3.0
                     let options = AblyTests.clientOptions()
                     options.useTokenAuth = true
@@ -4350,10 +4325,9 @@ override class var defaultTestSuite : XCTestSuite {
                         client.connect()
                     }
                 }
-            }
             
-            context("when the token request includes a clientId") {
-                it("the clientId is the same specified in the JWT token request") {
+            
+                func test__149__JWT_and_realtime__when_the_token_request_includes_a_clientId__the_clientId_is_the_same_specified_in_the_JWT_token_request() {
                     let clientId = "JWTClientId"
                     let options = AblyTests.clientOptions()
                     options.tokenDetails = ARTTokenDetails(token: getJWTToken(clientId: clientId)!)
@@ -4368,10 +4342,9 @@ override class var defaultTestSuite : XCTestSuite {
                         client.connect()
                     }
                 }
-            }
             
-            context("when the token request includes subscribe-only capabilities") {
-                it("fails to publish to a channel with subscribe-only capability") {
+            
+                func test__150__JWT_and_realtime__when_the_token_request_includes_subscribe_only_capabilities__fails_to_publish_to_a_channel_with_subscribe_only_capability() {
                     let capability = "{\"\(channelName)\":[\"subscribe\"]}"
                     let options = AblyTests.clientOptions()
                     options.tokenDetails = ARTTokenDetails(token: getJWTToken(capability: capability)!)
@@ -4388,21 +4361,19 @@ override class var defaultTestSuite : XCTestSuite {
                         })
                     }
                 }
-            }
-        }
 
         // RSA11
-        context("currentTokenDetails") {
+        
 
             // RSA11b
-            it("should hold a @TokenDetails@ instance in which only the @token@ attribute is populated with that token string") {
+            func test__151__currentTokenDetails__should_hold_a__TokenDetails__instance_in_which_only_the__token__attribute_is_populated_with_that_token_string() {
                 let token = getTestToken()
                 let rest = ARTRest(token: token)
                 expect(rest.auth.tokenDetails?.token).to(equal(token))
             }
 
             // RSA11c
-            it("should be set with the current token (if applicable) on instantiation and each time it is replaced") {
+            func test__152__currentTokenDetails__should_be_set_with_the_current_token__if_applicable__on_instantiation_and_each_time_it_is_replaced() {
                 let rest = ARTRest(options: AblyTests.commonAppSetup())
                 expect(rest.auth.tokenDetails).to(beNil())
                 var authenticatedTokenDetails: ARTTokenDetails?
@@ -4417,18 +4388,16 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSA11d
-            it("should be empty if there is no current token") {
+            func test__153__currentTokenDetails__should_be_empty_if_there_is_no_current_token() {
                 let rest = ARTRest(options: AblyTests.commonAppSetup())
                 expect(rest.auth.tokenDetails).to(beNil())
             }
-
-        }
         
         // RSC1 RSC1a RSC1c RSA3d
-        describe("JWT and rest") {
+        
             
-            context("when the JWT token embeds an Ably token") {
-                it ("pulls stats successfully") {
+            
+                func test__154__JWT_and_rest__when_the_JWT_token_embeds_an_Ably_token__pulls_stats_successfully() {
                     jwtAndRestTestsOptions.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded")!)
                     let client = ARTRest(options: jwtAndRestTestsOptions)
                     waitUntil(timeout: testTimeout) { done in
@@ -4438,10 +4407,9 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
             
-            context("when the JWT token embeds an Ably token and it is requested as encrypted") {
-                it ("pulls stats successfully") {
+            
+                func test__155__JWT_and_rest__when_the_JWT_token_embeds_an_Ably_token_and_it_is_requested_as_encrypted__pulls_stats_successfully() {
                     jwtAndRestTestsOptions.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded", encrypted: 1)!)
                     let client = ARTRest(options: jwtAndRestTestsOptions)
                     waitUntil(timeout: testTimeout) { done in
@@ -4451,16 +4419,17 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
             
             // RSA4f, RSA8c
-            context("when the JWT token is returned with application/jwt content type") {
+            
 
-                beforeEach {
+                func beforeEach__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type() {
                     jwtContentTypeTestsSetupDependencies()
                 }
                 
-                it("the client successfully connects and pulls stats") {
+                func test__156__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type__the_client_successfully_connects_and_pulls_stats() {
+beforeEach__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type()
+
                     waitUntil(timeout: testTimeout) { done in
                         client.stats { stats, error in
                             expect(error).to(beNil())
@@ -4469,7 +4438,9 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
                 
-                it("the client can request a new token to initilize another client that connects and pulls stats") {
+                func test__157__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type__the_client_can_request_a_new_token_to_initilize_another_client_that_connects_and_pulls_stats() {
+beforeEach__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type()
+
                     waitUntil(timeout: testTimeout) { done in
                         client.auth.requestToken(nil, with: nil, callback: { tokenDetails, error in
                             let newClientOptions = AblyTests.clientOptions()
@@ -4482,19 +4453,16 @@ override class var defaultTestSuite : XCTestSuite {
                         })
                     }
                 }
-            }
-
-        }
 
         // https://github.com/ably/ably-cocoa/issues/849
-        it("should not force token auth when clientId is set") {
+        func test__001__should_not_force_token_auth_when_clientId_is_set() {
             let options = AblyTests.commonAppSetup()
             options.clientId = "foo"
             expect(options.isBasicAuth()).to(beTrue())
         }
 
         // https://github.com/ably/ably-cocoa/issues/1093
-        it("should accept authURL response with timestamp argument as string") {
+        func test__002__should_accept_authURL_response_with_timestamp_argument_as_string() {
             var originalTokenRequest: ARTTokenRequest!
             let tmpRest = ARTRest(options: AblyTests.commonAppSetup())
             waitUntil(timeout: testTimeout) { done in
@@ -4543,6 +4511,4 @@ override class var defaultTestSuite : XCTestSuite {
             expect(tokenDetails.clientId).to(equal(originalTokenRequest.clientId))
             expect(tokenDetails.token).toNot(beNil())
         }
-
-    }
 }

--- a/Spec/Crypto.swift
+++ b/Spec/Crypto.swift
@@ -1,6 +1,6 @@
 import Ably
 import Nimble
-import Quick
+import XCTest
 import SwiftyJSON
 
 private let key = "+/h4eHh4eHh4eHh4eHh4eA=="

--- a/Spec/Crypto.swift
+++ b/Spec/Crypto.swift
@@ -7,7 +7,7 @@ import SwiftyJSON
             private let binaryKey = Data(base64Encoded: key, options: .ignoreUnknownCharacters)!
             private let longKey = binaryKey + binaryKey
 
-class Crypto : QuickSpec {    
+class Crypto : XCTestCase {    
 
 // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
 override class var defaultTestSuite : XCTestSuite {
@@ -17,14 +17,12 @@ override class var defaultTestSuite : XCTestSuite {
 
     return super.defaultTestSuite
 }
-
-    override func spec() {
-        describe("Crypto") {
+        
 
             // RSE1
-            context("getDefaultParams") {
+            
                 // RSE1a, RSE1b
-                it("returns a complete CipherParams instance, using the default values for any field not supplied") {
+                func test__001__Crypto__getDefaultParams__returns_a_complete_CipherParams_instance__using_the_default_values_for_any_field_not_supplied() {
                     expect{ARTCrypto.getDefaultParams(["nokey":"nokey"])}.to(raiseException())
 
                     var params: ARTCipherParams = ARTCrypto.getDefaultParams([
@@ -46,26 +44,25 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSE1c
-                context("key parameter") {
-                    it("can be a binary") {
+                
+                    func test__004__Crypto__getDefaultParams__key_parameter__can_be_a_binary() {
                         let params = ARTCrypto.getDefaultParams(["key": binaryKey])
                         expect(params.key).to(equal(binaryKey as Data))
                     }
 
-                    it("can be a base64-encoded string with standard encoding") {
+                    func test__005__Crypto__getDefaultParams__key_parameter__can_be_a_base64_encoded_string_with_standard_encoding() {
                         let params = ARTCrypto.getDefaultParams(["key": key])
                         expect(params.key).to(equal(binaryKey as Data))
                     }
 
-                    it("can be a base64-encoded string with URL encoding") {
+                    func test__006__Crypto__getDefaultParams__key_parameter__can_be_a_base64_encoded_string_with_URL_encoding() {
                         let key = "-_h4eHh4eHh4eHh4eHh4eA=="
                         let params = ARTCrypto.getDefaultParams(["key": key])
                         expect(params.key).to(equal(binaryKey as Data))
                     }
-                }
 
                 // RSE1d
-                it("calculates a keyLength from the key (its size in bits)") {
+                func test__002__Crypto__getDefaultParams__calculates_a_keyLength_from_the_key__its_size_in_bits_() {
                     var params = ARTCrypto.getDefaultParams(["key": binaryKey])
                     expect(params.keyLength).to(equal(128))
 
@@ -74,18 +71,16 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSE1e
-                it("should check that keyLength is valid for algorithm") {
+                func test__003__Crypto__getDefaultParams__should_check_that_keyLength_is_valid_for_algorithm() {
                     expect{ARTCrypto.getDefaultParams([
                         "key": binaryKey.subdata(in: 0..<10)
                     ])}.to(raiseException())
                 }
 
-            }
-
             // RSE2
-            context("generateRandomKey") {
+            
                 // RSE2a, RSE2b
-                it("takes a single length argument and returns a binary") {
+                func test__007__Crypto__generateRandomKey__takes_a_single_length_argument_and_returns_a_binary() {
                     var key: NSData = ARTCrypto.generateRandomKey(128) as NSData
                     expect(key.length).to(equal(128 / 8))
 
@@ -94,24 +89,22 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSE2a, RSE2b
-                it("takes no arguments and returns the default algorithm's default length") {
+                func test__008__Crypto__generateRandomKey__takes_no_arguments_and_returns_the_default_algorithm_s_default_length() {
                     let key: NSData = ARTCrypto.generateRandomKey() as NSData
                     expect(key.length).to(equal(256 / 8))
                 }
-            }
 
-            context("generateHashSHA256") {
-                it("takes data and returns a SHA256 digest") {
+            
+                func test__009__Crypto__generateHashSHA256__takes_data_and_returns_a_SHA256_digest() {
                     let string = "The quick brown fox jumps over the lazy dog"
                     let expectedHash = "D7A8FBB307D7809469CA9ABCB0082E4F8D5651E46D3CDB762D02D0BF37C9E592" //hex
                     let stringData = string.data(using: .utf8)!
                     let result = ARTCrypto.generateHashSHA256(stringData)
                     expect(result.hexString).to(equal(expectedHash))
                 }
-            }
 
-            context("encrypt") {
-                it("should generate a new IV every time it's called, and should be the first block encrypted") {
+            
+                func test__010__Crypto__encrypt__should_generate_a_new_IV_every_time_it_s_called__and_should_be_the_first_block_encrypted() {
                     let params = ARTCipherParams(algorithm: "aes", key: key as ARTCipherKeyCompatible)
                     let cipher = ARTCrypto.cipher(with: params)
                     let data = "data".data(using: String.Encoding.utf8)!
@@ -133,9 +126,13 @@ override class var defaultTestSuite : XCTestSuite {
 
                     expect(distinctOutputs.count).to(equal(3))
                 }
-            }
+enum TestCase_ReusableTestsTestFixture {
+case should_encrypt_messages_as_expected_in_the_fixtures
+case should_decrypt_messages_as_expected_in_the_fixtures
+}
 
-            func reusableTestsTestFixture(_ cryptoFixture: ( fileName: String, expectedEncryptedEncoding: String, keyLength: UInt)) {
+
+            func reusableTestsTestFixture(_ cryptoFixture: ( fileName: String, expectedEncryptedEncoding: String, keyLength: UInt), testCase: TestCase_ReusableTestsTestFixture, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil) {
                 let (key, iv, items) = AblyTests.loadCryptoTestData(cryptoFixture.fileName)
                 let decoder = ARTDataEncoder.init(cipherParams: nil, error: nil)
                 let cipherParams = ARTCipherParams(algorithm: "aes", key: key as ARTCipherKeyCompatible, iv: iv)
@@ -147,7 +144,9 @@ override class var defaultTestSuite : XCTestSuite {
                     return msg
                 }
                 
-                it("should encrypt messages as expected in the fixtures") {
+                func test__should_encrypt_messages_as_expected_in_the_fixtures() {
+contextBeforeEach?()
+
                     for item in items {
                         let fixture = extractMessage(item.encoded)
                         let encryptedFixture = extractMessage(item.encrypted)
@@ -164,9 +163,14 @@ override class var defaultTestSuite : XCTestSuite {
                         
                         expect((encrypted as! ARTMessage)).to(equal(encryptedFixture))
                     }
+
+contextAfterEach?()
+
                 }
                 
-                it("should decrypt messages as expected in the fixtures") {
+                func test__should_decrypt_messages_as_expected_in_the_fixtures() {
+contextBeforeEach?()
+
                     for item in items {
                         let fixture = extractMessage(item.encoded)
                         let encryptedFixture = extractMessage(item.encrypted)
@@ -183,16 +187,41 @@ override class var defaultTestSuite : XCTestSuite {
                         
                         expect((decrypted as! ARTMessage)).to(equal(decoded))
                     }
+
+contextAfterEach?()
+
                 }
+
+switch testCase  {
+case .should_encrypt_messages_as_expected_in_the_fixtures:
+    test__should_encrypt_messages_as_expected_in_the_fixtures()
+case .should_decrypt_messages_as_expected_in_the_fixtures:
+    test__should_decrypt_messages_as_expected_in_the_fixtures()
+}
+
             }
 
-            context("with fixtures from crypto-data-128.json") {
-                reusableTestsTestFixture(("crypto-data-128",  "cipher+aes-128-cbc", 128))
-            }
+            
+                func reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_128_json__reusableTestsTestFixture(testCase: TestCase_ReusableTestsTestFixture) {
+                reusableTestsTestFixture(("crypto-data-128",  "cipher+aes-128-cbc", 128), testCase: testCase)}
+func test__011__Crypto__with_fixtures_from_crypto_data_128_json__should_encrypt_messages_as_expected_in_the_fixtures() {
+reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_128_json__reusableTestsTestFixture(testCase: .should_encrypt_messages_as_expected_in_the_fixtures)
+}
 
-            context("with fixtures from crypto-data-256.json") {
-                reusableTestsTestFixture(("crypto-data-256",  "cipher+aes-256-cbc", 256))
-            }
-        }
-    }
+func test__012__Crypto__with_fixtures_from_crypto_data_128_json__should_decrypt_messages_as_expected_in_the_fixtures() {
+reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_128_json__reusableTestsTestFixture(testCase: .should_decrypt_messages_as_expected_in_the_fixtures)
+}
+
+
+            
+                func reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_256_json__reusableTestsTestFixture(testCase: TestCase_ReusableTestsTestFixture) {
+                reusableTestsTestFixture(("crypto-data-256",  "cipher+aes-256-cbc", 256), testCase: testCase)}
+func test__013__Crypto__with_fixtures_from_crypto_data_256_json__should_encrypt_messages_as_expected_in_the_fixtures() {
+reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_256_json__reusableTestsTestFixture(testCase: .should_encrypt_messages_as_expected_in_the_fixtures)
+}
+
+func test__014__Crypto__with_fixtures_from_crypto_data_256_json__should_decrypt_messages_as_expected_in_the_fixtures() {
+reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_256_json__reusableTestsTestFixture(testCase: .should_decrypt_messages_as_expected_in_the_fixtures)
+}
+
 }

--- a/Spec/Crypto.swift
+++ b/Spec/Crypto.swift
@@ -3,225 +3,218 @@ import Nimble
 import Quick
 import SwiftyJSON
 
-            private let key = "+/h4eHh4eHh4eHh4eHh4eA=="
-            private let binaryKey = Data(base64Encoded: key, options: .ignoreUnknownCharacters)!
-            private let longKey = binaryKey + binaryKey
+private let key = "+/h4eHh4eHh4eHh4eHh4eA=="
+private let binaryKey = Data(base64Encoded: key, options: .ignoreUnknownCharacters)!
+private let longKey = binaryKey + binaryKey
 
-class Crypto : XCTestCase {    
+class Crypto: XCTestCase {
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = key
+        _ = binaryKey
+        _ = longKey
 
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = key
-    let _ = binaryKey
-    let _ = longKey
+        return super.defaultTestSuite
+    }
 
-    return super.defaultTestSuite
-}
-        
+    // RSE1
 
-            // RSE1
-            
-                // RSE1a, RSE1b
-                func test__001__Crypto__getDefaultParams__returns_a_complete_CipherParams_instance__using_the_default_values_for_any_field_not_supplied() {
-                    expect{ARTCrypto.getDefaultParams(["nokey":"nokey"])}.to(raiseException())
+    // RSE1a, RSE1b
+    func test__001__Crypto__getDefaultParams__returns_a_complete_CipherParams_instance__using_the_default_values_for_any_field_not_supplied() {
+        expect { ARTCrypto.getDefaultParams(["nokey": "nokey"]) }.to(raiseException())
 
-                    var params: ARTCipherParams = ARTCrypto.getDefaultParams([
-                        "key": key
-                    ])
-                    expect(params.algorithm).to(equal("AES"))
-                    expect(params.key).to(equal(binaryKey as Data))
-                    expect(params.keyLength).to(equal(128))
-                    expect(params.mode).to(equal("CBC"))
+        var params: ARTCipherParams = ARTCrypto.getDefaultParams([
+            "key": key,
+        ])
+        expect(params.algorithm).to(equal("AES"))
+        expect(params.key).to(equal(binaryKey as Data))
+        expect(params.keyLength).to(equal(128))
+        expect(params.mode).to(equal("CBC"))
 
-                    params = ARTCrypto.getDefaultParams([
-                        "key": longKey,
-                        "algorithm": "DES"
-                    ])
-                    expect(params.algorithm).to(equal("DES"))
-                    expect(params.key).to(equal(longKey as Data))
-                    expect(params.keyLength).to(equal(256))
-                    expect(params.mode).to(equal("CBC"))
-                }
+        params = ARTCrypto.getDefaultParams([
+            "key": longKey,
+            "algorithm": "DES",
+        ])
+        expect(params.algorithm).to(equal("DES"))
+        expect(params.key).to(equal(longKey as Data))
+        expect(params.keyLength).to(equal(256))
+        expect(params.mode).to(equal("CBC"))
+    }
 
-                // RSE1c
-                
-                    func test__004__Crypto__getDefaultParams__key_parameter__can_be_a_binary() {
-                        let params = ARTCrypto.getDefaultParams(["key": binaryKey])
-                        expect(params.key).to(equal(binaryKey as Data))
-                    }
+    // RSE1c
 
-                    func test__005__Crypto__getDefaultParams__key_parameter__can_be_a_base64_encoded_string_with_standard_encoding() {
-                        let params = ARTCrypto.getDefaultParams(["key": key])
-                        expect(params.key).to(equal(binaryKey as Data))
-                    }
+    func test__004__Crypto__getDefaultParams__key_parameter__can_be_a_binary() {
+        let params = ARTCrypto.getDefaultParams(["key": binaryKey])
+        expect(params.key).to(equal(binaryKey as Data))
+    }
 
-                    func test__006__Crypto__getDefaultParams__key_parameter__can_be_a_base64_encoded_string_with_URL_encoding() {
-                        let key = "-_h4eHh4eHh4eHh4eHh4eA=="
-                        let params = ARTCrypto.getDefaultParams(["key": key])
-                        expect(params.key).to(equal(binaryKey as Data))
-                    }
+    func test__005__Crypto__getDefaultParams__key_parameter__can_be_a_base64_encoded_string_with_standard_encoding() {
+        let params = ARTCrypto.getDefaultParams(["key": key])
+        expect(params.key).to(equal(binaryKey as Data))
+    }
 
-                // RSE1d
-                func test__002__Crypto__getDefaultParams__calculates_a_keyLength_from_the_key__its_size_in_bits_() {
-                    var params = ARTCrypto.getDefaultParams(["key": binaryKey])
-                    expect(params.keyLength).to(equal(128))
+    func test__006__Crypto__getDefaultParams__key_parameter__can_be_a_base64_encoded_string_with_URL_encoding() {
+        let key = "-_h4eHh4eHh4eHh4eHh4eA=="
+        let params = ARTCrypto.getDefaultParams(["key": key])
+        expect(params.key).to(equal(binaryKey as Data))
+    }
 
-                    params = ARTCrypto.getDefaultParams(["key": longKey])
-                    expect(params.keyLength).to(equal(256))
-                }
+    // RSE1d
+    func test__002__Crypto__getDefaultParams__calculates_a_keyLength_from_the_key__its_size_in_bits_() {
+        var params = ARTCrypto.getDefaultParams(["key": binaryKey])
+        expect(params.keyLength).to(equal(128))
 
-                // RSE1e
-                func test__003__Crypto__getDefaultParams__should_check_that_keyLength_is_valid_for_algorithm() {
-                    expect{ARTCrypto.getDefaultParams([
-                        "key": binaryKey.subdata(in: 0..<10)
-                    ])}.to(raiseException())
-                }
+        params = ARTCrypto.getDefaultParams(["key": longKey])
+        expect(params.keyLength).to(equal(256))
+    }
 
-            // RSE2
-            
-                // RSE2a, RSE2b
-                func test__007__Crypto__generateRandomKey__takes_a_single_length_argument_and_returns_a_binary() {
-                    var key: NSData = ARTCrypto.generateRandomKey(128) as NSData
-                    expect(key.length).to(equal(128 / 8))
+    // RSE1e
+    func test__003__Crypto__getDefaultParams__should_check_that_keyLength_is_valid_for_algorithm() {
+        expect { ARTCrypto.getDefaultParams([
+            "key": binaryKey.subdata(in: 0 ..< 10),
+        ]) }.to(raiseException())
+    }
 
-                    key = ARTCrypto.generateRandomKey(256) as NSData
-                    expect(key.length).to(equal(256 / 8))
-                }
+    // RSE2
 
-                // RSE2a, RSE2b
-                func test__008__Crypto__generateRandomKey__takes_no_arguments_and_returns_the_default_algorithm_s_default_length() {
-                    let key: NSData = ARTCrypto.generateRandomKey() as NSData
-                    expect(key.length).to(equal(256 / 8))
-                }
+    // RSE2a, RSE2b
+    func test__007__Crypto__generateRandomKey__takes_a_single_length_argument_and_returns_a_binary() {
+        var key: NSData = ARTCrypto.generateRandomKey(128) as NSData
+        expect(key.length).to(equal(128 / 8))
 
-            
-                func test__009__Crypto__generateHashSHA256__takes_data_and_returns_a_SHA256_digest() {
-                    let string = "The quick brown fox jumps over the lazy dog"
-                    let expectedHash = "D7A8FBB307D7809469CA9ABCB0082E4F8D5651E46D3CDB762D02D0BF37C9E592" //hex
-                    let stringData = string.data(using: .utf8)!
-                    let result = ARTCrypto.generateHashSHA256(stringData)
-                    expect(result.hexString).to(equal(expectedHash))
-                }
+        key = ARTCrypto.generateRandomKey(256) as NSData
+        expect(key.length).to(equal(256 / 8))
+    }
 
-            
-                func test__010__Crypto__encrypt__should_generate_a_new_IV_every_time_it_s_called__and_should_be_the_first_block_encrypted() {
-                    let params = ARTCipherParams(algorithm: "aes", key: key as ARTCipherKeyCompatible)
-                    let cipher = ARTCrypto.cipher(with: params)
-                    let data = "data".data(using: String.Encoding.utf8)!
+    // RSE2a, RSE2b
+    func test__008__Crypto__generateRandomKey__takes_no_arguments_and_returns_the_default_algorithm_s_default_length() {
+        let key: NSData = ARTCrypto.generateRandomKey() as NSData
+        expect(key.length).to(equal(256 / 8))
+    }
 
-                    var distinctOutputs = Set<NSData>()
-                    var output: NSData?
+    func test__009__Crypto__generateHashSHA256__takes_data_and_returns_a_SHA256_digest() {
+        let string = "The quick brown fox jumps over the lazy dog"
+        let expectedHash = "D7A8FBB307D7809469CA9ABCB0082E4F8D5651E46D3CDB762D02D0BF37C9E592" // hex
+        let stringData = string.data(using: .utf8)!
+        let result = ARTCrypto.generateHashSHA256(stringData)
+        expect(result.hexString).to(equal(expectedHash))
+    }
 
-                    for _ in 0..<3 {
-                        cipher.encrypt(data, output:&output)
-                        distinctOutputs.insert(output!)
+    func test__010__Crypto__encrypt__should_generate_a_new_IV_every_time_it_s_called__and_should_be_the_first_block_encrypted() {
+        let params = ARTCipherParams(algorithm: "aes", key: key as ARTCipherKeyCompatible)
+        let cipher = ARTCrypto.cipher(with: params)
+        let data = "data".data(using: String.Encoding.utf8)!
 
-                        let firstBlock = output!.subdata(with: NSMakeRange(0, Int((cipher as! ARTCbcCipher).blockLength)))
-                        let paramsWithIV = ARTCipherParams(algorithm: "aes", key: key as ARTCipherKeyCompatible, iv: firstBlock)
-                        var sameOutput: NSData?
-                        ARTCrypto.cipher(with: paramsWithIV).encrypt(data, output:&sameOutput)
+        var distinctOutputs = Set<NSData>()
+        var output: NSData?
 
-                        expect(output!).to(equal(sameOutput!))
-                    }
+        for _ in 0 ..< 3 {
+            cipher.encrypt(data, output: &output)
+            distinctOutputs.insert(output!)
 
-                    expect(distinctOutputs.count).to(equal(3))
-                }
-enum TestCase_ReusableTestsTestFixture {
-case should_encrypt_messages_as_expected_in_the_fixtures
-case should_decrypt_messages_as_expected_in_the_fixtures
-}
+            let firstBlock = output!.subdata(with: NSMakeRange(0, Int((cipher as! ARTCbcCipher).blockLength)))
+            let paramsWithIV = ARTCipherParams(algorithm: "aes", key: key as ARTCipherKeyCompatible, iv: firstBlock)
+            var sameOutput: NSData?
+            ARTCrypto.cipher(with: paramsWithIV).encrypt(data, output: &sameOutput)
 
+            expect(output!).to(equal(sameOutput!))
+        }
 
-            func reusableTestsTestFixture(_ cryptoFixture: ( fileName: String, expectedEncryptedEncoding: String, keyLength: UInt), testCase: TestCase_ReusableTestsTestFixture, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil) {
-                let (key, iv, items) = AblyTests.loadCryptoTestData(cryptoFixture.fileName)
-                let decoder = ARTDataEncoder.init(cipherParams: nil, error: nil)
-                let cipherParams = ARTCipherParams(algorithm: "aes", key: key as ARTCipherKeyCompatible, iv: iv)
-                let encrypter = ARTDataEncoder.init(cipherParams: cipherParams, error: nil)
-                
-                func extractMessage(_ fixture: AblyTests.CryptoTestItem.TestMessage) -> ARTMessage {
-                    let msg = ARTMessage(name: fixture.name, data: fixture.data)
-                    msg.encoding = fixture.encoding
-                    return msg
-                }
-                
-                func test__should_encrypt_messages_as_expected_in_the_fixtures() {
-contextBeforeEach?()
+        expect(distinctOutputs.count).to(equal(3))
+    }
 
-                    for item in items {
-                        let fixture = extractMessage(item.encoded)
-                        let encryptedFixture = extractMessage(item.encrypted)
-                        expect(encryptedFixture.encoding).to(endWith("\(cryptoFixture.expectedEncryptedEncoding)/base64"))
-                        
-                        var error: NSError?
-                        let decoded = fixture.decode(with: decoder, error: &error) as! ARTMessage
-                        expect(error).to(beNil())
-                        expect(decoded).notTo(beNil())
-                        
-                        let encrypted = decoded.encode(with: encrypter, error: &error)
-                        expect(error).to(beNil())
-                        expect(encrypted).notTo(beNil())
-                        
-                        expect((encrypted as! ARTMessage)).to(equal(encryptedFixture))
-                    }
+    enum TestCase_ReusableTestsTestFixture {
+        case should_encrypt_messages_as_expected_in_the_fixtures
+        case should_decrypt_messages_as_expected_in_the_fixtures
+    }
 
-contextAfterEach?()
+    func reusableTestsTestFixture(_ cryptoFixture: (fileName: String, expectedEncryptedEncoding: String, keyLength: UInt), testCase: TestCase_ReusableTestsTestFixture, beforeEach contextBeforeEach: (() -> Void)? = nil, afterEach contextAfterEach: (() -> Void)? = nil) {
+        let (key, iv, items) = AblyTests.loadCryptoTestData(cryptoFixture.fileName)
+        let decoder = ARTDataEncoder(cipherParams: nil, error: nil)
+        let cipherParams = ARTCipherParams(algorithm: "aes", key: key as ARTCipherKeyCompatible, iv: iv)
+        let encrypter = ARTDataEncoder(cipherParams: cipherParams, error: nil)
 
-                }
-                
-                func test__should_decrypt_messages_as_expected_in_the_fixtures() {
-contextBeforeEach?()
+        func extractMessage(_ fixture: AblyTests.CryptoTestItem.TestMessage) -> ARTMessage {
+            let msg = ARTMessage(name: fixture.name, data: fixture.data)
+            msg.encoding = fixture.encoding
+            return msg
+        }
 
-                    for item in items {
-                        let fixture = extractMessage(item.encoded)
-                        let encryptedFixture = extractMessage(item.encrypted)
-                        expect(encryptedFixture.encoding).to(endWith("\(cryptoFixture.expectedEncryptedEncoding)/base64"))
-                        
-                        var error: NSError?
-                        let decoded = fixture.decode(with: decoder, error: &error) as! ARTMessage
-                        expect(error).to(beNil())
-                        expect(decoded).notTo(beNil())
-                        
-                        let decrypted = encryptedFixture.decode(with: encrypter, error: &error)
-                        expect(error).to(beNil())
-                        expect(decrypted).notTo(beNil())
-                        
-                        expect((decrypted as! ARTMessage)).to(equal(decoded))
-                    }
+        func test__should_encrypt_messages_as_expected_in_the_fixtures() {
+            contextBeforeEach?()
 
-contextAfterEach?()
+            for item in items {
+                let fixture = extractMessage(item.encoded)
+                let encryptedFixture = extractMessage(item.encrypted)
+                expect(encryptedFixture.encoding).to(endWith("\(cryptoFixture.expectedEncryptedEncoding)/base64"))
 
-                }
+                var error: NSError?
+                let decoded = fixture.decode(with: decoder, error: &error) as! ARTMessage
+                expect(error).to(beNil())
+                expect(decoded).notTo(beNil())
 
-switch testCase  {
-case .should_encrypt_messages_as_expected_in_the_fixtures:
-    test__should_encrypt_messages_as_expected_in_the_fixtures()
-case .should_decrypt_messages_as_expected_in_the_fixtures:
-    test__should_decrypt_messages_as_expected_in_the_fixtures()
-}
+                let encrypted = decoded.encode(with: encrypter, error: &error)
+                expect(error).to(beNil())
+                expect(encrypted).notTo(beNil())
 
+                expect(encrypted as! ARTMessage).to(equal(encryptedFixture))
             }
 
-            
-                func reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_128_json__reusableTestsTestFixture(testCase: TestCase_ReusableTestsTestFixture) {
-                reusableTestsTestFixture(("crypto-data-128",  "cipher+aes-128-cbc", 128), testCase: testCase)}
-func test__011__Crypto__with_fixtures_from_crypto_data_128_json__should_encrypt_messages_as_expected_in_the_fixtures() {
-reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_128_json__reusableTestsTestFixture(testCase: .should_encrypt_messages_as_expected_in_the_fixtures)
-}
+            contextAfterEach?()
+        }
 
-func test__012__Crypto__with_fixtures_from_crypto_data_128_json__should_decrypt_messages_as_expected_in_the_fixtures() {
-reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_128_json__reusableTestsTestFixture(testCase: .should_decrypt_messages_as_expected_in_the_fixtures)
-}
+        func test__should_decrypt_messages_as_expected_in_the_fixtures() {
+            contextBeforeEach?()
 
+            for item in items {
+                let fixture = extractMessage(item.encoded)
+                let encryptedFixture = extractMessage(item.encrypted)
+                expect(encryptedFixture.encoding).to(endWith("\(cryptoFixture.expectedEncryptedEncoding)/base64"))
 
-            
-                func reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_256_json__reusableTestsTestFixture(testCase: TestCase_ReusableTestsTestFixture) {
-                reusableTestsTestFixture(("crypto-data-256",  "cipher+aes-256-cbc", 256), testCase: testCase)}
-func test__013__Crypto__with_fixtures_from_crypto_data_256_json__should_encrypt_messages_as_expected_in_the_fixtures() {
-reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_256_json__reusableTestsTestFixture(testCase: .should_encrypt_messages_as_expected_in_the_fixtures)
-}
+                var error: NSError?
+                let decoded = fixture.decode(with: decoder, error: &error) as! ARTMessage
+                expect(error).to(beNil())
+                expect(decoded).notTo(beNil())
 
-func test__014__Crypto__with_fixtures_from_crypto_data_256_json__should_decrypt_messages_as_expected_in_the_fixtures() {
-reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_256_json__reusableTestsTestFixture(testCase: .should_decrypt_messages_as_expected_in_the_fixtures)
-}
+                let decrypted = encryptedFixture.decode(with: encrypter, error: &error)
+                expect(error).to(beNil())
+                expect(decrypted).notTo(beNil())
 
+                expect(decrypted as! ARTMessage).to(equal(decoded))
+            }
+
+            contextAfterEach?()
+        }
+
+        switch testCase {
+        case .should_encrypt_messages_as_expected_in_the_fixtures:
+            test__should_encrypt_messages_as_expected_in_the_fixtures()
+        case .should_decrypt_messages_as_expected_in_the_fixtures:
+            test__should_decrypt_messages_as_expected_in_the_fixtures()
+        }
+    }
+
+    func reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_128_json__reusableTestsTestFixture(testCase: TestCase_ReusableTestsTestFixture) {
+        reusableTestsTestFixture(("crypto-data-128", "cipher+aes-128-cbc", 128), testCase: testCase)
+    }
+
+    func test__011__Crypto__with_fixtures_from_crypto_data_128_json__should_encrypt_messages_as_expected_in_the_fixtures() {
+        reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_128_json__reusableTestsTestFixture(testCase: .should_encrypt_messages_as_expected_in_the_fixtures)
+    }
+
+    func test__012__Crypto__with_fixtures_from_crypto_data_128_json__should_decrypt_messages_as_expected_in_the_fixtures() {
+        reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_128_json__reusableTestsTestFixture(testCase: .should_decrypt_messages_as_expected_in_the_fixtures)
+    }
+
+    func reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_256_json__reusableTestsTestFixture(testCase: TestCase_ReusableTestsTestFixture) {
+        reusableTestsTestFixture(("crypto-data-256", "cipher+aes-256-cbc", 256), testCase: testCase)
+    }
+
+    func test__013__Crypto__with_fixtures_from_crypto_data_256_json__should_encrypt_messages_as_expected_in_the_fixtures() {
+        reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_256_json__reusableTestsTestFixture(testCase: .should_encrypt_messages_as_expected_in_the_fixtures)
+    }
+
+    func test__014__Crypto__with_fixtures_from_crypto_data_256_json__should_decrypt_messages_as_expected_in_the_fixtures() {
+        reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_256_json__reusableTestsTestFixture(testCase: .should_decrypt_messages_as_expected_in_the_fixtures)
+    }
 }

--- a/Spec/Crypto.swift
+++ b/Spec/Crypto.swift
@@ -3,12 +3,23 @@ import Nimble
 import Quick
 import SwiftyJSON
 
+            private let key = "+/h4eHh4eHh4eHh4eHh4eA=="
+            private let binaryKey = Data(base64Encoded: key, options: .ignoreUnknownCharacters)!
+            private let longKey = binaryKey + binaryKey
+
 class Crypto : QuickSpec {    
+
+// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+override class var defaultTestSuite : XCTestSuite {
+    let _ = key
+    let _ = binaryKey
+    let _ = longKey
+
+    return super.defaultTestSuite
+}
+
     override func spec() {
         describe("Crypto") {
-            let key = "+/h4eHh4eHh4eHh4eHh4eA=="
-            let binaryKey = Data(base64Encoded: key, options: .ignoreUnknownCharacters)!
-            let longKey = binaryKey + binaryKey
 
             // RSE1
             context("getDefaultParams") {

--- a/Spec/DeltaCodec.swift
+++ b/Spec/DeltaCodec.swift
@@ -12,7 +12,7 @@ import AblyDeltaCodec
                     "{ foo: \"bar\", count: 3, status: \"active\" }"
                 ]
 
-class DeltaCodec: QuickSpec {
+class DeltaCodec: XCTestCase {
 
 // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
 override class var defaultTestSuite : XCTestSuite {
@@ -20,14 +20,12 @@ override class var defaultTestSuite : XCTestSuite {
 
     return super.defaultTestSuite
 }
+        
 
-    override func spec() {
-        describe("DeltaCodec") {
-
-            context("decoding") {
+            
 
                 // RTL19
-                it("should decode vcdiff encoded messages") {
+                func test__001__DeltaCodec__decoding__should_decode_vcdiff_encoded_messages() {
                     let options = AblyTests.commonAppSetup()
                     let client = AblyTests.newRealtime(options)
                     defer { client.dispose(); client.close() }
@@ -81,7 +79,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL20
-                it("should fail and recover when the vcdiff messages are out of order") {
+                func test__002__DeltaCodec__decoding__should_fail_and_recover_when_the_vcdiff_messages_are_out_of_order() {
                     let options = AblyTests.commonAppSetup()
                     let client = AblyTests.newRealtime(options)
                     defer { client.dispose(); client.close() }
@@ -139,7 +137,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL18
-                it("should recover when the vcdiff message decoding fails") {
+                func test__003__DeltaCodec__decoding__should_recover_when_the_vcdiff_message_decoding_fails() {
                     let options = AblyTests.commonAppSetup()
                     let client = AblyTests.newRealtime(options)
                     defer { client.dispose(); client.close() }
@@ -193,9 +191,4 @@ override class var defaultTestSuite : XCTestSuite {
 
                     expect(receivedMessages).toEventually(haveCount(testData.count))
                 }
-
-            }
-
-        }
-    }
 }

--- a/Spec/DeltaCodec.swift
+++ b/Spec/DeltaCodec.swift
@@ -3,19 +3,28 @@ import Quick
 import Nimble
 import AblyDeltaCodec
 
-class DeltaCodec: QuickSpec {
-    override func spec() {
-        describe("DeltaCodec") {
 
-            context("decoding") {
-
-                let testData: [String] = [
+                private let testData: [String] = [
                     "{ foo: \"bar\", count: 1, status: \"active\" }",
                     "{ foo: \"bar\", count: 2, status: \"active\" }",
                     "{ foo: \"bar\", count: 2, status: \"inactive\" }",
                     "{ foo: \"bar\", count: 3, status: \"inactive\" }",
                     "{ foo: \"bar\", count: 3, status: \"active\" }"
                 ]
+
+class DeltaCodec: QuickSpec {
+
+// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+override class var defaultTestSuite : XCTestSuite {
+    let _ = testData
+
+    return super.defaultTestSuite
+}
+
+    override func spec() {
+        describe("DeltaCodec") {
+
+            context("decoding") {
 
                 // RTL19
                 it("should decode vcdiff encoded messages") {

--- a/Spec/DeltaCodec.swift
+++ b/Spec/DeltaCodec.swift
@@ -1,7 +1,7 @@
 import Ably
 import AblyDeltaCodec
 import Nimble
-import Quick
+import XCTest
 
 private let testData: [String] = [
     "{ foo: \"bar\", count: 1, status: \"active\" }",

--- a/Spec/Info-iOS.plist
+++ b/Spec/Info-iOS.plist
@@ -20,6 +20,8 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSPrincipalClass</key>
+	<string>Ably_iOS_Tests.AblyTestsConfiguration</string>
 	<key>ABLY_ENV</key>
 	<string>$(ABLY_ENV)</string>
 </dict>

--- a/Spec/Info-macOS.plist
+++ b/Spec/Info-macOS.plist
@@ -18,6 +18,8 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSPrincipalClass</key>
+	<string>Ably_iOS_Tests.AblyTestsConfiguration</string>
 	<key>ABLY_ENV</key>
 	<string>$(ABLY_ENV)</string>
 </dict>

--- a/Spec/Info-tvOS.plist
+++ b/Spec/Info-tvOS.plist
@@ -18,5 +18,7 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSPrincipalClass</key>
+	<string>Ably_iOS_Tests.AblyTestsConfiguration</string>
 </dict>
 </plist>

--- a/Spec/ObjectLifetimes.swift
+++ b/Spec/ObjectLifetimes.swift
@@ -8,7 +8,7 @@ import Nimble
                 return options
             }()
 
-class ObjectLifetimes: QuickSpec {
+class ObjectLifetimes: XCTestCase {
 
 // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
 override class var defaultTestSuite : XCTestSuite {
@@ -16,12 +16,10 @@ override class var defaultTestSuite : XCTestSuite {
 
     return super.defaultTestSuite
 }
-
-    override func spec() {
-        describe("ObjectLifetimes") {
+        
             
-            context("user code releases public object") {
-                it("the object's internal child's back-reference is released too") {
+            
+                func test__001__ObjectLifetimes__user_code_releases_public_object__the_object_s_internal_child_s_back_reference_is_released_too() {
                     var realtime: ARTRealtime? = ARTRealtime(options: options)
                     weak var internalRealtime: ARTRealtimeInternal? = realtime!.internal
                     weak var internalConn: ARTConnectionInternal? = realtime!.connection.internal
@@ -48,10 +46,9 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
-            context("user code holds only reference to public object's public child") {
-                it("still can access parent's internal object") {
+            
+                func test__002__ObjectLifetimes__user_code_holds_only_reference_to_public_object_s_public_child__still_can_access_parent_s_internal_object() {
                     let conn = ARTRealtime(options: options).connection
 
                     waitUntil(timeout: testTimeout) { done in
@@ -61,8 +58,8 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
                 
-                context("when it's released") {
-                    it("schedules async release of parent's internal object in internal queue") {
+                
+                    func test__003__ObjectLifetimes__user_code_holds_only_reference_to_public_object_s_public_child__when_it_s_released__schedules_async_release_of_parent_s_internal_object_in_internal_queue() {
                         var conn: ARTConnection? = ARTRealtime(options: options).connection
                         weak var weakConn = conn!.internal_nosync
 
@@ -83,11 +80,9 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                         }
                     }
-                }
-            }
             
-            context("when user leaves Realtime open") {
-                it("still works") {
+            
+                func test__004__ObjectLifetimes__when_user_leaves_Realtime_open__still_works() {
                     let options = AblyTests.commonAppSetup()
                     
                     var client: ARTRealtime? = ARTRealtime(options: options)
@@ -106,10 +101,9 @@ override class var defaultTestSuite : XCTestSuite {
                         })
                     }
                 }
-            }
 
-            context("when Realtime is closed and user loses its reference") {
-                it("channels don't leak") {
+            
+                func test__005__ObjectLifetimes__when_Realtime_is_closed_and_user_loses_its_reference__channels_don_t_leak() {
                     let options = AblyTests.commonAppSetup()
 
                     var client: ARTRealtime? = ARTRealtime(options: options)
@@ -148,7 +142,4 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
-        }
-    }
 }

--- a/Spec/ObjectLifetimes.swift
+++ b/Spec/ObjectLifetimes.swift
@@ -1,145 +1,138 @@
 import Ably
-import Quick
 import Nimble
+import Quick
 
-            private let options: ARTClientOptions = {
-                let options = ARTClientOptions(key: "fake:key")
-                options.autoConnect = false
-                return options
-            }()
+private let options: ARTClientOptions = {
+    let options = ARTClientOptions(key: "fake:key")
+    options.autoConnect = false
+    return options
+}()
 
 class ObjectLifetimes: XCTestCase {
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = options
 
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = options
+        return super.defaultTestSuite
+    }
 
-    return super.defaultTestSuite
-}
-        
-            
-            
-                func test__001__ObjectLifetimes__user_code_releases_public_object__the_object_s_internal_child_s_back_reference_is_released_too() {
-                    var realtime: ARTRealtime? = ARTRealtime(options: options)
-                    weak var internalRealtime: ARTRealtimeInternal? = realtime!.internal
-                    weak var internalConn: ARTConnectionInternal? = realtime!.connection.internal
-                    weak var internalRest: ARTRestInternal? = realtime!.internal.rest
+    func test__001__ObjectLifetimes__user_code_releases_public_object__the_object_s_internal_child_s_back_reference_is_released_too() {
+        var realtime: ARTRealtime? = ARTRealtime(options: options)
+        weak var internalRealtime: ARTRealtimeInternal? = realtime!.internal
+        weak var internalConn: ARTConnectionInternal? = realtime!.connection.internal
+        weak var internalRest: ARTRestInternal? = realtime!.internal.rest
 
-                    waitUntil(timeout: testTimeout) { done in
-                        options.internalDispatchQueue.async {
-                            realtime = nil // Schedule deallocation for later in this queue
-                            expect(internalConn).toNot(beNil()) // Deallocation still hasn't happened.
-                            expect(internalRealtime).toNot(beNil())
-                            expect(internalRest).toNot(beNil())
-                            done()
-                        }
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            options.internalDispatchQueue.async {
+                realtime = nil // Schedule deallocation for later in this queue
+                expect(internalConn).toNot(beNil()) // Deallocation still hasn't happened.
+                expect(internalRealtime).toNot(beNil())
+                expect(internalRest).toNot(beNil())
+                done()
+            }
+        }
 
-                    // Deallocation should happen here.
+        // Deallocation should happen here.
 
-                    waitUntil(timeout: testTimeout) { done in
-                        options.internalDispatchQueue.async {
-                            expect(internalConn).to(beNil())
-                            expect(internalRealtime).to(beNil())
-                            expect(internalRest).to(beNil())
-                            done()
-                        }
-                    }
-                }
+        waitUntil(timeout: testTimeout) { done in
+            options.internalDispatchQueue.async {
+                expect(internalConn).to(beNil())
+                expect(internalRealtime).to(beNil())
+                expect(internalRest).to(beNil())
+                done()
+            }
+        }
+    }
 
-            
-                func test__002__ObjectLifetimes__user_code_holds_only_reference_to_public_object_s_public_child__still_can_access_parent_s_internal_object() {
-                    let conn = ARTRealtime(options: options).connection
+    func test__002__ObjectLifetimes__user_code_holds_only_reference_to_public_object_s_public_child__still_can_access_parent_s_internal_object() {
+        let conn = ARTRealtime(options: options).connection
 
-                    waitUntil(timeout: testTimeout) { done in
-                        conn.ping { _ in
-                            done()
-                        }
-                    }
-                }
-                
-                
-                    func test__003__ObjectLifetimes__user_code_holds_only_reference_to_public_object_s_public_child__when_it_s_released__schedules_async_release_of_parent_s_internal_object_in_internal_queue() {
-                        var conn: ARTConnection? = ARTRealtime(options: options).connection
-                        weak var weakConn = conn!.internal_nosync
+        waitUntil(timeout: testTimeout) { done in
+            conn.ping { _ in
+                done()
+            }
+        }
+    }
 
-                        waitUntil(timeout: testTimeout) { done in
-                            options.internalDispatchQueue.async {
-                                conn = nil // Schedule deallocation for later in this queue
-                                expect(weakConn).toNot(beNil()) // Deallocation still hasn't happened.
-                                done()
-                            }
-                        }
-                        
-                        // Deallocation should happen here.
-                        
-                        waitUntil(timeout: testTimeout) { done in
-                            options.internalDispatchQueue.async {
-                                expect(weakConn).to(beNil())
-                                done()
-                            }
-                        }
-                    }
-            
-            
-                func test__004__ObjectLifetimes__when_user_leaves_Realtime_open__still_works() {
-                    let options = AblyTests.commonAppSetup()
-                    
-                    var client: ARTRealtime? = ARTRealtime(options: options)
-                    
-                    weak var weakClient = client!.internal
-                    expect(weakClient).toNot(beNil())
-                    defer { client?.close() }
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        client!.channels.get("foo").subscribe(attachCallback: { _ in
-                            client = nil
-                            ARTRest(options: options).channels.get("foo").publish(nil, data: "bar")
-                        }, callback: { msg in
-                            expect(msg.data as? String).to(equal("bar"))
-                            done()
-                        })
-                    }
-                }
+    func test__003__ObjectLifetimes__user_code_holds_only_reference_to_public_object_s_public_child__when_it_s_released__schedules_async_release_of_parent_s_internal_object_in_internal_queue() {
+        var conn: ARTConnection? = ARTRealtime(options: options).connection
+        weak var weakConn = conn!.internal_nosync
 
-            
-                func test__005__ObjectLifetimes__when_Realtime_is_closed_and_user_loses_its_reference__channels_don_t_leak() {
-                    let options = AblyTests.commonAppSetup()
+        waitUntil(timeout: testTimeout) { done in
+            options.internalDispatchQueue.async {
+                conn = nil // Schedule deallocation for later in this queue
+                expect(weakConn).toNot(beNil()) // Deallocation still hasn't happened.
+                done()
+            }
+        }
 
-                    var client: ARTRealtime? = ARTRealtime(options: options)
-                    weak var weakClient = client!.internal
+        // Deallocation should happen here.
 
-                    var channel: ARTRealtimeChannel? = client!.channels.get("foo")
-                    weak var weakChannel = channel!.internal
+        waitUntil(timeout: testTimeout) { done in
+            options.internalDispatchQueue.async {
+                expect(weakConn).to(beNil())
+                done()
+            }
+        }
+    }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel!.attach { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            done()
-                        }
-                    }
+    func test__004__ObjectLifetimes__when_user_leaves_Realtime_open__still_works() {
+        let options = AblyTests.commonAppSetup()
 
-                    waitUntil(timeout: testTimeout) { done in
-                        client!.connection.on(.closed) { _ in
-                            done()
-                        }
-                        client!.close()
-                    }
+        var client: ARTRealtime? = ARTRealtime(options: options)
 
-                    waitUntil(timeout: testTimeout) { done in
-                        AblyTests.queue.async {
-                            client = nil // should enqueue a release
-                            channel = nil // should enqueue a release
-                            done()
-                        }
-                    }
+        weak var weakClient = client!.internal
+        expect(weakClient).toNot(beNil())
+        defer { client?.close() }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        AblyTests.queue.async {
-                            expect(weakClient).to(beNil())
-                            expect(weakChannel).to(beNil())
-                            done()
-                        }
-                    }
-                }
+        waitUntil(timeout: testTimeout) { done in
+            client!.channels.get("foo").subscribe(attachCallback: { _ in
+                client = nil
+                ARTRest(options: options).channels.get("foo").publish(nil, data: "bar")
+            }, callback: { msg in
+                expect(msg.data as? String).to(equal("bar"))
+                done()
+            })
+        }
+    }
+
+    func test__005__ObjectLifetimes__when_Realtime_is_closed_and_user_loses_its_reference__channels_don_t_leak() {
+        let options = AblyTests.commonAppSetup()
+
+        var client: ARTRealtime? = ARTRealtime(options: options)
+        weak var weakClient = client!.internal
+
+        var channel: ARTRealtimeChannel? = client!.channels.get("foo")
+        weak var weakChannel = channel!.internal
+
+        waitUntil(timeout: testTimeout) { done in
+            channel!.attach { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            client!.connection.on(.closed) { _ in
+                done()
+            }
+            client!.close()
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            AblyTests.queue.async {
+                client = nil // should enqueue a release
+                channel = nil // should enqueue a release
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            AblyTests.queue.async {
+                expect(weakClient).to(beNil())
+                expect(weakChannel).to(beNil())
+                done()
+            }
+        }
+    }
 }

--- a/Spec/ObjectLifetimes.swift
+++ b/Spec/ObjectLifetimes.swift
@@ -2,14 +2,23 @@ import Ably
 import Quick
 import Nimble
 
-class ObjectLifetimes: QuickSpec {
-    override func spec() {
-        describe("ObjectLifetimes") {
-            let options: ARTClientOptions = {
+            private let options: ARTClientOptions = {
                 let options = ARTClientOptions(key: "fake:key")
                 options.autoConnect = false
                 return options
             }()
+
+class ObjectLifetimes: QuickSpec {
+
+// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+override class var defaultTestSuite : XCTestSuite {
+    let _ = options
+
+    return super.defaultTestSuite
+}
+
+    override func spec() {
+        describe("ObjectLifetimes") {
             
             context("user code releases public object") {
                 it("the object's internal child's back-reference is released too") {

--- a/Spec/ObjectLifetimes.swift
+++ b/Spec/ObjectLifetimes.swift
@@ -1,6 +1,6 @@
 import Ably
 import Nimble
-import Quick
+import XCTest
 
 private let options: ARTClientOptions = {
     let options = ARTClientOptions(key: "fake:key")

--- a/Spec/Push.swift
+++ b/Spec/Push.swift
@@ -1,6 +1,6 @@
 import Ably
 import Nimble
-import Quick
+import XCTest
 
 private var rest: ARTRest!
 private var mockHttpExecutor: MockHTTPExecutor!

--- a/Spec/Push.swift
+++ b/Spec/Push.swift
@@ -2,6 +2,12 @@ import Ably
 import Nimble
 import Quick
 
+
+        private var rest: ARTRest!
+        private var mockHttpExecutor: MockHTTPExecutor!
+        private var storage: MockDeviceStorage!
+        private var stateMachineDelegate: StateMachineDelegate!
+
 class Push : QuickSpec {
 
     struct TestDeviceToken {
@@ -10,12 +16,18 @@ class Push : QuickSpec {
         static let tokenString = tokenData.map { String(format: "%02x", $0) }.joined()
     }
 
-    override func spec() {
+// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+override class var defaultTestSuite : XCTestSuite {
+    let _ = rest
+    let _ = mockHttpExecutor
+    let _ = storage
+    let _ = stateMachineDelegate
 
-        var rest: ARTRest!
-        var mockHttpExecutor: MockHTTPExecutor!
-        var storage: MockDeviceStorage!
-        var stateMachineDelegate: StateMachineDelegate!
+    return super.defaultTestSuite
+}
+
+
+    override func spec() {
 
         beforeEach {
             rest = ARTRest(key: "xxxx:xxxx")

--- a/Spec/Push.swift
+++ b/Spec/Push.swift
@@ -8,7 +8,7 @@ import Quick
         private var storage: MockDeviceStorage!
         private var stateMachineDelegate: StateMachineDelegate!
 
-class Push : QuickSpec {
+class Push : XCTestCase {
 
     struct TestDeviceToken {
         static let tokenBase64 = "HYRXxPSQdt1pnxqtDAvc6PTTLH7N6okiBhYyLClJdmQ="
@@ -26,10 +26,10 @@ override class var defaultTestSuite : XCTestSuite {
     return super.defaultTestSuite
 }
 
+        override func setUp() {
+super.setUp()
 
-    override func spec() {
 
-        beforeEach {
             rest = ARTRest(key: "xxxx:xxxx")
             rest.internal.resetDeviceSingleton()
             mockHttpExecutor = MockHTTPExecutor()
@@ -41,10 +41,10 @@ override class var defaultTestSuite : XCTestSuite {
         }
 
         // RSH2
-        describe("activation") {
+        
 
             // RSH2a
-            it("activate method should send a CalledActivate event to the state machine") {
+            func test__001__activation__activate_method_should_send_a_CalledActivate_event_to_the_state_machine() {
                 defer { rest.push.internal.activationMachine.transitions = nil }
                 waitUntil(timeout: testTimeout) { done in
                     rest.push.internal.activationMachine.transitions = { event, _, _ in
@@ -57,7 +57,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSH2b
-            it("deactivate method should send a CalledDeactivate event to the state machine") {
+            func test__002__activation__deactivate_method_should_send_a_CalledDeactivate_event_to_the_state_machine() {
                 defer { rest.push.internal.activationMachine.transitions = nil }
                 waitUntil(timeout: testTimeout) { done in
                     rest.push.internal.activationMachine.transitions = { event, _, _ in
@@ -70,7 +70,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSH2c / RSH8g
-            it("should handle GotPushDeviceDetails event when platform’s APIs sends the details for push notifications") {
+            func test__003__activation__should_handle_GotPushDeviceDetails_event_when_platform_s_APIs_sends_the_details_for_push_notifications() {
                 let stateMachine = rest.push.internal.activationMachine
                 let testDeviceToken = "xxxx-xxxx-xxxx-xxxx-xxxx"
                 stateMachine.rest.device.setAndPersistAPNSDeviceToken(testDeviceToken)
@@ -92,7 +92,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
             
             // RSH2d / RSH8h
-            it("sends GettingPushDeviceDetailsFailed when push registration fails") {
+            func test__004__activation__sends_GettingPushDeviceDetailsFailed_when_push_registration_fails() {
                 let stateMachine = rest.push.internal.activationMachine
                 defer { stateMachine.transitions = nil }
                 waitUntil(timeout: testTimeout) { done in
@@ -109,7 +109,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // https://github.com/ably/ably-cocoa/issues/877
-            it("should update LocalDevice.clientId when it's null with auth.clientId") {
+            func test__005__activation__should_update_LocalDevice_clientId_when_it_s_null_with_auth_clientId() {
                 let expectedClientId = "foo"
                 let options = AblyTests.clientOptions()
 
@@ -186,7 +186,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // https://github.com/ably/ably-cocoa/issues/889
-            it("should store the device token data as string") {
+            func test__006__activation__should_store_the_device_token_data_as_string() {
                 let expectedDeviceToken = TestDeviceToken.tokenString
                 defer { rest.push.internal.activationMachine.transitions = nil }
                 waitUntil(timeout: testTimeout) { done in
@@ -202,21 +202,19 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // https://github.com/ably/ably-cocoa/issues/888
-            it("should not sync the local device dispatched in internal queue") {
+            func test__007__activation__should_not_sync_the_local_device_dispatched_in_internal_queue() {
                 expect { ARTPush.didRegisterForRemoteNotifications(withDeviceToken: TestDeviceToken.tokenData, rest: rest) }.toNot(raiseException())
             }
 
-        }
-
-        context("LocalDevice") {
+        
             // RSH8
-            it("has a device method that returns a LocalDevice") {
+            func test__008__LocalDevice__has_a_device_method_that_returns_a_LocalDevice() {
                 let _: ARTLocalDevice = ARTRest(key: "fake:key").device
                 let _: ARTLocalDevice = ARTRealtime(key: "fake:key").device
             }
             
             // RSH8a
-            it("the device is lazily populated from the persisted state") {
+            func test__009__LocalDevice__the_device_is_lazily_populated_from_the_persisted_state() {
                 let testToken = "testDeviceToken"
                 let testIdentity = ARTDeviceIdentityTokenDetails(
                     token: "123456",
@@ -238,8 +236,8 @@ override class var defaultTestSuite : XCTestSuite {
             }
             
             // RSH8d
-            context("when using token authentication") {
-                it("new clientID is set") {
+            
+                func test__012__LocalDevice__when_using_token_authentication__new_clientID_is_set() {
                     let options = ARTClientOptions(key: "fake:key")
                     options.autoConnect = false
                     options.authCallback = { _, callback in
@@ -259,11 +257,10 @@ override class var defaultTestSuite : XCTestSuite {
 
                     expect(realtime.device.clientId).to(equal("testClient"))
                 }
-            }
             
             // RSH8d
-            context("when getting a client ID from CONNECTED message") {
-                it("new clientID is set") {
+            
+                func test__013__LocalDevice__when_getting_a_client_ID_from_CONNECTED_message__new_clientID_is_set() {
                     let options = ARTClientOptions(key: "fake:key")
                     options.autoConnect = false
 
@@ -285,10 +282,9 @@ override class var defaultTestSuite : XCTestSuite {
 
                     expect(realtime.device.clientId).to(equal("testClient"))
                 }
-            }
             
             // RSH8e
-            it("authentication on registered device sends a GotPushDeviceDetails with new clientID") {
+            func test__010__LocalDevice__authentication_on_registered_device_sends_a_GotPushDeviceDetails_with_new_clientID() {
                 let testDeviceToken = "testDeviceToken"
                 let testDeviceIdentity = ARTDeviceIdentityTokenDetails(
                     token: "123456",
@@ -359,7 +355,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSH8f
-            it("sets device's client ID from registration response") {
+            func test__011__LocalDevice__sets_device_s_client_ID_from_registration_response() {
                 let expectedClientId = "testClientId"
 
                 let stateMachineDelegate = StateMachineDelegateCustomCallbacks()
@@ -388,11 +384,10 @@ override class var defaultTestSuite : XCTestSuite {
                 
                 expect(rest.device.clientId).to(equal(expectedClientId))
             }
-        }
 
-        context("Registerer Delegate option") {
+        
 
-            it("a successful activation should call the correct registerer delegate method") {
+            func test__014__Registerer_Delegate_option__a_successful_activation_should_call_the_correct_registerer_delegate_method() {
                 let options = AblyTests.commonAppSetup()
                 options.key = "xxxx:xxxx"
                 let pushRegistererDelegate = StateMachineDelegate()
@@ -410,7 +405,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
             }
 
-            it("registerer delegate should not hold a strong instance reference") {
+            func test__015__Registerer_Delegate_option__registerer_delegate_should_not_hold_a_strong_instance_reference() {
                 let options = AblyTests.commonAppSetup()
                 options.key = "xxxx:xxxx"
                 var pushRegistererDelegate: StateMachineDelegate? = StateMachineDelegate()
@@ -420,7 +415,4 @@ override class var defaultTestSuite : XCTestSuite {
                 pushRegistererDelegate = nil
                 expect(rest.internal.options.pushRegistererDelegate).to(beNil())
             }
-
-        }
-    }
 }

--- a/Spec/Push.swift
+++ b/Spec/Push.swift
@@ -2,417 +2,409 @@ import Ably
 import Nimble
 import Quick
 
+private var rest: ARTRest!
+private var mockHttpExecutor: MockHTTPExecutor!
+private var storage: MockDeviceStorage!
+private var stateMachineDelegate: StateMachineDelegate!
 
-        private var rest: ARTRest!
-        private var mockHttpExecutor: MockHTTPExecutor!
-        private var storage: MockDeviceStorage!
-        private var stateMachineDelegate: StateMachineDelegate!
-
-class Push : XCTestCase {
-
-    struct TestDeviceToken {
+class Push: XCTestCase {
+    enum TestDeviceToken {
         static let tokenBase64 = "HYRXxPSQdt1pnxqtDAvc6PTTLH7N6okiBhYyLClJdmQ="
         static let tokenData = Data(base64Encoded: tokenBase64, options: [])!
         static let tokenString = tokenData.map { String(format: "%02x", $0) }.joined()
     }
 
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = rest
-    let _ = mockHttpExecutor
-    let _ = storage
-    let _ = stateMachineDelegate
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = rest
+        _ = mockHttpExecutor
+        _ = storage
+        _ = stateMachineDelegate
 
-    return super.defaultTestSuite
-}
+        return super.defaultTestSuite
+    }
 
-        override func setUp() {
-super.setUp()
+    override func setUp() {
+        super.setUp()
 
+        rest = ARTRest(key: "xxxx:xxxx")
+        rest.internal.resetDeviceSingleton()
+        mockHttpExecutor = MockHTTPExecutor()
+        rest.internal.httpExecutor = mockHttpExecutor
+        storage = MockDeviceStorage()
+        rest.internal.storage = storage
+        stateMachineDelegate = StateMachineDelegate()
+        rest.push.internal.createActivationStateMachine(withDelegate: stateMachineDelegate!)
+    }
 
-            rest = ARTRest(key: "xxxx:xxxx")
-            rest.internal.resetDeviceSingleton()
-            mockHttpExecutor = MockHTTPExecutor()
-            rest.internal.httpExecutor = mockHttpExecutor
-            storage = MockDeviceStorage()
-            rest.internal.storage = storage
-            stateMachineDelegate = StateMachineDelegate()
-            rest.push.internal.createActivationStateMachine(withDelegate: stateMachineDelegate!)
+    // RSH2
+
+    // RSH2a
+    func test__001__activation__activate_method_should_send_a_CalledActivate_event_to_the_state_machine() {
+        defer { rest.push.internal.activationMachine.transitions = nil }
+        waitUntil(timeout: testTimeout) { done in
+            rest.push.internal.activationMachine.transitions = { event, _, _ in
+                if event is ARTPushActivationEventCalledActivate {
+                    done()
+                }
+            }
+            rest.push.activate()
+        }
+    }
+
+    // RSH2b
+    func test__002__activation__deactivate_method_should_send_a_CalledDeactivate_event_to_the_state_machine() {
+        defer { rest.push.internal.activationMachine.transitions = nil }
+        waitUntil(timeout: testTimeout) { done in
+            rest.push.internal.activationMachine.transitions = { event, _, _ in
+                if event is ARTPushActivationEventCalledDeactivate {
+                    done()
+                }
+            }
+            rest.push.deactivate()
+        }
+    }
+
+    // RSH2c / RSH8g
+    func test__003__activation__should_handle_GotPushDeviceDetails_event_when_platform_s_APIs_sends_the_details_for_push_notifications() {
+        let stateMachine = rest.push.internal.activationMachine
+        let testDeviceToken = "xxxx-xxxx-xxxx-xxxx-xxxx"
+        stateMachine.rest.device.setAndPersistAPNSDeviceToken(testDeviceToken)
+        let stateMachineDelegate = StateMachineDelegate()
+        stateMachine.delegate = stateMachineDelegate
+        defer {
+            stateMachine.transitions = nil
+            stateMachine.delegate = nil
+            stateMachine.rest.device.setAndPersistAPNSDeviceToken(nil)
+        }
+        waitUntil(timeout: testTimeout) { done in
+            stateMachine.transitions = { event, _, _ in
+                if event is ARTPushActivationEventGotPushDeviceDetails {
+                    done()
+                }
+            }
+            rest.push.activate()
+        }
+    }
+
+    // RSH2d / RSH8h
+    func test__004__activation__sends_GettingPushDeviceDetailsFailed_when_push_registration_fails() {
+        let stateMachine = rest.push.internal.activationMachine
+        defer { stateMachine.transitions = nil }
+        waitUntil(timeout: testTimeout) { done in
+            stateMachine.transitions = { event, _, _ in
+                if event is ARTPushActivationEventGettingPushDeviceDetailsFailed {
+                    done()
+                }
+            }
+            rest.push.activate()
+
+            let error = NSError(domain: ARTAblyErrorDomain, code: 42, userInfo: nil)
+            ARTPush.didFailToRegisterForRemoteNotificationsWithError(error, rest: rest)
+        }
+    }
+
+    // https://github.com/ably/ably-cocoa/issues/877
+    func test__005__activation__should_update_LocalDevice_clientId_when_it_s_null_with_auth_clientId() {
+        let expectedClientId = "foo"
+        let options = AblyTests.clientOptions()
+
+        options.authCallback = { _, completion in
+            getTestTokenDetails(clientId: expectedClientId, completion: { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    fail("TokenDetails are missing"); return
+                }
+                expect(tokenDetails.clientId) == expectedClientId
+                completion(tokenDetails, error)
+            })
         }
 
-        // RSH2
-        
+        let rest = ARTRest(options: options)
+        let mockHttpExecutor = MockHTTPExecutor()
+        rest.internal.httpExecutor = mockHttpExecutor
+        let storage = MockDeviceStorage()
+        rest.internal.storage = storage
 
-            // RSH2a
-            func test__001__activation__activate_method_should_send_a_CalledActivate_event_to_the_state_machine() {
-                defer { rest.push.internal.activationMachine.transitions = nil }
-                waitUntil(timeout: testTimeout) { done in
-                    rest.push.internal.activationMachine.transitions = { event, _, _ in
-                        if event is ARTPushActivationEventCalledActivate {
-                            done()
-                        }
-                    }
-                    rest.push.activate()
-                }
+        rest.internal.resetDeviceSingleton()
+
+        var stateMachine: ARTPushActivationStateMachine!
+        waitUntil(timeout: testTimeout) { done in
+            rest.push.internal.getActivationMachine { machine in
+                stateMachine = machine
+                done()
             }
+        }
 
-            // RSH2b
-            func test__002__activation__deactivate_method_should_send_a_CalledDeactivate_event_to_the_state_machine() {
-                defer { rest.push.internal.activationMachine.transitions = nil }
-                waitUntil(timeout: testTimeout) { done in
-                    rest.push.internal.activationMachine.transitions = { event, _, _ in
-                        if event is ARTPushActivationEventCalledDeactivate {
-                            done()
-                        }
-                    }
-                    rest.push.deactivate()
-                }
-            }
+        let testDeviceToken = "xxxx-xxxx-xxxx-xxxx-xxxx"
+        stateMachine.rest.device.setAndPersistAPNSDeviceToken(testDeviceToken)
+        let stateMachineDelegate = StateMachineDelegate()
+        stateMachine.delegate = stateMachineDelegate
+        defer {
+            stateMachine.transitions = nil
+            stateMachine.delegate = nil
+            stateMachine.rest.device.setAndPersistAPNSDeviceToken(nil)
+        }
 
-            // RSH2c / RSH8g
-            func test__003__activation__should_handle_GotPushDeviceDetails_event_when_platform_s_APIs_sends_the_details_for_push_notifications() {
-                let stateMachine = rest.push.internal.activationMachine
-                let testDeviceToken = "xxxx-xxxx-xxxx-xxxx-xxxx"
-                stateMachine.rest.device.setAndPersistAPNSDeviceToken(testDeviceToken)
-                let stateMachineDelegate = StateMachineDelegate()
-                stateMachine.delegate = stateMachineDelegate
-                defer {
+        expect(rest.device.clientId).to(beNil())
+        expect(rest.auth.clientId).to(beNil())
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            stateMachine.transitions = { event, _, _ in
+                if event is ARTPushActivationEventGotPushDeviceDetails {
+                    partialDone()
+                } else if event is ARTPushActivationEventGotDeviceRegistration {
                     stateMachine.transitions = nil
-                    stateMachine.delegate = nil
-                    stateMachine.rest.device.setAndPersistAPNSDeviceToken(nil)
-                }
-                waitUntil(timeout: testTimeout) { done in
-                    stateMachine.transitions = { event, _, _ in
-                        if event is ARTPushActivationEventGotPushDeviceDetails {
-                            done()
-                        }
-                    }
-                    rest.push.activate()
+                    partialDone()
                 }
             }
-            
-            // RSH2d / RSH8h
-            func test__004__activation__sends_GettingPushDeviceDetailsFailed_when_push_registration_fails() {
-                let stateMachine = rest.push.internal.activationMachine
-                defer { stateMachine.transitions = nil }
-                waitUntil(timeout: testTimeout) { done in
-                    stateMachine.transitions = { event, _, _ in
-                        if event is ARTPushActivationEventGettingPushDeviceDetailsFailed {
-                            done()
-                        }
-                    }
-                    rest.push.activate()
-                    
-                    let error = NSError(domain: ARTAblyErrorDomain, code: 42, userInfo: nil)
-                    ARTPush.didFailToRegisterForRemoteNotificationsWithError(error, rest: rest)
+            rest.push.activate()
+        }
+
+        expect(rest.device.clientId) == expectedClientId
+        expect(rest.auth.clientId) == expectedClientId
+
+        let registerRequest = mockHttpExecutor.requests.filter { req in
+            req.httpMethod == "POST" && req.url?.path == "/push/deviceRegistrations"
+        }.first
+
+        switch extractBodyAsMsgPack(registerRequest) {
+        case let .failure(error):
+            fail(error)
+        case let .success(httpBody):
+            guard let requestedClientId = httpBody.unbox["clientId"] as? String else {
+                fail("No clientId field in HTTPBody"); return
+            }
+            expect(requestedClientId).to(equal(expectedClientId))
+        }
+    }
+
+    // https://github.com/ably/ably-cocoa/issues/889
+    func test__006__activation__should_store_the_device_token_data_as_string() {
+        let expectedDeviceToken = TestDeviceToken.tokenString
+        defer { rest.push.internal.activationMachine.transitions = nil }
+        waitUntil(timeout: testTimeout) { done in
+            rest.push.internal.activationMachine.onEvent = { event, _ in
+                if event is ARTPushActivationEventGotPushDeviceDetails {
+                    done()
                 }
             }
+            ARTPush.didRegisterForRemoteNotifications(withDeviceToken: TestDeviceToken.tokenData, rest: rest)
+        }
+        expect(storage.keysWritten.keys).to(contain(["ARTAPNSDeviceToken"]))
+        expect(storage.keysWritten.at("ARTAPNSDeviceToken")?.value as? String).to(equal(expectedDeviceToken))
+    }
 
-            // https://github.com/ably/ably-cocoa/issues/877
-            func test__005__activation__should_update_LocalDevice_clientId_when_it_s_null_with_auth_clientId() {
-                let expectedClientId = "foo"
-                let options = AblyTests.clientOptions()
+    // https://github.com/ably/ably-cocoa/issues/888
+    func test__007__activation__should_not_sync_the_local_device_dispatched_in_internal_queue() {
+        expect { ARTPush.didRegisterForRemoteNotifications(withDeviceToken: TestDeviceToken.tokenData, rest: rest) }.toNot(raiseException())
+    }
 
-                options.authCallback = { tokenParams, completion in
-                    getTestTokenDetails(clientId: expectedClientId, completion: { tokenDetails, error in
-                        expect(error).to(beNil())
-                        guard let tokenDetails = tokenDetails else {
-                            fail("TokenDetails are missing"); return
-                        }
-                        expect(tokenDetails.clientId) == expectedClientId
-                        completion(tokenDetails, error)
-                    })
-                }
+    // RSH8
+    func test__008__LocalDevice__has_a_device_method_that_returns_a_LocalDevice() {
+        let _: ARTLocalDevice = ARTRest(key: "fake:key").device
+        let _: ARTLocalDevice = ARTRealtime(key: "fake:key").device
+    }
 
-                let rest = ARTRest(options: options)
-                let mockHttpExecutor = MockHTTPExecutor()
-                rest.internal.httpExecutor = mockHttpExecutor
-                let storage = MockDeviceStorage()
-                rest.internal.storage = storage
-                
-                rest.internal.resetDeviceSingleton()
+    // RSH8a
+    func test__009__LocalDevice__the_device_is_lazily_populated_from_the_persisted_state() {
+        let testToken = "testDeviceToken"
+        let testIdentity = ARTDeviceIdentityTokenDetails(
+            token: "123456",
+            issued: Date(),
+            expires: Date.distantFuture,
+            capability: "",
+            clientId: ""
+        )
 
-                var stateMachine: ARTPushActivationStateMachine!
-                waitUntil(timeout: testTimeout) { done in
-                    rest.push.internal.getActivationMachine { machine in
-                        stateMachine = machine
-                        done()
-                    }
-                }
+        let rest = ARTRest(key: "fake:key")
+        rest.internal.storage = storage
+        storage.simulateOnNextRead(string: testToken, for: ARTAPNSDeviceTokenKey)
+        storage.simulateOnNextRead(data: testIdentity.archive(), for: ARTDeviceIdentityTokenKey)
 
-                let testDeviceToken = "xxxx-xxxx-xxxx-xxxx-xxxx"
-                stateMachine.rest.device.setAndPersistAPNSDeviceToken(testDeviceToken)
-                let stateMachineDelegate = StateMachineDelegate()
-                stateMachine.delegate = stateMachineDelegate
-                defer {
-                    stateMachine.transitions = nil
-                    stateMachine.delegate = nil
-                    stateMachine.rest.device.setAndPersistAPNSDeviceToken(nil)
-                }
+        let device = rest.device
 
-                expect(rest.device.clientId).to(beNil())
-                expect(rest.auth.clientId).to(beNil())
+        expect(device.apnsDeviceToken()).to(equal(testToken))
+        expect(device.identityTokenDetails?.token).to(equal(testIdentity.token))
+    }
 
-                waitUntil(timeout: testTimeout) { done in
-                    let partialDone = AblyTests.splitDone(2, done: done)
-                    stateMachine.transitions = { event, _, _ in
-                        if event is ARTPushActivationEventGotPushDeviceDetails {
-                            partialDone()
-                        }
-                        else if event is ARTPushActivationEventGotDeviceRegistration {
-                            stateMachine.transitions = nil
-                            partialDone()
-                        }
-                    }
-                    rest.push.activate()
-                }
+    // RSH8d
 
-                expect(rest.device.clientId) == expectedClientId
-                expect(rest.auth.clientId) == expectedClientId
-                
-                let registerRequest = mockHttpExecutor.requests.filter { req in
-                    req.httpMethod == "POST" && req.url?.path == "/push/deviceRegistrations"
-                }.first
+    func test__012__LocalDevice__when_using_token_authentication__new_clientID_is_set() {
+        let options = ARTClientOptions(key: "fake:key")
+        options.autoConnect = false
+        options.authCallback = { _, callback in
+            delay(0.1) {
+                callback(ARTTokenDetails(token: "fake:token", expires: nil, issued: nil, capability: nil, clientId: "testClient"), nil)
+            }
+        }
 
-                switch extractBodyAsMsgPack(registerRequest) {
-                case .failure(let error):
-                    fail(error)
-                case .success(let httpBody):
-                    guard let requestedClientId = httpBody.unbox["clientId"] as? String else {
-                        fail("No clientId field in HTTPBody"); return
-                    }
-                    expect(requestedClientId).to(equal(expectedClientId))
+        let realtime = ARTRealtime(options: options)
+        expect(realtime.device.clientId).to(beNil())
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.auth.authorize { _, _ in
+                done()
+            }
+        }
+
+        expect(realtime.device.clientId).to(equal("testClient"))
+    }
+
+    // RSH8d
+
+    func test__013__LocalDevice__when_getting_a_client_ID_from_CONNECTED_message__new_clientID_is_set() {
+        let options = ARTClientOptions(key: "fake:key")
+        options.autoConnect = false
+
+        let realtime = ARTRealtime(options: options)
+        expect(realtime.device.clientId).to(beNil())
+
+        realtime.internal.setTransport(TestProxyTransport.self)
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.connected) { _ in
+                done()
+            }
+            realtime.connect()
+
+            let transport = realtime.internal.transport as! TestProxyTransport
+            transport.actionsIgnored += [.error]
+            transport.simulateTransportSuccess(clientId: "testClient")
+        }
+
+        expect(realtime.device.clientId).to(equal("testClient"))
+    }
+
+    // RSH8e
+    func test__010__LocalDevice__authentication_on_registered_device_sends_a_GotPushDeviceDetails_with_new_clientID() {
+        let testDeviceToken = "testDeviceToken"
+        let testDeviceIdentity = ARTDeviceIdentityTokenDetails(
+            token: "123456",
+            issued: Date(),
+            expires: Date.distantFuture,
+            capability: "",
+            clientId: ""
+        )
+        let expectedClient = "testClient"
+
+        let options = ARTClientOptions(key: "fake:key")
+        options.autoConnect = false
+        options.authCallback = { _, callback in
+            delay(0.1) {
+                callback(ARTTokenDetails(token: "fake:token", expires: nil, issued: nil, capability: nil, clientId: expectedClient), nil)
+            }
+        }
+
+        let realtime = ARTRealtime(options: options)
+        let mockHttpExecutor = MockHTTPExecutor()
+        realtime.internal.rest.httpExecutor = mockHttpExecutor
+
+        let storage = MockDeviceStorage(
+            startWith: ARTPushActivationStateWaitingForNewPushDeviceDetails(
+                machine: ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
+            )
+        )
+        realtime.internal.rest.storage = storage
+
+        var stateMachine: ARTPushActivationStateMachine!
+        waitUntil(timeout: testTimeout) { done in
+            realtime.internal.rest.push.getActivationMachine { machine in
+                stateMachine = machine
+                done()
+            }
+        }
+        let delegate = StateMachineDelegate()
+        stateMachine.delegate = delegate
+
+        storage.simulateOnNextRead(string: testDeviceToken, for: ARTAPNSDeviceTokenKey)
+        storage.simulateOnNextRead(data: testDeviceIdentity.archive(), for: ARTDeviceIdentityTokenKey)
+
+        expect(realtime.device.clientId).to(beNil())
+
+        waitUntil(timeout: testTimeout) { done in
+            stateMachine.transitions = { event, _, _ in
+                if event is ARTPushActivationEventGotPushDeviceDetails {
+                    done()
                 }
             }
+            realtime.auth.authorize { _, _ in }
+        }
 
-            // https://github.com/ably/ably-cocoa/issues/889
-            func test__006__activation__should_store_the_device_token_data_as_string() {
-                let expectedDeviceToken = TestDeviceToken.tokenString
-                defer { rest.push.internal.activationMachine.transitions = nil }
-                waitUntil(timeout: testTimeout) { done in
-                    rest.push.internal.activationMachine.onEvent = { event, _ in
-                        if event is ARTPushActivationEventGotPushDeviceDetails {
-                            done()
-                        }
-                    }
-                    ARTPush.didRegisterForRemoteNotifications(withDeviceToken: TestDeviceToken.tokenData, rest: rest)
-                }
-                expect(storage.keysWritten.keys).to(contain(["ARTAPNSDeviceToken"]))
-                expect(storage.keysWritten.at("ARTAPNSDeviceToken")?.value as? String).to(equal(expectedDeviceToken))
+        expect(realtime.device.clientId).to(equal(expectedClient))
+
+        let expectation = XCTestExpectation(description: "Consecutive Authorization")
+        expectation.isInverted = true
+        stateMachine.transitions = { event, _, _ in
+            if event is ARTPushActivationEventGotPushDeviceDetails {
+                fail("GotPushDeviceDetails should only be emitted when clientId is different from the present identified client")
+            }
+        }
+        realtime.auth.authorize { _, _ in }
+        wait(for: [expectation], timeout: 3.0)
+
+        expect(mockHttpExecutor.requests.filter { $0.url?.pathComponents.contains("deviceRegistrations") == true }).to(haveCount(1))
+        expect(realtime.device.clientId).to(equal(expectedClient))
+    }
+
+    // RSH8f
+    func test__011__LocalDevice__sets_device_s_client_ID_from_registration_response() {
+        let expectedClientId = "testClientId"
+
+        let stateMachineDelegate = StateMachineDelegateCustomCallbacks()
+        stateMachineDelegate.onPushCustomRegisterIdentity = { _, _ in
+            ARTDeviceIdentityTokenDetails(
+                token: "123456",
+                issued: Date(),
+                expires: Date.distantFuture,
+                capability: "",
+                clientId: expectedClientId
+            )
+        }
+        rest.push.internal.activationMachine.delegate = stateMachineDelegate
+
+        expect(rest.device.clientId).to(beNil())
+
+        waitUntil(timeout: testTimeout) { done in
+            stateMachineDelegate.onDidActivateAblyPush = { _ in
+                done()
             }
 
-            // https://github.com/ably/ably-cocoa/issues/888
-            func test__007__activation__should_not_sync_the_local_device_dispatched_in_internal_queue() {
-                expect { ARTPush.didRegisterForRemoteNotifications(withDeviceToken: TestDeviceToken.tokenData, rest: rest) }.toNot(raiseException())
+            rest.push.activate()
+
+            ARTPush.didRegisterForRemoteNotifications(withDeviceToken: "testDeviceToken".data(using: .utf8)!, rest: rest)
+        }
+
+        expect(rest.device.clientId).to(equal(expectedClientId))
+    }
+
+    func test__014__Registerer_Delegate_option__a_successful_activation_should_call_the_correct_registerer_delegate_method() {
+        let options = AblyTests.commonAppSetup()
+        options.key = "xxxx:xxxx"
+        let pushRegistererDelegate = StateMachineDelegate()
+        options.pushRegistererDelegate = pushRegistererDelegate
+        let rest = ARTRest(options: options)
+        waitUntil(timeout: testTimeout) { done in
+            pushRegistererDelegate.onDidActivateAblyPush = { _ in
+                done()
             }
-
-        
-            // RSH8
-            func test__008__LocalDevice__has_a_device_method_that_returns_a_LocalDevice() {
-                let _: ARTLocalDevice = ARTRest(key: "fake:key").device
-                let _: ARTLocalDevice = ARTRealtime(key: "fake:key").device
+            pushRegistererDelegate.onDidDeactivateAblyPush = { _ in
+                fail("should not be called")
             }
-            
-            // RSH8a
-            func test__009__LocalDevice__the_device_is_lazily_populated_from_the_persisted_state() {
-                let testToken = "testDeviceToken"
-                let testIdentity = ARTDeviceIdentityTokenDetails(
-                    token: "123456",
-                    issued: Date(),
-                    expires: Date.distantFuture,
-                    capability: "",
-                    clientId: ""
-                )
+            rest.push.activate()
+            ARTPush.didRegisterForRemoteNotifications(withDeviceToken: TestDeviceToken.tokenData, rest: rest)
+        }
+    }
 
-                let rest = ARTRest(key: "fake:key")
-                rest.internal.storage = storage
-                storage.simulateOnNextRead(string: testToken, for: ARTAPNSDeviceTokenKey)
-                storage.simulateOnNextRead(data: testIdentity.archive(), for: ARTDeviceIdentityTokenKey)
-
-                let device = rest.device
-                
-                expect(device.apnsDeviceToken()).to(equal(testToken))
-                expect(device.identityTokenDetails?.token).to(equal(testIdentity.token))
-            }
-            
-            // RSH8d
-            
-                func test__012__LocalDevice__when_using_token_authentication__new_clientID_is_set() {
-                    let options = ARTClientOptions(key: "fake:key")
-                    options.autoConnect = false
-                    options.authCallback = { _, callback in
-                        delay(0.1) {
-                            callback(ARTTokenDetails(token: "fake:token", expires: nil, issued: nil, capability: nil, clientId: "testClient"), nil)
-                        }
-                    }
-
-                    let realtime = ARTRealtime(options: options)
-                    expect(realtime.device.clientId).to(beNil())
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.auth.authorize { _, _ in
-                            done()
-                        }
-                    }
-
-                    expect(realtime.device.clientId).to(equal("testClient"))
-                }
-            
-            // RSH8d
-            
-                func test__013__LocalDevice__when_getting_a_client_ID_from_CONNECTED_message__new_clientID_is_set() {
-                    let options = ARTClientOptions(key: "fake:key")
-                    options.autoConnect = false
-
-                    let realtime = ARTRealtime(options: options)
-                    expect(realtime.device.clientId).to(beNil())
-                    
-                    realtime.internal.setTransport(TestProxyTransport.self)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.connection.once(.connected) { _ in
-                            done()
-                        }
-                        realtime.connect()
-                        
-                        let transport = realtime.internal.transport as! TestProxyTransport
-                        transport.actionsIgnored += [.error]
-                        transport.simulateTransportSuccess(clientId: "testClient")
-                    }
-
-                    expect(realtime.device.clientId).to(equal("testClient"))
-                }
-            
-            // RSH8e
-            func test__010__LocalDevice__authentication_on_registered_device_sends_a_GotPushDeviceDetails_with_new_clientID() {
-                let testDeviceToken = "testDeviceToken"
-                let testDeviceIdentity = ARTDeviceIdentityTokenDetails(
-                    token: "123456",
-                    issued: Date(),
-                    expires: Date.distantFuture,
-                    capability: "",
-                    clientId: ""
-                )
-                let expectedClient = "testClient"
-
-                let options = ARTClientOptions(key: "fake:key")
-                options.autoConnect = false
-                options.authCallback = { _, callback in
-                    delay(0.1) {
-                        callback(ARTTokenDetails(token: "fake:token", expires: nil, issued: nil, capability: nil, clientId: expectedClient), nil)
-                    }
-                }
-
-                let realtime = ARTRealtime(options: options)
-                let mockHttpExecutor = MockHTTPExecutor()
-                realtime.internal.rest.httpExecutor = mockHttpExecutor
-
-                let storage = MockDeviceStorage(
-                    startWith: ARTPushActivationStateWaitingForNewPushDeviceDetails(
-                        machine: ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
-                    )
-                )
-                realtime.internal.rest.storage = storage
-
-                var stateMachine: ARTPushActivationStateMachine!
-                waitUntil(timeout: testTimeout) { done in
-                    realtime.internal.rest.push.getActivationMachine { machine in
-                        stateMachine = machine
-                        done()
-                    }
-                }
-                let delegate = StateMachineDelegate()
-                stateMachine.delegate = delegate
-
-                storage.simulateOnNextRead(string: testDeviceToken, for: ARTAPNSDeviceTokenKey)
-                storage.simulateOnNextRead(data: testDeviceIdentity.archive(), for: ARTDeviceIdentityTokenKey)
-
-                expect(realtime.device.clientId).to(beNil())
-
-                waitUntil(timeout: testTimeout) { done in
-                    stateMachine.transitions = { event, _, _ in
-                        if event is ARTPushActivationEventGotPushDeviceDetails {
-                            done()
-                        }
-                    }
-                    realtime.auth.authorize { _, _ in }
-                }
-
-                expect(realtime.device.clientId).to(equal(expectedClient))
-
-                let expectation = XCTestExpectation(description: "Consecutive Authorization")
-                expectation.isInverted = true
-                stateMachine.transitions = { event, _, _ in
-                    if event is ARTPushActivationEventGotPushDeviceDetails {
-                        fail("GotPushDeviceDetails should only be emitted when clientId is different from the present identified client")
-                    }
-                }
-                realtime.auth.authorize { _, _ in }
-                self.wait(for: [expectation], timeout: 3.0)
-
-                expect(mockHttpExecutor.requests.filter({ $0.url?.pathComponents.contains("deviceRegistrations") == true })).to(haveCount(1))
-                expect(realtime.device.clientId).to(equal(expectedClient))
-            }
-
-            // RSH8f
-            func test__011__LocalDevice__sets_device_s_client_ID_from_registration_response() {
-                let expectedClientId = "testClientId"
-
-                let stateMachineDelegate = StateMachineDelegateCustomCallbacks()
-                stateMachineDelegate.onPushCustomRegisterIdentity = { _, _ in
-                    return ARTDeviceIdentityTokenDetails(
-                        token: "123456",
-                        issued: Date(),
-                        expires: Date.distantFuture,
-                        capability: "",
-                        clientId: expectedClientId
-                    )
-                }
-                rest.push.internal.activationMachine.delegate = stateMachineDelegate
-                                
-                expect(rest.device.clientId).to(beNil())
-                
-                waitUntil(timeout: testTimeout) { done in
-                    stateMachineDelegate.onDidActivateAblyPush = { _ in
-                        done()
-                    }
-
-                    rest.push.activate()
-                    
-                    ARTPush.didRegisterForRemoteNotifications(withDeviceToken: "testDeviceToken".data(using: .utf8)!, rest: rest)
-                }
-                
-                expect(rest.device.clientId).to(equal(expectedClientId))
-            }
-
-        
-
-            func test__014__Registerer_Delegate_option__a_successful_activation_should_call_the_correct_registerer_delegate_method() {
-                let options = AblyTests.commonAppSetup()
-                options.key = "xxxx:xxxx"
-                let pushRegistererDelegate = StateMachineDelegate()
-                options.pushRegistererDelegate = pushRegistererDelegate
-                let rest = ARTRest(options: options)
-                waitUntil(timeout: testTimeout) { done in
-                    pushRegistererDelegate.onDidActivateAblyPush = { _ in
-                        done()
-                    }
-                    pushRegistererDelegate.onDidDeactivateAblyPush = { _ in
-                        fail("should not be called")
-                    }
-                    rest.push.activate()
-                    ARTPush.didRegisterForRemoteNotifications(withDeviceToken: TestDeviceToken.tokenData, rest: rest)
-                }
-            }
-
-            func test__015__Registerer_Delegate_option__registerer_delegate_should_not_hold_a_strong_instance_reference() {
-                let options = AblyTests.commonAppSetup()
-                options.key = "xxxx:xxxx"
-                var pushRegistererDelegate: StateMachineDelegate? = StateMachineDelegate()
-                options.pushRegistererDelegate = pushRegistererDelegate
-                let rest = ARTRest(options: options)
-                expect(rest.internal.options.pushRegistererDelegate).toNot(beNil())
-                pushRegistererDelegate = nil
-                expect(rest.internal.options.pushRegistererDelegate).to(beNil())
-            }
+    func test__015__Registerer_Delegate_option__registerer_delegate_should_not_hold_a_strong_instance_reference() {
+        let options = AblyTests.commonAppSetup()
+        options.key = "xxxx:xxxx"
+        var pushRegistererDelegate: StateMachineDelegate? = StateMachineDelegate()
+        options.pushRegistererDelegate = pushRegistererDelegate
+        let rest = ARTRest(options: options)
+        expect(rest.internal.options.pushRegistererDelegate).toNot(beNil())
+        pushRegistererDelegate = nil
+        expect(rest.internal.options.pushRegistererDelegate).to(beNil())
+    }
 }

--- a/Spec/PushActivationStateMachine.swift
+++ b/Spec/PushActivationStateMachine.swift
@@ -14,7 +14,7 @@ import Quick
 
         private var stateMachine: ARTPushActivationStateMachine!
 
-class PushActivationStateMachine : QuickSpec {
+class PushActivationStateMachine : XCTestCase {
 
 // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
 override class var defaultTestSuite : XCTestSuite {
@@ -30,9 +30,10 @@ override class var defaultTestSuite : XCTestSuite {
     return super.defaultTestSuite
 }
 
-    override func spec() {
+        override func setUp() {
+super.setUp()
 
-        beforeEach {
+
             rest = ARTRest(key: "xxxx:xxxx")
             httpExecutor = MockHTTPExecutor()
             rest.internal.httpExecutor = httpExecutor
@@ -41,17 +42,20 @@ override class var defaultTestSuite : XCTestSuite {
             initialStateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
         }
 
-        afterEach {
+        override func tearDown() {
            rest.internal.resetDeviceSingleton()
+
+super.tearDown()
+
         }
 
-        describe("Activation state machine") {
+        
 
-            it("should set NotActivated state as current state when disk is empty") {
+            func test__002__Activation_state_machine__should_set_NotActivated_state_as_current_state_when_disk_is_empty() {
                 expect(initialStateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
             }
 
-            it("should read the current state from disk") {
+            func test__003__Activation_state_machine__should_read_the_current_state_from_disk() {
                 let storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForDeviceRegistration(machine: initialStateMachine))
                 rest.internal.storage = storage
                 let stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
@@ -61,7 +65,7 @@ override class var defaultTestSuite : XCTestSuite {
                 expect(storage.keysWritten).to(beEmpty())
             }
 
-            it("AfterRegistrationUpdateFailed state from persistence gets migrated to AfterRegistrationSyncFailed") {
+            func test__004__Activation_state_machine__AfterRegistrationUpdateFailed_state_from_persistence_gets_migrated_to_AfterRegistrationSyncFailed() {
                 let stateEncodedFromOldVersionBase64 = "YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05TS2V5ZWRBcmNoaXZlctEICVRyb290gAGjCwwPVSRudWxs0Q0OViRjbGFzc4AC0hAREhNaJGNsYXNzbmFtZVgkY2xhc3Nlc18QM0FSVFB1c2hBY3RpdmF0aW9uU3RhdGVBZnRlclJlZ2lzdHJhdGlvblVwZGF0ZUZhaWxlZKQUFRYXXxAzQVJUUHVzaEFjdGl2YXRpb25TdGF0ZUFmdGVyUmVnaXN0cmF0aW9uVXBkYXRlRmFpbGVkXxAgQVJUUHVzaEFjdGl2YXRpb25QZXJzaXN0ZW50U3RhdGVfEBZBUlRQdXNoQWN0aXZhdGlvblN0YXRlWE5TT2JqZWN0AAgAEQAaACQAKQAyADcASQBMAFEAUwBXAF0AYABnAGkAbgB5AIIAuAC9APMBFgEvAAAAAAAAAgEAAAAAAAAAGAAAAAAAAAAAAAAAAAAAATg="
                 let stateEncodedFromOldVersion = Data.init(base64Encoded: stateEncodedFromOldVersionBase64, options: .init())!
 
@@ -73,16 +77,18 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSH3a
-            context("State NotActivated") {
+            
 
-                beforeEach {
+                func beforeEach__Activation_state_machine__State_NotActivated() {
                     storage = MockDeviceStorage(startWith: ARTPushActivationStateNotActivated(machine: initialStateMachine))
                     rest.internal.storage = storage
                     stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
                 }
 
                 // RSH3a1
-                it("on Event CalledDeactivate, should transition to NotActivated") {
+                func test__007__Activation_state_machine__State_NotActivated__on_Event_CalledDeactivate__should_transition_to_NotActivated() {
+beforeEach__Activation_state_machine__State_NotActivated()
+
                     var deactivatedCallbackCalled = false
                     let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callDeactivatedCallback:")) {
                         deactivatedCallbackCalled = true
@@ -96,17 +102,35 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSH3a2
-                context("on Event CalledActivate") {
+                
                     // RSH3a2a
-                    reusableTestsRsh3a2a()
+                    func reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a) {
+                    // RSH3a2a
+                    reusableTestsRsh3a2a(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_NotActivated)}
+func test__011__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() {
+reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match)
+}
+
+func test__012__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() {
+reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync)
+}
+
+func test__013__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() {
+reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync)
+}
+
 
                     // RSH3a2b
-                    context("local device") {
-                        it("should have a generated id") {
+                    
+                        func test__014__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__local_device__should_have_a_generated_id() {
+beforeEach__Activation_state_machine__State_NotActivated()
+
                             rest.internal.resetDeviceSingleton()
                             expect(rest.device.id.count) == 36
                         }
-                        it("should have a generated secret") {
+                        func test__015__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__local_device__should_have_a_generated_secret() {
+beforeEach__Activation_state_machine__State_NotActivated()
+
                             guard let deviceSecret = rest.device.secret else {
                                 fail("Device Secret should be available because it's loaded when the getter of the property is called"); return
                             }
@@ -117,17 +141,20 @@ override class var defaultTestSuite : XCTestSuite {
                         }
 
                         // RSH8b
-                        it("should have a clientID if the client is identified") {
+                        func test__016__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__local_device__should_have_a_clientID_if_the_client_is_identified() {
+beforeEach__Activation_state_machine__State_NotActivated()
+
                             let options = ARTClientOptions(key: "xxxx:xxxx")
                             options.clientId = "deviceClient"
                             let rest = ARTRest(options: options)
                             rest.internal.storage = storage
                             expect(rest.device.clientId).to(equal("deviceClient"))
                         }
-                    }
 
                     // RSH3a2c
-                    it("if the local device has the necessary push details should send event GotPushDeviceDetails") {
+                    func test__009__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__if_the_local_device_has_the_necessary_push_details_should_send_event_GotPushDeviceDetails() {
+beforeEach__Activation_state_machine__State_NotActivated()
+
                         let delegate = StateMachineDelegate()
                         stateMachine.delegate = delegate
 
@@ -150,37 +177,42 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSH3a2d
-                    it("none of them then should transition to WaitingForPushDeviceDetails") {
+                    func test__010__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__none_of_them_then_should_transition_to_WaitingForPushDeviceDetails() {
+beforeEach__Activation_state_machine__State_NotActivated()
+
                         stateMachine.send(ARTPushActivationEventCalledActivate())
                         expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
                     }
-                }
 
                 // RSH3a3
-                it("on Event GotPushDeviceDetails") {
+                func test__008__Activation_state_machine__State_NotActivated__on_Event_GotPushDeviceDetails() {
+beforeEach__Activation_state_machine__State_NotActivated()
+
                     stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
                     expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
                 }
 
-            }
-
             // RSH3b
-            context("State WaitingForPushDeviceDetails") {
+            
 
-                beforeEach {
+                func beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails() {
                     storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForPushDeviceDetails(machine: initialStateMachine))
                     rest.internal.storage = storage
                     stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
                 }
 
                 // RSH3b1
-                it("on Event CalledActivate") {
+                func test__017__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_CalledActivate() {
+beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
                     stateMachine.send(ARTPushActivationEventCalledActivate())
                     expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
                 }
 
                 // RSH3b2
-                it("on Event CalledDeactivate") {
+                func test__018__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_CalledDeactivate() {
+beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
                     var deactivatedCallbackCalled = false
                     let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callDeactivatedCallback:")) {
                         deactivatedCallbackCalled = true
@@ -193,10 +225,12 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSH3b3
-                context("on Event GotPushDeviceDetails") {
+                
 
                     // TODO: The exception is raised but the `send:` method is doing an async call and the `expect` doesn't catch it
-                    xit("should raise exception if ARTPushRegistererDelegate is not implemented") {
+                    func skipped__test__021__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_raise_exception_if_ARTPushRegistererDelegate_is_not_implemented() {
+beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
                         expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
                         expect {
                             stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
@@ -206,7 +240,9 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSH3b3a, RSH3b3c
-                    it("should use custom registerCallback and fire GotDeviceRegistration event") {
+                    func test__022__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_use_custom_registerCallback_and_fire_GotDeviceRegistration_event() {
+beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
                         expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
 
                         let delegate = StateMachineDelegateCustomCallbacks()
@@ -238,7 +274,9 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSH3b3c
-                    it("should use custom registerCallback and fire GettingDeviceRegistrationFailed event") {
+                    func test__023__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_use_custom_registerCallback_and_fire_GettingDeviceRegistrationFailed_event() {
+beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
                         expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
 
                         let delegate = StateMachineDelegateCustomCallbacks()
@@ -273,7 +311,9 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSH3b3b, RSH3b3c
-                    it("should fire GotDeviceRegistration event") {
+                    func test__024__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_fire_GotDeviceRegistration_event() {
+beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
                         expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
 
                         let delegate = StateMachineDelegate()
@@ -333,7 +373,9 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSH3b3c
-                    it("should fire GettingDeviceRegistrationFailed event") {
+                    func test__025__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_fire_GettingDeviceRegistrationFailed_event() {
+beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
                         expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
 
                         let delegate = StateMachineDelegate()
@@ -389,7 +431,9 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSH3b3d
-                    it("should transition to WaitingForDeviceRegistration") {
+                    func test__026__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_transition_to_WaitingForDeviceRegistration() {
+beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
                         expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
 
                         let delegate = StateMachineDelegate()
@@ -418,11 +462,11 @@ override class var defaultTestSuite : XCTestSuite {
 
                         expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
                     }
-
-                }
                 
                 // RSH3b4
-                it("on Event GettingPushDeviceDetailsFailed") {
+                func test__019__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GettingPushDeviceDetailsFailed() {
+beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
                     let expectedError = ARTErrorInfo(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
 
                     let delegate = StateMachineDelegate()
@@ -440,7 +484,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 
                 // https://github.com/ably/ably-cocoa/issues/966
-                it("when initializing from persistent state with a deviceToken, GotPushDeviceDetails should be re-emitted") {
+                func test__020__Activation_state_machine__State_WaitingForPushDeviceDetails__when_initializing_from_persistent_state_with_a_deviceToken__GotPushDeviceDetails_should_be_re_emitted() {
+beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
                     storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForPushDeviceDetails(machine: initialStateMachine))
                     rest.internal.storage = storage
                     rest.device.setAndPersistAPNSDeviceToken("foo")
@@ -457,25 +503,28 @@ override class var defaultTestSuite : XCTestSuite {
 
                     expect(registered).toEventually(beTrue())
                 }
-            }
 
             // RSH3c
-            context("State WaitingForDeviceRegistration") {
+            
 
-                beforeEach {
+                func beforeEach__Activation_state_machine__State_WaitingForDeviceRegistration() {
                     storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForDeviceRegistration(machine: initialStateMachine))
                     rest.internal.storage = storage
                     stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
                 }
 
                 // RSH3c1
-                it("on Event CalledActivate") {
+                func test__027__Activation_state_machine__State_WaitingForDeviceRegistration__on_Event_CalledActivate() {
+beforeEach__Activation_state_machine__State_WaitingForDeviceRegistration()
+
                     stateMachine.send(ARTPushActivationEventCalledActivate())
                     expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForDeviceRegistration.self))
                 }
 
                 // RSH3c2 / RSH8c
-                it("on Event GotDeviceRegistration") {
+                func test__028__Activation_state_machine__State_WaitingForDeviceRegistration__on_Event_GotDeviceRegistration() {
+beforeEach__Activation_state_machine__State_WaitingForDeviceRegistration()
+
                     rest.internal.resetDeviceSingleton()
 
                     var activatedCallbackCalled = false
@@ -506,7 +555,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSH3c3
-                it("on Event GettingDeviceRegistrationFailed") {
+                func test__029__Activation_state_machine__State_WaitingForDeviceRegistration__on_Event_GettingDeviceRegistrationFailed() {
+beforeEach__Activation_state_machine__State_WaitingForDeviceRegistration()
+
                     let expectedError = ARTErrorInfo(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
 
                     var activatedCallbackCalled = false
@@ -524,19 +575,19 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(activatedCallbackCalled).to(beTrue())
                 }
 
-            }
-
             // RSH3d
-            context("State WaitingForNewPushDeviceDetails") {
+            
 
-                beforeEach {
+                func beforeEach__Activation_state_machine__State_WaitingForNewPushDeviceDetails() {
                     storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForNewPushDeviceDetails(machine: initialStateMachine))
                     rest.internal.storage = storage
                     stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
                 }
 
                 // RSH3d1
-                it("on Event CalledActivate") {
+                func test__030__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledActivate() {
+beforeEach__Activation_state_machine__State_WaitingForNewPushDeviceDetails()
+
                     var activatedCallbackCalled = false
                     let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callActivatedCallback:")) {
                         activatedCallbackCalled = true
@@ -549,15 +600,41 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSH3d2
-                context("on Event CalledDeactivate") {
-                    reusableTestsRsh3d2()
-                }
+                
+                    func reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: TestCase_ReusableTestsRsh3d2) {
+                    reusableTestsRsh3d2(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_WaitingForNewPushDeviceDetails)}
+func test__031__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_Deregistered_event() {
+reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_Deregistered_event)
+}
 
-            }
+func test__032__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event() {
+reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event)
+}
+
+func test__033__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header() {
+reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header)
+}
+
+func test__034__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header() {
+reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header)
+}
+
+func test__035__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_fire_DeregistrationFailed_event() {
+reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_DeregistrationFailed_event)
+}
+
+enum TestCase_ReusableTestsTestStateWaitingForRegistrationSyncThrough {
+case on_Event_CalledActivate
+case on_Event_RegistrationSynced
+case on_Event_SyncRegistrationFailed
+}
+
 
             // RSH3e
-            func reusableTestsTestStateWaitingForRegistrationSyncThrough(_ fromEvent: ARTPushActivationEvent) {
-                beforeEach {
+            func reusableTestsTestStateWaitingForRegistrationSyncThrough(_ fromEvent: ARTPushActivationEvent, testCase: TestCase_ReusableTestsTestStateWaitingForRegistrationSyncThrough, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil) {
+                func beforeEach() {
+contextBeforeEach?()
+
                     storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForRegistrationSync(machine: initialStateMachine, from: fromEvent))
                     rest.internal.storage = storage
                     stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
@@ -565,7 +642,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 
                 // RSH3e1
-                it("on Event CalledActivate") {
+                func test__on_Event_CalledActivate() {
+beforeEach()
+
                     var activatedCallbackCalled = false
                     let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callActivatedCallback:")) {
                         activatedCallbackCalled = true
@@ -580,10 +659,15 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(activatedCallbackCalled).to(beFalse())
                         expect(stateMachine.pendingEvents).to(haveCount(1))
                     }
+
+contextAfterEach?()
+
                 }
                 
                 // RSH3e2
-                it("on Event RegistrationSynced") {
+                func test__on_Event_RegistrationSynced() {
+beforeEach()
+
                     var setAndPersistIdentityTokenDetailsCalled = false
                     let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
                         setAndPersistIdentityTokenDetailsCalled = true
@@ -613,10 +697,15 @@ override class var defaultTestSuite : XCTestSuite {
                     
                     // RSH3e2b
                     expect(activateCallbackCalled).toEventually(equal(fromEvent is ARTPushActivationEventCalledActivate), timeout: testTimeout)
+
+contextAfterEach?()
+
                 }
                 
                 // RSH3e3
-                it("on Event SyncRegistrationFailed") {
+                func test__on_Event_SyncRegistrationFailed() {
+beforeEach()
+
                     let expectedError = ARTErrorInfo(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
                     
                     var updateFailedCallbackCalled = false
@@ -645,60 +734,143 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(updateFailedCallbackCalled).toEventually(equal(!(fromEvent is ARTPushActivationEventCalledActivate)), timeout: testTimeout)
                     // RSH3e3c
                     expect(activateCallbackCalled).toEventually(equal(fromEvent is ARTPushActivationEventCalledActivate), timeout: testTimeout)
+
+contextAfterEach?()
+
                 }
+
+switch testCase  {
+case .on_Event_CalledActivate:
+    test__on_Event_CalledActivate()
+case .on_Event_RegistrationSynced:
+    test__on_Event_RegistrationSynced()
+case .on_Event_SyncRegistrationFailed:
+    test__on_Event_SyncRegistrationFailed()
+}
+
             }
             
-            context("State WaitingForRegistrationSync through ARTPushActivationEventCalledActivate") {
-                reusableTestsTestStateWaitingForRegistrationSyncThrough(ARTPushActivationEventCalledActivate())
-            }
             
-            context("State WaitingForRegistrationSync through ARTPushActivationEventGotPushDeviceDetails") {
-                reusableTestsTestStateWaitingForRegistrationSyncThrough(ARTPushActivationEventGotPushDeviceDetails())
-            }
+                func reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: TestCase_ReusableTestsTestStateWaitingForRegistrationSyncThrough) {
+                reusableTestsTestStateWaitingForRegistrationSyncThrough(ARTPushActivationEventCalledActivate(), testCase: testCase)}
+func test__036__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__on_Event_CalledActivate() {
+reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_CalledActivate)
+}
+
+func test__037__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__on_Event_RegistrationSynced() {
+reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_RegistrationSynced)
+}
+
+func test__038__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__on_Event_SyncRegistrationFailed() {
+reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_SyncRegistrationFailed)
+}
+
+            
+            
+                func reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: TestCase_ReusableTestsTestStateWaitingForRegistrationSyncThrough) {
+                reusableTestsTestStateWaitingForRegistrationSyncThrough(ARTPushActivationEventGotPushDeviceDetails(), testCase: testCase)}
+func test__039__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__on_Event_CalledActivate() {
+reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_CalledActivate)
+}
+
+func test__040__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__on_Event_RegistrationSynced() {
+reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_RegistrationSynced)
+}
+
+func test__041__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__on_Event_SyncRegistrationFailed() {
+reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_SyncRegistrationFailed)
+}
+
             
             // RSH3f
-            context("State AfterRegistrationSyncFailed") {
+            
 
-                beforeEach {
+                func beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed() {
                     storage = MockDeviceStorage(startWith: ARTPushActivationStateAfterRegistrationSyncFailed(machine: initialStateMachine))
                     rest.internal.storage = storage
                     stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
                 }
 
                 // RSH3f1
-                context("on Event CalledActivate") {
-                    reusableTestsRsh3a2a()
-                }
+                
+                    func reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a) {
+                    reusableTestsRsh3a2a(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed)}
+func test__042__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() {
+reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match)
+}
+
+func test__043__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() {
+reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync)
+}
+
+func test__044__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() {
+reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync)
+}
+
 
                 // RSH3f1
-                context("on Event GotPushDeviceDetails") {
-                    reusableTestsRsh3a2a()
-                }
+                
+                    func reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a) {
+                    reusableTestsRsh3a2a(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed)}
+func test__045__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() {
+reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match)
+}
+
+func test__046__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() {
+reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync)
+}
+
+func test__047__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() {
+reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync)
+}
+
 
                 // RSH3f2
-                context("on Event CalledDeactivate") {
-                    reusableTestsRsh3d2()
-                }
+                
+                    func reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: TestCase_ReusableTestsRsh3d2) {
+                    reusableTestsRsh3d2(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed)}
+func test__048__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_Deregistered_event() {
+reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_Deregistered_event)
+}
 
-            }
+func test__049__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event() {
+reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event)
+}
+
+func test__050__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header() {
+reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header)
+}
+
+func test__051__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header() {
+reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header)
+}
+
+func test__052__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_fire_DeregistrationFailed_event() {
+reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_DeregistrationFailed_event)
+}
+
 
             // RSH3g
-            context("State WaitingForDeregistration") {
+            
 
-                beforeEach {
+                func beforeEach__Activation_state_machine__State_WaitingForDeregistration() {
                     storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForDeregistration(machine: initialStateMachine))
                     rest.internal.storage = storage
                     stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
                 }
 
                 // RSH3g1
-                it("on Event CalledDeactivate") {
+                func test__053__Activation_state_machine__State_WaitingForDeregistration__on_Event_CalledDeactivate() {
+beforeEach__Activation_state_machine__State_WaitingForDeregistration()
+
                     stateMachine.send(ARTPushActivationEventCalledDeactivate())
                     expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
                 }
 
                 // RSH3g2
-                it("on Event Deregistered") {
+                func test__054__Activation_state_machine__State_WaitingForDeregistration__on_Event_Deregistered() {
+beforeEach__Activation_state_machine__State_WaitingForDeregistration()
+
                     var deactivatedCallbackCalled = false
                     let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callDeactivatedCallback:")) {
                         deactivatedCallbackCalled = true
@@ -720,7 +892,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSH3g3
-                it("on Event DeregistrationFailed") {
+                func test__055__Activation_state_machine__State_WaitingForDeregistration__on_Event_DeregistrationFailed() {
+beforeEach__Activation_state_machine__State_WaitingForDeregistration()
+
                     let expectedError = ARTErrorInfo(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
 
                     var deactivatedCallbackCalled = false
@@ -738,10 +912,8 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(deactivatedCallbackCalled).to(beTrue())
                 }
 
-            }
-
             // RSH4
-            it("should queue event that has no transition defined for it") {
+            func test__005__Activation_state_machine__should_queue_event_that_has_no_transition_defined_for_it() {
                 // Start with WaitingForDeregistration state
                 let storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForDeregistration(machine: initialStateMachine))
                 rest.internal.storage = storage
@@ -782,7 +954,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSH5
-            it("event handling sould be atomic and sequential") {
+            func test__006__Activation_state_machine__event_handling_sould_be_atomic_and_sequential() {
                 let storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForDeregistration(machine: initialStateMachine))
                 rest.internal.storage = storage
                 let stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
@@ -793,9 +965,7 @@ override class var defaultTestSuite : XCTestSuite {
                 expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
             }
 
-        }
-
-        it("should remove identityTokenDetails from cache and storage") {
+        func test__001__should_remove_identityTokenDetails_from_cache_and_storage() {
             let storage = MockDeviceStorage()
             rest.internal.storage = storage
             rest.device.setAndPersistIdentityTokenDetails(nil)
@@ -804,13 +974,21 @@ override class var defaultTestSuite : XCTestSuite {
             expect(rest.device.isRegistered()) == false
             expect(storage.object(forKey: ARTDeviceIdentityTokenKey)).to(beNil())
         }
+enum TestCase_ReusableTestsRsh3a2a {
+case the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match
+case the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync
+case the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync
+}
 
-        func reusableTestsRsh3a2a() {
-            context("the local device has id and deviceIdentityToken") {
+
+        func reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil) {
+            
                 let testDeviceId = "aaaa"
                 
                 // RSH3a2a1
-                it("emits a SyncRegistrationFailed event with code 61002 if client IDs don't match") {
+                func test__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() {
+contextBeforeEach?()
+
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.clientId = "deviceClient"
                     let rest = ARTRest(options: options)
@@ -838,22 +1016,31 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                         stateMachine.send(ARTPushActivationEventCalledActivate())
                     }
+
+contextAfterEach?()
+
                 }
                 
-                context("the local DeviceDetails matches the instance's client ID") {
-                    beforeEach {
+                
+                    func beforeEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID() {
+contextBeforeEach?()
+
                         storage.simulateOnNextRead(string: testDeviceId, for: ARTDeviceIdKey)
 
                         let testDeviceIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
                         stateMachine.rest.device.setAndPersistIdentityTokenDetails(testDeviceIdentityTokenDetails)
                     }
                         
-                    afterEach {
+                    func afterEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID() {
                         stateMachine.rest.device.setAndPersistIdentityTokenDetails(nil)
+contextAfterEach?()
+
                     }
                     
                     // RSH3a2a2, RSH3a2a4
-                    it("calls registerCallback, transitions to WaitingForRegistrationSync") {
+                    func test__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() {
+beforeEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID()
+
                         let delegate = StateMachineDelegateCustomCallbacks()
                         stateMachine.delegate = delegate
 
@@ -879,10 +1066,15 @@ override class var defaultTestSuite : XCTestSuite {
                         }
 
                         expect(httpExecutor.requests.count) == 0
+
+afterEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID()
+
                     }
                     
                     // RSH3a2a3, RSH3a2a4, RSH3b3c
-                    it("PUTs device registration, transitions to WaitingForRegistrationSync") {
+                    func test__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() {
+beforeEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID()
+
                         let delegate = StateMachineDelegate()
                         stateMachine.delegate = delegate
 
@@ -928,14 +1120,35 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(body.value(forKey: "push") as? [String: [String: String]]).to(equal(expectedPushRecipient))
                         expect(body.value(forKey: "formFactor") as? String) == expectedFormFactor
                         expect(body.value(forKey: "platform") as? String) == expectedPlatform
-                    }
-                }
-            }
-        }
 
-        func reusableTestsRsh3d2() {
+afterEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID()
+
+                    }
+
+switch testCase  {
+case .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match:
+    test__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match()
+case .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync:
+    test__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync()
+case .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync:
+    test__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync()
+}
+
+        }
+enum TestCase_ReusableTestsRsh3d2 {
+case should_use_custom_deregisterCallback_and_fire_Deregistered_event
+case should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event
+case should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header
+case should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header
+case should_fire_DeregistrationFailed_event
+}
+
+
+        func reusableTestsRsh3d2(testCase: TestCase_ReusableTestsRsh3d2, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil) {
             // RSH3d2a, RSH3d2c, RSH3d2d
-            it("should use custom deregisterCallback and fire Deregistered event") {
+            func test__should_use_custom_deregisterCallback_and_fire_Deregistered_event() {
+contextBeforeEach?()
+
                 let delegate = StateMachineDelegateCustomCallbacks()
                 stateMachine.delegate = delegate
 
@@ -963,10 +1176,15 @@ override class var defaultTestSuite : XCTestSuite {
 
                 expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
                 expect(httpExecutor.requests.count) == 0
+
+contextAfterEach?()
+
             }
 
             // RSH3d2c
-            it("should use custom deregisterCallback and fire DeregistrationFailed event") {
+            func test__should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event() {
+contextBeforeEach?()
+
                 let delegate = StateMachineDelegateCustomCallbacks()
                 stateMachine.delegate = delegate
 
@@ -996,10 +1214,15 @@ override class var defaultTestSuite : XCTestSuite {
 
                 expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
                 expect(httpExecutor.requests.count) == 0
+
+contextAfterEach?()
+
             }
 
             // RSH3d2b, RSH3d2c, RSH3d2d
-            it("should fire Deregistered event and include DeviceSecret HTTP header") {
+            func test__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header() {
+contextBeforeEach?()
+
                 let delegate = StateMachineDelegate()
                 stateMachine.delegate = delegate
 
@@ -1034,10 +1257,15 @@ override class var defaultTestSuite : XCTestSuite {
                 expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
                 let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
                 expect(deviceAuthorization).to(equal(rest.device.secret))
+
+contextAfterEach?()
+
             }
 
             // RSH3d2b, RSH3d2c, RSH3d2d
-            it("should fire Deregistered event and include DeviceIdentityToken HTTP header") {
+            func test__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header() {
+contextBeforeEach?()
+
                 let delegate = StateMachineDelegate()
                 stateMachine.delegate = delegate
 
@@ -1086,10 +1314,15 @@ override class var defaultTestSuite : XCTestSuite {
                 expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
                 let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
                 expect(deviceAuthorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
+
+contextAfterEach?()
+
             }
 
             // RSH3d2c
-            it("should fire DeregistrationFailed event") {
+            func test__should_fire_DeregistrationFailed_event() {
+contextBeforeEach?()
+
                 let delegate = StateMachineDelegate()
                 stateMachine.delegate = delegate
 
@@ -1125,9 +1358,25 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 expect(url.host).to(equal(rest.internal.options.restUrl().host))
                 expect(request.httpMethod) == "DELETE"
+
+contextAfterEach?()
+
             }
+
+switch testCase  {
+case .should_use_custom_deregisterCallback_and_fire_Deregistered_event:
+    test__should_use_custom_deregisterCallback_and_fire_Deregistered_event()
+case .should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event:
+    test__should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event()
+case .should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header:
+    test__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header()
+case .should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header:
+    test__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header()
+case .should_fire_DeregistrationFailed_event:
+    test__should_fire_DeregistrationFailed_event()
+}
+
         }   
-    }
 
 }
 

--- a/Spec/PushActivationStateMachine.swift
+++ b/Spec/PushActivationStateMachine.swift
@@ -2,1386 +2,1344 @@ import Ably
 import Nimble
 import Quick
 
+private var rest: ARTRest!
+private var httpExecutor: MockHTTPExecutor!
+private var storage: MockDeviceStorage!
+private var initialStateMachine: ARTPushActivationStateMachine!
 
-        private var rest: ARTRest!
-        private var httpExecutor: MockHTTPExecutor!
-        private var storage: MockDeviceStorage!
-        private var initialStateMachine: ARTPushActivationStateMachine!
+private let expectedFormFactor = "phone"
+private let expectedPlatform = "ios"
+private let expectedPushRecipient: [String: [String: String]] = ["recipient": ["transportType": "apns"]]
 
-        private let expectedFormFactor = "phone"
-        private let expectedPlatform = "ios"
-        private let expectedPushRecipient: [String: [String: String]] = ["recipient": ["transportType": "apns"]]
+private var stateMachine: ARTPushActivationStateMachine!
 
-        private var stateMachine: ARTPushActivationStateMachine!
+class PushActivationStateMachine: XCTestCase {
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = rest
+        _ = httpExecutor
+        _ = storage
+        _ = initialStateMachine
+        _ = expectedFormFactor
+        _ = expectedPlatform
+        _ = expectedPushRecipient
+        _ = stateMachine
 
-class PushActivationStateMachine : XCTestCase {
+        return super.defaultTestSuite
+    }
 
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = rest
-    let _ = httpExecutor
-    let _ = storage
-    let _ = initialStateMachine
-    let _ = expectedFormFactor
-    let _ = expectedPlatform
-    let _ = expectedPushRecipient
-    let _ = stateMachine
+    override func setUp() {
+        super.setUp()
 
-    return super.defaultTestSuite
-}
+        rest = ARTRest(key: "xxxx:xxxx")
+        httpExecutor = MockHTTPExecutor()
+        rest.internal.httpExecutor = httpExecutor
+        storage = MockDeviceStorage()
+        rest.internal.storage = storage
+        initialStateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
+    }
 
-        override func setUp() {
-super.setUp()
+    override func tearDown() {
+        rest.internal.resetDeviceSingleton()
 
+        super.tearDown()
+    }
 
-            rest = ARTRest(key: "xxxx:xxxx")
-            httpExecutor = MockHTTPExecutor()
-            rest.internal.httpExecutor = httpExecutor
-            storage = MockDeviceStorage()
+    func test__002__Activation_state_machine__should_set_NotActivated_state_as_current_state_when_disk_is_empty() {
+        expect(initialStateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
+    }
+
+    func test__003__Activation_state_machine__should_read_the_current_state_from_disk() {
+        let storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForDeviceRegistration(machine: initialStateMachine))
+        rest.internal.storage = storage
+        let stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForDeviceRegistration.self))
+        expect(storage.keysRead).to(haveCount(2))
+        expect(storage.keysRead.filter { $0.hasSuffix("CurrentState") }).to(haveCount(1))
+        expect(storage.keysWritten).to(beEmpty())
+    }
+
+    func test__004__Activation_state_machine__AfterRegistrationUpdateFailed_state_from_persistence_gets_migrated_to_AfterRegistrationSyncFailed() {
+        let stateEncodedFromOldVersionBase64 = "YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05TS2V5ZWRBcmNoaXZlctEICVRyb290gAGjCwwPVSRudWxs0Q0OViRjbGFzc4AC0hAREhNaJGNsYXNzbmFtZVgkY2xhc3Nlc18QM0FSVFB1c2hBY3RpdmF0aW9uU3RhdGVBZnRlclJlZ2lzdHJhdGlvblVwZGF0ZUZhaWxlZKQUFRYXXxAzQVJUUHVzaEFjdGl2YXRpb25TdGF0ZUFmdGVyUmVnaXN0cmF0aW9uVXBkYXRlRmFpbGVkXxAgQVJUUHVzaEFjdGl2YXRpb25QZXJzaXN0ZW50U3RhdGVfEBZBUlRQdXNoQWN0aXZhdGlvblN0YXRlWE5TT2JqZWN0AAgAEQAaACQAKQAyADcASQBMAFEAUwBXAF0AYABnAGkAbgB5AIIAuAC9APMBFgEvAAAAAAAAAgEAAAAAAAAAGAAAAAAAAAAAAAAAAAAAATg="
+        let stateEncodedFromOldVersion = Data(base64Encoded: stateEncodedFromOldVersionBase64, options: .init())!
+
+        let storage = MockDeviceStorage()
+        storage.simulateOnNextRead(data: stateEncodedFromOldVersion, for: ARTPushActivationCurrentStateKey)
+        rest.internal.storage = storage
+        let stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateAfterRegistrationSyncFailed.self))
+    }
+
+    // RSH3a
+
+    func beforeEach__Activation_state_machine__State_NotActivated() {
+        storage = MockDeviceStorage(startWith: ARTPushActivationStateNotActivated(machine: initialStateMachine))
+        rest.internal.storage = storage
+        stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
+    }
+
+    // RSH3a1
+    func test__007__Activation_state_machine__State_NotActivated__on_Event_CalledDeactivate__should_transition_to_NotActivated() {
+        beforeEach__Activation_state_machine__State_NotActivated()
+
+        var deactivatedCallbackCalled = false
+        let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callDeactivatedCallback:")) {
+            deactivatedCallbackCalled = true
+        }
+        defer { hook.remove() }
+
+        stateMachine.send(ARTPushActivationEventCalledDeactivate())
+
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
+        expect(deactivatedCallbackCalled).to(beTrue())
+    }
+
+    // RSH3a2
+
+    // RSH3a2a
+    func reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a) {
+        // RSH3a2a
+        reusableTestsRsh3a2a(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_NotActivated)
+    }
+
+    func test__011__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() {
+        reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match)
+    }
+
+    func test__012__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() {
+        reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync)
+    }
+
+    func test__013__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() {
+        reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync)
+    }
+
+    // RSH3a2b
+
+    func test__014__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__local_device__should_have_a_generated_id() {
+        beforeEach__Activation_state_machine__State_NotActivated()
+
+        rest.internal.resetDeviceSingleton()
+        expect(rest.device.id.count) == 36
+    }
+
+    func test__015__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__local_device__should_have_a_generated_secret() {
+        beforeEach__Activation_state_machine__State_NotActivated()
+
+        guard let deviceSecret = rest.device.secret else {
+            fail("Device Secret should be available because it's loaded when the getter of the property is called"); return
+        }
+        guard let data = Data(base64Encoded: deviceSecret) else {
+            fail("Device Secret should be encoded with Base64"); return
+        }
+        expect(data.count) == 32 // 32 bytes digest
+    }
+
+    // RSH8b
+    func test__016__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__local_device__should_have_a_clientID_if_the_client_is_identified() {
+        beforeEach__Activation_state_machine__State_NotActivated()
+
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.clientId = "deviceClient"
+        let rest = ARTRest(options: options)
+        rest.internal.storage = storage
+        expect(rest.device.clientId).to(equal("deviceClient"))
+    }
+
+    // RSH3a2c
+    func test__009__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__if_the_local_device_has_the_necessary_push_details_should_send_event_GotPushDeviceDetails() {
+        beforeEach__Activation_state_machine__State_NotActivated()
+
+        let delegate = StateMachineDelegate()
+        stateMachine.delegate = delegate
+
+        let testDeviceToken = "xxxx-xxxx-xxxx-xxxx-xxxx"
+        stateMachine.rest.device.setAndPersistAPNSDeviceToken(testDeviceToken)
+        defer { stateMachine.rest.device.setAndPersistAPNSDeviceToken(nil) }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            stateMachine.transitions = { event, _, _ in
+                if event is ARTPushActivationEventCalledActivate {
+                    partialDone()
+                }
+                if event is ARTPushActivationEventGotPushDeviceDetails {
+                    partialDone()
+                }
+            }
+            stateMachine.send(ARTPushActivationEventCalledActivate())
+        }
+    }
+
+    // RSH3a2d
+    func test__010__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__none_of_them_then_should_transition_to_WaitingForPushDeviceDetails() {
+        beforeEach__Activation_state_machine__State_NotActivated()
+
+        stateMachine.send(ARTPushActivationEventCalledActivate())
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
+    }
+
+    // RSH3a3
+    func test__008__Activation_state_machine__State_NotActivated__on_Event_GotPushDeviceDetails() {
+        beforeEach__Activation_state_machine__State_NotActivated()
+
+        stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
+    }
+
+    // RSH3b
+
+    func beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails() {
+        storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForPushDeviceDetails(machine: initialStateMachine))
+        rest.internal.storage = storage
+        stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
+    }
+
+    // RSH3b1
+    func test__017__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_CalledActivate() {
+        beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
+        stateMachine.send(ARTPushActivationEventCalledActivate())
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
+    }
+
+    // RSH3b2
+    func test__018__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_CalledDeactivate() {
+        beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
+        var deactivatedCallbackCalled = false
+        let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callDeactivatedCallback:")) {
+            deactivatedCallbackCalled = true
+        }
+        defer { hook.remove() }
+
+        stateMachine.send(ARTPushActivationEventCalledDeactivate())
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
+        expect(deactivatedCallbackCalled).to(beTrue())
+    }
+
+    // RSH3b3
+
+    // TODO: The exception is raised but the `send:` method is doing an async call and the `expect` doesn't catch it
+    func skipped__test__021__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_raise_exception_if_ARTPushRegistererDelegate_is_not_implemented() {
+        beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
+        expect {
+            stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
+        }.to(raiseException { exception in
+            expect(exception.reason).to(contain("ARTPushRegistererDelegate must be implemented"))
+        })
+    }
+
+    // RSH3b3a, RSH3b3c
+    func test__022__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_use_custom_registerCallback_and_fire_GotDeviceRegistration_event() {
+        beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
+
+        let delegate = StateMachineDelegateCustomCallbacks()
+        stateMachine.delegate = delegate
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(3, done: done)
+            stateMachine.transitions = { event, _, currentState in
+                if event is ARTPushActivationEventGotPushDeviceDetails {
+                    expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeviceRegistration.self))
+                    partialDone()
+                } else if event is ARTPushActivationEventGotDeviceRegistration {
+                    stateMachine.transitions = nil
+                    partialDone()
+                }
+            }
+            delegate.onPushCustomRegister = { error, deviceDetails in
+                expect(error).to(beNil())
+                expect(deviceDetails).to(beIdenticalTo(rest.device))
+                partialDone()
+                return nil
+            }
+            stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
+        }
+
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
+        expect(httpExecutor.requests.count) == 0
+    }
+
+    // RSH3b3c
+    func test__023__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_use_custom_registerCallback_and_fire_GettingDeviceRegistrationFailed_event() {
+        beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
+
+        let delegate = StateMachineDelegateCustomCallbacks()
+        stateMachine.delegate = delegate
+
+        waitUntil(timeout: testTimeout) { done in
+            let simulatedError = NSError(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
+            let partialDone = AblyTests.splitDone(3, done: done)
+            stateMachine.transitions = { event, _, currentState in
+                if event is ARTPushActivationEventGotPushDeviceDetails {
+                    expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeviceRegistration.self))
+                    partialDone()
+                } else if let event = event as? ARTPushActivationEventGettingDeviceRegistrationFailed {
+                    expect(event.error.domain) == ARTAblyErrorDomain
+                    expect(event.error.code) == simulatedError.code
+                    stateMachine.transitions = nil
+                    partialDone()
+                }
+            }
+            delegate.onPushCustomRegister = { error, deviceDetails in
+                expect(error).to(beNil())
+                expect(deviceDetails).to(beIdenticalTo(rest.device))
+                partialDone()
+                return simulatedError
+            }
+            stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
+        }
+
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
+        expect(httpExecutor.requests.count) == 0
+    }
+
+    // RSH3b3b, RSH3b3c
+    func test__024__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_fire_GotDeviceRegistration_event() {
+        beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
+
+        let delegate = StateMachineDelegate()
+        stateMachine.delegate = delegate
+
+        var setAndPersistIdentityTokenDetailsCalled = false
+        let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
+            setAndPersistIdentityTokenDetailsCalled = true
+        }
+        defer { hookDevice.remove() }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            stateMachine.transitions = { event, _, currentState in
+                if event is ARTPushActivationEventGotPushDeviceDetails {
+                    expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeviceRegistration.self))
+                    partialDone()
+                } else if event is ARTPushActivationEventGotDeviceRegistration {
+                    stateMachine.transitions = nil
+                    partialDone()
+                }
+            }
+            stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
+        }
+
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
+        expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
+        expect(httpExecutor.requests.count) == 1
+        let requests = httpExecutor.requests.compactMap { $0.url?.path }.filter { $0 == "/push/deviceRegistrations" }
+        expect(requests).to(haveCount(1))
+        guard let request = httpExecutor.requests.first else {
+            fail("should have a \"/push/deviceRegistrations\" request"); return
+        }
+        guard let url = request.url else {
+            fail("should have a \"/push/deviceRegistrations\" URL"); return
+        }
+        guard let rawBody = request.httpBody else {
+            fail("should have a body"); return
+        }
+        let decodedBody: Any
+        do {
+            decodedBody = try stateMachine.rest.defaultEncoder.decode(rawBody)
+        } catch {
+            fail("Decode failed: \(error)"); return
+        }
+        guard let body = decodedBody as? NSDictionary else {
+            fail("body is invalid"); return
+        }
+        expect(url.host).to(equal(rest.internal.options.restUrl().host))
+        expect(request.httpMethod) == "POST"
+        expect(body.value(forKey: "id") as? String).to(equal(rest.device.id))
+        expect(body.value(forKey: "push") as? [String: [String: String]]).to(equal(expectedPushRecipient))
+        expect(body.value(forKey: "formFactor") as? String) == expectedFormFactor
+        expect(body.value(forKey: "platform") as? String) == expectedPlatform
+    }
+
+    // RSH3b3c
+    func test__025__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_fire_GettingDeviceRegistrationFailed_event() {
+        beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
+
+        let delegate = StateMachineDelegate()
+        stateMachine.delegate = delegate
+
+        let simulatedError = NSError(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
+        httpExecutor.simulateIncomingErrorOnNextRequest(simulatedError)
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            stateMachine.transitions = { event, _, currentState in
+                if event is ARTPushActivationEventGotPushDeviceDetails {
+                    expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeviceRegistration.self))
+                    partialDone()
+                } else if let event = event as? ARTPushActivationEventGettingDeviceRegistrationFailed {
+                    expect(event.error.domain) == ARTAblyErrorDomain
+                    expect(event.error.code) == simulatedError.code
+                    stateMachine.transitions = nil
+                    partialDone()
+                }
+            }
+            stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
+        }
+
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
+        expect(httpExecutor.requests.count) == 1
+        let requests = httpExecutor.requests.compactMap { $0.url?.path }.filter { $0 == "/push/deviceRegistrations" }
+        expect(requests).to(haveCount(1))
+        guard let request = httpExecutor.requests.first else {
+            fail("should have a \"/push/deviceRegistrations\" request"); return
+        }
+        guard request.url != nil else {
+            fail("should have a \"/push/deviceRegistrations\" URL"); return
+        }
+        guard let rawBody = request.httpBody else {
+            fail("should have a body"); return
+        }
+        let decodedBody: Any
+        do {
+            decodedBody = try stateMachine.rest.defaultEncoder.decode(rawBody)
+        } catch {
+            fail("Decode failed: \(error)"); return
+        }
+        guard let body = decodedBody as? NSDictionary else {
+            fail("body is invalid"); return
+        }
+        expect(body.value(forKey: "id") as? String).to(equal(rest.device.id))
+        expect(body.value(forKey: "push") as? [String: [String: String]]).to(equal(expectedPushRecipient))
+        expect(body.value(forKey: "formFactor") as? String) == expectedFormFactor
+        expect(body.value(forKey: "platform") as? String) == expectedPlatform
+    }
+
+    // RSH3b3d
+    func test__026__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_transition_to_WaitingForDeviceRegistration() {
+        beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
+
+        let delegate = StateMachineDelegate()
+        stateMachine.delegate = delegate
+
+        var setAndPersistIdentityTokenDetailsCalled = false
+        let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
+            setAndPersistIdentityTokenDetailsCalled = true
+        }
+        defer { hookDevice.remove() }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            stateMachine.transitions = { event, _, currentState in
+                if event is ARTPushActivationEventGotPushDeviceDetails {
+                    expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeviceRegistration.self))
+                    partialDone()
+                } else if event is ARTPushActivationEventGotDeviceRegistration {
+                    stateMachine.transitions = nil
+                    partialDone()
+                }
+            }
+            stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
+        }
+
+        expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
+    }
+
+    // RSH3b4
+    func test__019__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GettingPushDeviceDetailsFailed() {
+        beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
+        let expectedError = ARTErrorInfo(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
+
+        let delegate = StateMachineDelegate()
+        stateMachine.delegate = delegate
+
+        waitUntil(timeout: testTimeout) { done in
+            delegate.onDidActivateAblyPush = { error in
+                expect(error).to(equal(expectedError))
+                done()
+            }
+            stateMachine.send(ARTPushActivationEventGettingPushDeviceDetailsFailed(error: expectedError))
+        }
+
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
+    }
+
+    // https://github.com/ably/ably-cocoa/issues/966
+    func test__020__Activation_state_machine__State_WaitingForPushDeviceDetails__when_initializing_from_persistent_state_with_a_deviceToken__GotPushDeviceDetails_should_be_re_emitted() {
+        beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
+
+        storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForPushDeviceDetails(machine: initialStateMachine))
+        rest.internal.storage = storage
+        rest.device.setAndPersistAPNSDeviceToken("foo")
+        defer { rest.device.setAndPersistAPNSDeviceToken(nil) }
+
+        var registered = false
+
+        let delegate = StateMachineDelegateCustomCallbacks()
+        stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: delegate)
+        delegate.onPushCustomRegister = { _, _ in
+            registered = true
+            return nil
+        }
+
+        expect(registered).toEventually(beTrue())
+    }
+
+    // RSH3c
+
+    func beforeEach__Activation_state_machine__State_WaitingForDeviceRegistration() {
+        storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForDeviceRegistration(machine: initialStateMachine))
+        rest.internal.storage = storage
+        stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
+    }
+
+    // RSH3c1
+    func test__027__Activation_state_machine__State_WaitingForDeviceRegistration__on_Event_CalledActivate() {
+        beforeEach__Activation_state_machine__State_WaitingForDeviceRegistration()
+
+        stateMachine.send(ARTPushActivationEventCalledActivate())
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForDeviceRegistration.self))
+    }
+
+    // RSH3c2 / RSH8c
+    func test__028__Activation_state_machine__State_WaitingForDeviceRegistration__on_Event_GotDeviceRegistration() {
+        beforeEach__Activation_state_machine__State_WaitingForDeviceRegistration()
+
+        rest.internal.resetDeviceSingleton()
+
+        var activatedCallbackCalled = false
+        let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callActivatedCallback:")) {
+            activatedCallbackCalled = true
+        }
+        defer { hook.remove() }
+
+        var setAndPersistIdentityTokenDetailsCalled = false
+        let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
+            setAndPersistIdentityTokenDetailsCalled = true
+        }
+        defer { hookDevice.remove() }
+
+        let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(
+            token: "123456",
+            issued: Date(),
+            expires: Date.distantFuture,
+            capability: "",
+            clientId: ""
+        )
+
+        stateMachine.send(ARTPushActivationEventGotDeviceRegistration(identityTokenDetails: testIdentityTokenDetails))
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
+        expect(activatedCallbackCalled).to(beTrue())
+        expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
+        expect(storage.keysWritten.keys).to(contain(["ARTDeviceId", "ARTDeviceSecret", "ARTDeviceIdentityToken"]))
+    }
+
+    // RSH3c3
+    func test__029__Activation_state_machine__State_WaitingForDeviceRegistration__on_Event_GettingDeviceRegistrationFailed() {
+        beforeEach__Activation_state_machine__State_WaitingForDeviceRegistration()
+
+        let expectedError = ARTErrorInfo(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
+
+        var activatedCallbackCalled = false
+        let hook = stateMachine.testSuite_getArgument(from: NSSelectorFromString("callActivatedCallback:"), at: 0, callback: { arg0 in
+            activatedCallbackCalled = true
+            guard let error = arg0 as? ARTErrorInfo else {
+                fail("Error is missing"); return
+            }
+            expect(error) == expectedError
+        })
+        defer { hook.remove() }
+
+        stateMachine.send(ARTPushActivationEventGettingDeviceRegistrationFailed(error: expectedError))
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
+        expect(activatedCallbackCalled).to(beTrue())
+    }
+
+    // RSH3d
+
+    func beforeEach__Activation_state_machine__State_WaitingForNewPushDeviceDetails() {
+        storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForNewPushDeviceDetails(machine: initialStateMachine))
+        rest.internal.storage = storage
+        stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
+    }
+
+    // RSH3d1
+    func test__030__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledActivate() {
+        beforeEach__Activation_state_machine__State_WaitingForNewPushDeviceDetails()
+
+        var activatedCallbackCalled = false
+        let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callActivatedCallback:")) {
+            activatedCallbackCalled = true
+        }
+        defer { hook.remove() }
+
+        stateMachine.send(ARTPushActivationEventCalledActivate())
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
+        expect(activatedCallbackCalled).to(beTrue())
+    }
+
+    // RSH3d2
+
+    func reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: TestCase_ReusableTestsRsh3d2) {
+        reusableTestsRsh3d2(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_WaitingForNewPushDeviceDetails)
+    }
+
+    func test__031__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_Deregistered_event() {
+        reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_Deregistered_event)
+    }
+
+    func test__032__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event() {
+        reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event)
+    }
+
+    func test__033__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header() {
+        reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header)
+    }
+
+    func test__034__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header() {
+        reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header)
+    }
+
+    func test__035__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_fire_DeregistrationFailed_event() {
+        reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_DeregistrationFailed_event)
+    }
+
+    enum TestCase_ReusableTestsTestStateWaitingForRegistrationSyncThrough {
+        case on_Event_CalledActivate
+        case on_Event_RegistrationSynced
+        case on_Event_SyncRegistrationFailed
+    }
+
+    // RSH3e
+    func reusableTestsTestStateWaitingForRegistrationSyncThrough(_ fromEvent: ARTPushActivationEvent, testCase: TestCase_ReusableTestsTestStateWaitingForRegistrationSyncThrough, beforeEach contextBeforeEach: (() -> Void)? = nil, afterEach contextAfterEach: (() -> Void)? = nil) {
+        func beforeEach() {
+            contextBeforeEach?()
+
+            storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForRegistrationSync(machine: initialStateMachine, from: fromEvent))
             rest.internal.storage = storage
-            initialStateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
+            stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
+            (stateMachine.current as! ARTPushActivationStateWaitingForRegistrationSync).fromEvent = fromEvent
         }
 
-        override func tearDown() {
-           rest.internal.resetDeviceSingleton()
+        // RSH3e1
+        func test__on_Event_CalledActivate() {
+            beforeEach()
 
-super.tearDown()
+            var activatedCallbackCalled = false
+            let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callActivatedCallback:")) {
+                activatedCallbackCalled = true
+            }
+            defer { hook.remove() }
 
+            stateMachine.send(ARTPushActivationEventCalledActivate())
+            expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForRegistrationSync.self))
+            if !fromEvent.isKind(of: ARTPushActivationEventCalledActivate.self) { expect(activatedCallbackCalled).to(beTrue())
+                expect(stateMachine.pendingEvents).to(haveCount(0))
+            } else {
+                expect(activatedCallbackCalled).to(beFalse())
+                expect(stateMachine.pendingEvents).to(haveCount(1))
+            }
+
+            contextAfterEach?()
         }
 
-        
+        // RSH3e2
+        func test__on_Event_RegistrationSynced() {
+            beforeEach()
 
-            func test__002__Activation_state_machine__should_set_NotActivated_state_as_current_state_when_disk_is_empty() {
-                expect(initialStateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
+            var setAndPersistIdentityTokenDetailsCalled = false
+            let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
+                setAndPersistIdentityTokenDetailsCalled = true
+            }
+            defer { hookDevice.remove() }
+
+            let delegate = StateMachineDelegate()
+            stateMachine.delegate = delegate
+
+            var activateCallbackCalled = false
+            delegate.onDidActivateAblyPush = { error in
+                expect(error).to(beNil())
+                activateCallbackCalled = true
             }
 
-            func test__003__Activation_state_machine__should_read_the_current_state_from_disk() {
-                let storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForDeviceRegistration(machine: initialStateMachine))
-                rest.internal.storage = storage
-                let stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
-                expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForDeviceRegistration.self))
-                expect(storage.keysRead).to(haveCount(2))
-                expect(storage.keysRead.filter({ $0.hasSuffix("CurrentState") })).to(haveCount(1))
-                expect(storage.keysWritten).to(beEmpty())
+            let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(
+                token: "123456",
+                issued: Date(),
+                expires: Date.distantFuture,
+                capability: "",
+                clientId: ""
+            )
+
+            stateMachine.send(ARTPushActivationEventRegistrationSynced(identityTokenDetails: testIdentityTokenDetails))
+            expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
+            expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
+
+            // RSH3e2b
+            expect(activateCallbackCalled).toEventually(equal(fromEvent is ARTPushActivationEventCalledActivate), timeout: testTimeout)
+
+            contextAfterEach?()
+        }
+
+        // RSH3e3
+        func test__on_Event_SyncRegistrationFailed() {
+            beforeEach()
+
+            let expectedError = ARTErrorInfo(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
+
+            var updateFailedCallbackCalled = false
+            let hook = stateMachine.testSuite_getArgument(from: NSSelectorFromString("callUpdateFailedCallback:"), at: 0, callback: { arg0 in
+                updateFailedCallbackCalled = true
+                guard let error = arg0 as? ARTErrorInfo else {
+                    fail("Error is missing"); return
+                }
+                expect(error) == expectedError
+            })
+            defer { hook.remove() }
+
+            let delegate = StateMachineDelegate()
+            stateMachine.delegate = delegate
+
+            var activateCallbackCalled = false
+            delegate.onDidActivateAblyPush = { error in
+                expect(error) == expectedError
+                activateCallbackCalled = true
             }
 
-            func test__004__Activation_state_machine__AfterRegistrationUpdateFailed_state_from_persistence_gets_migrated_to_AfterRegistrationSyncFailed() {
-                let stateEncodedFromOldVersionBase64 = "YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05TS2V5ZWRBcmNoaXZlctEICVRyb290gAGjCwwPVSRudWxs0Q0OViRjbGFzc4AC0hAREhNaJGNsYXNzbmFtZVgkY2xhc3Nlc18QM0FSVFB1c2hBY3RpdmF0aW9uU3RhdGVBZnRlclJlZ2lzdHJhdGlvblVwZGF0ZUZhaWxlZKQUFRYXXxAzQVJUUHVzaEFjdGl2YXRpb25TdGF0ZUFmdGVyUmVnaXN0cmF0aW9uVXBkYXRlRmFpbGVkXxAgQVJUUHVzaEFjdGl2YXRpb25QZXJzaXN0ZW50U3RhdGVfEBZBUlRQdXNoQWN0aXZhdGlvblN0YXRlWE5TT2JqZWN0AAgAEQAaACQAKQAyADcASQBMAFEAUwBXAF0AYABnAGkAbgB5AIIAuAC9APMBFgEvAAAAAAAAAgEAAAAAAAAAGAAAAAAAAAAAAAAAAAAAATg="
-                let stateEncodedFromOldVersion = Data.init(base64Encoded: stateEncodedFromOldVersionBase64, options: .init())!
+            stateMachine.send(ARTPushActivationEventSyncRegistrationFailed(error: expectedError))
+            expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateAfterRegistrationSyncFailed.self))
 
-                let storage = MockDeviceStorage()
-                storage.simulateOnNextRead(data: stateEncodedFromOldVersion, for: ARTPushActivationCurrentStateKey)
-                rest.internal.storage = storage
-                let stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
-                expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateAfterRegistrationSyncFailed.self))
+            // RSH3e3a
+            expect(updateFailedCallbackCalled).toEventually(equal(!(fromEvent is ARTPushActivationEventCalledActivate)), timeout: testTimeout)
+            // RSH3e3c
+            expect(activateCallbackCalled).toEventually(equal(fromEvent is ARTPushActivationEventCalledActivate), timeout: testTimeout)
+
+            contextAfterEach?()
+        }
+
+        switch testCase {
+        case .on_Event_CalledActivate:
+            test__on_Event_CalledActivate()
+        case .on_Event_RegistrationSynced:
+            test__on_Event_RegistrationSynced()
+        case .on_Event_SyncRegistrationFailed:
+            test__on_Event_SyncRegistrationFailed()
+        }
+    }
+
+    func reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: TestCase_ReusableTestsTestStateWaitingForRegistrationSyncThrough) {
+        reusableTestsTestStateWaitingForRegistrationSyncThrough(ARTPushActivationEventCalledActivate(), testCase: testCase)
+    }
+
+    func test__036__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__on_Event_CalledActivate() {
+        reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_CalledActivate)
+    }
+
+    func test__037__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__on_Event_RegistrationSynced() {
+        reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_RegistrationSynced)
+    }
+
+    func test__038__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__on_Event_SyncRegistrationFailed() {
+        reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_SyncRegistrationFailed)
+    }
+
+    func reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: TestCase_ReusableTestsTestStateWaitingForRegistrationSyncThrough) {
+        reusableTestsTestStateWaitingForRegistrationSyncThrough(ARTPushActivationEventGotPushDeviceDetails(), testCase: testCase)
+    }
+
+    func test__039__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__on_Event_CalledActivate() {
+        reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_CalledActivate)
+    }
+
+    func test__040__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__on_Event_RegistrationSynced() {
+        reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_RegistrationSynced)
+    }
+
+    func test__041__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__on_Event_SyncRegistrationFailed() {
+        reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_SyncRegistrationFailed)
+    }
+
+    // RSH3f
+
+    func beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed() {
+        storage = MockDeviceStorage(startWith: ARTPushActivationStateAfterRegistrationSyncFailed(machine: initialStateMachine))
+        rest.internal.storage = storage
+        stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
+    }
+
+    // RSH3f1
+
+    func reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a) {
+        reusableTestsRsh3a2a(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed)
+    }
+
+    func test__042__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() {
+        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match)
+    }
+
+    func test__043__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() {
+        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync)
+    }
+
+    func test__044__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() {
+        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync)
+    }
+
+    // RSH3f1
+
+    func reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a) {
+        reusableTestsRsh3a2a(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed)
+    }
+
+    func test__045__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() {
+        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match)
+    }
+
+    func test__046__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() {
+        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync)
+    }
+
+    func test__047__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() {
+        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync)
+    }
+
+    // RSH3f2
+
+    func reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: TestCase_ReusableTestsRsh3d2) {
+        reusableTestsRsh3d2(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed)
+    }
+
+    func test__048__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_Deregistered_event() {
+        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_Deregistered_event)
+    }
+
+    func test__049__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event() {
+        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event)
+    }
+
+    func test__050__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header() {
+        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header)
+    }
+
+    func test__051__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header() {
+        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header)
+    }
+
+    func test__052__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_fire_DeregistrationFailed_event() {
+        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_DeregistrationFailed_event)
+    }
+
+    // RSH3g
+
+    func beforeEach__Activation_state_machine__State_WaitingForDeregistration() {
+        storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForDeregistration(machine: initialStateMachine))
+        rest.internal.storage = storage
+        stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
+    }
+
+    // RSH3g1
+    func test__053__Activation_state_machine__State_WaitingForDeregistration__on_Event_CalledDeactivate() {
+        beforeEach__Activation_state_machine__State_WaitingForDeregistration()
+
+        stateMachine.send(ARTPushActivationEventCalledDeactivate())
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
+    }
+
+    // RSH3g2
+    func test__054__Activation_state_machine__State_WaitingForDeregistration__on_Event_Deregistered() {
+        beforeEach__Activation_state_machine__State_WaitingForDeregistration()
+
+        var deactivatedCallbackCalled = false
+        let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callDeactivatedCallback:")) {
+            deactivatedCallbackCalled = true
+        }
+        defer { hook.remove() }
+
+        var setAndPersistIdentityTokenDetailsCalled = false
+        let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
+            setAndPersistIdentityTokenDetailsCalled = true
+        }
+        defer { hookDevice.remove() }
+
+        stateMachine.send(ARTPushActivationEventDeregistered())
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
+        expect(deactivatedCallbackCalled).to(beTrue())
+        expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
+        // RSH3g2a
+        expect(stateMachine.rest.device.identityTokenDetails).to(beNil())
+    }
+
+    // RSH3g3
+    func test__055__Activation_state_machine__State_WaitingForDeregistration__on_Event_DeregistrationFailed() {
+        beforeEach__Activation_state_machine__State_WaitingForDeregistration()
+
+        let expectedError = ARTErrorInfo(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
+
+        var deactivatedCallbackCalled = false
+        let hook = stateMachine.testSuite_getArgument(from: NSSelectorFromString("callDeactivatedCallback:"), at: 0, callback: { arg0 in
+            deactivatedCallbackCalled = true
+            guard let error = arg0 as? ARTErrorInfo else {
+                fail("Error is missing"); return
             }
+            expect(error) == expectedError
+        })
+        defer { hook.remove() }
 
-            // RSH3a
-            
+        stateMachine.send(ARTPushActivationEventDeregistrationFailed(error: expectedError))
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
+        expect(deactivatedCallbackCalled).to(beTrue())
+    }
 
-                func beforeEach__Activation_state_machine__State_NotActivated() {
-                    storage = MockDeviceStorage(startWith: ARTPushActivationStateNotActivated(machine: initialStateMachine))
-                    rest.internal.storage = storage
-                    stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
+    // RSH4
+    func test__005__Activation_state_machine__should_queue_event_that_has_no_transition_defined_for_it() {
+        // Start with WaitingForDeregistration state
+        let storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForDeregistration(machine: initialStateMachine))
+        rest.internal.storage = storage
+        let stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
+
+        stateMachine.transitions = { _, _, _ in
+            fail("Should not handle the CalledActivate event because it should be queued")
+        }
+
+        stateMachine.send(ARTPushActivationEventCalledActivate())
+
+        expect(stateMachine.pendingEvents).toEventually(haveCount(1), timeout: testTimeout)
+        stateMachine.transitions = nil
+
+        guard let pendingEvent = stateMachine.pendingEvents.firstObject else {
+            fail("Pending event is missing"); return
+        }
+        expect(pendingEvent).to(beAKindOf(ARTPushActivationEventCalledActivate.self))
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            stateMachine.transitions = { event, previousState, currentState in
+                if previousState is ARTPushActivationStateWaitingForDeregistration, currentState is ARTPushActivationStateNotActivated {
+                    // Handle Deregistered event
+                    partialDone()
+                } else if event is ARTPushActivationEventDeregistered, previousState is ARTPushActivationStateNotActivated, currentState is ARTPushActivationStateWaitingForPushDeviceDetails {
+                    // Consume queued CalledActivate event
+                    partialDone()
                 }
-
-                // RSH3a1
-                func test__007__Activation_state_machine__State_NotActivated__on_Event_CalledDeactivate__should_transition_to_NotActivated() {
-beforeEach__Activation_state_machine__State_NotActivated()
-
-                    var deactivatedCallbackCalled = false
-                    let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callDeactivatedCallback:")) {
-                        deactivatedCallbackCalled = true
-                    }
-                    defer { hook.remove() }
-
-                    stateMachine.send(ARTPushActivationEventCalledDeactivate())
-
-                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
-                    expect(deactivatedCallbackCalled).to(beTrue())
-                }
-
-                // RSH3a2
-                
-                    // RSH3a2a
-                    func reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a) {
-                    // RSH3a2a
-                    reusableTestsRsh3a2a(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_NotActivated)}
-func test__011__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() {
-reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match)
-}
-
-func test__012__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() {
-reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync)
-}
-
-func test__013__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() {
-reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync)
-}
-
-
-                    // RSH3a2b
-                    
-                        func test__014__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__local_device__should_have_a_generated_id() {
-beforeEach__Activation_state_machine__State_NotActivated()
-
-                            rest.internal.resetDeviceSingleton()
-                            expect(rest.device.id.count) == 36
-                        }
-                        func test__015__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__local_device__should_have_a_generated_secret() {
-beforeEach__Activation_state_machine__State_NotActivated()
-
-                            guard let deviceSecret = rest.device.secret else {
-                                fail("Device Secret should be available because it's loaded when the getter of the property is called"); return
-                            }
-                            guard let data = Data(base64Encoded: deviceSecret) else {
-                                fail("Device Secret should be encoded with Base64"); return
-                            }
-                            expect(data.count) == 32 //32 bytes digest
-                        }
-
-                        // RSH8b
-                        func test__016__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__local_device__should_have_a_clientID_if_the_client_is_identified() {
-beforeEach__Activation_state_machine__State_NotActivated()
-
-                            let options = ARTClientOptions(key: "xxxx:xxxx")
-                            options.clientId = "deviceClient"
-                            let rest = ARTRest(options: options)
-                            rest.internal.storage = storage
-                            expect(rest.device.clientId).to(equal("deviceClient"))
-                        }
-
-                    // RSH3a2c
-                    func test__009__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__if_the_local_device_has_the_necessary_push_details_should_send_event_GotPushDeviceDetails() {
-beforeEach__Activation_state_machine__State_NotActivated()
-
-                        let delegate = StateMachineDelegate()
-                        stateMachine.delegate = delegate
-
-                        let testDeviceToken = "xxxx-xxxx-xxxx-xxxx-xxxx"
-                        stateMachine.rest.device.setAndPersistAPNSDeviceToken(testDeviceToken)
-                        defer { stateMachine.rest.device.setAndPersistAPNSDeviceToken(nil) }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            stateMachine.transitions = { event, _, _ in
-                                if event is ARTPushActivationEventCalledActivate {
-                                    partialDone()
-                                }
-                                if event is ARTPushActivationEventGotPushDeviceDetails {
-                                    partialDone()
-                                }
-                            }
-                            stateMachine.send(ARTPushActivationEventCalledActivate())
-                        }
-                    }
-
-                    // RSH3a2d
-                    func test__010__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__none_of_them_then_should_transition_to_WaitingForPushDeviceDetails() {
-beforeEach__Activation_state_machine__State_NotActivated()
-
-                        stateMachine.send(ARTPushActivationEventCalledActivate())
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
-                    }
-
-                // RSH3a3
-                func test__008__Activation_state_machine__State_NotActivated__on_Event_GotPushDeviceDetails() {
-beforeEach__Activation_state_machine__State_NotActivated()
-
-                    stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
-                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
-                }
-
-            // RSH3b
-            
-
-                func beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails() {
-                    storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForPushDeviceDetails(machine: initialStateMachine))
-                    rest.internal.storage = storage
-                    stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
-                }
-
-                // RSH3b1
-                func test__017__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_CalledActivate() {
-beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
-
-                    stateMachine.send(ARTPushActivationEventCalledActivate())
-                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
-                }
-
-                // RSH3b2
-                func test__018__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_CalledDeactivate() {
-beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
-
-                    var deactivatedCallbackCalled = false
-                    let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callDeactivatedCallback:")) {
-                        deactivatedCallbackCalled = true
-                    }
-                    defer { hook.remove() }
-
-                    stateMachine.send(ARTPushActivationEventCalledDeactivate())
-                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
-                    expect(deactivatedCallbackCalled).to(beTrue())
-                }
-
-                // RSH3b3
-                
-
-                    // TODO: The exception is raised but the `send:` method is doing an async call and the `expect` doesn't catch it
-                    func skipped__test__021__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_raise_exception_if_ARTPushRegistererDelegate_is_not_implemented() {
-beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
-
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
-                        expect {
-                            stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
-                        }.to(raiseException { exception in
-                            expect(exception.reason).to(contain("ARTPushRegistererDelegate must be implemented"))
-                        })
-                    }
-
-                    // RSH3b3a, RSH3b3c
-                    func test__022__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_use_custom_registerCallback_and_fire_GotDeviceRegistration_event() {
-beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
-
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
-
-                        let delegate = StateMachineDelegateCustomCallbacks()
-                        stateMachine.delegate = delegate
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(3, done: done)
-                            stateMachine.transitions = { event, previousState, currentState in
-                                if event is ARTPushActivationEventGotPushDeviceDetails {
-                                    expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeviceRegistration.self))
-                                    partialDone()
-                                }
-                                else if event is ARTPushActivationEventGotDeviceRegistration {
-                                    stateMachine.transitions = nil
-                                    partialDone()
-                                }
-                            }
-                            delegate.onPushCustomRegister = { error, deviceDetails in
-                                expect(error).to(beNil())
-                                expect(deviceDetails).to(beIdenticalTo(rest.device))
-                                partialDone()
-                                return nil
-                            }
-                            stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
-                        }
-
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
-                        expect(httpExecutor.requests.count) == 0
-                    }
-
-                    // RSH3b3c
-                    func test__023__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_use_custom_registerCallback_and_fire_GettingDeviceRegistrationFailed_event() {
-beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
-
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
-
-                        let delegate = StateMachineDelegateCustomCallbacks()
-                        stateMachine.delegate = delegate
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let simulatedError = NSError(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
-                            let partialDone = AblyTests.splitDone(3, done: done)
-                            stateMachine.transitions = { event, previousState, currentState in
-                                if event is ARTPushActivationEventGotPushDeviceDetails {
-                                    expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeviceRegistration.self))
-                                    partialDone()
-                                }
-                                else if let event = event as? ARTPushActivationEventGettingDeviceRegistrationFailed {
-                                    expect(event.error.domain) == ARTAblyErrorDomain
-                                    expect(event.error.code) == simulatedError.code
-                                    stateMachine.transitions = nil
-                                    partialDone()
-                                }
-                            }
-                            delegate.onPushCustomRegister = { error, deviceDetails in
-                                expect(error).to(beNil())
-                                expect(deviceDetails).to(beIdenticalTo(rest.device))
-                                partialDone()
-                                return simulatedError
-                            }
-                            stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
-                        }
-
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
-                        expect(httpExecutor.requests.count) == 0
-                    }
-
-                    // RSH3b3b, RSH3b3c
-                    func test__024__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_fire_GotDeviceRegistration_event() {
-beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
-
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
-
-                        let delegate = StateMachineDelegate()
-                        stateMachine.delegate = delegate
-
-                        var setAndPersistIdentityTokenDetailsCalled = false
-                        let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
-                            setAndPersistIdentityTokenDetailsCalled = true
-                        }
-                        defer { hookDevice.remove() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            stateMachine.transitions = { event, previousState, currentState in
-                                if event is ARTPushActivationEventGotPushDeviceDetails {
-                                    expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeviceRegistration.self))
-                                    partialDone()
-                                }
-                                else if event is ARTPushActivationEventGotDeviceRegistration {
-                                    stateMachine.transitions = nil
-                                    partialDone()
-                                }
-                            }
-                            stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
-                        }
-
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
-                        expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
-                        expect(httpExecutor.requests.count) == 1
-                        let requests = httpExecutor.requests.compactMap({ $0.url?.path }).filter({ $0 == "/push/deviceRegistrations" })
-                        expect(requests).to(haveCount(1))
-                        guard let request = httpExecutor.requests.first else {
-                            fail("should have a \"/push/deviceRegistrations\" request"); return
-                        }
-                        guard let url = request.url else {
-                            fail("should have a \"/push/deviceRegistrations\" URL"); return
-                        }
-                        guard let rawBody = request.httpBody else {
-                            fail("should have a body"); return
-                        }
-                        let decodedBody: Any
-                        do {
-                            decodedBody = try stateMachine.rest.defaultEncoder.decode(rawBody)
-                        }
-                        catch {
-                            fail("Decode failed: \(error)"); return
-                        }
-                        guard let body = decodedBody as? NSDictionary else {
-                            fail("body is invalid"); return
-                        }
-                        expect(url.host).to(equal(rest.internal.options.restUrl().host))
-                        expect(request.httpMethod) == "POST"
-                        expect(body.value(forKey: "id") as? String).to(equal(rest.device.id))
-                        expect(body.value(forKey: "push") as? [String: [String: String]]).to(equal(expectedPushRecipient))
-                        expect(body.value(forKey: "formFactor") as? String) == expectedFormFactor
-                        expect(body.value(forKey: "platform") as? String) == expectedPlatform
-                    }
-
-                    // RSH3b3c
-                    func test__025__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_fire_GettingDeviceRegistrationFailed_event() {
-beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
-
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
-
-                        let delegate = StateMachineDelegate()
-                        stateMachine.delegate = delegate
-
-                        let simulatedError = NSError(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
-                        httpExecutor.simulateIncomingErrorOnNextRequest(simulatedError)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            stateMachine.transitions = { event, previousState, currentState in
-                                if event is ARTPushActivationEventGotPushDeviceDetails {
-                                    expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeviceRegistration.self))
-                                    partialDone()
-                                }
-                                else if let event = event as? ARTPushActivationEventGettingDeviceRegistrationFailed {
-                                    expect(event.error.domain) == ARTAblyErrorDomain
-                                    expect(event.error.code) == simulatedError.code
-                                    stateMachine.transitions = nil
-                                    partialDone()
-                                }
-                            }
-                            stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
-                        }
-
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
-                        expect(httpExecutor.requests.count) == 1
-                        let requests = httpExecutor.requests.compactMap({ $0.url?.path }).filter({ $0 == "/push/deviceRegistrations" })
-                        expect(requests).to(haveCount(1))
-                        guard let request = httpExecutor.requests.first else {
-                            fail("should have a \"/push/deviceRegistrations\" request"); return
-                        }
-                        guard request.url != nil else {
-                            fail("should have a \"/push/deviceRegistrations\" URL"); return
-                        }
-                        guard let rawBody = request.httpBody else {
-                            fail("should have a body"); return
-                        }
-                        let decodedBody: Any
-                        do {
-                            decodedBody = try stateMachine.rest.defaultEncoder.decode(rawBody)
-                        }
-                        catch {
-                            fail("Decode failed: \(error)"); return
-                        }
-                        guard let body = decodedBody as? NSDictionary else {
-                            fail("body is invalid"); return
-                        }
-                        expect(body.value(forKey: "id") as? String).to(equal(rest.device.id))
-                        expect(body.value(forKey: "push") as? [String: [String: String]]).to(equal(expectedPushRecipient))
-                        expect(body.value(forKey: "formFactor") as? String) == expectedFormFactor
-                        expect(body.value(forKey: "platform") as? String) == expectedPlatform
-                    }
-
-                    // RSH3b3d
-                    func test__026__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_transition_to_WaitingForDeviceRegistration() {
-beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
-
-                        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
-
-                        let delegate = StateMachineDelegate()
-                        stateMachine.delegate = delegate
-
-                        var setAndPersistIdentityTokenDetailsCalled = false
-                        let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
-                            setAndPersistIdentityTokenDetailsCalled = true
-                        }
-                        defer { hookDevice.remove() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            stateMachine.transitions = { event, previousState, currentState in
-                                if event is ARTPushActivationEventGotPushDeviceDetails {
-                                    expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeviceRegistration.self))
-                                    partialDone()
-                                }
-                                else if event is ARTPushActivationEventGotDeviceRegistration {
-                                    stateMachine.transitions = nil
-                                    partialDone()
-                                }
-                            }
-                            stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
-                        }
-
-                        expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
-                    }
-                
-                // RSH3b4
-                func test__019__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GettingPushDeviceDetailsFailed() {
-beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
-
-                    let expectedError = ARTErrorInfo(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
-
-                    let delegate = StateMachineDelegate()
-                    stateMachine.delegate = delegate
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        delegate.onDidActivateAblyPush = { error in
-                            expect(error).to(equal(expectedError))
-                            done()
-                        }
-                        stateMachine.send(ARTPushActivationEventGettingPushDeviceDetailsFailed(error: expectedError))
-                    }
-
-                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
-                }
-                
-                // https://github.com/ably/ably-cocoa/issues/966
-                func test__020__Activation_state_machine__State_WaitingForPushDeviceDetails__when_initializing_from_persistent_state_with_a_deviceToken__GotPushDeviceDetails_should_be_re_emitted() {
-beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
-
-                    storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForPushDeviceDetails(machine: initialStateMachine))
-                    rest.internal.storage = storage
-                    rest.device.setAndPersistAPNSDeviceToken("foo")
-                    defer { rest.device.setAndPersistAPNSDeviceToken(nil) }
-                    
-                    var registered = false
-
-                    let delegate = StateMachineDelegateCustomCallbacks()
-                    stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: delegate)
-                    delegate.onPushCustomRegister = { error, deviceDetails in
-                        registered = true
-                        return nil
-                    }
-
-                    expect(registered).toEventually(beTrue())
-                }
-
-            // RSH3c
-            
-
-                func beforeEach__Activation_state_machine__State_WaitingForDeviceRegistration() {
-                    storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForDeviceRegistration(machine: initialStateMachine))
-                    rest.internal.storage = storage
-                    stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
-                }
-
-                // RSH3c1
-                func test__027__Activation_state_machine__State_WaitingForDeviceRegistration__on_Event_CalledActivate() {
-beforeEach__Activation_state_machine__State_WaitingForDeviceRegistration()
-
-                    stateMachine.send(ARTPushActivationEventCalledActivate())
-                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForDeviceRegistration.self))
-                }
-
-                // RSH3c2 / RSH8c
-                func test__028__Activation_state_machine__State_WaitingForDeviceRegistration__on_Event_GotDeviceRegistration() {
-beforeEach__Activation_state_machine__State_WaitingForDeviceRegistration()
-
-                    rest.internal.resetDeviceSingleton()
-
-                    var activatedCallbackCalled = false
-                    let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callActivatedCallback:")) {
-                        activatedCallbackCalled = true
-                    }
-                    defer { hook.remove() }
-
-                    var setAndPersistIdentityTokenDetailsCalled = false
-                    let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
-                        setAndPersistIdentityTokenDetailsCalled = true
-                    }
-                    defer { hookDevice.remove() }
-
-                    let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(
-                        token: "123456",
-                        issued: Date(),
-                        expires: Date.distantFuture,
-                        capability: "",
-                        clientId: ""
-                    )
-
-                    stateMachine.send(ARTPushActivationEventGotDeviceRegistration(identityTokenDetails: testIdentityTokenDetails))
-                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
-                    expect(activatedCallbackCalled).to(beTrue())
-                    expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
-                    expect(storage.keysWritten.keys).to(contain(["ARTDeviceId", "ARTDeviceSecret", "ARTDeviceIdentityToken"]))
-                }
-
-                // RSH3c3
-                func test__029__Activation_state_machine__State_WaitingForDeviceRegistration__on_Event_GettingDeviceRegistrationFailed() {
-beforeEach__Activation_state_machine__State_WaitingForDeviceRegistration()
-
-                    let expectedError = ARTErrorInfo(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
-
-                    var activatedCallbackCalled = false
-                    let hook = stateMachine.testSuite_getArgument(from: NSSelectorFromString("callActivatedCallback:"), at: 0, callback: { arg0 in
-                        activatedCallbackCalled = true
-                        guard let error = arg0 as? ARTErrorInfo else {
-                            fail("Error is missing"); return
-                        }
-                        expect(error) == expectedError
-                    })
-                    defer { hook.remove() }
-
-                    stateMachine.send(ARTPushActivationEventGettingDeviceRegistrationFailed(error: expectedError))
-                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
-                    expect(activatedCallbackCalled).to(beTrue())
-                }
-
-            // RSH3d
-            
-
-                func beforeEach__Activation_state_machine__State_WaitingForNewPushDeviceDetails() {
-                    storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForNewPushDeviceDetails(machine: initialStateMachine))
-                    rest.internal.storage = storage
-                    stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
-                }
-
-                // RSH3d1
-                func test__030__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledActivate() {
-beforeEach__Activation_state_machine__State_WaitingForNewPushDeviceDetails()
-
-                    var activatedCallbackCalled = false
-                    let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callActivatedCallback:")) {
-                        activatedCallbackCalled = true
-                    }
-                    defer { hook.remove() }
-
-                    stateMachine.send(ARTPushActivationEventCalledActivate())
-                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
-                    expect(activatedCallbackCalled).to(beTrue())
-                }
-
-                // RSH3d2
-                
-                    func reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: TestCase_ReusableTestsRsh3d2) {
-                    reusableTestsRsh3d2(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_WaitingForNewPushDeviceDetails)}
-func test__031__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_Deregistered_event() {
-reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_Deregistered_event)
-}
-
-func test__032__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event() {
-reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event)
-}
-
-func test__033__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header() {
-reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header)
-}
-
-func test__034__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header() {
-reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header)
-}
-
-func test__035__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_fire_DeregistrationFailed_event() {
-reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_DeregistrationFailed_event)
-}
-
-enum TestCase_ReusableTestsTestStateWaitingForRegistrationSyncThrough {
-case on_Event_CalledActivate
-case on_Event_RegistrationSynced
-case on_Event_SyncRegistrationFailed
-}
-
-
-            // RSH3e
-            func reusableTestsTestStateWaitingForRegistrationSyncThrough(_ fromEvent: ARTPushActivationEvent, testCase: TestCase_ReusableTestsTestStateWaitingForRegistrationSyncThrough, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil) {
-                func beforeEach() {
-contextBeforeEach?()
-
-                    storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForRegistrationSync(machine: initialStateMachine, from: fromEvent))
-                    rest.internal.storage = storage
-                    stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
-                    (stateMachine.current as! ARTPushActivationStateWaitingForRegistrationSync).fromEvent = fromEvent
-                }
-                
-                // RSH3e1
-                func test__on_Event_CalledActivate() {
-beforeEach()
-
-                    var activatedCallbackCalled = false
-                    let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callActivatedCallback:")) {
-                        activatedCallbackCalled = true
-                    }
-                    defer { hook.remove() }
-                    
-                    stateMachine.send(ARTPushActivationEventCalledActivate())
-                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForRegistrationSync.self))
-                    if (!fromEvent.isKind(of: ARTPushActivationEventCalledActivate.self)) {                        expect(activatedCallbackCalled).to(beTrue())
-                        expect(stateMachine.pendingEvents).to(haveCount(0))
-                    } else {
-                        expect(activatedCallbackCalled).to(beFalse())
-                        expect(stateMachine.pendingEvents).to(haveCount(1))
-                    }
-
-contextAfterEach?()
-
-                }
-                
-                // RSH3e2
-                func test__on_Event_RegistrationSynced() {
-beforeEach()
-
-                    var setAndPersistIdentityTokenDetailsCalled = false
-                    let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
-                        setAndPersistIdentityTokenDetailsCalled = true
-                    }
-                    defer { hookDevice.remove() }
-                    
-                    let delegate = StateMachineDelegate()
-                    stateMachine.delegate = delegate
-                    
-                    var activateCallbackCalled = false
-                    delegate.onDidActivateAblyPush = { error in
-                        expect(error).to(beNil())
-                        activateCallbackCalled = true
-                    }
-                    
-                    let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(
-                        token: "123456",
-                        issued: Date(),
-                        expires: Date.distantFuture,
-                        capability: "",
-                        clientId: ""
-                    )
-                    
-                    stateMachine.send(ARTPushActivationEventRegistrationSynced(identityTokenDetails: testIdentityTokenDetails))
-                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForNewPushDeviceDetails.self))
-                    expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
-                    
-                    // RSH3e2b
-                    expect(activateCallbackCalled).toEventually(equal(fromEvent is ARTPushActivationEventCalledActivate), timeout: testTimeout)
-
-contextAfterEach?()
-
-                }
-                
-                // RSH3e3
-                func test__on_Event_SyncRegistrationFailed() {
-beforeEach()
-
-                    let expectedError = ARTErrorInfo(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
-                    
-                    var updateFailedCallbackCalled = false
-                    let hook = stateMachine.testSuite_getArgument(from: NSSelectorFromString("callUpdateFailedCallback:"), at: 0, callback: { arg0 in
-                        updateFailedCallbackCalled = true
-                        guard let error = arg0 as? ARTErrorInfo else {
-                            fail("Error is missing"); return
-                        }
-                        expect(error) == expectedError
-                    })
-                    defer { hook.remove() }
-                    
-                    let delegate = StateMachineDelegate()
-                    stateMachine.delegate = delegate
-                    
-                    var activateCallbackCalled = false
-                    delegate.onDidActivateAblyPush = { error in
-                        expect(error) == expectedError
-                        activateCallbackCalled = true
-                    }
-                    
-                    stateMachine.send(ARTPushActivationEventSyncRegistrationFailed(error: expectedError))
-                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateAfterRegistrationSyncFailed.self))
-                    
-                    // RSH3e3a
-                    expect(updateFailedCallbackCalled).toEventually(equal(!(fromEvent is ARTPushActivationEventCalledActivate)), timeout: testTimeout)
-                    // RSH3e3c
-                    expect(activateCallbackCalled).toEventually(equal(fromEvent is ARTPushActivationEventCalledActivate), timeout: testTimeout)
-
-contextAfterEach?()
-
-                }
-
-switch testCase  {
-case .on_Event_CalledActivate:
-    test__on_Event_CalledActivate()
-case .on_Event_RegistrationSynced:
-    test__on_Event_RegistrationSynced()
-case .on_Event_SyncRegistrationFailed:
-    test__on_Event_SyncRegistrationFailed()
-}
-
             }
-            
-            
-                func reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: TestCase_ReusableTestsTestStateWaitingForRegistrationSyncThrough) {
-                reusableTestsTestStateWaitingForRegistrationSyncThrough(ARTPushActivationEventCalledActivate(), testCase: testCase)}
-func test__036__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__on_Event_CalledActivate() {
-reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_CalledActivate)
-}
+            stateMachine.send(ARTPushActivationEventDeregistered())
+            expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
+        }
+        stateMachine.transitions = nil
 
-func test__037__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__on_Event_RegistrationSynced() {
-reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_RegistrationSynced)
-}
+        expect(stateMachine.pendingEvents).to(beEmpty())
+    }
 
-func test__038__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__on_Event_SyncRegistrationFailed() {
-reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventCalledActivate__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_SyncRegistrationFailed)
-}
+    // RSH5
+    func test__006__Activation_state_machine__event_handling_sould_be_atomic_and_sequential() {
+        let storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForDeregistration(machine: initialStateMachine))
+        rest.internal.storage = storage
+        let stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
+        stateMachine.send(ARTPushActivationEventCalledActivate())
+        DispatchQueue(label: "QueueA").sync {
+            stateMachine.send(ARTPushActivationEventDeregistered())
+        }
+        expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
+    }
 
-            
-            
-                func reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: TestCase_ReusableTestsTestStateWaitingForRegistrationSyncThrough) {
-                reusableTestsTestStateWaitingForRegistrationSyncThrough(ARTPushActivationEventGotPushDeviceDetails(), testCase: testCase)}
-func test__039__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__on_Event_CalledActivate() {
-reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_CalledActivate)
-}
+    func test__001__should_remove_identityTokenDetails_from_cache_and_storage() {
+        let storage = MockDeviceStorage()
+        rest.internal.storage = storage
+        rest.device.setAndPersistIdentityTokenDetails(nil)
+        rest.internal.resetDeviceSingleton()
+        expect(rest.device.identityTokenDetails).to(beNil())
+        expect(rest.device.isRegistered()) == false
+        expect(storage.object(forKey: ARTDeviceIdentityTokenKey)).to(beNil())
+    }
 
-func test__040__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__on_Event_RegistrationSynced() {
-reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_RegistrationSynced)
-}
+    enum TestCase_ReusableTestsRsh3a2a {
+        case the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match
+        case the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync
+        case the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync
+    }
 
-func test__041__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__on_Event_SyncRegistrationFailed() {
-reusableTestsWrapper__Activation_state_machine__State_WaitingForRegistrationSync_through_ARTPushActivationEventGotPushDeviceDetails__reusableTestsTestStateWaitingForRegistrationSyncThrough(testCase: .on_Event_SyncRegistrationFailed)
-}
+    func reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a, beforeEach contextBeforeEach: (() -> Void)? = nil, afterEach contextAfterEach: (() -> Void)? = nil) {
+        let testDeviceId = "aaaa"
 
-            
-            // RSH3f
-            
+        // RSH3a2a1
+        func test__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() {
+            contextBeforeEach?()
 
-                func beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed() {
-                    storage = MockDeviceStorage(startWith: ARTPushActivationStateAfterRegistrationSyncFailed(machine: initialStateMachine))
-                    rest.internal.storage = storage
-                    stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
-                }
-
-                // RSH3f1
-                
-                    func reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a) {
-                    reusableTestsRsh3a2a(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed)}
-func test__042__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() {
-reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match)
-}
-
-func test__043__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() {
-reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync)
-}
-
-func test__044__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() {
-reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync)
-}
-
-
-                // RSH3f1
-                
-                    func reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a) {
-                    reusableTestsRsh3a2a(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed)}
-func test__045__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() {
-reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match)
-}
-
-func test__046__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() {
-reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync)
-}
-
-func test__047__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() {
-reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync)
-}
-
-
-                // RSH3f2
-                
-                    func reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: TestCase_ReusableTestsRsh3d2) {
-                    reusableTestsRsh3d2(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed)}
-func test__048__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_Deregistered_event() {
-reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_Deregistered_event)
-}
-
-func test__049__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event() {
-reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event)
-}
-
-func test__050__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header() {
-reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header)
-}
-
-func test__051__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header() {
-reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header)
-}
-
-func test__052__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_fire_DeregistrationFailed_event() {
-reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_DeregistrationFailed_event)
-}
-
-
-            // RSH3g
-            
-
-                func beforeEach__Activation_state_machine__State_WaitingForDeregistration() {
-                    storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForDeregistration(machine: initialStateMachine))
-                    rest.internal.storage = storage
-                    stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
-                }
-
-                // RSH3g1
-                func test__053__Activation_state_machine__State_WaitingForDeregistration__on_Event_CalledDeactivate() {
-beforeEach__Activation_state_machine__State_WaitingForDeregistration()
-
-                    stateMachine.send(ARTPushActivationEventCalledDeactivate())
-                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
-                }
-
-                // RSH3g2
-                func test__054__Activation_state_machine__State_WaitingForDeregistration__on_Event_Deregistered() {
-beforeEach__Activation_state_machine__State_WaitingForDeregistration()
-
-                    var deactivatedCallbackCalled = false
-                    let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callDeactivatedCallback:")) {
-                        deactivatedCallbackCalled = true
-                    }
-                    defer { hook.remove() }
-
-                    var setAndPersistIdentityTokenDetailsCalled = false
-                    let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
-                        setAndPersistIdentityTokenDetailsCalled = true
-                    }
-                    defer { hookDevice.remove() }
-
-                    stateMachine.send(ARTPushActivationEventDeregistered())
-                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
-                    expect(deactivatedCallbackCalled).to(beTrue())
-                    expect(setAndPersistIdentityTokenDetailsCalled).to(beTrue())
-                    // RSH3g2a
-                    expect(stateMachine.rest.device.identityTokenDetails).to(beNil())
-                }
-
-                // RSH3g3
-                func test__055__Activation_state_machine__State_WaitingForDeregistration__on_Event_DeregistrationFailed() {
-beforeEach__Activation_state_machine__State_WaitingForDeregistration()
-
-                    let expectedError = ARTErrorInfo(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
-
-                    var deactivatedCallbackCalled = false
-                    let hook = stateMachine.testSuite_getArgument(from: NSSelectorFromString("callDeactivatedCallback:"), at: 0, callback: { arg0 in
-                        deactivatedCallbackCalled = true
-                        guard let error = arg0 as? ARTErrorInfo else {
-                            fail("Error is missing"); return
-                        }
-                        expect(error) == expectedError
-                    })
-                    defer { hook.remove() }
-
-                    stateMachine.send(ARTPushActivationEventDeregistrationFailed(error: expectedError))
-                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
-                    expect(deactivatedCallbackCalled).to(beTrue())
-                }
-
-            // RSH4
-            func test__005__Activation_state_machine__should_queue_event_that_has_no_transition_defined_for_it() {
-                // Start with WaitingForDeregistration state
-                let storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForDeregistration(machine: initialStateMachine))
-                rest.internal.storage = storage
-                let stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
-
-                stateMachine.transitions = { event, from, to in
-                    fail("Should not handle the CalledActivate event because it should be queued")
-                }
-
-                stateMachine.send(ARTPushActivationEventCalledActivate())
-
-                expect(stateMachine.pendingEvents).toEventually(haveCount(1), timeout: testTimeout)
-                stateMachine.transitions = nil
-
-                guard let pendingEvent = stateMachine.pendingEvents.firstObject else {
-                    fail("Pending event is missing"); return
-                }
-                expect(pendingEvent).to(beAKindOf(ARTPushActivationEventCalledActivate.self))
-
-                waitUntil(timeout: testTimeout) { done in
-                    let partialDone = AblyTests.splitDone(2, done: done)
-                    stateMachine.transitions = { event, previousState, currentState in
-                        if previousState is ARTPushActivationStateWaitingForDeregistration, currentState is ARTPushActivationStateNotActivated {
-                            // Handle Deregistered event
-                            partialDone()
-                        }
-                        else if event is ARTPushActivationEventDeregistered, previousState is ARTPushActivationStateNotActivated, currentState is ARTPushActivationStateWaitingForPushDeviceDetails {
-                            // Consume queued CalledActivate event
-                            partialDone()
-                        }
-                    }
-                    stateMachine.send(ARTPushActivationEventDeregistered())
-                    expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
-                }
-                stateMachine.transitions = nil
-
-                expect(stateMachine.pendingEvents).to(beEmpty())
-            }
-
-            // RSH5
-            func test__006__Activation_state_machine__event_handling_sould_be_atomic_and_sequential() {
-                let storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForDeregistration(machine: initialStateMachine))
-                rest.internal.storage = storage
-                let stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate())
-                stateMachine.send(ARTPushActivationEventCalledActivate())
-                DispatchQueue(label: "QueueA").sync {
-                    stateMachine.send(ARTPushActivationEventDeregistered())
-                }
-                expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
-            }
-
-        func test__001__should_remove_identityTokenDetails_from_cache_and_storage() {
-            let storage = MockDeviceStorage()
+            let options = ARTClientOptions(key: "xxxx:xxxx")
+            options.clientId = "deviceClient"
+            let rest = ARTRest(options: options)
             rest.internal.storage = storage
-            rest.device.setAndPersistIdentityTokenDetails(nil)
-            rest.internal.resetDeviceSingleton()
-            expect(rest.device.identityTokenDetails).to(beNil())
-            expect(rest.device.isRegistered()) == false
-            expect(storage.object(forKey: ARTDeviceIdentityTokenKey)).to(beNil())
+            expect(rest.device.clientId).to(equal("deviceClient"))
+
+            let newOptions = ARTClientOptions(key: "xxxx:xxxx")
+            newOptions.clientId = "instanceClient"
+            let newRest = ARTRest(options: newOptions)
+            newRest.internal.storage = storage
+            let stateMachine = ARTPushActivationStateMachine(rest: newRest.internal, delegate: StateMachineDelegate())
+
+            storage.simulateOnNextRead(string: testDeviceId, for: ARTDeviceIdKey)
+
+            let testDeviceIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "deviceClient")
+            stateMachine.rest.device.setAndPersistIdentityTokenDetails(testDeviceIdentityTokenDetails)
+            defer { stateMachine.rest.device.setAndPersistIdentityTokenDetails(nil) }
+
+            waitUntil(timeout: testTimeout) { done in
+                stateMachine.transitions = { event, _, _ in
+                    if let event = event as? ARTPushActivationEventSyncRegistrationFailed {
+                        expect(event.error.code).to(equal(61002))
+                        done()
+                    }
+                }
+                stateMachine.send(ARTPushActivationEventCalledActivate())
+            }
+
+            contextAfterEach?()
         }
-enum TestCase_ReusableTestsRsh3a2a {
-case the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match
-case the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync
-case the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync
-}
 
+        func beforeEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID() {
+            contextBeforeEach?()
 
-        func reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil) {
-            
-                let testDeviceId = "aaaa"
-                
-                // RSH3a2a1
-                func test__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() {
-contextBeforeEach?()
+            storage.simulateOnNextRead(string: testDeviceId, for: ARTDeviceIdKey)
 
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.clientId = "deviceClient"
-                    let rest = ARTRest(options: options)
-                    rest.internal.storage = storage
-                    expect(rest.device.clientId).to(equal("deviceClient"))
-
-                    let newOptions = ARTClientOptions(key: "xxxx:xxxx")
-                    newOptions.clientId = "instanceClient"
-                    let newRest = ARTRest(options: newOptions)
-                    newRest.internal.storage = storage
-                    let stateMachine = ARTPushActivationStateMachine(rest: newRest.internal, delegate: StateMachineDelegate())
-                    
-                    storage.simulateOnNextRead(string: testDeviceId, for: ARTDeviceIdKey)
-
-                    let testDeviceIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "deviceClient")
-                    stateMachine.rest.device.setAndPersistIdentityTokenDetails(testDeviceIdentityTokenDetails)
-                    defer { stateMachine.rest.device.setAndPersistIdentityTokenDetails(nil) }
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        stateMachine.transitions = { event, _, _ in
-                            if let event = event as? ARTPushActivationEventSyncRegistrationFailed {
-                                expect(event.error.code).to(equal(61002))
-                                done()
-                            }
-                        }
-                        stateMachine.send(ARTPushActivationEventCalledActivate())
-                    }
-
-contextAfterEach?()
-
-                }
-                
-                
-                    func beforeEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID() {
-contextBeforeEach?()
-
-                        storage.simulateOnNextRead(string: testDeviceId, for: ARTDeviceIdKey)
-
-                        let testDeviceIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
-                        stateMachine.rest.device.setAndPersistIdentityTokenDetails(testDeviceIdentityTokenDetails)
-                    }
-                        
-                    func afterEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID() {
-                        stateMachine.rest.device.setAndPersistIdentityTokenDetails(nil)
-contextAfterEach?()
-
-                    }
-                    
-                    // RSH3a2a2, RSH3a2a4
-                    func test__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() {
-beforeEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID()
-
-                        let delegate = StateMachineDelegateCustomCallbacks()
-                        stateMachine.delegate = delegate
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(3, done: done)
-                            stateMachine.transitions = { event, previousState, currentState in
-                                if event is ARTPushActivationEventCalledActivate {
-                                    expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForRegistrationSync.self))
-                                    partialDone()
-                                }
-                                else if event is ARTPushActivationEventRegistrationSynced {
-                                    stateMachine.transitions = nil
-                                    partialDone()
-                                }
-                            }
-                            delegate.onPushCustomRegister = { error, deviceDetails in
-                                expect(error).to(beNil())
-                                expect(deviceDetails).to(beIdenticalTo(rest.device))
-                                partialDone()
-                                return nil
-                            }
-                            stateMachine.send(ARTPushActivationEventCalledActivate())
-                        }
-
-                        expect(httpExecutor.requests.count) == 0
-
-afterEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID()
-
-                    }
-                    
-                    // RSH3a2a3, RSH3a2a4, RSH3b3c
-                    func test__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() {
-beforeEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID()
-
-                        let delegate = StateMachineDelegate()
-                        stateMachine.delegate = delegate
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            stateMachine.transitions = { event, previousState, currentState in
-                                if event is ARTPushActivationEventCalledActivate {
-                                    expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForRegistrationSync.self))
-                                    partialDone()
-                                }
-                                else if event is ARTPushActivationEventRegistrationSynced || event is ARTPushActivationEventSyncRegistrationFailed {
-                                    stateMachine.transitions = nil
-                                    partialDone()
-                                }
-                            }
-                            stateMachine.send(ARTPushActivationEventCalledActivate())
-                        }
-                        
-                        let requests = httpExecutor.requests.compactMap({ $0.url?.path }).filter({ $0 == "/push/deviceRegistrations/\(rest.device.id)" })
-                        expect(requests).to(haveCount(1))
-                        guard let request = httpExecutor.requests.first else {
-                            fail("should have a \"/push/deviceRegistrations/:deviceId\" request"); return
-                        }
-                        guard let url = request.url else {
-                            fail("should have a URL"); return
-                        }
-                        guard let rawBody = request.httpBody else {
-                            fail("should have a body"); return
-                        }
-                        let decodedBody: Any
-                        do {
-                            decodedBody = try stateMachine.rest.defaultEncoder.decode(rawBody)
-                        }
-                        catch {
-                            fail("Decode failed: \(error)"); return
-                        }
-                        guard let body = decodedBody as? NSDictionary else {
-                            fail("body is invalid"); return
-                        }
-                        expect(url.host).to(equal(rest.internal.options.restUrl().host))
-                        expect(request.httpMethod) == "PUT"
-                        expect(body.value(forKey: "id") as? String).to(equal(rest.device.id))
-                        expect(body.value(forKey: "push") as? [String: [String: String]]).to(equal(expectedPushRecipient))
-                        expect(body.value(forKey: "formFactor") as? String) == expectedFormFactor
-                        expect(body.value(forKey: "platform") as? String) == expectedPlatform
-
-afterEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID()
-
-                    }
-
-switch testCase  {
-case .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match:
-    test__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match()
-case .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync:
-    test__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync()
-case .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync:
-    test__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync()
-}
-
+            let testDeviceIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
+            stateMachine.rest.device.setAndPersistIdentityTokenDetails(testDeviceIdentityTokenDetails)
         }
-enum TestCase_ReusableTestsRsh3d2 {
-case should_use_custom_deregisterCallback_and_fire_Deregistered_event
-case should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event
-case should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header
-case should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header
-case should_fire_DeregistrationFailed_event
-}
 
+        func afterEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID() {
+            stateMachine.rest.device.setAndPersistIdentityTokenDetails(nil)
+            contextAfterEach?()
+        }
 
-        func reusableTestsRsh3d2(testCase: TestCase_ReusableTestsRsh3d2, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil) {
-            // RSH3d2a, RSH3d2c, RSH3d2d
-            func test__should_use_custom_deregisterCallback_and_fire_Deregistered_event() {
-contextBeforeEach?()
+        // RSH3a2a2, RSH3a2a4
+        func test__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() {
+            beforeEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID()
 
-                let delegate = StateMachineDelegateCustomCallbacks()
-                stateMachine.delegate = delegate
+            let delegate = StateMachineDelegateCustomCallbacks()
+            stateMachine.delegate = delegate
 
-                waitUntil(timeout: testTimeout) { done in
-                    let partialDone = AblyTests.splitDone(3, done: done)
-                    stateMachine.transitions = { event, previousState, currentState in
-                        if event is ARTPushActivationEventCalledDeactivate {
-                            // RSH3d2d
-                            expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
-                            partialDone()
-                        }
-                        else if event is ARTPushActivationEventDeregistered {
-                            stateMachine.transitions = nil
-                            partialDone()
-                        }
-                    }
-                    delegate.onPushCustomDeregister = { error, deviceId in
-                        expect(error).to(beNil())
-                        expect(deviceId) == rest.device.id
+            waitUntil(timeout: testTimeout) { done in
+                let partialDone = AblyTests.splitDone(3, done: done)
+                stateMachine.transitions = { event, _, currentState in
+                    if event is ARTPushActivationEventCalledActivate {
+                        expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForRegistrationSync.self))
                         partialDone()
-                        return nil
-                    }
-                    stateMachine.send(ARTPushActivationEventCalledDeactivate())
-                }
-
-                expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
-                expect(httpExecutor.requests.count) == 0
-
-contextAfterEach?()
-
-            }
-
-            // RSH3d2c
-            func test__should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event() {
-contextBeforeEach?()
-
-                let delegate = StateMachineDelegateCustomCallbacks()
-                stateMachine.delegate = delegate
-
-                waitUntil(timeout: testTimeout) { done in
-                    let simulatedError = NSError(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
-                    let partialDone = AblyTests.splitDone(3, done: done)
-                    stateMachine.transitions = { event, previousState, currentState in
-                        if event is ARTPushActivationEventCalledDeactivate {
-                            expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
-                            partialDone()
-                        }
-                        else if let event = event as? ARTPushActivationEventDeregistrationFailed {
-                            expect(event.error.domain) == ARTAblyErrorDomain
-                            expect(event.error.code) == simulatedError.code
-                            stateMachine.transitions = nil
-                            partialDone()
-                        }
-                    }
-                    delegate.onPushCustomDeregister = { error, deviceId in
-                        expect(error).to(beNil())
-                        expect(deviceId) == rest.device.id
+                    } else if event is ARTPushActivationEventRegistrationSynced {
+                        stateMachine.transitions = nil
                         partialDone()
-                        return simulatedError
                     }
-                    stateMachine.send(ARTPushActivationEventCalledDeactivate())
                 }
-
-                expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
-                expect(httpExecutor.requests.count) == 0
-
-contextAfterEach?()
-
+                delegate.onPushCustomRegister = { error, deviceDetails in
+                    expect(error).to(beNil())
+                    expect(deviceDetails).to(beIdenticalTo(rest.device))
+                    partialDone()
+                    return nil
+                }
+                stateMachine.send(ARTPushActivationEventCalledActivate())
             }
 
-            // RSH3d2b, RSH3d2c, RSH3d2d
-            func test__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header() {
-contextBeforeEach?()
+            expect(httpExecutor.requests.count) == 0
 
-                let delegate = StateMachineDelegate()
-                stateMachine.delegate = delegate
+            afterEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID()
+        }
 
-                waitUntil(timeout: testTimeout) { done in
-                    let partialDone = AblyTests.splitDone(2, done: done)
-                    stateMachine.transitions = { event, previousState, currentState in
-                        if event is ARTPushActivationEventCalledDeactivate {
-                            // RSH3d2d
-                            expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
-                            partialDone()
-                        }
-                        else if event is ARTPushActivationEventDeregistered {
-                            stateMachine.transitions = nil
-                            partialDone()
-                        }
+        // RSH3a2a3, RSH3a2a4, RSH3b3c
+        func test__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() {
+            beforeEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID()
+
+            let delegate = StateMachineDelegate()
+            stateMachine.delegate = delegate
+
+            waitUntil(timeout: testTimeout) { done in
+                let partialDone = AblyTests.splitDone(2, done: done)
+                stateMachine.transitions = { event, _, currentState in
+                    if event is ARTPushActivationEventCalledActivate {
+                        expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForRegistrationSync.self))
+                        partialDone()
+                    } else if event is ARTPushActivationEventRegistrationSynced || event is ARTPushActivationEventSyncRegistrationFailed {
+                        stateMachine.transitions = nil
+                        partialDone()
                     }
-                    stateMachine.send(ARTPushActivationEventCalledDeactivate())
                 }
-
-                expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
-                expect(httpExecutor.requests.count) == 1
-                let requests = httpExecutor.requests.compactMap({ $0.url?.path }).filter({ $0 == "/push/deviceRegistrations/\(rest.device.id)" })
-                expect(requests).to(haveCount(1))
-                guard let request = httpExecutor.requests.first else {
-                    fail("should have a \"/push/deviceRegistrations\" request"); return
-                }
-                guard let url = request.url else {
-                    fail("should have a \"/push/deviceRegistrations\" URL"); return
-                }
-                expect(url.host).to(equal(rest.internal.options.restUrl().host))
-                expect(request.httpMethod) == "DELETE"
-                expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
-                let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
-                expect(deviceAuthorization).to(equal(rest.device.secret))
-
-contextAfterEach?()
-
+                stateMachine.send(ARTPushActivationEventCalledActivate())
             }
 
-            // RSH3d2b, RSH3d2c, RSH3d2d
-            func test__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header() {
-contextBeforeEach?()
+            let requests = httpExecutor.requests.compactMap { $0.url?.path }.filter { $0 == "/push/deviceRegistrations/\(rest.device.id)" }
+            expect(requests).to(haveCount(1))
+            guard let request = httpExecutor.requests.first else {
+                fail("should have a \"/push/deviceRegistrations/:deviceId\" request"); return
+            }
+            guard let url = request.url else {
+                fail("should have a URL"); return
+            }
+            guard let rawBody = request.httpBody else {
+                fail("should have a body"); return
+            }
+            let decodedBody: Any
+            do {
+                decodedBody = try stateMachine.rest.defaultEncoder.decode(rawBody)
+            } catch {
+                fail("Decode failed: \(error)"); return
+            }
+            guard let body = decodedBody as? NSDictionary else {
+                fail("body is invalid"); return
+            }
+            expect(url.host).to(equal(rest.internal.options.restUrl().host))
+            expect(request.httpMethod) == "PUT"
+            expect(body.value(forKey: "id") as? String).to(equal(rest.device.id))
+            expect(body.value(forKey: "push") as? [String: [String: String]]).to(equal(expectedPushRecipient))
+            expect(body.value(forKey: "formFactor") as? String) == expectedFormFactor
+            expect(body.value(forKey: "platform") as? String) == expectedPlatform
 
-                let delegate = StateMachineDelegate()
-                stateMachine.delegate = delegate
+            afterEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID()
+        }
 
-                let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(
-                    token: "123456",
-                    issued: Date(),
-                    expires: Date.distantFuture,
-                    capability: "",
-                    clientId: ""
-                )
+        switch testCase {
+        case .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match:
+            test__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match()
+        case .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync:
+            test__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync()
+        case .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync:
+            test__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync()
+        }
+    }
 
-                expect(rest.device.identityTokenDetails).to(beNil())
-                rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
-                defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
-                expect(rest.device.identityTokenDetails).toNot(beNil())
+    enum TestCase_ReusableTestsRsh3d2 {
+        case should_use_custom_deregisterCallback_and_fire_Deregistered_event
+        case should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event
+        case should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header
+        case should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header
+        case should_fire_DeregistrationFailed_event
+    }
 
-                waitUntil(timeout: testTimeout) { done in
-                    let partialDone = AblyTests.splitDone(2, done: done)
-                    stateMachine.transitions = { event, previousState, currentState in
-                        if event is ARTPushActivationEventCalledDeactivate {
-                            // RSH3d2d
-                            expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
-                            partialDone()
-                        }
-                        else if event is ARTPushActivationEventDeregistered {
-                            stateMachine.transitions = nil
-                            partialDone()
-                        }
+    func reusableTestsRsh3d2(testCase: TestCase_ReusableTestsRsh3d2, beforeEach contextBeforeEach: (() -> Void)? = nil, afterEach contextAfterEach: (() -> Void)? = nil) {
+        // RSH3d2a, RSH3d2c, RSH3d2d
+        func test__should_use_custom_deregisterCallback_and_fire_Deregistered_event() {
+            contextBeforeEach?()
+
+            let delegate = StateMachineDelegateCustomCallbacks()
+            stateMachine.delegate = delegate
+
+            waitUntil(timeout: testTimeout) { done in
+                let partialDone = AblyTests.splitDone(3, done: done)
+                stateMachine.transitions = { event, _, currentState in
+                    if event is ARTPushActivationEventCalledDeactivate {
+                        // RSH3d2d
+                        expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
+                        partialDone()
+                    } else if event is ARTPushActivationEventDeregistered {
+                        stateMachine.transitions = nil
+                        partialDone()
                     }
-                    stateMachine.send(ARTPushActivationEventCalledDeactivate())
                 }
-
-                expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
-                expect(httpExecutor.requests.count) == 1
-                let requests = httpExecutor.requests.compactMap({ $0.url?.path }).filter({ $0 == "/push/deviceRegistrations/\(rest.device.id)" })
-                expect(requests).to(haveCount(1))
-                guard let request = httpExecutor.requests.first else {
-                    fail("should have a \"/push/deviceRegistrations\" request"); return
+                delegate.onPushCustomDeregister = { error, deviceId in
+                    expect(error).to(beNil())
+                    expect(deviceId) == rest.device.id
+                    partialDone()
+                    return nil
                 }
-                guard let url = request.url else {
-                    fail("should have a \"/push/deviceRegistrations\" URL"); return
-                }
-                expect(url.host).to(equal(rest.internal.options.restUrl().host))
-                expect(request.httpMethod) == "DELETE"
-                expect(rest.device.identityTokenDetails).to(beNil())
-                expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
-                let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
-                expect(deviceAuthorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
-
-contextAfterEach?()
-
+                stateMachine.send(ARTPushActivationEventCalledDeactivate())
             }
 
-            // RSH3d2c
-            func test__should_fire_DeregistrationFailed_event() {
-contextBeforeEach?()
+            expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
+            expect(httpExecutor.requests.count) == 0
 
-                let delegate = StateMachineDelegate()
-                stateMachine.delegate = delegate
+            contextAfterEach?()
+        }
 
+        // RSH3d2c
+        func test__should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event() {
+            contextBeforeEach?()
+
+            let delegate = StateMachineDelegateCustomCallbacks()
+            stateMachine.delegate = delegate
+
+            waitUntil(timeout: testTimeout) { done in
                 let simulatedError = NSError(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
-                httpExecutor.simulateIncomingErrorOnNextRequest(simulatedError)
-
-                waitUntil(timeout: testTimeout) { done in
-                    let partialDone = AblyTests.splitDone(2, done: done)
-                    stateMachine.transitions = { event, previousState, currentState in
-                        if event is ARTPushActivationEventCalledDeactivate {
-                            expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
-                            partialDone()
-                        }
-                        else if let event = event as? ARTPushActivationEventDeregistrationFailed {
-                            expect(event.error.domain) == ARTAblyErrorDomain
-                            expect(event.error.code) == simulatedError.code
-                            stateMachine.transitions = nil
-                            partialDone()
-                        }
+                let partialDone = AblyTests.splitDone(3, done: done)
+                stateMachine.transitions = { event, _, currentState in
+                    if event is ARTPushActivationEventCalledDeactivate {
+                        expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
+                        partialDone()
+                    } else if let event = event as? ARTPushActivationEventDeregistrationFailed {
+                        expect(event.error.domain) == ARTAblyErrorDomain
+                        expect(event.error.code) == simulatedError.code
+                        stateMachine.transitions = nil
+                        partialDone()
                     }
-                    stateMachine.send(ARTPushActivationEventCalledDeactivate())
                 }
-
-                expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
-                expect(httpExecutor.requests.count) == 1
-                let requests = httpExecutor.requests.compactMap({ $0.url?.path }).filter({ $0 == "/push/deviceRegistrations/\(rest.device.id)" })
-                expect(requests).to(haveCount(1))
-                guard let request = httpExecutor.requests.first else {
-                    fail("should have a \"/push/deviceRegistrations\" request"); return
+                delegate.onPushCustomDeregister = { error, deviceId in
+                    expect(error).to(beNil())
+                    expect(deviceId) == rest.device.id
+                    partialDone()
+                    return simulatedError
                 }
-                guard let url = request.url else {
-                    fail("should have a \"/push/deviceRegistrations\" URL"); return
-                }
-                expect(url.host).to(equal(rest.internal.options.restUrl().host))
-                expect(request.httpMethod) == "DELETE"
-
-contextAfterEach?()
-
+                stateMachine.send(ARTPushActivationEventCalledDeactivate())
             }
 
-switch testCase  {
-case .should_use_custom_deregisterCallback_and_fire_Deregistered_event:
-    test__should_use_custom_deregisterCallback_and_fire_Deregistered_event()
-case .should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event:
-    test__should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event()
-case .should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header:
-    test__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header()
-case .should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header:
-    test__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header()
-case .should_fire_DeregistrationFailed_event:
-    test__should_fire_DeregistrationFailed_event()
-}
+            expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
+            expect(httpExecutor.requests.count) == 0
 
-        }   
+            contextAfterEach?()
+        }
 
+        // RSH3d2b, RSH3d2c, RSH3d2d
+        func test__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header() {
+            contextBeforeEach?()
+
+            let delegate = StateMachineDelegate()
+            stateMachine.delegate = delegate
+
+            waitUntil(timeout: testTimeout) { done in
+                let partialDone = AblyTests.splitDone(2, done: done)
+                stateMachine.transitions = { event, _, currentState in
+                    if event is ARTPushActivationEventCalledDeactivate {
+                        // RSH3d2d
+                        expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
+                        partialDone()
+                    } else if event is ARTPushActivationEventDeregistered {
+                        stateMachine.transitions = nil
+                        partialDone()
+                    }
+                }
+                stateMachine.send(ARTPushActivationEventCalledDeactivate())
+            }
+
+            expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
+            expect(httpExecutor.requests.count) == 1
+            let requests = httpExecutor.requests.compactMap { $0.url?.path }.filter { $0 == "/push/deviceRegistrations/\(rest.device.id)" }
+            expect(requests).to(haveCount(1))
+            guard let request = httpExecutor.requests.first else {
+                fail("should have a \"/push/deviceRegistrations\" request"); return
+            }
+            guard let url = request.url else {
+                fail("should have a \"/push/deviceRegistrations\" URL"); return
+            }
+            expect(url.host).to(equal(rest.internal.options.restUrl().host))
+            expect(request.httpMethod) == "DELETE"
+            expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
+            let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
+            expect(deviceAuthorization).to(equal(rest.device.secret))
+
+            contextAfterEach?()
+        }
+
+        // RSH3d2b, RSH3d2c, RSH3d2d
+        func test__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header() {
+            contextBeforeEach?()
+
+            let delegate = StateMachineDelegate()
+            stateMachine.delegate = delegate
+
+            let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(
+                token: "123456",
+                issued: Date(),
+                expires: Date.distantFuture,
+                capability: "",
+                clientId: ""
+            )
+
+            expect(rest.device.identityTokenDetails).to(beNil())
+            rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
+            defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
+            expect(rest.device.identityTokenDetails).toNot(beNil())
+
+            waitUntil(timeout: testTimeout) { done in
+                let partialDone = AblyTests.splitDone(2, done: done)
+                stateMachine.transitions = { event, _, currentState in
+                    if event is ARTPushActivationEventCalledDeactivate {
+                        // RSH3d2d
+                        expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
+                        partialDone()
+                    } else if event is ARTPushActivationEventDeregistered {
+                        stateMachine.transitions = nil
+                        partialDone()
+                    }
+                }
+                stateMachine.send(ARTPushActivationEventCalledDeactivate())
+            }
+
+            expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
+            expect(httpExecutor.requests.count) == 1
+            let requests = httpExecutor.requests.compactMap { $0.url?.path }.filter { $0 == "/push/deviceRegistrations/\(rest.device.id)" }
+            expect(requests).to(haveCount(1))
+            guard let request = httpExecutor.requests.first else {
+                fail("should have a \"/push/deviceRegistrations\" request"); return
+            }
+            guard let url = request.url else {
+                fail("should have a \"/push/deviceRegistrations\" URL"); return
+            }
+            expect(url.host).to(equal(rest.internal.options.restUrl().host))
+            expect(request.httpMethod) == "DELETE"
+            expect(rest.device.identityTokenDetails).to(beNil())
+            expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
+            let deviceAuthorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
+            expect(deviceAuthorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
+
+            contextAfterEach?()
+        }
+
+        // RSH3d2c
+        func test__should_fire_DeregistrationFailed_event() {
+            contextBeforeEach?()
+
+            let delegate = StateMachineDelegate()
+            stateMachine.delegate = delegate
+
+            let simulatedError = NSError(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
+            httpExecutor.simulateIncomingErrorOnNextRequest(simulatedError)
+
+            waitUntil(timeout: testTimeout) { done in
+                let partialDone = AblyTests.splitDone(2, done: done)
+                stateMachine.transitions = { event, _, currentState in
+                    if event is ARTPushActivationEventCalledDeactivate {
+                        expect(currentState).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
+                        partialDone()
+                    } else if let event = event as? ARTPushActivationEventDeregistrationFailed {
+                        expect(event.error.domain) == ARTAblyErrorDomain
+                        expect(event.error.code) == simulatedError.code
+                        stateMachine.transitions = nil
+                        partialDone()
+                    }
+                }
+                stateMachine.send(ARTPushActivationEventCalledDeactivate())
+            }
+
+            expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForDeregistration.self))
+            expect(httpExecutor.requests.count) == 1
+            let requests = httpExecutor.requests.compactMap { $0.url?.path }.filter { $0 == "/push/deviceRegistrations/\(rest.device.id)" }
+            expect(requests).to(haveCount(1))
+            guard let request = httpExecutor.requests.first else {
+                fail("should have a \"/push/deviceRegistrations\" request"); return
+            }
+            guard let url = request.url else {
+                fail("should have a \"/push/deviceRegistrations\" URL"); return
+            }
+            expect(url.host).to(equal(rest.internal.options.restUrl().host))
+            expect(request.httpMethod) == "DELETE"
+
+            contextAfterEach?()
+        }
+
+        switch testCase {
+        case .should_use_custom_deregisterCallback_and_fire_Deregistered_event:
+            test__should_use_custom_deregisterCallback_and_fire_Deregistered_event()
+        case .should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event:
+            test__should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event()
+        case .should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header:
+            test__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header()
+        case .should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header:
+            test__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header()
+        case .should_fire_DeregistrationFailed_event:
+            test__should_fire_DeregistrationFailed_event()
+        }
+    }
 }
 
 class StateMachineDelegate: NSObject, ARTPushRegistererDelegate {
-
     var onDidActivateAblyPush: ((ARTErrorInfo?) -> Void)?
     var onDidDeactivateAblyPush: ((ARTErrorInfo?) -> Void)?
     var onDidAblyPushRegistrationFail: ((ARTErrorInfo?) -> Void)?
@@ -1397,13 +1355,11 @@ class StateMachineDelegate: NSObject, ARTPushRegistererDelegate {
     func didAblyPushRegistrationFail(_ error: ARTErrorInfo?) {
         onDidAblyPushRegistrationFail?(error)
     }
-
 }
 
 typealias ARTDeviceId = String
 
 class StateMachineDelegateCustomCallbacks: StateMachineDelegate {
-
     var onPushCustomRegister: ((ARTErrorInfo?, ARTDeviceDetails?) -> NSError?)?
     var onPushCustomRegisterIdentity: ((ARTErrorInfo?, ARTDeviceDetails?) throws -> ARTDeviceIdentityTokenDetails)?
     var onPushCustomDeregister: ((ARTErrorInfo?, ARTDeviceId?) -> NSError?)?
@@ -1432,5 +1388,4 @@ class StateMachineDelegateCustomCallbacks: StateMachineDelegate {
             callback?(error == nil ? nil : ARTErrorInfo.create(from: error!))
         }
     }
-
 }

--- a/Spec/PushActivationStateMachine.swift
+++ b/Spec/PushActivationStateMachine.swift
@@ -2,19 +2,35 @@ import Ably
 import Nimble
 import Quick
 
+
+        private var rest: ARTRest!
+        private var httpExecutor: MockHTTPExecutor!
+        private var storage: MockDeviceStorage!
+        private var initialStateMachine: ARTPushActivationStateMachine!
+
+        private let expectedFormFactor = "phone"
+        private let expectedPlatform = "ios"
+        private let expectedPushRecipient: [String: [String: String]] = ["recipient": ["transportType": "apns"]]
+
+        private var stateMachine: ARTPushActivationStateMachine!
+
 class PushActivationStateMachine : QuickSpec {
+
+// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+override class var defaultTestSuite : XCTestSuite {
+    let _ = rest
+    let _ = httpExecutor
+    let _ = storage
+    let _ = initialStateMachine
+    let _ = expectedFormFactor
+    let _ = expectedPlatform
+    let _ = expectedPushRecipient
+    let _ = stateMachine
+
+    return super.defaultTestSuite
+}
+
     override func spec() {
-
-        var rest: ARTRest!
-        var httpExecutor: MockHTTPExecutor!
-        var storage: MockDeviceStorage!
-        var initialStateMachine: ARTPushActivationStateMachine!
-
-        let expectedFormFactor = "phone"
-        let expectedPlatform = "ios"
-        let expectedPushRecipient: [String: [String: String]] = ["recipient": ["transportType": "apns"]]
-
-        var stateMachine: ARTPushActivationStateMachine!
 
         beforeEach {
             rest = ARTRest(key: "xxxx:xxxx")

--- a/Spec/PushActivationStateMachine.swift
+++ b/Spec/PushActivationStateMachine.swift
@@ -1,6 +1,6 @@
 import Ably
 import Nimble
-import Quick
+import XCTest
 
 private var rest: ARTRest!
 private var httpExecutor: MockHTTPExecutor!

--- a/Spec/PushAdmin.swift
+++ b/Spec/PushAdmin.swift
@@ -2,6 +2,26 @@ import Ably
 import Nimble
 import Quick
 
+
+        private var rest: ARTRest!
+        private var mockHttpExecutor: MockHTTPExecutor!
+        private var storage: MockDeviceStorage!
+        private var localDevice: ARTLocalDevice!
+
+        private let recipient = [
+            "clientId": "bob"
+        ]
+
+        private let payload = [
+            "notification": [
+                "title": "Welcome"
+            ]
+        ]
+        
+        private let quxChannelName = "pushenabled:qux"
+
+            private let subscription = ARTPushChannelSubscription(clientId: "newClient", channel: quxChannelName)
+
 class PushAdmin : QuickSpec {
 
     private static let deviceDetails: ARTDeviceDetails = {
@@ -140,22 +160,22 @@ class PushAdmin : QuickSpec {
         super.tearDown()
     }
 
+// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+override class var defaultTestSuite : XCTestSuite {
+    let _ = rest
+    let _ = mockHttpExecutor
+    let _ = storage
+    let _ = localDevice
+    let _ = recipient
+    let _ = payload
+    let _ = quxChannelName
+    let _ = subscription
+
+    return super.defaultTestSuite
+}
+
+
     override func spec() {
-
-        var rest: ARTRest!
-        var mockHttpExecutor: MockHTTPExecutor!
-        var storage: MockDeviceStorage!
-        var localDevice: ARTLocalDevice!
-
-        let recipient = [
-            "clientId": "bob"
-        ]
-
-        let payload = [
-            "notification": [
-                "title": "Welcome"
-            ]
-        ]
 
         beforeEach {
             rest = ARTRest(key: "xxxx:xxxx")
@@ -165,8 +185,6 @@ class PushAdmin : QuickSpec {
             rest.internal.storage = storage
             localDevice = rest.device
         }
-        
-        let quxChannelName = "pushenabled:qux"
 
         // RSH1a
         describe("publish") {
@@ -668,8 +686,6 @@ class PushAdmin : QuickSpec {
         }
 
         describe("Channel Subscriptions") {
-
-            let subscription = ARTPushChannelSubscription(clientId: "newClient", channel: quxChannelName)
 
             // RSH1c3
             context("save") {

--- a/Spec/PushAdmin.swift
+++ b/Spec/PushAdmin.swift
@@ -1,6 +1,6 @@
 import Ably
 import Nimble
-import Quick
+import XCTest
 
 private var rest: ARTRest!
 private var mockHttpExecutor: MockHTTPExecutor!

--- a/Spec/PushAdmin.swift
+++ b/Spec/PushAdmin.swift
@@ -22,7 +22,7 @@ import Quick
 
             private let subscription = ARTPushChannelSubscription(clientId: "newClient", channel: quxChannelName)
 
-class PushAdmin : QuickSpec {
+class PushAdmin : XCTestCase {
 
     private static let deviceDetails: ARTDeviceDetails = {
         let deviceDetails = ARTDeviceDetails(id: "testDeviceDetails")
@@ -174,10 +174,10 @@ override class var defaultTestSuite : XCTestSuite {
     return super.defaultTestSuite
 }
 
+        override func setUp() {
+super.setUp()
 
-    override func spec() {
 
-        beforeEach {
             rest = ARTRest(key: "xxxx:xxxx")
             mockHttpExecutor = MockHTTPExecutor()
             rest.internal.httpExecutor = mockHttpExecutor
@@ -187,9 +187,9 @@ override class var defaultTestSuite : XCTestSuite {
         }
 
         // RSH1a
-        describe("publish") {
+        
 
-            it("should perform an HTTP request to /push/publish") {
+            func test__001__publish__should_perform_an_HTTP_request_to__push_publish() {
                 waitUntil(timeout: testTimeout) { done in
                     rest.push.admin.publish(recipient, data: payload) { error in
                         expect(error).to(beNil())
@@ -222,7 +222,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
             }
 
-            xit("should publish successfully") {
+            func skipped__test__002__publish__should_publish_successfully() {
                 let options = AblyTests.commonAppSetup()
                 let realtime = ARTRealtime(options: options)
                 defer { realtime.dispose(); realtime.close() }
@@ -255,7 +255,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
             }
 
-            xit("should fail with a bad recipient") {
+            func skipped__test__003__publish__should_fail_with_a_bad_recipient() {
                 let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                 defer { realtime.dispose(); realtime.close() }
                 let channel = realtime.channels.get("pushenabled:push_admin_publish-bad-recipient")
@@ -282,7 +282,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
             }
 
-            xit("should fail with an empty recipient") {
+            func skipped__test__004__publish__should_fail_with_an_empty_recipient() {
                 let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                 defer { realtime.dispose(); realtime.close() }
                 let channel = realtime.channels.get("pushenabled:push_admin_publish-empty-recipient")
@@ -308,7 +308,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
             }
 
-            it("should fail with an empty payload") {
+            func test__005__publish__should_fail_with_an_empty_payload() {
                 let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                 defer { realtime.dispose(); realtime.close() }
                 let channel = realtime.channels.get("pushenabled:push_admin_publish-empty-payload")
@@ -334,13 +334,11 @@ override class var defaultTestSuite : XCTestSuite {
                 }
             }
 
-        }
-
-        describe("Device Registrations") {
+        
 
             // RSH1b1
-            context("get") {
-                it("should return a device") {
+            
+                func test__006__Device_Registrations__get__should_return_a_device() {
                     let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { realtime.dispose(); realtime.close() }
                     waitUntil(timeout: testTimeout) { done in
@@ -355,7 +353,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should not return a device if it doesnt exist") {
+                func test__007__Device_Registrations__get__should_not_return_a_device_if_it_doesnt_exist() {
                     let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { realtime.dispose(); realtime.close() }
                     waitUntil(timeout: testTimeout) { done in
@@ -371,8 +369,8 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                context("push device authentication") {
-                    it("should include DeviceIdentityToken HTTP header") {
+                
+                    func test__008__Device_Registrations__get__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() {
                         let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { realtime.dispose(); realtime.close() }
                         realtime.internal.rest.httpExecutor = mockHttpExecutor
@@ -404,7 +402,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
                     }
 
-                    it("should include DeviceSecret HTTP header") {
+                    func test__009__Device_Registrations__get__push_device_authentication__should_include_DeviceSecret_HTTP_header() {
                         let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { realtime.dispose(); realtime.close() }
                         realtime.internal.rest.httpExecutor = mockHttpExecutor
@@ -423,12 +421,10 @@ override class var defaultTestSuite : XCTestSuite {
                         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
                         expect(authorization).to(equal(localDevice.secret))
                     }
-                }
-            }
 
             // RSH1b2
-            context("list") {
-                it("should list devices by id") {
+            
+                func test__010__Device_Registrations__list__should_list_devices_by_id() {
                     let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { realtime.dispose(); realtime.close() }
                     waitUntil(timeout: testTimeout) { done in
@@ -443,7 +439,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should list devices by client id") {
+                func test__011__Device_Registrations__list__should_list_devices_by_client_id() {
                     let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { realtime.dispose(); realtime.close() }
                     waitUntil(timeout: testTimeout) { done in
@@ -458,7 +454,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should list devices sorted") {
+                func test__012__Device_Registrations__list__should_list_devices_sorted() {
                     let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { realtime.dispose(); realtime.close() }
                     waitUntil(timeout: testTimeout) { done in
@@ -473,7 +469,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should return an empty list when id does not exist") {
+                func test__013__Device_Registrations__list__should_return_an_empty_list_when_id_does_not_exist() {
                     let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { realtime.dispose(); realtime.close() }
                     waitUntil(timeout: testTimeout) { done in
@@ -487,11 +483,10 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
             // RSH1b4
-            context("remove") {
-                it("should unregister a device") {
+            
+                func test__014__Device_Registrations__remove__should_unregister_a_device() {
                     let options = AblyTests.commonAppSetup()
                     options.pushFullWait = true
                     let realtime = ARTRealtime(options: options)
@@ -513,11 +508,10 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
                 }
-            }
 
             // RSH1b3
-            context("save") {
-                it("should register a device") {
+            
+                func test__015__Device_Registrations__save__should_register_a_device() {
                     let options = AblyTests.commonAppSetup()
                     options.pushFullWait = true
                     let realtime = ARTRealtime(options: options)
@@ -540,8 +534,8 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
                 }
 
-                context("push device authentication") {
-                    it("should include DeviceIdentityToken HTTP header") {
+                
+                    func test__016__Device_Registrations__save__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() {
                         let options = AblyTests.commonAppSetup()
                         options.pushFullWait = true
                         let realtime = ARTRealtime(options: options)
@@ -577,7 +571,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
                     }
 
-                    it("should include DeviceSecret HTTP header") {
+                    func test__017__Device_Registrations__save__push_device_authentication__should_include_DeviceSecret_HTTP_header() {
                         let options = AblyTests.commonAppSetup()
                         options.pushFullWait = true
                         let realtime = ARTRealtime(options: options)
@@ -600,12 +594,10 @@ override class var defaultTestSuite : XCTestSuite {
                         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
                         expect(authorization).to(equal(localDevice.secret))
                     }
-                }
-            }
 
             // RSH1b5
-            context("removeWhere") {
-                it("should unregister a device") {
+            
+                func test__018__Device_Registrations__removeWhere__should_unregister_a_device() {
                     let options = AblyTests.commonAppSetup()
                     options.pushFullWait = true
                     let realtime = ARTRealtime(options: options)
@@ -681,15 +673,12 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
-        }
-
-        describe("Channel Subscriptions") {
+        
 
             // RSH1c3
-            context("save") {
-                it("should add a subscription") {
+            
+                func test__019__Channel_Subscriptions__save__should_add_a_subscription() {
                     let options = AblyTests.commonAppSetup()
                     let realtime = ARTRealtime(options: options)
                     defer { realtime.dispose(); realtime.close() }
@@ -713,7 +702,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
                 }
 
-                it("should update a subscription") {
+                func test__020__Channel_Subscriptions__save__should_update_a_subscription() {
                     let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { realtime.dispose(); realtime.close() }
                     let updateSubscription = ARTPushChannelSubscription(clientId: subscription.clientId!, channel: "pushenabled:foo")
@@ -725,7 +714,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should fail with a bad recipient") {
+                func test__021__Channel_Subscriptions__save__should_fail_with_a_bad_recipient() {
                     let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { realtime.dispose(); realtime.close() }
                     let invalidSubscription = ARTPushChannelSubscription(deviceId: "madeup", channel: "pushenabled:foo")
@@ -741,8 +730,8 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                context("push device authentication") {
-                    it("should include DeviceIdentityToken HTTP header") {
+                
+                    func test__022__Channel_Subscriptions__save__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() {
                         let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { realtime.dispose(); realtime.close() }
                         realtime.internal.rest.httpExecutor = mockHttpExecutor
@@ -777,7 +766,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
                     }
 
-                    it("should include DeviceSecret HTTP header") {
+                    func test__023__Channel_Subscriptions__save__push_device_authentication__should_include_DeviceSecret_HTTP_header() {
                         let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { realtime.dispose(); realtime.close() }
                         realtime.internal.rest.httpExecutor = mockHttpExecutor
@@ -799,12 +788,10 @@ override class var defaultTestSuite : XCTestSuite {
                         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
                         expect(authorization).to(equal(localDevice.secret))
                     }
-                }
-            }
 
             // RSH1c1
-            context("list") {
-                it("should receive a list of subscriptions") {
+            
+                func test__024__Channel_Subscriptions__list__should_receive_a_list_of_subscriptions() {
                     let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { realtime.dispose(); realtime.close() }
                     waitUntil(timeout: testTimeout) { done in
@@ -821,11 +808,10 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
             // RSH1c2
-            context("listChannels") {
-                it("should receive a list of subscriptions") {
+            
+                func test__025__Channel_Subscriptions__listChannels__should_receive_a_list_of_subscriptions() {
                     let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { realtime.dispose(); realtime.close() }
                     waitUntil(timeout: testTimeout) { done in
@@ -839,11 +825,10 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
             // RSH1c4
-            context("remove") {
-                it("should remove a subscription") {
+            
+                func test__026__Channel_Subscriptions__remove__should_remove_a_subscription() {
                     let options = AblyTests.commonAppSetup()
                     let realtime = ARTRealtime(options: options)
                     defer { realtime.dispose(); realtime.close() }
@@ -878,8 +863,8 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                context("push device authentication") {
-                    it("should include DeviceIdentityToken HTTP header") {
+                
+                    func test__027__Channel_Subscriptions__remove__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() {
                         let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { realtime.dispose(); realtime.close() }
                         realtime.internal.rest.httpExecutor = mockHttpExecutor
@@ -914,7 +899,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
                     }
 
-                    it("should include DeviceSecret HTTP header") {
+                    func test__028__Channel_Subscriptions__remove__push_device_authentication__should_include_DeviceSecret_HTTP_header() {
                         let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { realtime.dispose(); realtime.close() }
                         realtime.internal.rest.httpExecutor = mockHttpExecutor
@@ -936,12 +921,10 @@ override class var defaultTestSuite : XCTestSuite {
                         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
                         expect(authorization).to(equal(localDevice.secret))
                     }
-                }
-            }
 
             // RSH1c5
-            context("removeWhere") {
-                it("should remove by cliendId") {
+            
+                func test__029__Channel_Subscriptions__removeWhere__should_remove_by_cliendId() {
                     let options = AblyTests.commonAppSetup()
                     options.pushFullWait = true
                     let realtime = ARTRealtime(options: options)
@@ -996,7 +979,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should remove by cliendId and channel") {
+                func test__030__Channel_Subscriptions__removeWhere__should_remove_by_cliendId_and_channel() {
                     let options = AblyTests.commonAppSetup()
                     options.pushFullWait = true
                     let realtime = ARTRealtime(options: options)
@@ -1041,7 +1024,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should remove by deviceId") {
+                func test__031__Channel_Subscriptions__removeWhere__should_remove_by_deviceId() {
                     let options = AblyTests.commonAppSetup()
                     options.pushFullWait = true
                     let realtime = ARTRealtime(options: options)
@@ -1086,7 +1069,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should not remove by inexistent deviceId") {
+                func test__032__Channel_Subscriptions__removeWhere__should_not_remove_by_inexistent_deviceId() {
                     let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { realtime.dispose(); realtime.close() }
 
@@ -1112,20 +1095,13 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
-        }
+        
 
-        describe("local device") {
-
-            it("should include an id and a secret") {
+            func test__033__local_device__should_include_an_id_and_a_secret() {
                 expect(localDevice.id).toNot(beNil())
                 expect(localDevice.secret).toNot(beNil())
                 expect(localDevice.identityTokenDetails).to(beNil())
             }
-
-        }
-
-    }
 
 }

--- a/Spec/PushAdmin.swift
+++ b/Spec/PushAdmin.swift
@@ -2,28 +2,26 @@ import Ably
 import Nimble
 import Quick
 
+private var rest: ARTRest!
+private var mockHttpExecutor: MockHTTPExecutor!
+private var storage: MockDeviceStorage!
+private var localDevice: ARTLocalDevice!
 
-        private var rest: ARTRest!
-        private var mockHttpExecutor: MockHTTPExecutor!
-        private var storage: MockDeviceStorage!
-        private var localDevice: ARTLocalDevice!
+private let recipient = [
+    "clientId": "bob",
+]
 
-        private let recipient = [
-            "clientId": "bob"
-        ]
+private let payload = [
+    "notification": [
+        "title": "Welcome",
+    ],
+]
 
-        private let payload = [
-            "notification": [
-                "title": "Welcome"
-            ]
-        ]
-        
-        private let quxChannelName = "pushenabled:qux"
+private let quxChannelName = "pushenabled:qux"
 
-            private let subscription = ARTPushChannelSubscription(clientId: "newClient", channel: quxChannelName)
+private let subscription = ARTPushChannelSubscription(clientId: "newClient", channel: quxChannelName)
 
-class PushAdmin : XCTestCase {
-
+class PushAdmin: XCTestCase {
     private static let deviceDetails: ARTDeviceDetails = {
         let deviceDetails = ARTDeviceDetails(id: "testDeviceDetails")
         deviceDetails.platform = "ios"
@@ -31,7 +29,7 @@ class PushAdmin : XCTestCase {
         deviceDetails.metadata = NSMutableDictionary()
         deviceDetails.push.recipient = [
             "transportType": "apns",
-            "deviceToken": "foo"
+            "deviceToken": "foo",
         ]
         return deviceDetails
     }()
@@ -44,7 +42,7 @@ class PushAdmin : XCTestCase {
         deviceDetails.metadata = NSMutableDictionary()
         deviceDetails.push.recipient = [
             "transportType": "gcm",
-            "registrationToken": "qux"
+            "registrationToken": "qux",
         ]
         return deviceDetails
     }()
@@ -57,7 +55,7 @@ class PushAdmin : XCTestCase {
         deviceDetails.metadata = NSMutableDictionary()
         deviceDetails.push.recipient = [
             "transportType": "gcm",
-            "registrationToken": "qux"
+            "registrationToken": "qux",
         ]
         return deviceDetails
     }()
@@ -70,7 +68,7 @@ class PushAdmin : XCTestCase {
         deviceDetails.metadata = NSMutableDictionary()
         deviceDetails.push.recipient = [
             "transportType": "gcm",
-            "registrationToken": "qux"
+            "registrationToken": "qux",
         ]
         return deviceDetails
     }()
@@ -100,7 +98,7 @@ class PushAdmin : XCTestCase {
 
     private static let allSubscriptionsChannels: [String] = {
         var seen = Set<String>()
-        return allSubscriptions.filter({ seen.insert($0.channel).inserted }).map({ $0.channel })
+        return allSubscriptions.filter { seen.insert($0.channel).inserted }.map { $0.channel }
     }()
 
     override class func setUp() {
@@ -116,7 +114,7 @@ class PushAdmin : XCTestCase {
         for device in allDeviceDetails {
             rest.push.admin.deviceRegistrations.save(device) { error in
                 assert(error == nil, error?.message ?? "no message")
-                if (allDeviceDetails.last == device) {
+                if allDeviceDetails.last == device {
                     group.leave()
                 }
             }
@@ -127,7 +125,7 @@ class PushAdmin : XCTestCase {
         for subscription in allSubscriptions {
             rest.push.admin.channelSubscriptions.save(subscription) { error in
                 assert(error == nil, error?.message ?? "no message")
-                if (allSubscriptions.last == subscription) {
+                if allSubscriptions.last == subscription {
                     group.leave()
                 }
             }
@@ -160,948 +158,935 @@ class PushAdmin : XCTestCase {
         super.tearDown()
     }
 
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = rest
-    let _ = mockHttpExecutor
-    let _ = storage
-    let _ = localDevice
-    let _ = recipient
-    let _ = payload
-    let _ = quxChannelName
-    let _ = subscription
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = rest
+        _ = mockHttpExecutor
+        _ = storage
+        _ = localDevice
+        _ = recipient
+        _ = payload
+        _ = quxChannelName
+        _ = subscription
 
-    return super.defaultTestSuite
-}
+        return super.defaultTestSuite
+    }
 
-        override func setUp() {
-super.setUp()
+    override func setUp() {
+        super.setUp()
 
+        rest = ARTRest(key: "xxxx:xxxx")
+        mockHttpExecutor = MockHTTPExecutor()
+        rest.internal.httpExecutor = mockHttpExecutor
+        storage = MockDeviceStorage()
+        rest.internal.storage = storage
+        localDevice = rest.device
+    }
 
-            rest = ARTRest(key: "xxxx:xxxx")
-            mockHttpExecutor = MockHTTPExecutor()
-            rest.internal.httpExecutor = mockHttpExecutor
-            storage = MockDeviceStorage()
-            rest.internal.storage = storage
-            localDevice = rest.device
+    // RSH1a
+
+    func test__001__publish__should_perform_an_HTTP_request_to__push_publish() {
+        waitUntil(timeout: testTimeout) { done in
+            rest.push.admin.publish(recipient, data: payload) { error in
+                expect(error).to(beNil())
+                done()
+            }
         }
 
-        // RSH1a
-        
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("Request is missing"); return
+        }
+        guard let url = request.url else {
+            fail("URL is missing"); return
+        }
 
-            func test__001__publish__should_perform_an_HTTP_request_to__push_publish() {
-                waitUntil(timeout: testTimeout) { done in
-                    rest.push.admin.publish(recipient, data: payload) { error in
-                        expect(error).to(beNil())
-                        done()
-                    }
+        expect(url.absoluteString).to(contain("/push/publish"))
+
+        switch extractBodyAsMsgPack(request) {
+        case let .failure(error):
+            XCTFail(error)
+        case let .success(httpBody):
+            guard let bodyRecipient = httpBody.unbox["recipient"] as? [String: String] else {
+                fail("recipient is missing"); return
+            }
+            expect(bodyRecipient).to(equal(recipient))
+
+            guard let bodyPayload = httpBody.unbox["notification"] as? [String: String] else {
+                fail("notification is missing"); return
+            }
+            expect(bodyPayload).to(equal(payload["notification"]))
+        }
+    }
+
+    func skipped__test__002__publish__should_publish_successfully() {
+        let options = AblyTests.commonAppSetup()
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+        let channel = realtime.channels.get("pushenabled:push_admin_publish-ok")
+        let publishObject = ["transportType": "ablyChannel",
+                             "channel": channel.name,
+                             "ablyKey": options.key!,
+                             "ablyUrl": "https://\(options.restHost)"]
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.subscribe("__ably_push__") { message in
+                guard let data = message.data as? String else {
+                    fail("Failure in reading returned data"); partialDone(); return
                 }
+                expect(data).to(contain("foo"))
+                partialDone()
+            }
+            realtime.push.admin.publish(publishObject, data: ["data": ["foo": "bar"]]) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
+    }
 
-                guard let request = mockHttpExecutor.requests.first else {
-                    fail("Request is missing"); return
+    func skipped__test__003__publish__should_fail_with_a_bad_recipient() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        let channel = realtime.channels.get("pushenabled:push_admin_publish-bad-recipient")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.subscribe("__ably_push__") { _ in
+                fail("Should not be called")
+            }
+            realtime.push.admin.publish(["foo": "bar"], data: ["data": ["foo": "bar"]]) { error in
+                guard let error = error else {
+                    fail("Error is missing"); done(); return
                 }
-                guard let url = request.url else {
-                    fail("URL is missing"); return
+                expect(error.statusCode) == 400
+                expect(error.message).to(contain("recipient must contain"))
+                done()
+            }
+        }
+    }
+
+    func skipped__test__004__publish__should_fail_with_an_empty_recipient() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        let channel = realtime.channels.get("pushenabled:push_admin_publish-empty-recipient")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.subscribe("__ably_push__") { _ in
+                fail("Should not be called")
+            }
+            realtime.push.admin.publish([:], data: ["data": ["foo": "bar"]]) { error in
+                guard let error = error else {
+                    fail("Error is missing"); done(); return
                 }
+                expect(error.message.lowercased()).to(contain("recipient is missing"))
+                done()
+            }
+        }
+    }
 
-                expect(url.absoluteString).to(contain("/push/publish"))
+    func test__005__publish__should_fail_with_an_empty_payload() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        let channel = realtime.channels.get("pushenabled:push_admin_publish-empty-payload")
 
-                switch extractBodyAsMsgPack(request) {
-                case .failure(let error):
-                    XCTFail(error)
-                case .success(let httpBody):
-                    guard let bodyRecipient = httpBody.unbox["recipient"] as? [String: String]  else {
-                        fail("recipient is missing"); return
-                    }
-                    expect(bodyRecipient).to(equal(recipient))
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
 
-                    guard let bodyPayload = httpBody.unbox["notification"] as? [String: String] else {
-                        fail("notification is missing"); return
-                    }
-                    expect(bodyPayload).to(equal(payload["notification"]))
+        waitUntil(timeout: testTimeout) { done in
+            channel.subscribe("__ably_push__") { _ in
+                fail("Should not be called")
+            }
+            realtime.push.admin.publish(["ablyChannel": channel.name], data: [:]) { error in
+                guard let error = error else {
+                    fail("Error is missing"); done(); return
+                }
+                expect(error.message.lowercased()).to(contain("data payload is missing"))
+                done()
+            }
+        }
+    }
+
+    // RSH1b1
+
+    func test__006__Device_Registrations__get__should_return_a_device() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.deviceRegistrations.get("testDeviceDetails") { device, error in
+                guard let device = device else {
+                    fail("Device is missing"); done(); return
+                }
+                expect(device).to(equal(Self.deviceDetails))
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__007__Device_Registrations__get__should_not_return_a_device_if_it_doesnt_exist() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.deviceRegistrations.get("madeup") { device, error in
+                expect(device).to(beNil())
+                guard let error = error else {
+                    fail("Error should not be empty"); done(); return
+                }
+                expect(error.statusCode) == 404
+                expect(error.message).to(contain("not found"))
+                done()
+            }
+        }
+    }
+
+    func test__008__Device_Registrations__get__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        realtime.internal.rest.httpExecutor = mockHttpExecutor
+
+        let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(
+            token: "123456",
+            issued: Date(),
+            expires: Date.distantFuture,
+            capability: "",
+            clientId: ""
+        )
+
+        expect(localDevice.identityTokenDetails).to(beNil())
+        realtime.internal.rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
+        defer { realtime.internal.rest.device.setAndPersistIdentityTokenDetails(nil) }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.deviceRegistrations.get(localDevice.id) { _, _ in
+                done()
+            }
+        }
+
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("No requests found")
+            return
+        }
+
+        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
+        expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
+    }
+
+    func test__009__Device_Registrations__get__push_device_authentication__should_include_DeviceSecret_HTTP_header() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        realtime.internal.rest.httpExecutor = mockHttpExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.deviceRegistrations.get(localDevice.id) { _, _ in
+                done()
+            }
+        }
+
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("No requests found")
+            return
+        }
+
+        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
+        expect(authorization).to(equal(localDevice.secret))
+    }
+
+    // RSH1b2
+
+    func test__010__Device_Registrations__list__should_list_devices_by_id() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.deviceRegistrations.list(["deviceId": "testDeviceDetails"]) { result, error in
+                guard let result = result else {
+                    fail("PaginatedResult should not be empty"); done(); return
+                }
+                expect(result.items.count) == 1
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__011__Device_Registrations__list__should_list_devices_by_client_id() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.deviceRegistrations.list(["clientId": "clientA"]) { result, error in
+                guard let result = result else {
+                    fail("PaginatedResult should not be empty"); done(); return
+                }
+                expect(result.items.count) == Self.allDeviceDetails.filter { $0.clientId == "clientA" }.count
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__012__Device_Registrations__list__should_list_devices_sorted() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.deviceRegistrations.list(["direction": "forwards"]) { result, error in
+                guard let result = result else {
+                    fail("PaginatedResult should not be empty"); done(); return
+                }
+                expect(result.items.count) == Self.allDeviceDetails.count
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__013__Device_Registrations__list__should_return_an_empty_list_when_id_does_not_exist() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.deviceRegistrations.list(["deviceId": "madeup"]) { result, error in
+                guard let result = result else {
+                    fail("PaginatedResult should not be empty"); done(); return
+                }
+                expect(result.items.count) == 0
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RSH1b4
+
+    func test__014__Device_Registrations__remove__should_unregister_a_device() {
+        let options = AblyTests.commonAppSetup()
+        options.pushFullWait = true
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+        realtime.internal.rest.httpExecutor = mockHttpExecutor
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.deviceRegistrations.remove(Self.deviceDetails.id) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("No requests found")
+            return
+        }
+
+        expect(request.httpMethod) == "DELETE"
+        expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
+        expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
+    }
+
+    // RSH1b3
+
+    func test__015__Device_Registrations__save__should_register_a_device() {
+        let options = AblyTests.commonAppSetup()
+        options.pushFullWait = true
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+        realtime.internal.rest.httpExecutor = mockHttpExecutor
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.deviceRegistrations.save(Self.deviceDetails) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("No requests found")
+            return
+        }
+
+        expect(request.httpMethod) == "PUT"
+        expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
+        expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
+    }
+
+    func test__016__Device_Registrations__save__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() {
+        let options = AblyTests.commonAppSetup()
+        options.pushFullWait = true
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+        realtime.internal.rest.httpExecutor = mockHttpExecutor
+
+        let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(
+            token: "123456",
+            issued: Date(),
+            expires: Date.distantFuture,
+            capability: "",
+            clientId: ""
+        )
+
+        expect(localDevice.identityTokenDetails).to(beNil())
+        realtime.internal.rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
+        defer { realtime.internal.rest.device.setAndPersistIdentityTokenDetails(nil) }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.deviceRegistrations.save(localDevice) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("No requests found")
+            return
+        }
+        expect(request.httpMethod).to(equal("PUT"))
+
+        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
+        expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
+    }
+
+    func test__017__Device_Registrations__save__push_device_authentication__should_include_DeviceSecret_HTTP_header() {
+        let options = AblyTests.commonAppSetup()
+        options.pushFullWait = true
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+        realtime.internal.rest.httpExecutor = mockHttpExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.deviceRegistrations.save(localDevice) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("No requests found")
+            return
+        }
+        expect(request.httpMethod).to(equal("PUT"))
+
+        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
+        expect(authorization).to(equal(localDevice.secret))
+    }
+
+    // RSH1b5
+
+    func test__018__Device_Registrations__removeWhere__should_unregister_a_device() {
+        let options = AblyTests.commonAppSetup()
+        options.pushFullWait = true
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+
+        let params = [
+            "clientId": "clientA",
+        ]
+
+        let expectedRemoved = Self.allDeviceDetails.filter { $0.clientId == "clientA" }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.deviceRegistrations.list(params) { result, error in
+                guard let result = result else {
+                    fail("PaginatedResult should not be nil"); done(); return
+                }
+                expect(result.items).to(contain(expectedRemoved))
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        realtime.internal.rest.httpExecutor = mockHttpExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.deviceRegistrations.removeWhere(params) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("No requests found")
+            return
+        }
+
+        expect(request.httpMethod) == "DELETE"
+        expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
+        expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.deviceRegistrations.list(params) { result, error in
+                guard let result = result else {
+                    fail("PaginatedResult should not be nil"); done(); return
+                }
+                expect(result.items.count) == 0
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        // --- Restore state for next tests ---
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(expectedRemoved.count, done: done)
+            for removedDevice in expectedRemoved {
+                realtime.push.admin.deviceRegistrations.save(removedDevice) { error in
+                    expect(error).to(beNil())
+                    partialDone()
                 }
             }
+        }
 
-            func skipped__test__002__publish__should_publish_successfully() {
-                let options = AblyTests.commonAppSetup()
-                let realtime = ARTRealtime(options: options)
-                defer { realtime.dispose(); realtime.close() }
-                let channel = realtime.channels.get("pushenabled:push_admin_publish-ok")
-                let publishObject = ["transportType": "ablyChannel",
-                                     "channel": channel.name,
-                                     "ablyKey": options.key!,
-                                     "ablyUrl": "https://\(options.restHost)"]
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            realtime.push.admin.channelSubscriptions.save(Self.subscriptionFooDevice2) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+            realtime.push.admin.channelSubscriptions.save(Self.subscriptionBarDevice2) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
+    }
 
-                waitUntil(timeout: testTimeout) { done in
-                    channel.attach() { error in
-                        expect(error).to(beNil())
-                        done()
-                    }
+    // RSH1c3
+
+    func test__019__Channel_Subscriptions__save__should_add_a_subscription() {
+        let options = AblyTests.commonAppSetup()
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+        let testProxyHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        realtime.internal.rest.httpExecutor = testProxyHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.save(subscription) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let request = testProxyHTTPExecutor.requests.first else {
+            fail("No requests found")
+            return
+        }
+
+        expect(request.httpMethod).to(equal("POST"))
+        expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
+        expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
+    }
+
+    func test__020__Channel_Subscriptions__save__should_update_a_subscription() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        let updateSubscription = ARTPushChannelSubscription(clientId: subscription.clientId!, channel: "pushenabled:foo")
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.save(updateSubscription) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__021__Channel_Subscriptions__save__should_fail_with_a_bad_recipient() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        let invalidSubscription = ARTPushChannelSubscription(deviceId: "madeup", channel: "pushenabled:foo")
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.save(invalidSubscription) { error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
                 }
+                expect(error.statusCode) == 400
+                expect(error.message).to(contain("device madeup doesn't exist"))
+                done()
+            }
+        }
+    }
 
-                waitUntil(timeout: testTimeout) { done in
-                    let partialDone = AblyTests.splitDone(2, done: done)
-                    channel.subscribe("__ably_push__") { message in
-                        guard let data = message.data as? String else {
-                            fail("Failure in reading returned data"); partialDone(); return
-                        }
-                        expect(data).to(contain("foo"))
-                        partialDone()
+    func test__022__Channel_Subscriptions__save__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        realtime.internal.rest.httpExecutor = mockHttpExecutor
+
+        let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(
+            token: "123456",
+            issued: Date(),
+            expires: Date.distantFuture,
+            capability: "",
+            clientId: ""
+        )
+
+        expect(localDevice.identityTokenDetails).to(beNil())
+        realtime.internal.rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
+        defer { realtime.internal.rest.device.setAndPersistIdentityTokenDetails(nil) }
+
+        let subscription = ARTPushChannelSubscription(deviceId: localDevice.id, channel: quxChannelName)
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.save(subscription) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("No requests found")
+            return
+        }
+
+        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
+        expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
+    }
+
+    func test__023__Channel_Subscriptions__save__push_device_authentication__should_include_DeviceSecret_HTTP_header() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        realtime.internal.rest.httpExecutor = mockHttpExecutor
+
+        let subscription = ARTPushChannelSubscription(deviceId: localDevice.id, channel: quxChannelName)
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.save(subscription) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("No requests found")
+            return
+        }
+
+        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
+        expect(authorization).to(equal(localDevice.secret))
+    }
+
+    // RSH1c1
+
+    func test__024__Channel_Subscriptions__list__should_receive_a_list_of_subscriptions() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.save(subscription) { error in
+                expect(error).to(beNil())
+                realtime.push.admin.channelSubscriptions.list(["channel": quxChannelName]) { result, error in
+                    guard let result = result else {
+                        fail("PaginatedResult should not be empty"); done(); return
                     }
-                    realtime.push.admin.publish(publishObject, data: ["data": ["foo": "bar"]]) { error in
-                        expect(error).to(beNil())
-                        partialDone()
-                    }
+                    expect(result.items.count) == 1
+                    expect(error).to(beNil())
+                    done()
                 }
             }
+        }
+    }
 
-            func skipped__test__003__publish__should_fail_with_a_bad_recipient() {
-                let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                defer { realtime.dispose(); realtime.close() }
-                let channel = realtime.channels.get("pushenabled:push_admin_publish-bad-recipient")
+    // RSH1c2
 
-                waitUntil(timeout: testTimeout) { done in
-                    channel.attach() { error in
-                        expect(error).to(beNil())
-                        done()
-                    }
+    func test__025__Channel_Subscriptions__listChannels__should_receive_a_list_of_subscriptions() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.listChannels { result, error in
+                expect(error).to(beNil())
+                guard let result = result else {
+                    fail("PaginatedResult should not be empty"); done(); return
                 }
+                expect(result.items as [String]).to(contain(Self.allSubscriptionsChannels + [subscription.channel]))
+                done()
+            }
+        }
+    }
 
-                waitUntil(timeout: testTimeout) { done in
-                    channel.subscribe("__ably_push__") { message in
-                        fail("Should not be called")
-                    }
-                    realtime.push.admin.publish(["foo": "bar"], data: ["data": ["foo": "bar"]]) { error in
-                        guard let error = error else {
-                            fail("Error is missing"); done(); return
-                        }
-                        expect(error.statusCode) == 400
-                        expect(error.message).to(contain("recipient must contain"))
-                        done()
-                    }
+    // RSH1c4
+
+    func test__026__Channel_Subscriptions__remove__should_remove_a_subscription() {
+        let options = AblyTests.commonAppSetup()
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+        let testProxyHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        realtime.internal.rest.httpExecutor = testProxyHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.remove(subscription) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let request = testProxyHTTPExecutor.requests.first else {
+            fail("No requests found")
+            return
+        }
+
+        expect(request.httpMethod).to(equal("DELETE"))
+        expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
+        expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.list(["channel": quxChannelName]) { result, error in
+                guard let result = result else {
+                    fail("PaginatedResult should not be empty"); done(); return
+                }
+                expect(result.items.count) == 0
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__027__Channel_Subscriptions__remove__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        realtime.internal.rest.httpExecutor = mockHttpExecutor
+
+        let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(
+            token: "123456",
+            issued: Date(),
+            expires: Date.distantFuture,
+            capability: "",
+            clientId: ""
+        )
+
+        expect(localDevice.identityTokenDetails).to(beNil())
+        realtime.internal.rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
+        defer { realtime.internal.rest.device.setAndPersistIdentityTokenDetails(nil) }
+
+        let subscription = ARTPushChannelSubscription(deviceId: localDevice.id, channel: quxChannelName)
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.remove(subscription) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("No requests found")
+            return
+        }
+
+        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
+        expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
+    }
+
+    func test__028__Channel_Subscriptions__remove__push_device_authentication__should_include_DeviceSecret_HTTP_header() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        realtime.internal.rest.httpExecutor = mockHttpExecutor
+
+        let subscription = ARTPushChannelSubscription(deviceId: localDevice.id, channel: quxChannelName)
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.remove(subscription) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("No requests found")
+            return
+        }
+
+        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
+        expect(authorization).to(equal(localDevice.secret))
+    }
+
+    // RSH1c5
+
+    func test__029__Channel_Subscriptions__removeWhere__should_remove_by_cliendId() {
+        let options = AblyTests.commonAppSetup()
+        options.pushFullWait = true
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+
+        let params = [
+            "clientId": "clientB",
+        ]
+
+        let expectedRemoved = [
+            Self.subscriptionFooClientB,
+            Self.subscriptionBarClientB,
+        ]
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.list(params) { result, error in
+                guard let result = result else {
+                    fail("PaginatedResult should not be empty"); done(); return
+                }
+                expect(result.items).to(contain(expectedRemoved))
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.removeWhere(params) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.list(params) { result, error in
+                guard let result = result else {
+                    fail("PaginatedResult should not be empty"); done(); return
+                }
+                expect(result.items.count) == 0
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(expectedRemoved.count, done: done)
+            for removedSubscription in expectedRemoved {
+                realtime.push.admin.channelSubscriptions.save(removedSubscription) { error in
+                    expect(error).to(beNil())
+                    partialDone()
                 }
             }
+        }
+    }
 
-            func skipped__test__004__publish__should_fail_with_an_empty_recipient() {
-                let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                defer { realtime.dispose(); realtime.close() }
-                let channel = realtime.channels.get("pushenabled:push_admin_publish-empty-recipient")
+    func test__030__Channel_Subscriptions__removeWhere__should_remove_by_cliendId_and_channel() {
+        let options = AblyTests.commonAppSetup()
+        options.pushFullWait = true
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
 
-                waitUntil(timeout: testTimeout) { done in
-                    channel.attach() { error in
-                        expect(error).to(beNil())
-                        done()
-                    }
+        let params = [
+            "clientId": "clientB",
+            "channel": "pushenabled:foo",
+        ]
+
+        let expectedRemoved = [
+            Self.subscriptionFooClientB,
+        ]
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.list(params) { result, error in
+                guard let result = result else {
+                    fail("PaginatedResult should not be empty"); done(); return
                 }
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.subscribe("__ably_push__") { message in
-                        fail("Should not be called")
-                    }
-                    realtime.push.admin.publish([:], data: ["data": ["foo": "bar"]]) { error in
-                        guard let error = error else {
-                            fail("Error is missing"); done(); return
-                        }
-                        expect(error.message.lowercased()).to(contain("recipient is missing"))
-                        done()
-                    }
-                }
+                expect(result.items).to(contain(expectedRemoved))
+                expect(error).to(beNil())
+                done()
             }
+        }
 
-            func test__005__publish__should_fail_with_an_empty_payload() {
-                let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                defer { realtime.dispose(); realtime.close() }
-                let channel = realtime.channels.get("pushenabled:push_admin_publish-empty-payload")
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.attach() { error in
-                        expect(error).to(beNil())
-                        done()
-                    }
-                }
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.subscribe("__ably_push__") { message in
-                        fail("Should not be called")
-                    }
-                    realtime.push.admin.publish(["ablyChannel": channel.name], data: [:]) { error in
-                        guard let error = error else {
-                            fail("Error is missing"); done(); return
-                        }
-                        expect(error.message.lowercased()).to(contain("data payload is missing"))
-                        done()
-                    }
-                }
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.removeWhere(params) { error in
+                expect(error).to(beNil())
+                done()
             }
+        }
 
-        
-
-            // RSH1b1
-            
-                func test__006__Device_Registrations__get__should_return_a_device() {
-                    let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { realtime.dispose(); realtime.close() }
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.deviceRegistrations.get("testDeviceDetails") { device, error in
-                            guard let device = device else {
-                                fail("Device is missing"); done(); return;
-                            }
-                            expect(device).to(equal(Self.deviceDetails))
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.list(params) { result, error in
+                guard let result = result else {
+                    fail("PaginatedResult should not be empty"); done(); return
                 }
-
-                func test__007__Device_Registrations__get__should_not_return_a_device_if_it_doesnt_exist() {
-                    let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { realtime.dispose(); realtime.close() }
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.deviceRegistrations.get("madeup") { device, error in
-                            expect(device).to(beNil())
-                            guard let error = error else {
-                                fail("Error should not be empty"); done(); return
-                            }
-                            expect(error.statusCode) == 404
-                            expect(error.message).to(contain("not found"))
-                            done()
-                        }
-                    }
-                }
-
-                
-                    func test__008__Device_Registrations__get__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() {
-                        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { realtime.dispose(); realtime.close() }
-                        realtime.internal.rest.httpExecutor = mockHttpExecutor
-
-                        let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(
-                            token: "123456",
-                            issued: Date(),
-                            expires: Date.distantFuture,
-                            capability: "",
-                            clientId: ""
-                        )
-
-                        expect(localDevice.identityTokenDetails).to(beNil())
-                        realtime.internal.rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
-                        defer { realtime.internal.rest.device.setAndPersistIdentityTokenDetails(nil) }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            realtime.push.admin.deviceRegistrations.get(localDevice.id) { device, error in
-                                done()
-                            }
-                        }
-
-                        guard let request = mockHttpExecutor.requests.first else {
-                            fail("No requests found")
-                            return
-                        }
-
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
-                        expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
-                    }
-
-                    func test__009__Device_Registrations__get__push_device_authentication__should_include_DeviceSecret_HTTP_header() {
-                        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { realtime.dispose(); realtime.close() }
-                        realtime.internal.rest.httpExecutor = mockHttpExecutor
-
-                        waitUntil(timeout: testTimeout) { done in
-                            realtime.push.admin.deviceRegistrations.get(localDevice.id) { device, error in
-                                done()
-                            }
-                        }
-
-                        guard let request = mockHttpExecutor.requests.first else {
-                            fail("No requests found")
-                            return
-                        }
-
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
-                        expect(authorization).to(equal(localDevice.secret))
-                    }
-
-            // RSH1b2
-            
-                func test__010__Device_Registrations__list__should_list_devices_by_id() {
-                    let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { realtime.dispose(); realtime.close() }
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.deviceRegistrations.list(["deviceId": "testDeviceDetails"]) { result, error in
-                            guard let result = result else {
-                                fail("PaginatedResult should not be empty"); done(); return
-                            }
-                            expect(result.items.count) == 1
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
-
-                func test__011__Device_Registrations__list__should_list_devices_by_client_id() {
-                    let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { realtime.dispose(); realtime.close() }
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.deviceRegistrations.list(["clientId": "clientA"]) { result, error in
-                            guard let result = result else {
-                                fail("PaginatedResult should not be empty"); done(); return
-                            }
-                            expect(result.items.count) == Self.allDeviceDetails.filter({ $0.clientId == "clientA" }).count
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
-
-                func test__012__Device_Registrations__list__should_list_devices_sorted() {
-                    let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { realtime.dispose(); realtime.close() }
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.deviceRegistrations.list(["direction": "forwards"]) { result, error in
-                            guard let result = result else {
-                                fail("PaginatedResult should not be empty"); done(); return
-                            }
-                            expect(result.items.count) == Self.allDeviceDetails.count
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
-
-                func test__013__Device_Registrations__list__should_return_an_empty_list_when_id_does_not_exist() {
-                    let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { realtime.dispose(); realtime.close() }
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.deviceRegistrations.list(["deviceId": "madeup"]) { result, error in
-                            guard let result = result else {
-                                fail("PaginatedResult should not be empty"); done(); return
-                            }
-                            expect(result.items.count) == 0
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
-
-            // RSH1b4
-            
-                func test__014__Device_Registrations__remove__should_unregister_a_device() {
-                    let options = AblyTests.commonAppSetup()
-                    options.pushFullWait = true
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.dispose(); realtime.close() }
-                    realtime.internal.rest.httpExecutor = mockHttpExecutor
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.deviceRegistrations.remove(Self.deviceDetails.id) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    guard let request = mockHttpExecutor.requests.first else {
-                        fail("No requests found")
-                        return
-                    }
-
-                    expect(request.httpMethod) == "DELETE"
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
-                }
-
-            // RSH1b3
-            
-                func test__015__Device_Registrations__save__should_register_a_device() {
-                    let options = AblyTests.commonAppSetup()
-                    options.pushFullWait = true
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.dispose(); realtime.close() }
-                    realtime.internal.rest.httpExecutor = mockHttpExecutor
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.deviceRegistrations.save(Self.deviceDetails) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    guard let request = mockHttpExecutor.requests.first else {
-                        fail("No requests found")
-                        return
-                    }
-
-                    expect(request.httpMethod) == "PUT"
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
-                }
-
-                
-                    func test__016__Device_Registrations__save__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() {
-                        let options = AblyTests.commonAppSetup()
-                        options.pushFullWait = true
-                        let realtime = ARTRealtime(options: options)
-                        defer { realtime.dispose(); realtime.close() }
-                        realtime.internal.rest.httpExecutor = mockHttpExecutor
-
-                        let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(
-                            token: "123456",
-                            issued: Date(),
-                            expires: Date.distantFuture,
-                            capability: "",
-                            clientId: ""
-                        )
-
-                        expect(localDevice.identityTokenDetails).to(beNil())
-                        realtime.internal.rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
-                        defer { realtime.internal.rest.device.setAndPersistIdentityTokenDetails(nil) }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            realtime.push.admin.deviceRegistrations.save(localDevice) { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        guard let request = mockHttpExecutor.requests.first else {
-                            fail("No requests found")
-                            return
-                        }
-                        expect(request.httpMethod).to(equal("PUT"))
-
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
-                        expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
-                    }
-
-                    func test__017__Device_Registrations__save__push_device_authentication__should_include_DeviceSecret_HTTP_header() {
-                        let options = AblyTests.commonAppSetup()
-                        options.pushFullWait = true
-                        let realtime = ARTRealtime(options: options)
-                        defer { realtime.dispose(); realtime.close() }
-                        realtime.internal.rest.httpExecutor = mockHttpExecutor
-
-                        waitUntil(timeout: testTimeout) { done in
-                            realtime.push.admin.deviceRegistrations.save(localDevice) { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        guard let request = mockHttpExecutor.requests.first else {
-                            fail("No requests found")
-                            return
-                        }
-                        expect(request.httpMethod).to(equal("PUT"))
-
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
-                        expect(authorization).to(equal(localDevice.secret))
-                    }
-
-            // RSH1b5
-            
-                func test__018__Device_Registrations__removeWhere__should_unregister_a_device() {
-                    let options = AblyTests.commonAppSetup()
-                    options.pushFullWait = true
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.dispose(); realtime.close() }
-
-                    let params = [
-                        "clientId": "clientA"
-                    ]
-
-                    let expectedRemoved = Self.allDeviceDetails.filter({ $0.clientId == "clientA" })
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.deviceRegistrations.list(params) { result, error in
-                            guard let result = result else {
-                                fail("PaginatedResult should not be nil"); done(); return
-                            }
-                            expect(result.items).to(contain(expectedRemoved))
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    realtime.internal.rest.httpExecutor = mockHttpExecutor
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.deviceRegistrations.removeWhere(params) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    guard let request = mockHttpExecutor.requests.first else {
-                        fail("No requests found")
-                        return
-                    }
-
-                    expect(request.httpMethod) == "DELETE"
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.deviceRegistrations.list(params) { result, error in
-                            guard let result = result else {
-                                fail("PaginatedResult should not be nil"); done(); return
-                            }
-                            expect(result.items.count) == 0
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    // --- Restore state for next tests ---
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(expectedRemoved.count, done: done)
-                        for removedDevice in expectedRemoved {
-                            realtime.push.admin.deviceRegistrations.save(removedDevice) { error in
-                                expect(error).to(beNil())
-                                partialDone()
-                            }
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        realtime.push.admin.channelSubscriptions.save(Self.subscriptionFooDevice2) { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                        realtime.push.admin.channelSubscriptions.save(Self.subscriptionBarDevice2) { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                    }
-                }
-
-        
-
-            // RSH1c3
-            
-                func test__019__Channel_Subscriptions__save__should_add_a_subscription() {
-                    let options = AblyTests.commonAppSetup()
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.dispose(); realtime.close() }
-                    let testProxyHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    realtime.internal.rest.httpExecutor = testProxyHTTPExecutor
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.save(subscription) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    guard let request = testProxyHTTPExecutor.requests.first else {
-                        fail("No requests found")
-                        return
-                    }
-
-                    expect(request.httpMethod).to(equal("POST"))
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
-                }
-
-                func test__020__Channel_Subscriptions__save__should_update_a_subscription() {
-                    let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { realtime.dispose(); realtime.close() }
-                    let updateSubscription = ARTPushChannelSubscription(clientId: subscription.clientId!, channel: "pushenabled:foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.save(updateSubscription) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
-
-                func test__021__Channel_Subscriptions__save__should_fail_with_a_bad_recipient() {
-                    let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { realtime.dispose(); realtime.close() }
-                    let invalidSubscription = ARTPushChannelSubscription(deviceId: "madeup", channel: "pushenabled:foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.save(invalidSubscription) { error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.statusCode) == 400
-                            expect(error.message).to(contain("device madeup doesn't exist"))
-                            done()
-                        }
-                    }
-                }
-
-                
-                    func test__022__Channel_Subscriptions__save__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() {
-                        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { realtime.dispose(); realtime.close() }
-                        realtime.internal.rest.httpExecutor = mockHttpExecutor
-
-                        let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(
-                            token: "123456",
-                            issued: Date(),
-                            expires: Date.distantFuture,
-                            capability: "",
-                            clientId: ""
-                        )
-
-                        expect(localDevice.identityTokenDetails).to(beNil())
-                        realtime.internal.rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
-                        defer { realtime.internal.rest.device.setAndPersistIdentityTokenDetails(nil) }
-
-                        let subscription = ARTPushChannelSubscription(deviceId: localDevice.id, channel: quxChannelName)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            realtime.push.admin.channelSubscriptions.save(subscription) { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        guard let request = mockHttpExecutor.requests.first else {
-                            fail("No requests found")
-                            return
-                        }
-
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
-                        expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
-                    }
-
-                    func test__023__Channel_Subscriptions__save__push_device_authentication__should_include_DeviceSecret_HTTP_header() {
-                        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { realtime.dispose(); realtime.close() }
-                        realtime.internal.rest.httpExecutor = mockHttpExecutor
-
-                        let subscription = ARTPushChannelSubscription(deviceId: localDevice.id, channel: quxChannelName)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            realtime.push.admin.channelSubscriptions.save(subscription) { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        guard let request = mockHttpExecutor.requests.first else {
-                            fail("No requests found")
-                            return
-                        }
-
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
-                        expect(authorization).to(equal(localDevice.secret))
-                    }
-
-            // RSH1c1
-            
-                func test__024__Channel_Subscriptions__list__should_receive_a_list_of_subscriptions() {
-                    let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { realtime.dispose(); realtime.close() }
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.save(subscription) { error in
-                            expect(error).to(beNil())
-                            realtime.push.admin.channelSubscriptions.list(["channel": quxChannelName]) { result, error in
-                                guard let result = result else {
-                                    fail("PaginatedResult should not be empty"); done(); return
-                                }
-                                expect(result.items.count) == 1
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-                    }
-                }
-
-            // RSH1c2
-            
-                func test__025__Channel_Subscriptions__listChannels__should_receive_a_list_of_subscriptions() {
-                    let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { realtime.dispose(); realtime.close() }
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.listChannels() { result, error in
-                            expect(error).to(beNil())
-                            guard let result = result else {
-                                fail("PaginatedResult should not be empty"); done(); return
-                            }
-                            expect(result.items as [String]).to(contain(Self.allSubscriptionsChannels + [subscription.channel]))
-                            done()
-                        }
-                    }
-                }
-
-            // RSH1c4
-            
-                func test__026__Channel_Subscriptions__remove__should_remove_a_subscription() {
-                    let options = AblyTests.commonAppSetup()
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.dispose(); realtime.close() }
-                    let testProxyHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    realtime.internal.rest.httpExecutor = testProxyHTTPExecutor
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.remove(subscription) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    guard let request = testProxyHTTPExecutor.requests.first else {
-                        fail("No requests found")
-                        return
-                    }
-
-                    expect(request.httpMethod).to(equal("DELETE"))
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.list(["channel": quxChannelName]) { result, error in
-                            guard let result = result else {
-                                fail("PaginatedResult should not be empty"); done(); return
-                            }
-                            expect(result.items.count) == 0
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
-
-                
-                    func test__027__Channel_Subscriptions__remove__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() {
-                        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { realtime.dispose(); realtime.close() }
-                        realtime.internal.rest.httpExecutor = mockHttpExecutor
-
-                        let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(
-                            token: "123456",
-                            issued: Date(),
-                            expires: Date.distantFuture,
-                            capability: "",
-                            clientId: ""
-                        )
-
-                        expect(localDevice.identityTokenDetails).to(beNil())
-                        realtime.internal.rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
-                        defer { realtime.internal.rest.device.setAndPersistIdentityTokenDetails(nil) }
-
-                        let subscription = ARTPushChannelSubscription(deviceId: localDevice.id, channel: quxChannelName)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            realtime.push.admin.channelSubscriptions.remove(subscription) { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        guard let request = mockHttpExecutor.requests.first else {
-                            fail("No requests found")
-                            return
-                        }
-
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
-                        expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
-                    }
-
-                    func test__028__Channel_Subscriptions__remove__push_device_authentication__should_include_DeviceSecret_HTTP_header() {
-                        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { realtime.dispose(); realtime.close() }
-                        realtime.internal.rest.httpExecutor = mockHttpExecutor
-
-                        let subscription = ARTPushChannelSubscription(deviceId: localDevice.id, channel: quxChannelName)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            realtime.push.admin.channelSubscriptions.remove(subscription) { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        guard let request = mockHttpExecutor.requests.first else {
-                            fail("No requests found")
-                            return
-                        }
-
-                        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
-                        expect(authorization).to(equal(localDevice.secret))
-                    }
-
-            // RSH1c5
-            
-                func test__029__Channel_Subscriptions__removeWhere__should_remove_by_cliendId() {
-                    let options = AblyTests.commonAppSetup()
-                    options.pushFullWait = true
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.dispose(); realtime.close() }
-
-                    let params = [
-                        "clientId": "clientB"
-                    ]
-
-                    let expectedRemoved = [
-                        Self.subscriptionFooClientB,
-                        Self.subscriptionBarClientB
-                    ]
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.list(params) { result, error in
-                            guard let result = result else {
-                                fail("PaginatedResult should not be empty"); done(); return
-                            }
-                            expect(result.items).to(contain(expectedRemoved))
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.removeWhere(params) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.list(params) { result, error in
-                            guard let result = result else {
-                                fail("PaginatedResult should not be empty"); done(); return
-                            }
-                            expect(result.items.count) == 0
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(expectedRemoved.count, done: done)
-                        for removedSubscription in expectedRemoved {
-                            realtime.push.admin.channelSubscriptions.save(removedSubscription) { error in
-                                expect(error).to(beNil())
-                                partialDone()
-                            }
-                        }
-                    }
-                }
-
-                func test__030__Channel_Subscriptions__removeWhere__should_remove_by_cliendId_and_channel() {
-                    let options = AblyTests.commonAppSetup()
-                    options.pushFullWait = true
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.dispose(); realtime.close() }
-
-                    let params = [
-                        "clientId": "clientB",
-                        "channel": "pushenabled:foo"
-                    ]
-
-                    let expectedRemoved = [
-                        Self.subscriptionFooClientB,
-                    ]
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.list(params) { result, error in
-                            guard let result = result else {
-                                fail("PaginatedResult should not be empty"); done(); return
-                            }
-                            expect(result.items).to(contain(expectedRemoved))
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.removeWhere(params) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.list(params) { result, error in
-                            guard let result = result else {
-                                fail("PaginatedResult should not be empty"); done(); return
-                            }
-                            expect(result.items.count) == 0
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
-
-                func test__031__Channel_Subscriptions__removeWhere__should_remove_by_deviceId() {
-                    let options = AblyTests.commonAppSetup()
-                    options.pushFullWait = true
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.dispose(); realtime.close() }
-
-                    let params = [
-                        "deviceId": "deviceDetails2ClientA",
-                    ]
-
-                    let expectedRemoved = [
-                        Self.subscriptionFooDevice2,
-                        Self.subscriptionBarDevice2,
-                    ]
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.list(params) { result, error in
-                            guard let result = result else {
-                                fail("PaginatedResult should not be empty"); done(); return
-                            }
-                            expect(result.items).to(contain(expectedRemoved))
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.removeWhere(params) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.list(params) { result, error in
-                            guard let result = result else {
-                                fail("PaginatedResult should not be empty"); done(); return
-                            }
-                            expect(result.items.count) == 0
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
-
-                func test__032__Channel_Subscriptions__removeWhere__should_not_remove_by_inexistent_deviceId() {
-                    let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { realtime.dispose(); realtime.close() }
-
-                    let params = [
-                        "deviceId": "madeup",
-                    ]
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.list(params) { result, error in
-                            guard let result = result else {
-                                fail("PaginatedResult should not be empty"); done(); return
-                            }
-                            expect(result.items.count) == 0
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtime.push.admin.channelSubscriptions.removeWhere(params) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
-
-        
-
-            func test__033__local_device__should_include_an_id_and_a_secret() {
-                expect(localDevice.id).toNot(beNil())
-                expect(localDevice.secret).toNot(beNil())
-                expect(localDevice.identityTokenDetails).to(beNil())
+                expect(result.items.count) == 0
+                expect(error).to(beNil())
+                done()
             }
+        }
+    }
 
+    func test__031__Channel_Subscriptions__removeWhere__should_remove_by_deviceId() {
+        let options = AblyTests.commonAppSetup()
+        options.pushFullWait = true
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+
+        let params = [
+            "deviceId": "deviceDetails2ClientA",
+        ]
+
+        let expectedRemoved = [
+            Self.subscriptionFooDevice2,
+            Self.subscriptionBarDevice2,
+        ]
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.list(params) { result, error in
+                guard let result = result else {
+                    fail("PaginatedResult should not be empty"); done(); return
+                }
+                expect(result.items).to(contain(expectedRemoved))
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.removeWhere(params) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.list(params) { result, error in
+                guard let result = result else {
+                    fail("PaginatedResult should not be empty"); done(); return
+                }
+                expect(result.items.count) == 0
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__032__Channel_Subscriptions__removeWhere__should_not_remove_by_inexistent_deviceId() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+
+        let params = [
+            "deviceId": "madeup",
+        ]
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.list(params) { result, error in
+                guard let result = result else {
+                    fail("PaginatedResult should not be empty"); done(); return
+                }
+                expect(result.items.count) == 0
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.push.admin.channelSubscriptions.removeWhere(params) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__033__local_device__should_include_an_id_and_a_secret() {
+        expect(localDevice.id).toNot(beNil())
+        expect(localDevice.secret).toNot(beNil())
+        expect(localDevice.identityTokenDetails).to(beNil())
+    }
 }

--- a/Spec/PushChannel.swift
+++ b/Spec/PushChannel.swift
@@ -2,382 +2,375 @@ import Ably
 import Nimble
 import Quick
 
+private var rest: ARTRest!
+private var mockHttpExecutor: MockHTTPExecutor!
 
-        private var rest: ARTRest!
-        private var mockHttpExecutor: MockHTTPExecutor!
+class PushChannel: XCTestCase {
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = rest
+        _ = mockHttpExecutor
 
-class PushChannel : XCTestCase {
+        return super.defaultTestSuite
+    }
 
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = rest
-    let _ = mockHttpExecutor
+    override func setUp() {
+        super.setUp()
 
-    return super.defaultTestSuite
-}
+        mockHttpExecutor = MockHTTPExecutor()
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.dispatchQueue = AblyTests.userQueue
+        options.internalDispatchQueue = AblyTests.queue
+        rest = ARTRest(options: options)
+        rest.internal.options.clientId = "tester"
+        rest.internal.httpExecutor = mockHttpExecutor
+        rest.internal.resetDeviceSingleton()
+    }
 
-        override func setUp() {
-super.setUp()
+    // RSH7
 
+    // RSH7a
 
-            mockHttpExecutor = MockHTTPExecutor()
-            let options = ARTClientOptions(key: "xxxx:xxxx")
-            options.dispatchQueue = AblyTests.userQueue
-            options.internalDispatchQueue = AblyTests.queue
-            rest = ARTRest(options: options)
-            rest.internal.options.clientId = "tester"
-            rest.internal.httpExecutor = mockHttpExecutor
-            rest.internal.resetDeviceSingleton()
+    // RSH7a1
+    func test__001__Push_Channel__subscribeDevice__should_fail_if_the_LocalDevice_doesn_t_have_an_deviceIdentityToken() {
+        waitUntil(timeout: testTimeout) { done in
+            rest.channels.get("foo").push.subscribeDevice { error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error.message).to(contain("cannot use device before device activation has finished"))
+                expect(AblyTests.currentQueueLabel() == AblyTests.userQueue.label).to(beTrue())
+                done()
+            }
+        }
+    }
+
+    // RSH7a2, RSH7a3
+    func test__002__Push_Channel__subscribeDevice__should_do_a_POST_request_to__push_channelSubscriptions_and_include_device_authentication() {
+        let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
+        rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
+        defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
+
+        let channel = rest.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.push.subscribeDevice { error in
+                expect(error).to(beNil())
+                done()
+            }
         }
 
-        // RSH7
-        
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("should have a \"/push/channelSubscriptions\" request"); return
+        }
+        guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
+            fail("should have a \"/push/channelSubscriptions\" URL"); return
+        }
+        guard let rawBody = request.httpBody else {
+            fail("should have a body"); return
+        }
+        let decodedBody: Any
+        do {
+            decodedBody = try rest.internal.defaultEncoder.decode(rawBody)
+        } catch {
+            fail("Decode failed: \(error)"); return
+        }
+        guard let body = decodedBody as? NSDictionary else {
+            fail("body is invalid"); return
+        }
 
-            // RSH7a
-            
-                // RSH7a1
-                func test__001__Push_Channel__subscribeDevice__should_fail_if_the_LocalDevice_doesn_t_have_an_deviceIdentityToken() {
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.channels.get("foo").push.subscribeDevice { error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.message).to(contain("cannot use device before device activation has finished"))
-                            expect(AblyTests.currentQueueLabel() == AblyTests.userQueue.label).to(beTrue())
-                            done()
-                        }
-                    }
+        expect(request.httpMethod) == "POST"
+        expect(body.value(forKey: "deviceId") as? String).to(equal(rest.device.id))
+        expect(body.value(forKey: "channel") as? String).to(equal(channel.name))
+
+        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
+        expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
+        expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecrect"]).to(beNil())
+    }
+
+    // RSH7b
+
+    // RSH7b1
+    func test__003__Push_Channel__subscribeClient__should_fail_if_the_LocalDevice_doesn_t_have_a_clientId() {
+        let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
+        rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
+        defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
+
+        let originalClientId = rest.device.clientId
+        rest.device.clientId = nil
+        defer { rest.device.clientId = originalClientId }
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.channels.get("foo").push.subscribeClient { error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
                 }
+                expect(error.message).to(contain("null client ID"))
+                expect(AblyTests.currentQueueLabel() == AblyTests.userQueue.label).to(beTrue())
+                done()
+            }
+        }
+    }
 
-                // RSH7a2, RSH7a3
-                func test__002__Push_Channel__subscribeDevice__should_do_a_POST_request_to__push_channelSubscriptions_and_include_device_authentication() {
-                    let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
-                    rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
-                    defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
+    // RSH7b2
+    func test__004__Push_Channel__subscribeClient__should_do_a_POST_request_to__push_channelSubscriptions() {
+        let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
+        rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
+        defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
 
-                    let channel = rest.channels.get("foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.push.subscribeDevice { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
+        let channel = rest.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.push.subscribeClient { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
 
-                    guard let request = mockHttpExecutor.requests.first else {
-                        fail("should have a \"/push/channelSubscriptions\" request"); return
-                    }
-                    guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
-                        fail("should have a \"/push/channelSubscriptions\" URL"); return
-                    }
-                    guard let rawBody = request.httpBody else {
-                        fail("should have a body"); return
-                    }
-                    let decodedBody: Any
-                    do {
-                        decodedBody = try rest.internal.defaultEncoder.decode(rawBody)
-                    }
-                    catch {
-                        fail("Decode failed: \(error)"); return
-                    }
-                    guard let body = decodedBody as? NSDictionary else {
-                        fail("body is invalid"); return
-                    }
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("should have a \"/push/channelSubscriptions\" request"); return
+        }
+        guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
+            fail("should have a \"/push/channelSubscriptions\" URL"); return
+        }
+        guard let rawBody = request.httpBody else {
+            fail("should have a body"); return
+        }
+        let decodedBody: Any
+        do {
+            decodedBody = try rest.internal.defaultEncoder.decode(rawBody)
+        } catch {
+            fail("Decode failed: \(error)"); return
+        }
+        guard let body = decodedBody as? NSDictionary else {
+            fail("body is invalid"); return
+        }
 
-                    expect(request.httpMethod) == "POST"
-                    expect(body.value(forKey: "deviceId") as? String).to(equal(rest.device.id))
-                    expect(body.value(forKey: "channel") as? String).to(equal(channel.name))
+        expect(request.httpMethod) == "POST"
+        expect(body.value(forKey: "clientId") as? String).to(equal(rest.device.clientId))
+        expect(body.value(forKey: "channel") as? String).to(equal(channel.name))
 
-                    let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
-                    expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecrect"]).to(beNil())
+        expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
+        expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecrect"]).to(beNil())
+    }
+
+    // RSH7c
+
+    // RSH7c1
+    func test__005__Push_Channel__unsubscribeDevice__should_fail_if_the_LocalDevice_doesn_t_have_a_deviceIdentityToken() {
+        waitUntil(timeout: testTimeout) { done in
+            rest.channels.get("foo").push.unsubscribeDevice { error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
                 }
+                expect(error.message).to(contain("cannot use device before device activation has finished"))
+                expect(AblyTests.currentQueueLabel() == AblyTests.userQueue.label).to(beTrue())
+                done()
+            }
+        }
+    }
 
-            // RSH7b
-            
-                // RSH7b1
-                func test__003__Push_Channel__subscribeClient__should_fail_if_the_LocalDevice_doesn_t_have_a_clientId() {
-                    let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
-                    rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
-                    defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
+    // RSH7c2, RSH7c3
+    func test__006__Push_Channel__unsubscribeDevice__should_do_a_DELETE_request_to__push_channelSubscriptions_and_include_device_authentication() {
+        let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
+        rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
+        defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
 
-                    let originalClientId = rest.device.clientId
-                    rest.device.clientId = nil
-                    defer { rest.device.clientId = originalClientId }
+        let channel = rest.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.push.unsubscribeDevice { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.channels.get("foo").push.subscribeClient { error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.message).to(contain("null client ID"))
-                            expect(AblyTests.currentQueueLabel() == AblyTests.userQueue.label).to(beTrue())
-                            done()
-                        }
-                    }
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("should have a \"/push/channelSubscriptions\" request"); return
+        }
+        guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
+            fail("should have a \"/push/channelSubscriptions\" URL"); return
+        }
+        guard let query = request.url?.query else {
+            fail("should have a body"); return
+        }
+
+        expect(request.httpMethod) == "DELETE"
+        expect(query).to(haveParam("deviceId", withValue: rest.device.id))
+        expect(query).to(haveParam("channel", withValue: channel.name))
+
+        let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
+        expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
+        expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecrect"]).to(beNil())
+    }
+
+    // RSH7d
+
+    // RSH7d1
+    func test__007__Push_Channel__unsubscribeClient__should_fail_if_the_LocalDevice_doesn_t_have_a_clientId() {
+        let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
+        rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
+        defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
+
+        let originalClientId = rest.device.clientId
+        rest.device.clientId = nil
+        defer { rest.device.clientId = originalClientId }
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.channels.get("foo").push.unsubscribeClient { error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
                 }
+                expect(error.message).to(contain("null client ID"))
+                expect(AblyTests.currentQueueLabel() == AblyTests.userQueue.label).to(beTrue())
+                done()
+            }
+        }
+    }
 
-                // RSH7b2
-                func test__004__Push_Channel__subscribeClient__should_do_a_POST_request_to__push_channelSubscriptions() {
-                    let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
-                    rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
-                    defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
+    // RSH7d2
+    func test__008__Push_Channel__unsubscribeClient__should_do_a_DELETE_request_to__push_channelSubscriptions() {
+        let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
+        rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
+        defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
 
-                    let channel = rest.channels.get("foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.push.subscribeClient { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
+        let channel = rest.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.push.unsubscribeClient { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
 
-                    guard let request = mockHttpExecutor.requests.first else {
-                        fail("should have a \"/push/channelSubscriptions\" request"); return
-                    }
-                    guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
-                        fail("should have a \"/push/channelSubscriptions\" URL"); return
-                    }
-                    guard let rawBody = request.httpBody else {
-                        fail("should have a body"); return
-                    }
-                    let decodedBody: Any
-                    do {
-                        decodedBody = try rest.internal.defaultEncoder.decode(rawBody)
-                    }
-                    catch {
-                        fail("Decode failed: \(error)"); return
-                    }
-                    guard let body = decodedBody as? NSDictionary else {
-                        fail("body is invalid"); return
-                    }
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("should have a \"/push/channelSubscriptions\" request"); return
+        }
+        guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
+            fail("should have a \"/push/channelSubscriptions\" URL"); return
+        }
+        guard let query = request.url?.query else {
+            fail("should have a body"); return
+        }
 
-                    expect(request.httpMethod) == "POST"
-                    expect(body.value(forKey: "clientId") as? String).to(equal(rest.device.clientId))
-                    expect(body.value(forKey: "channel") as? String).to(equal(channel.name))
+        expect(request.httpMethod) == "DELETE"
+        expect(query).to(haveParam("clientId", withValue: rest.device.clientId!))
+        expect(query).to(haveParam("channel", withValue: channel.name))
 
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecrect"]).to(beNil())
+        expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
+        expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecrect"]).to(beNil())
+    }
+
+    // RSH7e
+
+    func test__009__Push_Channel__listSubscriptions__should_return_a_paginated_result_with_PushChannelSubscription_filtered_by_channel_and_device() {
+        let params = [
+            "deviceId": "111",
+            "channel": "aaa",
+        ]
+        let channel = rest.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            try? channel.push.listSubscriptions(params) { result, error in
+                expect(error).to(beNil())
+                expect(result).toNot(beNil())
+                done()
+            }
+        }
+
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("should have a \"/push/channelSubscriptions\" request"); return
+        }
+        guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
+            fail("should have a \"/push/channelSubscriptions\" URL"); return
+        }
+        guard let query = request.url?.query else {
+            fail("should have a body"); return
+        }
+
+        expect(query).to(haveParam("deviceId", withValue: params["deviceId"]))
+        expect(query).toNot(haveParam("clientId", withValue: rest.device.clientId))
+        expect(query).to(haveParam("channel", withValue: params["channel"]))
+        expect(query).to(haveParam("concatFilters", withValue: "true"))
+    }
+
+    func test__010__Push_Channel__listSubscriptions__should_return_a_paginated_result_with_PushChannelSubscription_filtered_by_channel_and_client() {
+        let params = [
+            "clientId": "tester",
+            "channel": "aaa",
+        ]
+        let channel = rest.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            try? channel.push.listSubscriptions(params) { result, error in
+                expect(error).to(beNil())
+                expect(result).toNot(beNil())
+                done()
+            }
+        }
+
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("should have a \"/push/channelSubscriptions\" request"); return
+        }
+        guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
+            fail("should have a \"/push/channelSubscriptions\" URL"); return
+        }
+        guard let query = request.url?.query else {
+            fail("should have a body"); return
+        }
+
+        expect(query).to(haveParam("clientId", withValue: params["clientId"]))
+        expect(query).toNot(haveParam("deviceId", withValue: rest.device.id))
+        expect(query).to(haveParam("channel", withValue: params["channel"]))
+        expect(query).to(haveParam("concatFilters", withValue: "true"))
+    }
+
+    func test__011__Push_Channel__listSubscriptions__should_not_accept_null_deviceId_and_null_clientId() {
+        let channel = rest.channels.get("foo")
+        expect { try channel.push.listSubscriptions([:]) { _, _ in } }.to(throwError { (error: NSError) in
+            expect(error.code).to(equal(ARTDataQueryError.missingRequiredFields.rawValue))
+        })
+    }
+
+    func test__012__Push_Channel__listSubscriptions__should_not_accept_both_deviceId_and_clientId_params_at_the_same_time() {
+        let params = [
+            "deviceId": "x",
+            "clientId": "y",
+        ]
+        let channel = rest.channels.get("foo")
+        expect { try channel.push.listSubscriptions(params) { _, _ in } }.to(throwError { (error: NSError) in
+            expect(error.code).to(equal(ARTDataQueryError.invalidParameters.rawValue))
+        })
+    }
+
+    func test__013__Push_Channel__listSubscriptions__should_return_a_paginated_result_with_PushChannelSubscription() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "tester"
+        // Prevent channel name to be prefixed by test-*
+        options.channelNamePrefix = nil
+        let rest = ARTRest(options: options)
+        rest.internal.storage = MockDeviceStorage()
+
+        // Activate device
+        let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
+        rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
+        defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
+
+        let channel = rest.channels.get("pushenabled:foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.push.subscribeClient { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        let params: [String: String] = [
+            "clientId": options.clientId!,
+            "channel": channel.name,
+        ]
+        waitUntil(timeout: testTimeout) { done in
+            try! channel.push.listSubscriptions(params) { result, error in
+                expect(error).to(beNil())
+                guard let result = result else {
+                    fail("Result is nil"); done(); return
                 }
-
-            // RSH7c
-            
-                // RSH7c1
-                func test__005__Push_Channel__unsubscribeDevice__should_fail_if_the_LocalDevice_doesn_t_have_a_deviceIdentityToken() {
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.channels.get("foo").push.unsubscribeDevice { error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.message).to(contain("cannot use device before device activation has finished"))
-                            expect(AblyTests.currentQueueLabel() == AblyTests.userQueue.label).to(beTrue())
-                            done()
-                        }
-                    }
-                }
-
-                // RSH7c2, RSH7c3
-                func test__006__Push_Channel__unsubscribeDevice__should_do_a_DELETE_request_to__push_channelSubscriptions_and_include_device_authentication() {
-                    let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
-                    rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
-                    defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
-
-                    let channel = rest.channels.get("foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.push.unsubscribeDevice { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    guard let request = mockHttpExecutor.requests.first else {
-                        fail("should have a \"/push/channelSubscriptions\" request"); return
-                    }
-                    guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
-                        fail("should have a \"/push/channelSubscriptions\" URL"); return
-                    }
-                    guard let query = request.url?.query else {
-                        fail("should have a body"); return
-                    }
-
-                    expect(request.httpMethod) == "DELETE"
-                    expect(query).to(haveParam("deviceId", withValue: rest.device.id))
-                    expect(query).to(haveParam("channel", withValue: channel.name))
-
-                    let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
-                    expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecrect"]).to(beNil())
-                }
-
-            // RSH7d
-            
-                // RSH7d1
-                func test__007__Push_Channel__unsubscribeClient__should_fail_if_the_LocalDevice_doesn_t_have_a_clientId() {
-                    let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
-                    rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
-                    defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
-
-                    let originalClientId = rest.device.clientId
-                    rest.device.clientId = nil
-                    defer { rest.device.clientId = originalClientId }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.channels.get("foo").push.unsubscribeClient { error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.message).to(contain("null client ID"))
-                            expect(AblyTests.currentQueueLabel() == AblyTests.userQueue.label).to(beTrue())
-                            done()
-                        }
-                    }
-                }
-
-                // RSH7d2
-                func test__008__Push_Channel__unsubscribeClient__should_do_a_DELETE_request_to__push_channelSubscriptions() {
-                    let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
-                    rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
-                    defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
-
-                    let channel = rest.channels.get("foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.push.unsubscribeClient { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    guard let request = mockHttpExecutor.requests.first else {
-                        fail("should have a \"/push/channelSubscriptions\" request"); return
-                    }
-                    guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
-                        fail("should have a \"/push/channelSubscriptions\" URL"); return
-                    }
-                    guard let query = request.url?.query else {
-                        fail("should have a body"); return
-                    }
-
-                    expect(request.httpMethod) == "DELETE"
-                    expect(query).to(haveParam("clientId", withValue: rest.device.clientId!))
-                    expect(query).to(haveParam("channel", withValue: channel.name))
-
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
-                    expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecrect"]).to(beNil())
-                }
-
-            // RSH7e
-            
-                func test__009__Push_Channel__listSubscriptions__should_return_a_paginated_result_with_PushChannelSubscription_filtered_by_channel_and_device() {
-                    let params = [
-                        "deviceId": "111",
-                        "channel": "aaa"
-                    ]
-                    let channel = rest.channels.get("foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        try? channel.push.listSubscriptions(params) { result, error in
-                            expect(error).to(beNil())
-                            expect(result).toNot(beNil())
-                            done()
-                        }
-                    }
-
-                    guard let request = mockHttpExecutor.requests.first else {
-                        fail("should have a \"/push/channelSubscriptions\" request"); return
-                    }
-                    guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
-                        fail("should have a \"/push/channelSubscriptions\" URL"); return
-                    }
-                    guard let query = request.url?.query else {
-                        fail("should have a body"); return
-                    }
-
-                    expect(query).to(haveParam("deviceId", withValue: params["deviceId"]))
-                    expect(query).toNot(haveParam("clientId", withValue: rest.device.clientId))
-                    expect(query).to(haveParam("channel", withValue: params["channel"]))
-                    expect(query).to(haveParam("concatFilters", withValue: "true"))
-                }
-
-                func test__010__Push_Channel__listSubscriptions__should_return_a_paginated_result_with_PushChannelSubscription_filtered_by_channel_and_client() {
-                    let params = [
-                        "clientId": "tester",
-                        "channel": "aaa"
-                    ]
-                    let channel = rest.channels.get("foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        try? channel.push.listSubscriptions(params) { result, error in
-                            expect(error).to(beNil())
-                            expect(result).toNot(beNil())
-                            done()
-                        }
-                    }
-
-                    guard let request = mockHttpExecutor.requests.first else {
-                        fail("should have a \"/push/channelSubscriptions\" request"); return
-                    }
-                    guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
-                        fail("should have a \"/push/channelSubscriptions\" URL"); return
-                    }
-                    guard let query = request.url?.query else {
-                        fail("should have a body"); return
-                    }
-
-                    expect(query).to(haveParam("clientId", withValue: params["clientId"]))
-                    expect(query).toNot(haveParam("deviceId", withValue: rest.device.id))
-                    expect(query).to(haveParam("channel", withValue: params["channel"]))
-                    expect(query).to(haveParam("concatFilters", withValue: "true"))
-                }
-
-                func test__011__Push_Channel__listSubscriptions__should_not_accept_null_deviceId_and_null_clientId() {
-                    let channel = rest.channels.get("foo")
-                    expect { try channel.push.listSubscriptions([:]) { _, _ in } }.to(throwError { (error: NSError) in
-                        expect(error.code).to(equal(ARTDataQueryError.missingRequiredFields.rawValue))
-                    })
-                }
-
-                func test__012__Push_Channel__listSubscriptions__should_not_accept_both_deviceId_and_clientId_params_at_the_same_time() {
-                    let params = [
-                        "deviceId": "x",
-                        "clientId": "y"
-                    ]
-                    let channel = rest.channels.get("foo")
-                    expect { try channel.push.listSubscriptions(params) { _, _ in } }.to(throwError { (error: NSError) in
-                        expect(error.code).to(equal(ARTDataQueryError.invalidParameters.rawValue))
-                    })
-                }
-
-                func test__013__Push_Channel__listSubscriptions__should_return_a_paginated_result_with_PushChannelSubscription() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "tester"
-                    // Prevent channel name to be prefixed by test-*
-                    options.channelNamePrefix = nil
-                    let rest = ARTRest(options: options)
-                    rest.internal.storage = MockDeviceStorage()
-
-                    // Activate device
-                    let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
-                    rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
-                    defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
-
-                    let channel = rest.channels.get("pushenabled:foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.push.subscribeClient { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    let params: [String: String] = [
-                        "clientId": options.clientId!,
-                        "channel": channel.name
-                    ]
-                    waitUntil(timeout: testTimeout) { done in
-                        try! channel.push.listSubscriptions(params) { result, error in
-                            expect(error).to(beNil())
-                            guard let result = result else {
-                                fail("Result is nil"); done(); return
-                            }
-                            expect(result.items.count) == 1
-                            done()
-                        }
-                    }
-                }
-
+                expect(result.items.count) == 1
+                done()
+            }
+        }
+    }
 }

--- a/Spec/PushChannel.swift
+++ b/Spec/PushChannel.swift
@@ -2,11 +2,21 @@ import Ably
 import Nimble
 import Quick
 
-class PushChannel : QuickSpec {
-    override func spec() {
 
-        var rest: ARTRest!
-        var mockHttpExecutor: MockHTTPExecutor!
+        private var rest: ARTRest!
+        private var mockHttpExecutor: MockHTTPExecutor!
+
+class PushChannel : QuickSpec {
+
+// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+override class var defaultTestSuite : XCTestSuite {
+    let _ = rest
+    let _ = mockHttpExecutor
+
+    return super.defaultTestSuite
+}
+
+    override func spec() {
 
         beforeEach {
             mockHttpExecutor = MockHTTPExecutor()

--- a/Spec/PushChannel.swift
+++ b/Spec/PushChannel.swift
@@ -1,6 +1,6 @@
 import Ably
 import Nimble
-import Quick
+import XCTest
 
 private var rest: ARTRest!
 private var mockHttpExecutor: MockHTTPExecutor!

--- a/Spec/PushChannel.swift
+++ b/Spec/PushChannel.swift
@@ -6,7 +6,7 @@ import Quick
         private var rest: ARTRest!
         private var mockHttpExecutor: MockHTTPExecutor!
 
-class PushChannel : QuickSpec {
+class PushChannel : XCTestCase {
 
 // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
 override class var defaultTestSuite : XCTestSuite {
@@ -16,9 +16,10 @@ override class var defaultTestSuite : XCTestSuite {
     return super.defaultTestSuite
 }
 
-    override func spec() {
+        override func setUp() {
+super.setUp()
 
-        beforeEach {
+
             mockHttpExecutor = MockHTTPExecutor()
             let options = ARTClientOptions(key: "xxxx:xxxx")
             options.dispatchQueue = AblyTests.userQueue
@@ -30,12 +31,12 @@ override class var defaultTestSuite : XCTestSuite {
         }
 
         // RSH7
-        describe("Push Channel") {
+        
 
             // RSH7a
-            context("subscribeDevice") {
+            
                 // RSH7a1
-                it("should fail if the LocalDevice doesn't have an deviceIdentityToken") {
+                func test__001__Push_Channel__subscribeDevice__should_fail_if_the_LocalDevice_doesn_t_have_an_deviceIdentityToken() {
                     waitUntil(timeout: testTimeout) { done in
                         rest.channels.get("foo").push.subscribeDevice { error in
                             guard let error = error else {
@@ -49,7 +50,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSH7a2, RSH7a3
-                it("should do a POST request to /push/channelSubscriptions and include device authentication") {
+                func test__002__Push_Channel__subscribeDevice__should_do_a_POST_request_to__push_channelSubscriptions_and_include_device_authentication() {
                     let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
                     rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
                     defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
@@ -90,12 +91,11 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecrect"]).to(beNil())
                 }
-            }
 
             // RSH7b
-            context("subscribeClient") {
+            
                 // RSH7b1
-                it("should fail if the LocalDevice doesn't have a clientId") {
+                func test__003__Push_Channel__subscribeClient__should_fail_if_the_LocalDevice_doesn_t_have_a_clientId() {
                     let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
                     rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
                     defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
@@ -117,7 +117,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSH7b2
-                it("should do a POST request to /push/channelSubscriptions") {
+                func test__004__Push_Channel__subscribeClient__should_do_a_POST_request_to__push_channelSubscriptions() {
                     let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
                     rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
                     defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
@@ -157,12 +157,11 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecrect"]).to(beNil())
                 }
-            }
 
             // RSH7c
-            context("unsubscribeDevice") {
+            
                 // RSH7c1
-                it("should fail if the LocalDevice doesn't have a deviceIdentityToken") {
+                func test__005__Push_Channel__unsubscribeDevice__should_fail_if_the_LocalDevice_doesn_t_have_a_deviceIdentityToken() {
                     waitUntil(timeout: testTimeout) { done in
                         rest.channels.get("foo").push.unsubscribeDevice { error in
                             guard let error = error else {
@@ -176,7 +175,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSH7c2, RSH7c3
-                it("should do a DELETE request to /push/channelSubscriptions and include device authentication") {
+                func test__006__Push_Channel__unsubscribeDevice__should_do_a_DELETE_request_to__push_channelSubscriptions_and_include_device_authentication() {
                     let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
                     rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
                     defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
@@ -207,12 +206,11 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecrect"]).to(beNil())
                 }
-            }
 
             // RSH7d
-            context("unsubscribeClient") {
+            
                 // RSH7d1
-                it("should fail if the LocalDevice doesn't have a clientId") {
+                func test__007__Push_Channel__unsubscribeClient__should_fail_if_the_LocalDevice_doesn_t_have_a_clientId() {
                     let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
                     rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
                     defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
@@ -234,7 +232,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSH7d2
-                it("should do a DELETE request to /push/channelSubscriptions") {
+                func test__008__Push_Channel__unsubscribeClient__should_do_a_DELETE_request_to__push_channelSubscriptions() {
                     let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
                     rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
                     defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
@@ -264,11 +262,10 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
                     expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecrect"]).to(beNil())
                 }
-            }
 
             // RSH7e
-            context("listSubscriptions") {
-                it("should return a paginated result with PushChannelSubscription filtered by channel and device") {
+            
+                func test__009__Push_Channel__listSubscriptions__should_return_a_paginated_result_with_PushChannelSubscription_filtered_by_channel_and_device() {
                     let params = [
                         "deviceId": "111",
                         "channel": "aaa"
@@ -298,7 +295,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(query).to(haveParam("concatFilters", withValue: "true"))
                 }
 
-                it("should return a paginated result with PushChannelSubscription filtered by channel and client") {
+                func test__010__Push_Channel__listSubscriptions__should_return_a_paginated_result_with_PushChannelSubscription_filtered_by_channel_and_client() {
                     let params = [
                         "clientId": "tester",
                         "channel": "aaa"
@@ -328,14 +325,14 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(query).to(haveParam("concatFilters", withValue: "true"))
                 }
 
-                it("should not accept null deviceId and null clientId") {
+                func test__011__Push_Channel__listSubscriptions__should_not_accept_null_deviceId_and_null_clientId() {
                     let channel = rest.channels.get("foo")
                     expect { try channel.push.listSubscriptions([:]) { _, _ in } }.to(throwError { (error: NSError) in
                         expect(error.code).to(equal(ARTDataQueryError.missingRequiredFields.rawValue))
                     })
                 }
 
-                it("should not accept both deviceId and clientId params at the same time") {
+                func test__012__Push_Channel__listSubscriptions__should_not_accept_both_deviceId_and_clientId_params_at_the_same_time() {
                     let params = [
                         "deviceId": "x",
                         "clientId": "y"
@@ -346,7 +343,7 @@ override class var defaultTestSuite : XCTestSuite {
                     })
                 }
 
-                it("should return a paginated result with PushChannelSubscription") {
+                func test__013__Push_Channel__listSubscriptions__should_return_a_paginated_result_with_PushChannelSubscription() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "tester"
                     // Prevent channel name to be prefixed by test-*
@@ -382,10 +379,5 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
-
-        }
-
-    }
 
 }

--- a/Spec/ReadmeExamples.swift
+++ b/Spec/ReadmeExamples.swift
@@ -5,20 +5,19 @@ import Nimble
 
 // This file is to be kept in sync with the examples in README.md, to make sure they are kept valid.
 
-class ReadmeExamples : QuickSpec {
-    override func spec() {
+class ReadmeExamples : XCTestCase {
 
-        it("testMakeKeyInstance") {
+        func test__001__testMakeKeyInstance() {
             let client = ARTRealtime(key: "xxxx:xxxx")
             client.connection.close()
         }
 
-        it("testMakeTokenInstance") {
+        func test__002__testMakeTokenInstance() {
             let client = ARTRealtime(token: "xxxx")
             client.connection.close()
         }
 
-        it("testListenToConnectionStateChanges") {
+        func test__003__testListenToConnectionStateChanges() {
             let options = AblyTests.clientOptions(requestToken: true)
             let client = ARTRealtime(options: options)
             defer { client.close() }
@@ -35,7 +34,7 @@ class ReadmeExamples : QuickSpec {
             }
         }
 
-        it("testNoAutoConnect") {
+        func test__004__testNoAutoConnect() {
             let options = ARTClientOptions(key: "xxxx:xxxx")
             options.autoConnect = false
             let client = ARTRealtime(options: options)
@@ -43,7 +42,7 @@ class ReadmeExamples : QuickSpec {
             client.connection.close()
         }
 
-        it("testSubscribeAndPublishingToChannel") {
+        func test__005__testSubscribeAndPublishingToChannel() {
             let options = AblyTests.clientOptions(requestToken: true)
             let client = ARTRealtime(options: options)
             defer { client.close() }
@@ -63,7 +62,7 @@ class ReadmeExamples : QuickSpec {
             channel.publish("greeting", data: "Hello World!")
         }
 
-        it("testQueryingTheHistory") {
+        func test__006__testQueryingTheHistory() {
             let options = AblyTests.clientOptions(requestToken: true)
             let client = ARTRealtime(options: options)
             defer { client.close() }
@@ -83,7 +82,7 @@ class ReadmeExamples : QuickSpec {
             }
         }
 
-        it("testPresenceOnAChannel") {
+        func test__007__testPresenceOnAChannel() {
             let options = AblyTests.clientOptions(requestToken: true)
             options.clientId = "foo"
             let client = ARTRealtime(options: options)
@@ -102,7 +101,7 @@ class ReadmeExamples : QuickSpec {
             }
         }
 
-        it("testQueryingThePresenceHistory") {
+        func test__008__testQueryingThePresenceHistory() {
             let options = AblyTests.clientOptions(requestToken: true)
             let client = ARTRealtime(options: options)
             defer { client.close() }
@@ -122,13 +121,13 @@ class ReadmeExamples : QuickSpec {
             }
         }
 
-        it("testMakeRestClientAndChannel") {
+        func test__009__testMakeRestClientAndChannel() {
             let client = ARTRest(key: "xxxx:xxxx")
             let channel = client.channels.get("test")
             _ = channel
         }
 
-        it("testRestPublishMessage") {
+        func test__010__testRestPublishMessage() {
             let options = AblyTests.clientOptions(requestToken: true)
             let client = ARTRest(options: options)
             let channel = client.channels.get("test")
@@ -136,7 +135,7 @@ class ReadmeExamples : QuickSpec {
             channel.publish("myEvent", data: "Hello!")
         }
 
-        it("testRestQueryingTheHistory") {
+        func test__011__testRestQueryingTheHistory() {
             let options = AblyTests.clientOptions(requestToken: true)
             let client = ARTRest(options: options)
             let channel = client.channels.get("test")
@@ -152,7 +151,7 @@ class ReadmeExamples : QuickSpec {
             }
         }
 
-        it("testRestPresenceOnAChannel") {
+        func test__012__testRestPresenceOnAChannel() {
             let options = AblyTests.clientOptions(requestToken: true)
             let client = ARTRest(options: options)
             let channel = client.channels.get("test")
@@ -168,7 +167,7 @@ class ReadmeExamples : QuickSpec {
             }
         }
 
-        it("testRestQueryingThePresenceHistory") {
+        func test__013__testRestQueryingThePresenceHistory() {
             let options = AblyTests.clientOptions(requestToken: true)
             let client = ARTRest(options: options)
             let channel = client.channels.get("test")
@@ -184,7 +183,7 @@ class ReadmeExamples : QuickSpec {
             }
         }
 
-        it("testGenerateToken") {
+        func test__014__testGenerateToken() {
             let client = ARTRest(options: AblyTests.commonAppSetup())
 
             client.auth.requestToken(nil, with: nil) { tokenDetails, error in
@@ -195,7 +194,7 @@ class ReadmeExamples : QuickSpec {
             }
         }
         
-        it("testFetchingStats") {
+        func test__015__testFetchingStats() {
             let client = ARTRest(options: AblyTests.commonAppSetup())
             client.channels.get("test").publish("foo", data: "bar") { _ in
                 client.stats { statsPage, error in
@@ -208,14 +207,12 @@ class ReadmeExamples : QuickSpec {
             }
         }
         
-        it("testFetchingTime") {
+        func test__016__testFetchingTime() {
             let client = ARTRest(options: AblyTests.commonAppSetup())
             
             client.time { time, error in
                 print(time as Any) // 2016-02-09 03:59:24 +0000
             }
         }
-
-    }
 
 }

--- a/Spec/ReadmeExamples.swift
+++ b/Spec/ReadmeExamples.swift
@@ -1,7 +1,7 @@
 import Ably
 import Foundation
 import Nimble
-import Quick
+import XCTest
 
 // This file is to be kept in sync with the examples in README.md, to make sure they are kept valid.
 

--- a/Spec/ReadmeExamples.swift
+++ b/Spec/ReadmeExamples.swift
@@ -1,218 +1,216 @@
 import Ably
 import Foundation
-import Quick
 import Nimble
+import Quick
 
 // This file is to be kept in sync with the examples in README.md, to make sure they are kept valid.
 
-class ReadmeExamples : XCTestCase {
+class ReadmeExamples: XCTestCase {
+    func test__001__testMakeKeyInstance() {
+        let client = ARTRealtime(key: "xxxx:xxxx")
+        client.connection.close()
+    }
 
-        func test__001__testMakeKeyInstance() {
-            let client = ARTRealtime(key: "xxxx:xxxx")
-            client.connection.close()
+    func test__002__testMakeTokenInstance() {
+        let client = ARTRealtime(token: "xxxx")
+        client.connection.close()
+    }
+
+    func test__003__testListenToConnectionStateChanges() {
+        let options = AblyTests.clientOptions(requestToken: true)
+        let client = ARTRealtime(options: options)
+        defer { client.close() }
+
+        client.connection.on { stateChange in
+            switch stateChange.current {
+            case .connected:
+                print("connected!")
+            case .failed:
+                print("failed! \(String(describing: stateChange.reason))")
+            default:
+                break
+            }
+        }
+    }
+
+    func test__004__testNoAutoConnect() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.connection.connect()
+        client.connection.close()
+    }
+
+    func test__005__testSubscribeAndPublishingToChannel() {
+        let options = AblyTests.clientOptions(requestToken: true)
+        let client = ARTRealtime(options: options)
+        defer { client.close() }
+
+        let channel = client.channels.get("test")
+
+        channel.subscribe { message in
+            print(message.name as Any)
+            print(message.data as Any)
         }
 
-        func test__002__testMakeTokenInstance() {
-            let client = ARTRealtime(token: "xxxx")
-            client.connection.close()
+        channel.subscribe("myEvent") { message in
+            print(message.name as Any)
+            print(message.data as Any)
         }
 
-        func test__003__testListenToConnectionStateChanges() {
-            let options = AblyTests.clientOptions(requestToken: true)
-            let client = ARTRealtime(options: options)
-            defer { client.close() }
+        channel.publish("greeting", data: "Hello World!")
+    }
 
-            client.connection.on { stateChange in
-                switch stateChange.current {
-                case .connected:
-                    print("connected!")
-                case .failed:
-                    print("failed! \(String(describing: stateChange.reason))")
-                default:
-                    break
+    func test__006__testQueryingTheHistory() {
+        let options = AblyTests.clientOptions(requestToken: true)
+        let client = ARTRealtime(options: options)
+        defer { client.close() }
+
+        let channel = client.channels.get("test")
+
+        channel.history { messagesPage, _ in
+            let messagesPage = messagesPage!
+            print(messagesPage.items)
+            print(messagesPage.items.first as Any)
+            print(messagesPage.items.first?.data as Any) // payload for the message
+            print(messagesPage.items.count) // number of messages in the current page of history
+            messagesPage.next { _, _ in
+                // retrieved the next page in nextPage
+            }
+            print(messagesPage.hasNext) // true, there are more pages
+        }
+    }
+
+    func test__007__testPresenceOnAChannel() {
+        let options = AblyTests.clientOptions(requestToken: true)
+        options.clientId = "foo"
+        let client = ARTRealtime(options: options)
+        defer { client.close() }
+
+        client.connection.on { stateChange in
+            if stateChange.current == .connected {
+                let channel = client.channels.get("test")
+
+                channel.presence.enter("john.doe") { _ in
+                    channel.presence.get { _, _ in
+                        // members is the array of members present
+                    }
                 }
             }
         }
+    }
 
-        func test__004__testNoAutoConnect() {
-            let options = ARTClientOptions(key: "xxxx:xxxx")
-            options.autoConnect = false
-            let client = ARTRealtime(options: options)
-            client.connection.connect()
-            client.connection.close()
-        }
+    func test__008__testQueryingThePresenceHistory() {
+        let options = AblyTests.clientOptions(requestToken: true)
+        let client = ARTRealtime(options: options)
+        defer { client.close() }
 
-        func test__005__testSubscribeAndPublishingToChannel() {
-            let options = AblyTests.clientOptions(requestToken: true)
-            let client = ARTRealtime(options: options)
-            defer { client.close() }
+        let channel = client.channels.get("test")
 
-            let channel = client.channels.get("test")
-
-            channel.subscribe { message in
-                print(message.name as Any)
-                print(message.data as Any)
-            }
-
-            channel.subscribe("myEvent") { message in
-                print(message.name as Any)
-                print(message.data as Any)
-            }
-
-            channel.publish("greeting", data: "Hello World!")
-        }
-
-        func test__006__testQueryingTheHistory() {
-            let options = AblyTests.clientOptions(requestToken: true)
-            let client = ARTRealtime(options: options)
-            defer { client.close() }
-
-            let channel = client.channels.get("test")
-
-            channel.history { messagesPage, error in
-                let messagesPage = messagesPage!
-                print(messagesPage.items)
-                print(messagesPage.items.first as Any)
-                print(messagesPage.items.first?.data as Any) // payload for the message
-                print(messagesPage.items.count) // number of messages in the current page of history
-                messagesPage.next { nextPage, error in
+        channel.presence.history { presencePage, _ in
+            let presencePage = presencePage!
+            if let first = presencePage.items.first {
+                print(first.action) // Any of .enter, .update or .leave
+                print(first.clientId as Any) // client ID of member
+                print(first.data as Any) // optional data payload of member
+                presencePage.next { _, _ in
                     // retrieved the next page in nextPage
                 }
-                print(messagesPage.hasNext) // true, there are more pages
             }
         }
+    }
 
-        func test__007__testPresenceOnAChannel() {
-            let options = AblyTests.clientOptions(requestToken: true)
-            options.clientId = "foo"
-            let client = ARTRealtime(options: options)
-            defer { client.close() }
+    func test__009__testMakeRestClientAndChannel() {
+        let client = ARTRest(key: "xxxx:xxxx")
+        let channel = client.channels.get("test")
+        _ = channel
+    }
 
-            client.connection.on { stateChange in
-                if stateChange.current == .connected {
-                    let channel = client.channels.get("test")
+    func test__010__testRestPublishMessage() {
+        let options = AblyTests.clientOptions(requestToken: true)
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("test")
 
-                    channel.presence.enter("john.doe") { errorInfo in
-                        channel.presence.get { members, error in
-                            // members is the array of members present
-                        }
-                    }
-                }
+        channel.publish("myEvent", data: "Hello!")
+    }
+
+    func test__011__testRestQueryingTheHistory() {
+        let options = AblyTests.clientOptions(requestToken: true)
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("test")
+
+        channel.history { messagesPage, _ in
+            let messagesPage = messagesPage!
+            print(messagesPage.items.first as Any)
+            print(messagesPage.items.first?.data as Any) // payload for the message
+            messagesPage.next { _, _ in
+                // retrieved the next page in nextPage
             }
+            print(messagesPage.hasNext) // true, there are more pages
         }
+    }
 
-        func test__008__testQueryingThePresenceHistory() {
-            let options = AblyTests.clientOptions(requestToken: true)
-            let client = ARTRealtime(options: options)
-            defer { client.close() }
+    func test__012__testRestPresenceOnAChannel() {
+        let options = AblyTests.clientOptions(requestToken: true)
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("test")
 
-            let channel = client.channels.get("test")
-
-            channel.presence.history { presencePage, error in
-                let presencePage = presencePage!
-                if let first = presencePage.items.first {
-                    print(first.action) // Any of .enter, .update or .leave
-                    print(first.clientId as Any) // client ID of member
-                    print(first.data as Any) // optional data payload of member
-                    presencePage.next { nextPage, error in
-                        // retrieved the next page in nextPage
-                    }
-                }
+        channel.presence.get { membersPage, _ in
+            let membersPage = membersPage!
+            print(membersPage.items.first as Any)
+            print((membersPage.items.first)?.data as Any) // payload for the message
+            membersPage.next { _, _ in
+                // retrieved the next page in nextPage
             }
+            print(membersPage.hasNext) // true, there are more pages
         }
+    }
 
-        func test__009__testMakeRestClientAndChannel() {
-            let client = ARTRest(key: "xxxx:xxxx")
-            let channel = client.channels.get("test")
-            _ = channel
-        }
+    func test__013__testRestQueryingThePresenceHistory() {
+        let options = AblyTests.clientOptions(requestToken: true)
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("test")
 
-        func test__010__testRestPublishMessage() {
-            let options = AblyTests.clientOptions(requestToken: true)
-            let client = ARTRest(options: options)
-            let channel = client.channels.get("test")
-
-            channel.publish("myEvent", data: "Hello!")
-        }
-
-        func test__011__testRestQueryingTheHistory() {
-            let options = AblyTests.clientOptions(requestToken: true)
-            let client = ARTRest(options: options)
-            let channel = client.channels.get("test")
-
-            channel.history { messagesPage, error in
-                let messagesPage = messagesPage!
-                print(messagesPage.items.first as Any)
-                print(messagesPage.items.first?.data as Any) // payload for the message
-                messagesPage.next { nextPage, error in
+        channel.presence.history { presencePage, _ in
+            let presencePage = presencePage!
+            if let first = presencePage.items.first {
+                print(first.clientId as Any) // client ID of member
+                presencePage.next { _, _ in
                     // retrieved the next page in nextPage
                 }
-                print(messagesPage.hasNext) // true, there are more pages
             }
         }
+    }
 
-        func test__012__testRestPresenceOnAChannel() {
-            let options = AblyTests.clientOptions(requestToken: true)
-            let client = ARTRest(options: options)
-            let channel = client.channels.get("test")
+    func test__014__testGenerateToken() {
+        let client = ARTRest(options: AblyTests.commonAppSetup())
 
-            channel.presence.get { membersPage, error in
-                let membersPage = membersPage!
-                print(membersPage.items.first as Any)
-                print((membersPage.items.first)?.data as Any) // payload for the message
-                membersPage.next { nextPage, error in
+        client.auth.requestToken(nil, with: nil) { tokenDetails, _ in
+            let tokenDetails = tokenDetails!
+            print(tokenDetails.token) // "xVLyHw.CLchevH3hF....MDh9ZC_Q"
+            let client = ARTRest(token: tokenDetails.token)
+            _ = client
+        }
+    }
+
+    func test__015__testFetchingStats() {
+        let client = ARTRest(options: AblyTests.commonAppSetup())
+        client.channels.get("test").publish("foo", data: "bar") { _ in
+            client.stats { statsPage, _ in
+                let statsPage = statsPage!
+                print(statsPage.items.first as Any)
+                statsPage.next { _, _ in
                     // retrieved the next page in nextPage
                 }
-                print(membersPage.hasNext) // true, there are more pages
             }
         }
+    }
 
-        func test__013__testRestQueryingThePresenceHistory() {
-            let options = AblyTests.clientOptions(requestToken: true)
-            let client = ARTRest(options: options)
-            let channel = client.channels.get("test")
+    func test__016__testFetchingTime() {
+        let client = ARTRest(options: AblyTests.commonAppSetup())
 
-            channel.presence.history { presencePage, error in
-                let presencePage = presencePage!
-                if let first = presencePage.items.first {
-                    print(first.clientId as Any) // client ID of member
-                    presencePage.next { nextPage, error in
-                        // retrieved the next page in nextPage
-                    }
-                }
-            }
+        client.time { time, _ in
+            print(time as Any) // 2016-02-09 03:59:24 +0000
         }
-
-        func test__014__testGenerateToken() {
-            let client = ARTRest(options: AblyTests.commonAppSetup())
-
-            client.auth.requestToken(nil, with: nil) { tokenDetails, error in
-                let tokenDetails = tokenDetails!
-                print(tokenDetails.token) // "xVLyHw.CLchevH3hF....MDh9ZC_Q"
-                let client = ARTRest(token: tokenDetails.token)
-                _ = client
-            }
-        }
-        
-        func test__015__testFetchingStats() {
-            let client = ARTRest(options: AblyTests.commonAppSetup())
-            client.channels.get("test").publish("foo", data: "bar") { _ in
-                client.stats { statsPage, error in
-                    let statsPage = statsPage!
-                    print(statsPage.items.first as Any)
-                    statsPage.next { nextPage, error in
-                        // retrieved the next page in nextPage
-                    }
-                }
-            }
-        }
-        
-        func test__016__testFetchingTime() {
-            let client = ARTRest(options: AblyTests.commonAppSetup())
-            
-            client.time { time, error in
-                print(time as Any) // 2016-02-09 03:59:24 +0000
-            }
-        }
-
+    }
 }

--- a/Spec/RealtimeClient.swift
+++ b/Spec/RealtimeClient.swift
@@ -1,23 +1,22 @@
 import Ably
-import Quick
 import Nimble
+import Quick
 
-                private let query: ARTStatsQuery = {
-                    let query = ARTStatsQuery()
-                    query.unit = .minute
-                    return query
-                }()
-            private let channelName = "test-message-size"
-            private let presenceData = buildStringThatExceedMaxMessageSize()
-            private let clientId = "testMessageSizeClientId"
+private let query: ARTStatsQuery = {
+    let query = ARTStatsQuery()
+    query.unit = .minute
+    return query
+}()
+
+private let channelName = "test-message-size"
+private let presenceData = buildStringThatExceedMaxMessageSize()
+private let clientId = "testMessageSizeClientId"
 
 class RealtimeClient: XCTestCase {
-
     func checkError(_ errorInfo: ARTErrorInfo?, withAlternative message: String) {
         if let error = errorInfo {
-            XCTFail("\((error ).code): \(error.message)")
-        }
-        else if !message.isEmpty {
+            XCTFail("\(error.code): \(error.message)")
+        } else if !message.isEmpty {
             XCTFail(message)
         }
     }
@@ -26,1562 +25,1554 @@ class RealtimeClient: XCTestCase {
         checkError(errorInfo, withAlternative: "")
     }
 
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = query
-    let _ = channelName
-    let _ = presenceData
-    let _ = clientId
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = query
+        _ = channelName
+        _ = presenceData
+        _ = clientId
 
-    return super.defaultTestSuite
-}
+        return super.defaultTestSuite
+    }
 
+    enum AblyManager {
+        static let sharedClient = ARTRealtime(options: { $0.autoConnect = false; return $0 }(ARTClientOptions(key: "xxxx:xxxx")))
+    }
 
-            class AblyManager {
-                static let sharedClient = ARTRealtime(options: { $0.autoConnect = false; return $0 }(ARTClientOptions(key: "xxxx:xxxx")))
+    // G4
+    func test__001__RealtimeClient__All_WebSocket_connections_should_include_the_current_API_version() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { error in
+                expect(error).to(beNil())
+                let transport = client.internal.transport as! TestProxyTransport
+
+                // This test should not directly validate version against ARTDefault.version(), as
+                // ultimately the version header has been derived from that value.
+                expect(transport.lastUrl!.query).to(haveParam("v", withValue: "1.2"))
+
+                done()
             }
-        
-            // G4
-            func test__001__RealtimeClient__All_WebSocket_connections_should_include_the_current_API_version() {
-                let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                defer { client.dispose(); client.close() }
-                let channel = client.channels.get("test")
-                waitUntil(timeout: testTimeout) { done in
-                    channel.publish(nil, data: "message") { error in
-                        expect(error).to(beNil())
-                        let transport = client.internal.transport as! TestProxyTransport
-                                                
-                        // This test should not directly validate version against ARTDefault.version(), as
-                        // ultimately the version header has been derived from that value.
-                        expect(transport.lastUrl!.query).to(haveParam("v", withValue: "1.2"))
-                        
-                        done()
-                    }
-                }
-            }
-
-            // RTC1
-            
-                func test__013__RealtimeClient__options__should_support_the_same_options_as_the_Rest_client() {
-                    let options = AblyTests.commonAppSetup() //Same as Rest
-                    options.clientId = "client_string"
-
-                    let client = ARTRealtime(options: options)
-                    defer { client.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.on { stateChange in
-                            let state = stateChange.current
-                            let errorInfo = stateChange.reason
-                            switch state {
-                            case .connecting, .closing, .closed:
-                                break
-                            case .failed:
-                                self.checkError(errorInfo, withAlternative: "Failed state")
-                                done()
-                            default:
-                                expect(state).to(equal(ARTRealtimeConnectionState.connected))
-                                done()
-                                break
-                            }
-                        }
-                    }
-                }
-                
-                //RTC1a
-                func test__014__RealtimeClient__options__should_echoMessages_option_be_true_by_default() {
-                    let options = ARTClientOptions()
-                    expect(options.echoMessages) == true
-                }
-                
-                //RTC1b
-                func test__015__RealtimeClient__options__should_autoConnect_option_be_true_by_default() {
-                    let options = ARTClientOptions()
-                    expect(options.autoConnect) == true
-                }
-
-                //RTC1c
-                func test__016__RealtimeClient__options__should_attempt_to_recover_the_connection_state_if_recover_string_is_assigned() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "client_string"
-
-                    // First connection
-                    let client = ARTRealtime(options: options)
-                    defer { client.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.on { stateChange in
-                            let state = stateChange.current
-                            let errorInfo = stateChange.reason
-                            switch state {
-                            case .failed:
-                                self.checkError(errorInfo, withAlternative: "Failed state")
-                                done()
-                            case .connected:
-                                self.checkError(errorInfo)
-                                expect(client.connection.recoveryKey).to(equal("\(client.connection.key ?? ""):\(client.connection.serial):\(client.internal.msgSerial)"), description: "recoveryKey wrong formed")
-                                options.recover = client.connection.recoveryKey
-                                done()
-                            default:
-                                break
-                            }
-                        }
-                    }
-                    client.connection.off()
-
-                    // New connection
-                    let newClient = ARTRealtime(options: options)
-                    defer { newClient.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        newClient.connection.on { stateChange in
-                            let state = stateChange.current
-                            let errorInfo = stateChange.reason
-                            switch state {
-                            case .failed:
-                                self.checkError(errorInfo, withAlternative: "Failed state")
-                                done()
-                            case .connected:
-                                self.checkError(errorInfo)
-                                done()
-                            default:
-                                break
-                            }
-                        }
-                    }
-                    newClient.connection.off()
-                }
-
-                //RTC1d
-                func test__017__RealtimeClient__options__should_modify_the_realtime_endpoint_host_if_realtimeHost_is_assigned() {
-                    let options = ARTClientOptions(key: "secret:key")
-                    options.realtimeHost = "fake.ably.io"
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-
-                    waitUntil(timeout: testTimeout.multiplied(by: 2)) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        client.connection.once(.connecting) { _ in
-                            guard let webSocketTransport = client.internal.transport as? ARTWebSocketTransport else {
-                                fail("Transport should be of type ARTWebSocketTransport"); done()
-                                return
-                            }
-                            expect(webSocketTransport.websocketURL).toNot(beNil())
-                            expect(webSocketTransport.websocketURL?.host).to(equal("fake.ably.io"))
-                            partialDone()
-                        }
-                        client.connection.once(.disconnected) { stateChange in
-                            partialDone()
-                        }
-                        client.connect()
-                    }
-                }
-                
-                //RTC1e
-                func test__018__RealtimeClient__options__should_modify_both_the_REST_and_realtime_endpoint_if_environment_string_is_assigned() {
-                    let options = AblyTests.commonAppSetup()
-                    
-                    let oldRestHost = options.restHost
-                    let oldRealtimeHost = options.realtimeHost
-
-                    // Change REST and realtime endpoint hosts
-                    options.environment = "test"
-                    
-                    expect(options.restHost).to(equal("test-rest.ably.io"))
-                    expect(options.realtimeHost).to(equal("test-realtime.ably.io"))
-                    // Extra care
-                    expect(oldRestHost).to(equal("\(getEnvironment())-rest.ably.io"))
-                    expect(oldRealtimeHost).to(equal("\(getEnvironment())-realtime.ably.io"))
-                }
-                
-                //RTC1f
-                func test__019__RealtimeClient__options__url_should_contains_transport_params() {
-                    let options = AblyTests.commonAppSetup()
-                    options.transportParams = [
-                        "tpBool": .init(bool: true),
-                        "tpInt": .init(number: .init(value: 12)),
-                        "tpFloat": .init(number: .init(value: 12.12)),
-                        "tpString": .init(string: "Lorem ipsum"),
-                        "v": .init(string: "v12.34")
-                    ]
-                    
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-
-                    waitUntil(timeout: testTimeout.multiplied(by: 2)) { done in
-                        client.connection.once(.connecting) { _ in
-                            guard let webSocketTransport = client.internal.transport as? ARTWebSocketTransport else {
-                                fail("Transport should be of type ARTWebSocketTransport"); done()
-                                return
-                            }
-                            let absoluteString = webSocketTransport.websocketURL?.absoluteString
-                            
-                            expect(webSocketTransport.websocketURL).toNot(beNil())
-                            expect(absoluteString?.contains("tpBool=true")).to(beTrue())
-                            expect(absoluteString?.contains("tpInt=12")).to(beTrue())
-                            expect(absoluteString?.contains("tpFloat=12.12")).to(beTrue())
-                            expect(absoluteString?.contains("tpString=Lorem%20ipsum")).to(beTrue())
-                    
-                            /**
-                             Test that replacing query string default values in ARTClientOptions works properly
-                             */
-                            expect(absoluteString?.components(separatedBy: "v=").count).to(be(2))
-                            
-                            done()
-                        }
-                        client.connect()
-                    }
-                }
-
-            // RTC2
-            func test__002__RealtimeClient__should_have_access_to_the_underlying_Connection_object() {
-                let options = AblyTests.commonAppSetup()
-                options.autoConnect = false
-                let client = ARTRealtime(options: options)
-                expect(client.connection).to(beAKindOf(ARTConnection.self))
-            }
-
-            // RTC3
-            func test__003__RealtimeClient__should_provide_access_to_the_underlying_Channels_object() {
-                let options = AblyTests.commonAppSetup()
-                options.autoConnect = false
-
-                let client = ARTRealtime(options: options)
-                defer { client.dispose(); client.close() }
-
-                client.channels.get("test").subscribe({ message in
-                    // Attached
-                })
-
-                expect(client.channels.get("test")).toNot(beNil())
-            }
-
-            
-
-                // RTC4
-                func test__020__RealtimeClient__Auth_object__should_provide_access_to_the_Auth_object() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.close() }
-                    expect(client.auth.internal.options.key).to(equal(options.key))
-                }
-
-                // RTC4a
-                func test__021__RealtimeClient__Auth_object__clientId_may_be_populated_when_the_connection_is_established() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "client_string"
-                    let client = ARTRealtime(options: options)
-                    defer { client.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.on { stateChange in
-                            let state = stateChange.current
-                            let errorInfo = stateChange.reason
-                            switch state {
-                            case .failed:
-                                self.checkError(errorInfo, withAlternative: "Failed state")
-                                done()
-                            case .connected:
-                                self.checkError(errorInfo)
-                                expect(client.auth.clientId).to(equal(options.clientId))
-                                done()
-                            default:
-                                break
-                            }
-                        }
-                    }
-                }
-
-            
-
-                // RTC5a
-                func test__022__RealtimeClient__stats__should_present_an_async_interface() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.close() }
-                    // Async
-                    waitUntil(timeout: testTimeout) { done in
-                        // Proxy from `client.internal.rest.stats`
-                        expect {
-                            try client.stats(query, callback: { paginated, error in
-                                expect(paginated).toNot(beNil())
-                                done()
-                            })
-                        }.toNot(throwError() { err in fail("\(err)"); done() })
-                    }
-                }
-
-                // RTC5b
-                func skipped__test__023__RealtimeClient__stats__should_accept_all_the_same_params_as_RestClient() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.close() }
-                    var paginatedResult: ARTPaginatedResult<AnyObject>?
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { _ in
-                            done()
-                        }
-                    }
-
-                    // Realtime
-                    expect {
-                        try client.stats(query, callback: { paginated, error in
-                            if let e = error {
-                                XCTFail(e.localizedDescription)
-                            }
-                            paginatedResult = paginated as! ARTPaginatedResult<AnyObject>?
-                        })
-                    }.toNot(throwError())
-                    expect(paginatedResult).toEventuallyNot(beNil(), timeout: testTimeout)
-                    if paginatedResult == nil {
-                        return
-                    }
-
-                    // Rest
-                    waitUntil(timeout: testTimeout) { done in
-                        expect {
-                            try client.internal.rest.stats(query, callback: { paginated, error in
-                                defer { done() }
-                                if let e = error {
-                                    XCTFail(e.localizedDescription)
-                                    return
-                                }
-                                guard let paginated = paginated else {
-                                    XCTFail("both paginated and error are nil")
-                                    return
-                                } 
-                                expect(paginated.items.count).to(equal(paginatedResult!.items.count))
-                            })
-                        }.toNot(throwError() { err in fail("\(err)"); done() })
-                    }
-                }
-
-            
-                // RTC6a
-                func test__024__RealtimeClient__time__should_present_an_async_interface() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.close() }
-                    // Async
-                    waitUntil(timeout: testTimeout) { done in
-                        // Proxy from `client.internal.rest.time`
-                        client.time({ date, error in
-                            expect(date).toNot(beNil())
-                            done()
-                        })
-                    }
-                }
-
-            // RTC7
-            func test__004__RealtimeClient__should_use_the_configured_timeouts_specified() {
-                let options = AblyTests.commonAppSetup()
-                options.suspendedRetryTimeout = 6.0
-
-                let client = ARTRealtime(options: options)
-                defer { client.close() }
-
-                var start: NSDate?
-                var endInterval: UInt?
-
-                waitUntil(timeout: testTimeout.incremented(by: options.suspendedRetryTimeout)) { done in
-                    client.connection.on { stateChange in
-                        let state = stateChange.current
-                        let errorInfo = stateChange.reason
-                        switch state {
-                        case .failed:
-                            self.checkError(errorInfo, withAlternative: "Failed state")
-                            done()
-                        case .connecting:
-                            if let start = start {
-                                endInterval = UInt(start.timeIntervalSinceNow * -1)
-                                done()
-                            }
-                        case .connected:
-                            self.checkError(errorInfo)
-
-                            if start == nil {
-                                // Force
-                                delay(0) {
-                                    client.internal.onSuspended()
-                                }
-                            }
-                        case .suspended:
-                            start = NSDate()
-                        default:
-                            break
-                        }
-                    }
-                }
-
-                if let secs = endInterval {
-                    expect(secs).to(beLessThanOrEqualTo(UInt(options.suspendedRetryTimeout)))
-                }
-
-                expect(client.internal.connectionStateTtl).to(equal(120 as TimeInterval /*seconds*/))
-            }
-
-            // RTC8
-            
-
-                // RTC8a
-                func test__025__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__in_the_CONNECTED_state_and_auth_authorize_is_called__the_client_must_obtain_a_new_token__send_an_AUTH_ProtocolMessage_with_an_auth_attribute() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    options.useTokenAuth = true
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.internal.setTransport(TestProxyTransport.self)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    guard let firstToken = client.auth.tokenDetails?.token else {
-                        fail("Client has no token"); return
-                    }
-
-                    guard let transport = client.internal.transport as? TestProxyTransport else {
-                        fail("TestProxyTransport is not set"); return
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                fail("TokenDetails is nil"); done(); return
-                            }
-
-                            let authMessages = transport.protocolMessagesSent.filter({ $0.action == .auth })
-                            expect(authMessages).to(haveCount(1))
-
-                            guard let authMessage = authMessages.first else {
-                                fail("Missing AUTH protocol message"); done(); return
-                            }
-
-                            expect(authMessage.auth).toNot(beNil())
-
-                            guard let accessToken = authMessage.auth?.accessToken else {
-                                fail("Missing accessToken from AUTH ProtocolMessage auth attribute"); done(); return
-                            }
-
-                            expect(accessToken).toNot(equal(firstToken))
-                            expect(tokenDetails.token).toNot(equal(firstToken))
-                            expect(tokenDetails.token).to(equal(accessToken))
-
-                            expect(client.internal.transport).to(beIdenticalTo(transport))
-
-                            done()
-                        }
-                    }
-                }
-
-                // RTC8a1 - part 1
-                func test__026__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_authentication_token_change_is_successful__then_the_client_should_receive_a_new_CONNECTED_ProtocolMessage() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let testToken = getTestToken()
-                    options.token = testToken
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.internal.setTransport(TestProxyTransport.self)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-
-                        client.connection.once(.connected) { stateChange in
-                            fail("Should not receive a CONNECTED event because the connection is already connected"); partialDone(); return
-                        }
-
-                        client.connection.once(.update) { stateChange in
-                            expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connected))
-                            expect(stateChange.reason).to(beNil())
-
-                            guard let transport = client.internal.transport as? TestProxyTransport else {
-                                fail("TestProxyTransport is not set"); partialDone(); return
-                            }
-                            let connectedMessages = transport.protocolMessagesReceived.filter{ $0.action == .connected }
-                            expect(connectedMessages).to(haveCount(2))
-
-                            guard let connectedAfterAuth = connectedMessages.last, let connectionDetailsAfterAuth = connectedAfterAuth.connectionDetails else {
-                                fail("Missing CONNECTED protocol message after AUTH protocol message"); partialDone(); return
-                            }
-
-                            expect(client.auth.clientId).to(beNil())
-                            expect(connectionDetailsAfterAuth.clientId).to(beNil())
-                            expect(client.connection.key).to(equal(connectionDetailsAfterAuth.connectionKey))
-                            partialDone()
-                        }
-
-                        client.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                fail("TokenDetails is nil"); partialDone(); return
-                            }
-                            expect(tokenDetails.token).toNot(equal(testToken))
-                            partialDone()
-                        }
-
-                        expect(client.connection.errorReason).to(beNil())
-                    }
-
-                    expect(client.auth.tokenDetails?.token).toNot(equal(testToken))
-                }
-
-                // RTC8a1 - part 2
-                func test__027__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__performs_an_upgrade_of_capabilities_without_any_loss_of_continuity_or_connectivity_during_the_upgrade_process() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let testToken = getTestToken(capability: "{\"test\":[\"subscribe\"]}")
-                    options.token = testToken
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.internal.setTransport(TestProxyTransport.self)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    let channel = client.channels.get("foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.once(.failed) { stateChange in
-                            guard let error = stateChange.reason else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.message).to(contain("Channel denied access based on given capability"))
-                            done()
-                        }
-                        channel.attach()
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-
-                        client.connection.once(.update) { stateChange in
-                            expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connected))
-                            expect(stateChange.reason).to(beNil())
-                            partialDone()
-                        }
-
-                        client.connection.once(.connected) { _ in
-                            fail("Already connected")
-                        }
-                        client.connection.once(.disconnected) { _ in
-                            fail("Lost connectivity")
-                        }
-                        client.connection.once(.suspended) { _ in
-                            fail("Lost continuity")
-                        }
-                        client.connection.once(.failed) { _ in
-                            fail("Should not receive any failure")
-                        }
-
-                        let tokenParams = ARTTokenParams()
-                        tokenParams.capability = "{\"*\":[\"*\"]}"
-
-                        client.auth.authorize(tokenParams, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                fail("TokenDetails is nil"); partialDone(); return
-                            }
-                            expect(tokenDetails.token).toNot(equal(testToken))
-                            expect(tokenDetails.capability).to(equal(tokenParams.capability))
-                            partialDone()
-                        }
-                    }
-
-                    expect(client.auth.tokenDetails?.token).toNot(equal(testToken))
-
-                    guard let transport = client.internal.transport as? TestProxyTransport else {
-                        fail("TestProxyTransport is not set"); return
-                    }
-
-                    expect(transport.protocolMessagesReceived.filter{ $0.action == .disconnected }).to(beEmpty())
-                    // Should have one error: Channel denied access
-                    expect(transport.protocolMessagesReceived.filter{ $0.action == .error }).to(haveCount(1))
-
-                    // Retry Channel attach
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.once(.failed) { _ in
-                            fail("Should not reach Failed state"); done(); return
-                        }
-                        channel.once(.attached) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                        channel.attach()
-                    }
-
-                    expect(client.auth.tokenDetails?.token).toNot(equal(testToken))
-                }
-
-                // RTC8a1 - part 3
-                func test__028__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_capabilities_are_downgraded__client_should_receive_an_ERROR_ProtocolMessage_with_a_channel_property() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let testToken = getTestToken()
-                    options.token = testToken
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.internal.setTransport(TestProxyTransport.self)
-
-                    let channel = client.channels.get("foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connect()
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-
-                        channel.once(.failed) { stateChange in
-                            guard let error = stateChange.reason else {
-                                fail("ErrorInfo is nil"); partialDone(); return
-                            }
-                            expect(error).to(beIdenticalTo(channel.errorReason))
-                            expect(error.code).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
-
-                            guard let transport = client.internal.transport as? TestProxyTransport else {
-                                fail("TestProxyTransport is not set"); partialDone(); return
-                            }
-
-                            let errorMessages = transport.protocolMessagesReceived.filter{ $0.action == .error }
-                            expect(errorMessages).to(haveCount(1))
-
-                            guard let errorMessage = errorMessages.first else {
-                                fail("Missing ERROR protocol message"); partialDone(); return
-                            }
-                            expect(errorMessage.channel).to(contain("test"))
-                            expect(errorMessage.error?.code).to(equal(error.code))
-                            partialDone()
-                        }
-
-                        let tokenParams = ARTTokenParams()
-                        tokenParams.capability = "{\"test\":[\"subscribe\"]}"
-
-                        client.auth.authorize(tokenParams, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                fail("TokenDetails is nil"); partialDone(); return
-                            }
-                            expect(tokenDetails.token).toNot(equal(testToken))
-                            expect(tokenDetails.capability).to(equal(tokenParams.capability))
-                            partialDone()
-                        }
-                    }
-
-                    expect(client.auth.tokenDetails?.token).toNot(equal(testToken))
-                }
-
-                // RTC8a2
-                func test__029__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_authentication_token_change_fails__client_should_receive_an_ERROR_ProtocolMessage_triggering_the_connection_to_transition_to_the_FAILED_state() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    options.clientId = "ios"
-                    options.useTokenAuth = true
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.internal.setTransport(TestProxyTransport.self)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    var connectionError: NSError?
-                    var authError: NSError?
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-
-                        client.connection.once(.failed) { stateChange in
-                            expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connected))
-                            expect(stateChange.reason).toNot(beNil())
-                            connectionError = stateChange.reason
-                            partialDone()
-                        }
-
-                        let invalidToken = "xxxxxxxxxxxx"
-                        let authOptions = ARTAuthOptions()
-                        authOptions.authCallback = { tokenParams, completion in
-                            completion(invalidToken as ARTTokenDetailsCompatible, nil)
-                        }
-
-                        client.auth.authorize(nil, options: authOptions) { tokenDetails, error in
-                            guard let error = error else {
-                                fail("ErrorInfo is nil"); partialDone(); return
-                            }
-                            expect(error.localizedDescription).to(contain("Invalid accessToken"))
-                            expect(tokenDetails?.token).to(equal(invalidToken))
-                            authError = error as NSError?
-                            partialDone()
-                        }
-                    }
-
-                    expect(authError).to(beIdenticalTo(connectionError))
-                }
-
-                func test__030__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_an_error_if_the_request_fails() {
-                    let options = AblyTests.clientOptions()
-                    let testToken = getTestToken()
-                    options.token = testToken
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let tokenParams = ARTTokenParams()
-                        tokenParams.clientId = "john"
-
-                        let simulatedError = NSError(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
-
-                        let authOptions = ARTAuthOptions()
-                        authOptions.authCallback = { tokenParams, completion in
-                            DispatchQueue.main.async {
-                                completion(nil, simulatedError)
-                            }
-                        }
-
-                        client.auth.authorize(tokenParams, options: authOptions) { tokenDetails, error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error as NSError).to(equal(simulatedError))
-                            expect(tokenDetails).to(beNil())
-                            done()
-                        }
-                    }
-
-                    expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                    expect(client.auth.tokenDetails?.token).to(equal(testToken))
-                }
-
-                // RTC8a3
-                func test__031__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_be_indicated_as_completed_with_the_new_token_or_error_only_once_realtime_has_responded_to_the_AUTH_with_either_a_CONNECTED_or_ERROR_respectively() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    options.useTokenAuth = true
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.internal.setTransport(TestProxyTransport.self)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            expect(tokenDetails).toNot(beNil())
-
-                            guard let transport = client.internal.transport as? TestProxyTransport else {
-                                fail("TestProxyTransport is not set"); done(); return
-                            }
-
-                            expect(transport.protocolMessagesSent.filter({ $0.action == .auth })).to(haveCount(1))
-                            expect(transport.protocolMessagesReceived.filter({ $0.action == .connected })).to(haveCount(2))
-                            expect(transport.protocolMessagesReceived.filter({ $0.action == .error })).to(haveCount(0))
-                            done()
-                        }
-                    }
-                }
-
-                // RTC8b
-                func test__032__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_connection_is_CONNECTING__all_current_connection_attempts_should_be_halted__and_after_obtaining_a_new_token_the_library_should_immediately_initiate_a_connection_attempt_using_the_new_token() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    options.useTokenAuth = true
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.internal.setTransport(TestProxyTransport.self)
-
-                    var connections = 0
-                    let hook1 = TestProxyTransport.testSuite_injectIntoClassMethod(#selector(TestProxyTransport.connect(withToken:))) {
-                        connections += 1
-                    }
-                    defer { hook1?.remove() }
-
-                    var connectionsConnected = 0
-                    let hook2 = client.connection.on(.connected) { _ in
-                        connectionsConnected += 1
-                    }
-                    defer { client.connection.off(hook2) }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connecting) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-
-                            let authOptions = ARTAuthOptions()
-                            authOptions.key = AblyTests.commonAppSetup().key
-
-                            client.auth.authorize(nil, options: authOptions) { tokenDetails, error in
-                                expect(error).to(beNil())
-                                guard let tokenDetails = tokenDetails else {
-                                    fail("TokenDetails is nil"); done(); return
-                                }
-                                expect(tokenDetails.token).toNot(beNil())
-                                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-
-                                guard let transport = client.internal.transport as? TestProxyTransport else {
-                                    fail("TestProxyTransport is not set"); done(); return
-                                }
-                                expect(transport.protocolMessagesReceived.filter({ $0.action == .connected })).to(haveCount(1))
-                                done()
-                            }
-                        }
-                        client.connect()
-                    }
-
-                    expect(connections) == 2
-                    expect(connectionsConnected) == 1
-
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                }
-
-                // RTC8b1 - part 1
-                func test__033__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_the_new_token_once_the_connection_has_moved_to_the_CONNECTED_state() {
-                    let options = AblyTests.clientOptions()
-                    options.autoConnect = false
-                    let testToken = getTestToken()
-                    options.token = testToken
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let authOptions = ARTAuthOptions()
-                        authOptions.key = AblyTests.commonAppSetup().key
-
-                        client.auth.authorize(nil, options: authOptions) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                fail("TokenDetails is nil"); done(); return
-                            }
-                            expect(tokenDetails.token).toNot(equal(testToken))
-                            done()
-                        }
-                    }
-
-                    expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                }
-
-                // RTC8b1 - part 2
-                func test__034__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_an_error_if_the_connection_moves_to_the_FAILED_state() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    options.useTokenAuth = true
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.internal.setTransport(TestProxyTransport.self)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    let hook = client.auth.internal.testSuite_injectIntoMethod(after: #selector(client.auth.internal._authorize(_:options:callback:))) {
-                        guard let transport = client.internal.transport as? TestProxyTransport else {
-                            fail("TestProxyTransport is not set"); return
-                        }
-                        transport.simulateIncomingError()
-                    }
-                    defer { hook.remove() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-
-                        client.connection.once(.failed) { stateChange in
-                            guard let error = stateChange.reason else {
-                                fail("ErrorInfo is nil"); partialDone(); return
-                            }
-                            expect(error.message).to(contain("Fail test"))
-                            partialDone()
-                        }
-
-                        client.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            guard let error = error else {
-                                fail("ErrorInfo is nil"); partialDone(); return
-                            }
-                            expect((error as NSError).code) == URLError.cancelled.rawValue
-                            expect(client.connection.errorReason?.localizedDescription).to(contain("Fail test"))
-                            expect(tokenDetails).to(beNil())
-                            partialDone()
-                        }
-                    }
-
-                    expect(client.connection.state).to(equal(ARTRealtimeConnectionState.failed))
-                }
-
-                // RTC8b1 - part 3
-                func test__035__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_an_error_if_the_connection_moves_to_the_SUSPENDED_state() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    options.useTokenAuth = true
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.internal.setTransport(TestProxyTransport.self)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    let hook = client.auth.internal.testSuite_injectIntoMethod(after: #selector(client.auth.internal._authorize(_:options:callback:))) {
-                        client.internal.onSuspended()
-                    }
-                    defer { hook.remove() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-
-                        client.connection.once(.suspended) { _ in
-                            partialDone()
-                        }
-
-                        client.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            guard let error = error else {
-                                fail("ErrorInfo is nil"); partialDone(); return
-                            }
-                            expect((error as NSError).code) == URLError.cancelled.rawValue
-                            expect(tokenDetails).to(beNil())
-                            partialDone()
-                        }
-                    }
-
-                    expect(client.connection.state).to(equal(ARTRealtimeConnectionState.suspended))
-                }
-
-                // RTC8b1 - part 4
-                func skipped__test__036__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_an_error_if_the_connection_moves_to_the_CLOSED_state() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    options.useTokenAuth = true
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    let hook = client.auth.internal.testSuite_injectIntoMethod(after: #selector(client.auth.internal._authorize(_:options:callback:))) {
-                        delay(0) {
-                            client.close()
-                        }
-                    }
-                    defer { hook.remove() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-
-                        client.connection.once(.closed) { _ in
-                            partialDone()
-                        }
-
-                        client.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            guard let error = error else {
-                                fail("Error is nil"); partialDone(); return
-                            }
-                            expect((error as NSError).code) == URLError.cancelled.rawValue
-                            expect(tokenDetails).to(beNil())
-                            partialDone()
-                        }
-                    }
-
-                    expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closed))
-                }
-
-                // RTC8c - part 1
-                func test__037__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_connection_is_in_the_SUSPENDED_state_when_auth_authorize_is_called__after_obtaining_a_token_the_library_should_move_to_the_CONNECTING_state_and_initiate_a_connection_attempt_using_the_new_token() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let testToken = getTestToken()
-                    options.token = testToken
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.internal.setTransport(TestProxyTransport.self)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    client.internal.onSuspended()
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.suspended), timeout: testTimeout)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(3, done: done)
-
-                        client.connection.once(.connecting) { stateChange in
-                            expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.suspended))
-                            expect(stateChange.reason).to(beNil())
-                            partialDone()
-                        }
-
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
-                            expect(stateChange.reason).to(beNil())
-                            partialDone()
-                        }
-
-                        client.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                fail("TokenDetails is nil"); partialDone(); return
-                            }
-
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                            expect(tokenDetails.token).toNot(equal(testToken))
-
-                            guard let transport = client.internal.transport as? TestProxyTransport else {
-                                fail("TestProxyTransport is not set"); partialDone(); return
-                            }
-                            expect(transport.protocolMessagesSent.filter({ $0.action == .auth })).to(haveCount(0))
-                            expect(transport.protocolMessagesReceived.filter({ $0.action == .connected })).to(haveCount(1)) //New transport
-                            partialDone()
-                        }
-                    }
-                }
-
-                // RTC8c - part 2
-                func test__038__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_connection_is_in_the_CLOSED_state_when_auth_authorize_is_called__after_obtaining_a_token_the_library_should_move_to_the_CONNECTING_state_and_initiate_a_connection_attempt_using_the_new_token() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let testToken = getTestToken()
-                    options.token = testToken
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.internal.setTransport(TestProxyTransport.self)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    client.close()
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.closed), timeout: testTimeout)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(3, done: done)
-
-                        client.connection.once(.connecting) { stateChange in
-                            expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.closed))
-                            expect(stateChange.reason).to(beNil())
-                            partialDone()
-                        }
-
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
-                            expect(stateChange.reason).to(beNil())
-                            partialDone()
-                        }
-
-                        client.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                fail("TokenDetails is nil"); partialDone(); return
-                            }
-
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                            expect(tokenDetails.token).toNot(equal(testToken))
-
-                            guard let transport = client.internal.transport as? TestProxyTransport else {
-                                fail("TestProxyTransport is not set"); partialDone(); return
-                            }
-                            expect(transport.protocolMessagesSent.filter({ $0.action == .auth })).to(haveCount(0))
-                            expect(transport.protocolMessagesReceived.filter({ $0.action == .connected })).to(haveCount(1)) //New transport
-                            partialDone()
-                        }
-                    }
-                }
-
-                // RTC8c - part 3
-                func test__039__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_connection_is_in_the_DISCONNECTED_state_when_auth_authorize_is_called__after_obtaining_a_token_the_library_should_move_to_the_CONNECTING_state_and_initiate_a_connection_attempt_using_the_new_token() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let testToken = getTestToken()
-                    options.token = testToken
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.internal.setTransport(TestProxyTransport.self)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    client.internal.onDisconnected()
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.disconnected), timeout: testTimeout)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(3, done: done)
-
-                        client.connection.once(.connecting) { stateChange in
-                            expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.disconnected))
-                            expect(stateChange.reason).to(beNil())
-                            partialDone()
-                        }
-
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
-                            expect(stateChange.reason).to(beNil())
-                            partialDone()
-                        }
-
-                        client.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                fail("TokenDetails is nil"); partialDone(); return
-                            }
-
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                            expect(tokenDetails.token).toNot(equal(testToken))
-
-                            guard let transport = client.internal.transport as? TestProxyTransport else {
-                                fail("TestProxyTransport is not set"); partialDone(); return
-                            }
-                            expect(transport.protocolMessagesSent.filter({ $0.action == .auth })).to(haveCount(0))
-                            expect(transport.protocolMessagesReceived.filter({ $0.action == .connected })).to(haveCount(1)) //New transport
-                            partialDone()
-                        }
-                    }
-                }
-
-                // RTC8c - part 4
-                func test__040__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_connection_is_in_the_FAILED_state_when_auth_authorize_is_called__after_obtaining_a_token_the_library_should_move_to_the_CONNECTING_state_and_initiate_a_connection_attempt_using_the_new_token() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let testToken = getTestToken()
-                    options.token = testToken
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.internal.setTransport(TestProxyTransport.self)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    client.internal.onError(AblyTests.newErrorProtocolMessage())
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.failed), timeout: testTimeout)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(3, done: done)
-
-                        client.connection.once(.connecting) { stateChange in
-                            expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.failed))
-                            expect(stateChange.reason).to(beNil())
-                            partialDone()
-                        }
-
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
-                            expect(stateChange.reason).to(beNil())
-                            partialDone()
-                        }
-
-                        client.auth.authorize(nil, options: nil) { tokenDetails, error in
-                            expect(error).to(beNil())
-                            guard let tokenDetails = tokenDetails else {
-                                fail("TokenDetails is nil"); partialDone(); return
-                            }
-
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                            expect(tokenDetails.token).toNot(equal(testToken))
-
-                            guard let transport = client.internal.transport as? TestProxyTransport else {
-                                fail("TestProxyTransport is not set"); partialDone(); return
-                            }
-                            expect(transport.protocolMessagesSent.filter({ $0.action == .auth })).to(haveCount(0))
-                            expect(transport.protocolMessagesReceived.filter({ $0.action == .connected })).to(haveCount(1)) //New transport
-                            partialDone()
-                        }
-                    }
-                }
-
-            // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-            // https://github.com/ably/ably-cocoa/issues/577
-            func skipped__test__005__RealtimeClient__background_behaviour() {
-                waitUntil(timeout: testTimeout) { done in
-                  URLSession.shared.dataTask(with: URL(string:"https://ably.io")!) { _ , _ , _  in
-                        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                        realtime.channels.get("foo").attach { error in
-                            expect(error).to(beNil())
-                            realtime.close()
-                            done()
-                        }
-                    }.resume()
+        }
+    }
+
+    // RTC1
+
+    func test__013__RealtimeClient__options__should_support_the_same_options_as_the_Rest_client() {
+        let options = AblyTests.commonAppSetup() // Same as Rest
+        options.clientId = "client_string"
+
+        let client = ARTRealtime(options: options)
+        defer { client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let errorInfo = stateChange.reason
+                switch state {
+                case .connecting, .closing, .closed:
+                    break
+                case .failed:
+                    self.checkError(errorInfo, withAlternative: "Failed state")
+                    done()
+                default:
+                    expect(state).to(equal(ARTRealtimeConnectionState.connected))
+                    done()
                 }
             }
+        }
+    }
 
-            func test__006__RealtimeClient__should_accept_acks_with_different_order() {
-                let realtime = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                defer { realtime.dispose(); realtime.close() }
-                let channel = realtime.channels.get("foo")
-                waitUntil(timeout: testTimeout) { done in
-                    channel.attach { error in
-                        expect(error).to(beNil())
-                        done()
-                    }
-                }
-                guard let transport = realtime.internal.transport as? TestProxyTransport else {
-                    fail("TestProxyTransport is not set"); return
-                }
+    // RTC1a
+    func test__014__RealtimeClient__options__should_echoMessages_option_be_true_by_default() {
+        let options = ARTClientOptions()
+        expect(options.echoMessages) == true
+    }
 
-                waitUntil(timeout: testTimeout) { done in
-                    transport.setListenerBeforeProcessingIncomingMessage({ pm in
-                        if pm.action == .ack, let msgSerial = pm.msgSerial {
-                            switch msgSerial.intValue {
-                            case 0:
-                                pm.msgSerial = 3
-                            case 1:
-                                pm.msgSerial = 2
-                            case 2:
-                                pm.msgSerial = 1
-                            default:
-                                pm.msgSerial = 0
-                            }
-                        }
-                    })
+    // RTC1b
+    func test__015__RealtimeClient__options__should_autoConnect_option_be_true_by_default() {
+        let options = ARTClientOptions()
+        expect(options.autoConnect) == true
+    }
 
-                    let partialDone = AblyTests.splitDone(4, done: done)
-                    channel.publish("test1", data: nil) { error in
-                        expect(error).to(beNil())
-                        partialDone()
-                    }
-                    channel.publish("test2", data: nil) { error in
-                        expect(error).to(beNil())
-                        partialDone()
-                    }
-                    channel.publish("test3", data: nil) { error in
-                        expect(error).to(beNil())
-                        partialDone()
-                    }
-                    channel.publish("test4", data: nil) { error in
-                        expect(error).to(beNil())
-                        partialDone()
-                    }
+    // RTC1c
+    func test__016__RealtimeClient__options__should_attempt_to_recover_the_connection_state_if_recover_string_is_assigned() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "client_string"
+
+        // First connection
+        let client = ARTRealtime(options: options)
+        defer { client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let errorInfo = stateChange.reason
+                switch state {
+                case .failed:
+                    self.checkError(errorInfo, withAlternative: "Failed state")
+                    done()
+                case .connected:
+                    self.checkError(errorInfo)
+                    expect(client.connection.recoveryKey).to(equal("\(client.connection.key ?? ""):\(client.connection.serial):\(client.internal.msgSerial)"), description: "recoveryKey wrong formed")
+                    options.recover = client.connection.recoveryKey
+                    done()
+                default:
+                    break
                 }
             }
+        }
+        client.connection.off()
 
-            func test__007__RealtimeClient__transport_should_guarantee_the_incoming_message_order() {
-                let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                defer { realtime.dispose(); realtime.close() }
-                waitUntil(timeout: testTimeout) { done in
-                    realtime.connection.on(.connected) { _ in
-                        done()
-                    }
-                }
-                guard let webSocketTransport = realtime.internal.transport as? ARTWebSocketTransport else {
-                    fail("should be using a WebSocket transport"); return
-                }
+        // New connection
+        let newClient = ARTRealtime(options: options)
+        defer { newClient.close() }
 
-                var result: [Int] = []
-                let expectedOrder = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
-
-                waitUntil(timeout: testTimeout) { done in
-                    let partialDone = AblyTests.splitDone(expectedOrder.count, done: done)
-
-                    realtime.internal.testSuite_getArgument(from: NSSelectorFromString("ack:"), at: 0) { object in
-                        guard let value = (object as? ARTProtocolMessage)?.msgSerial?.intValue else {
-                            return
-                        }
-                        result.append(value)
-                        partialDone()
-                    }
-
-                    for i in expectedOrder {
-                        let message = ARTProtocolMessage()
-                        message.action = .ack
-                        message.msgSerial = i as NSNumber
-                        webSocketTransport.webSocket(webSocketTransport.websocket!, didReceiveMessage: message)
-                    }
-                }
-
-                expect(result).to(equal(expectedOrder))
-            }
-            
-            func test__008__RealtimeClient__subscriber_should_receive_messages_in_the_same_order_in_which_they_have_been_sent() {
-                let options = AblyTests.commonAppSetup()
-                let realtime1 = ARTRealtime(options: options)
-                let realtime2 = ARTRealtime(options: options)
-                defer {
-                    realtime1.dispose(); realtime1.close();
-                    realtime2.dispose(); realtime2.close();
-                }
-                
-                let subscribeChannel = realtime1.channels.get("testing")
-                let sendChannel = realtime2.channels.get("testing")
-
-                waitUntil(timeout: testTimeout) { done in
-                    subscribeChannel.attach() { _ in
-                        done()
-                    }
-                }
-
-                let expectedResults = [Int](1...50)
-                
-                waitUntil(timeout: testTimeout) { done in
-                    var index = 0
-                    subscribeChannel.subscribe({ message in
-                        let value = expectedResults[index]
-                        let receivedValue = message.name
-                        expect(receivedValue).to(equal(String(value)))
-                        index += 1
-                        if (receivedValue == String(describing: expectedResults.last!)) {
-                            done()
-                        }
-                    })
-                    for i in expectedResults {
-                        sendChannel.publish(String(i), data: nil)
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            newClient.connection.on { stateChange in
+                let state = stateChange.current
+                let errorInfo = stateChange.reason
+                switch state {
+                case .failed:
+                    self.checkError(errorInfo, withAlternative: "Failed state")
+                    done()
+                case .connected:
+                    self.checkError(errorInfo)
+                    done()
+                default:
+                    break
                 }
             }
+        }
+        newClient.connection.off()
+    }
 
-            // Issue https://github.com/ably/ably-cocoa/issues/640
-            func test__009__RealtimeClient__should_dispatch_in_user_queue_when_removing_an_observer() {
-                class Foo {
-                    init() {
-                        AblyManager.sharedClient.channels.get("foo").subscribe { _ in
-                            // keep reference
-                            self.update()
-                        }
-                    }
-                    func update() {
-                    }
-                    deinit {
-                        AblyManager.sharedClient.channels.get("foo").unsubscribe()
-                    }
-                }
+    // RTC1d
+    func test__017__RealtimeClient__options__should_modify_the_realtime_endpoint_host_if_realtimeHost_is_assigned() {
+        let options = ARTClientOptions(key: "secret:key")
+        options.realtimeHost = "fake.ably.io"
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
 
-                var foo: Foo? = Foo()
-                expect(foo).toNot(beNil())
-                foo = nil
-                AblyManager.sharedClient.channels.get("foo").unsubscribe()
-            }
-
-            func test__010__RealtimeClient__should_never_register_any_connection_listeners_for_internal_use_with_the_public_EventEmitter() {
-                let options = AblyTests.commonAppSetup()
-                options.autoConnect = false
-                let client = ARTRealtime(options: options)
-                defer { client.dispose(); client.close() }
-
-                client.connect()
-                client.close() // Before it connects; this registers a listener on the internal event emitter.
-                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connecting))
-                client.connection.off()
-                // If we didn't have a separate internal event emitter, the line above would unregister
-                // the listener, and the next lines would fail, because we would never move to 
-                // CLOSED, because we do that on the internal event listener registered when
-                // we called close().
-                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connecting)) // Still connecting...
-                expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.closed), timeout: testTimeout)
-            }
-
-            func test__011__RealtimeClient__should_never_register_any_message_and_channel_listeners_for_internal_use_with_the_public_EventEmitter() {
-                let options = AblyTests.commonAppSetup()
-                let client = ARTRealtime(options: options)
-                defer { client.dispose(); client.close() }
-
-                let channel = client.channels.get("test")
-                waitUntil(timeout: testTimeout) { done in
-                    channel.attach { _ in
-                        done()
-                    }
-                }
-                if channel.state != .attached {
-                    fail("Channel is not attached")
+        waitUntil(timeout: testTimeout.multiplied(by: 2)) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            client.connection.once(.connecting) { _ in
+                guard let webSocketTransport = client.internal.transport as? ARTWebSocketTransport else {
+                    fail("Transport should be of type ARTWebSocketTransport"); done()
                     return
                 }
+                expect(webSocketTransport.websocketURL).toNot(beNil())
+                expect(webSocketTransport.websocketURL?.host).to(equal("fake.ably.io"))
+                partialDone()
+            }
+            client.connection.once(.disconnected) { _ in
+                partialDone()
+            }
+            client.connect()
+        }
+    }
 
-                client.internal.onDisconnected()
-                expect(client.connection.state).to(equal(.disconnected))
+    // RTC1e
+    func test__018__RealtimeClient__options__should_modify_both_the_REST_and_realtime_endpoint_if_environment_string_is_assigned() {
+        let options = AblyTests.commonAppSetup()
 
-                // If we now send a message through the channel, it will be queued and the channel
-                // should register a listener in the connection's _internal_ event emitter.
-                // If we call client.connection.off(), reconnect, and never get the message ACK,
-                // we probably weren't using the internal event emitter but the public one.
+        let oldRestHost = options.restHost
+        let oldRealtimeHost = options.realtimeHost
 
-                client.connection.off()
+        // Change REST and realtime endpoint hosts
+        options.environment = "test"
 
-                waitUntil(timeout: testTimeout) { done in
-                    channel.publish("test", data: nil) { err in
-                        expect(err).to(beNil())
+        expect(options.restHost).to(equal("test-rest.ably.io"))
+        expect(options.realtimeHost).to(equal("test-realtime.ably.io"))
+        // Extra care
+        expect(oldRestHost).to(equal("\(getEnvironment())-rest.ably.io"))
+        expect(oldRealtimeHost).to(equal("\(getEnvironment())-realtime.ably.io"))
+    }
+
+    // RTC1f
+    func test__019__RealtimeClient__options__url_should_contains_transport_params() {
+        let options = AblyTests.commonAppSetup()
+        options.transportParams = [
+            "tpBool": .init(bool: true),
+            "tpInt": .init(number: .init(value: 12)),
+            "tpFloat": .init(number: .init(value: 12.12)),
+            "tpString": .init(string: "Lorem ipsum"),
+            "v": .init(string: "v12.34"),
+        ]
+
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout.multiplied(by: 2)) { done in
+            client.connection.once(.connecting) { _ in
+                guard let webSocketTransport = client.internal.transport as? ARTWebSocketTransport else {
+                    fail("Transport should be of type ARTWebSocketTransport"); done()
+                    return
+                }
+                let absoluteString = webSocketTransport.websocketURL?.absoluteString
+
+                expect(webSocketTransport.websocketURL).toNot(beNil())
+                expect(absoluteString?.contains("tpBool=true")).to(beTrue())
+                expect(absoluteString?.contains("tpInt=12")).to(beTrue())
+                expect(absoluteString?.contains("tpFloat=12.12")).to(beTrue())
+                expect(absoluteString?.contains("tpString=Lorem%20ipsum")).to(beTrue())
+
+                /**
+                 Test that replacing query string default values in ARTClientOptions works properly
+                 */
+                expect(absoluteString?.components(separatedBy: "v=").count).to(be(2))
+
+                done()
+            }
+            client.connect()
+        }
+    }
+
+    // RTC2
+    func test__002__RealtimeClient__should_have_access_to_the_underlying_Connection_object() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        expect(client.connection).to(beAKindOf(ARTConnection.self))
+    }
+
+    // RTC3
+    func test__003__RealtimeClient__should_provide_access_to_the_underlying_Channels_object() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        client.channels.get("test").subscribe { _ in
+            // Attached
+        }
+
+        expect(client.channels.get("test")).toNot(beNil())
+    }
+
+    // RTC4
+    func test__020__RealtimeClient__Auth_object__should_provide_access_to_the_Auth_object() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.close() }
+        expect(client.auth.internal.options.key).to(equal(options.key))
+    }
+
+    // RTC4a
+    func test__021__RealtimeClient__Auth_object__clientId_may_be_populated_when_the_connection_is_established() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "client_string"
+        let client = ARTRealtime(options: options)
+        defer { client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let errorInfo = stateChange.reason
+                switch state {
+                case .failed:
+                    self.checkError(errorInfo, withAlternative: "Failed state")
+                    done()
+                case .connected:
+                    self.checkError(errorInfo)
+                    expect(client.auth.clientId).to(equal(options.clientId))
+                    done()
+                default:
+                    break
+                }
+            }
+        }
+    }
+
+    // RTC5a
+    func test__022__RealtimeClient__stats__should_present_an_async_interface() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.close() }
+        // Async
+        waitUntil(timeout: testTimeout) { done in
+            // Proxy from `client.internal.rest.stats`
+            expect {
+                try client.stats(query, callback: { paginated, _ in
+                    expect(paginated).toNot(beNil())
+                    done()
+                })
+            }.toNot(throwError { err in fail("\(err)"); done() })
+        }
+    }
+
+    // RTC5b
+    func skipped__test__023__RealtimeClient__stats__should_accept_all_the_same_params_as_RestClient() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.close() }
+        var paginatedResult: ARTPaginatedResult<AnyObject>?
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                done()
+            }
+        }
+
+        // Realtime
+        expect {
+            try client.stats(query, callback: { paginated, error in
+                if let e = error {
+                    XCTFail(e.localizedDescription)
+                }
+                paginatedResult = paginated as! ARTPaginatedResult<AnyObject>?
+            })
+        }.toNot(throwError())
+        expect(paginatedResult).toEventuallyNot(beNil(), timeout: testTimeout)
+        if paginatedResult == nil {
+            return
+        }
+
+        // Rest
+        waitUntil(timeout: testTimeout) { done in
+            expect {
+                try client.internal.rest.stats(query, callback: { paginated, error in
+                    defer { done() }
+                    if let e = error {
+                        XCTFail(e.localizedDescription)
+                        return
+                    }
+                    guard let paginated = paginated else {
+                        XCTFail("both paginated and error are nil")
+                        return
+                    }
+                    expect(paginated.items.count).to(equal(paginatedResult!.items.count))
+                })
+            }.toNot(throwError { err in fail("\(err)"); done() })
+        }
+    }
+
+    // RTC6a
+    func test__024__RealtimeClient__time__should_present_an_async_interface() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.close() }
+        // Async
+        waitUntil(timeout: testTimeout) { done in
+            // Proxy from `client.internal.rest.time`
+            client.time { date, _ in
+                expect(date).toNot(beNil())
+                done()
+            }
+        }
+    }
+
+    // RTC7
+    func test__004__RealtimeClient__should_use_the_configured_timeouts_specified() {
+        let options = AblyTests.commonAppSetup()
+        options.suspendedRetryTimeout = 6.0
+
+        let client = ARTRealtime(options: options)
+        defer { client.close() }
+
+        var start: NSDate?
+        var endInterval: UInt?
+
+        waitUntil(timeout: testTimeout.incremented(by: options.suspendedRetryTimeout)) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let errorInfo = stateChange.reason
+                switch state {
+                case .failed:
+                    self.checkError(errorInfo, withAlternative: "Failed state")
+                    done()
+                case .connecting:
+                    if let start = start {
+                        endInterval = UInt(start.timeIntervalSinceNow * -1)
                         done()
                     }
-                    client.connect()
+                case .connected:
+                    self.checkError(errorInfo)
+
+                    if start == nil {
+                        // Force
+                        delay(0) {
+                            client.internal.onSuspended()
+                        }
+                    }
+                case .suspended:
+                    start = NSDate()
+                default:
+                    break
                 }
             }
-            
-            func skipped__test__012__RealtimeClient__moves_to_DISCONNECTED_on_an_unexpected_normal_WebSocket_close() {
-                let options = AblyTests.commonAppSetup()
-                let client = ARTRealtime(options: options)
-                defer { client.dispose(); client.close() }
-                
-                var received = false
-                client.channels.get("test").subscribe() { msg in
-                    received = true
+        }
+
+        if let secs = endInterval {
+            expect(secs).to(beLessThanOrEqualTo(UInt(options.suspendedRetryTimeout)))
+        }
+
+        expect(client.internal.connectionStateTtl).to(equal(120 as TimeInterval /* seconds */ ))
+    }
+
+    // RTC8
+
+    // RTC8a
+    func test__025__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__in_the_CONNECTED_state_and_auth_authorize_is_called__the_client_must_obtain_a_new_token__send_an_AUTH_ProtocolMessage_with_an_auth_attribute() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.useTokenAuth = true
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.internal.setTransport(TestProxyTransport.self)
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            client.connect()
+        }
+
+        guard let firstToken = client.auth.tokenDetails?.token else {
+            fail("Client has no token"); return
+        }
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    fail("TokenDetails is nil"); done(); return
                 }
 
-                expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                
-                let ws = (client.internal.transport! as! ARTWebSocketTransport).websocket!
-                ws.close(withCode: 1000, reason: "test")
-                
-                expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.disconnected), timeout: testTimeout)
-                expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                
-                client.channels.get("test").publish(nil, data: "test")
-                
-                expect(received).toEventually(beTrue(), timeout: testTimeout)
+                let authMessages = transport.protocolMessagesSent.filter { $0.action == .auth }
+                expect(authMessages).to(haveCount(1))
+
+                guard let authMessage = authMessages.first else {
+                    fail("Missing AUTH protocol message"); done(); return
+                }
+
+                expect(authMessage.auth).toNot(beNil())
+
+                guard let accessToken = authMessage.auth?.accessToken else {
+                    fail("Missing accessToken from AUTH ProtocolMessage auth attribute"); done(); return
+                }
+
+                expect(accessToken).toNot(equal(firstToken))
+                expect(tokenDetails.token).toNot(equal(firstToken))
+                expect(tokenDetails.token).to(equal(accessToken))
+
+                expect(client.internal.transport).to(beIdenticalTo(transport))
+
+                done()
             }
-        
-        // RSL1i
-        
-            
-            func test__041__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_the_publish_and_indicate_an_error() {
-                let options = AblyTests.commonAppSetup()
-                let client = ARTRealtime(options: options)
-                let channel = client.channels.get(channelName)
-                let messages = buildMessagesThatExceedMaxMessageSize()
-                
-                waitUntil(timeout: testTimeout, action: { done in
-                    // Wait for connected so that maxMessageSize is loaded from connection details
-                    client.connection.once(.connected) { _ in
-                        channel.publish(messages, callback: { err in
-                            expect(err?.code).to(equal(ARTErrorCode.maxMessageLengthExceeded.intValue))
-                            done()
-                        })
+        }
+    }
+
+    // RTC8a1 - part 1
+    func test__026__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_authentication_token_change_is_successful__then_the_client_should_receive_a_new_CONNECTED_ProtocolMessage() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let testToken = getTestToken()
+        options.token = testToken
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.internal.setTransport(TestProxyTransport.self)
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            client.connect()
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+
+            client.connection.once(.connected) { _ in
+                fail("Should not receive a CONNECTED event because the connection is already connected"); partialDone()
+            }
+
+            client.connection.once(.update) { stateChange in
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connected))
+                expect(stateChange.reason).to(beNil())
+
+                guard let transport = client.internal.transport as? TestProxyTransport else {
+                    fail("TestProxyTransport is not set"); partialDone(); return
+                }
+                let connectedMessages = transport.protocolMessagesReceived.filter { $0.action == .connected }
+                expect(connectedMessages).to(haveCount(2))
+
+                guard let connectedAfterAuth = connectedMessages.last, let connectionDetailsAfterAuth = connectedAfterAuth.connectionDetails else {
+                    fail("Missing CONNECTED protocol message after AUTH protocol message"); partialDone(); return
+                }
+
+                expect(client.auth.clientId).to(beNil())
+                expect(connectionDetailsAfterAuth.clientId).to(beNil())
+                expect(client.connection.key).to(equal(connectionDetailsAfterAuth.connectionKey))
+                partialDone()
+            }
+
+            client.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    fail("TokenDetails is nil"); partialDone(); return
+                }
+                expect(tokenDetails.token).toNot(equal(testToken))
+                partialDone()
+            }
+
+            expect(client.connection.errorReason).to(beNil())
+        }
+
+        expect(client.auth.tokenDetails?.token).toNot(equal(testToken))
+    }
+
+    // RTC8a1 - part 2
+    func test__027__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__performs_an_upgrade_of_capabilities_without_any_loss_of_continuity_or_connectivity_during_the_upgrade_process() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let testToken = getTestToken(capability: "{\"test\":[\"subscribe\"]}")
+        options.token = testToken
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.internal.setTransport(TestProxyTransport.self)
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            client.connect()
+        }
+
+        let channel = client.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.failed) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error.message).to(contain("Channel denied access based on given capability"))
+                done()
+            }
+            channel.attach()
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+
+            client.connection.once(.update) { stateChange in
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connected))
+                expect(stateChange.reason).to(beNil())
+                partialDone()
+            }
+
+            client.connection.once(.connected) { _ in
+                fail("Already connected")
+            }
+            client.connection.once(.disconnected) { _ in
+                fail("Lost connectivity")
+            }
+            client.connection.once(.suspended) { _ in
+                fail("Lost continuity")
+            }
+            client.connection.once(.failed) { _ in
+                fail("Should not receive any failure")
+            }
+
+            let tokenParams = ARTTokenParams()
+            tokenParams.capability = "{\"*\":[\"*\"]}"
+
+            client.auth.authorize(tokenParams, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    fail("TokenDetails is nil"); partialDone(); return
+                }
+                expect(tokenDetails.token).toNot(equal(testToken))
+                expect(tokenDetails.capability).to(equal(tokenParams.capability))
+                partialDone()
+            }
+        }
+
+        expect(client.auth.tokenDetails?.token).toNot(equal(testToken))
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        expect(transport.protocolMessagesReceived.filter { $0.action == .disconnected }).to(beEmpty())
+        // Should have one error: Channel denied access
+        expect(transport.protocolMessagesReceived.filter { $0.action == .error }).to(haveCount(1))
+
+        // Retry Channel attach
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.failed) { _ in
+                fail("Should not reach Failed state"); done()
+            }
+            channel.once(.attached) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            channel.attach()
+        }
+
+        expect(client.auth.tokenDetails?.token).toNot(equal(testToken))
+    }
+
+    // RTC8a1 - part 3
+    func test__028__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_capabilities_are_downgraded__client_should_receive_an_ERROR_ProtocolMessage_with_a_channel_property() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let testToken = getTestToken()
+        options.token = testToken
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.internal.setTransport(TestProxyTransport.self)
+
+        let channel = client.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            client.connect()
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+
+            channel.once(.failed) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("ErrorInfo is nil"); partialDone(); return
+                }
+                expect(error).to(beIdenticalTo(channel.errorReason))
+                expect(error.code).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
+
+                guard let transport = client.internal.transport as? TestProxyTransport else {
+                    fail("TestProxyTransport is not set"); partialDone(); return
+                }
+
+                let errorMessages = transport.protocolMessagesReceived.filter { $0.action == .error }
+                expect(errorMessages).to(haveCount(1))
+
+                guard let errorMessage = errorMessages.first else {
+                    fail("Missing ERROR protocol message"); partialDone(); return
+                }
+                expect(errorMessage.channel).to(contain("test"))
+                expect(errorMessage.error?.code).to(equal(error.code))
+                partialDone()
+            }
+
+            let tokenParams = ARTTokenParams()
+            tokenParams.capability = "{\"test\":[\"subscribe\"]}"
+
+            client.auth.authorize(tokenParams, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    fail("TokenDetails is nil"); partialDone(); return
+                }
+                expect(tokenDetails.token).toNot(equal(testToken))
+                expect(tokenDetails.capability).to(equal(tokenParams.capability))
+                partialDone()
+            }
+        }
+
+        expect(client.auth.tokenDetails?.token).toNot(equal(testToken))
+    }
+
+    // RTC8a2
+    func test__029__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_authentication_token_change_fails__client_should_receive_an_ERROR_ProtocolMessage_triggering_the_connection_to_transition_to_the_FAILED_state() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.clientId = "ios"
+        options.useTokenAuth = true
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.internal.setTransport(TestProxyTransport.self)
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            client.connect()
+        }
+
+        var connectionError: NSError?
+        var authError: NSError?
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+
+            client.connection.once(.failed) { stateChange in
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connected))
+                expect(stateChange.reason).toNot(beNil())
+                connectionError = stateChange.reason
+                partialDone()
+            }
+
+            let invalidToken = "xxxxxxxxxxxx"
+            let authOptions = ARTAuthOptions()
+            authOptions.authCallback = { _, completion in
+                completion(invalidToken as ARTTokenDetailsCompatible, nil)
+            }
+
+            client.auth.authorize(nil, options: authOptions) { tokenDetails, error in
+                guard let error = error else {
+                    fail("ErrorInfo is nil"); partialDone(); return
+                }
+                expect(error.localizedDescription).to(contain("Invalid accessToken"))
+                expect(tokenDetails?.token).to(equal(invalidToken))
+                authError = error as NSError?
+                partialDone()
+            }
+        }
+
+        expect(authError).to(beIdenticalTo(connectionError))
+    }
+
+    func test__030__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_an_error_if_the_request_fails() {
+        let options = AblyTests.clientOptions()
+        let testToken = getTestToken()
+        options.token = testToken
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let tokenParams = ARTTokenParams()
+            tokenParams.clientId = "john"
+
+            let simulatedError = NSError(domain: ARTAblyErrorDomain, code: 1234, userInfo: nil)
+
+            let authOptions = ARTAuthOptions()
+            authOptions.authCallback = { _, completion in
+                DispatchQueue.main.async {
+                    completion(nil, simulatedError)
+                }
+            }
+
+            client.auth.authorize(tokenParams, options: authOptions) { tokenDetails, error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error as NSError).to(equal(simulatedError))
+                expect(tokenDetails).to(beNil())
+                done()
+            }
+        }
+
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+        expect(client.auth.tokenDetails?.token).to(equal(testToken))
+    }
+
+    // RTC8a3
+    func test__031__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_be_indicated_as_completed_with_the_new_token_or_error_only_once_realtime_has_responded_to_the_AUTH_with_either_a_CONNECTED_or_ERROR_respectively() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.useTokenAuth = true
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.internal.setTransport(TestProxyTransport.self)
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            client.connect()
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+
+                guard let transport = client.internal.transport as? TestProxyTransport else {
+                    fail("TestProxyTransport is not set"); done(); return
+                }
+
+                expect(transport.protocolMessagesSent.filter { $0.action == .auth }).to(haveCount(1))
+                expect(transport.protocolMessagesReceived.filter { $0.action == .connected }).to(haveCount(2))
+                expect(transport.protocolMessagesReceived.filter { $0.action == .error }).to(haveCount(0))
+                done()
+            }
+        }
+    }
+
+    // RTC8b
+    func test__032__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_connection_is_CONNECTING__all_current_connection_attempts_should_be_halted__and_after_obtaining_a_new_token_the_library_should_immediately_initiate_a_connection_attempt_using_the_new_token() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.useTokenAuth = true
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.internal.setTransport(TestProxyTransport.self)
+
+        var connections = 0
+        let hook1 = TestProxyTransport.testSuite_injectIntoClassMethod(#selector(TestProxyTransport.connect(withToken:))) {
+            connections += 1
+        }
+        defer { hook1?.remove() }
+
+        var connectionsConnected = 0
+        let hook2 = client.connection.on(.connected) { _ in
+            connectionsConnected += 1
+        }
+        defer { client.connection.off(hook2) }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connecting) { stateChange in
+                expect(stateChange.reason).to(beNil())
+
+                let authOptions = ARTAuthOptions()
+                authOptions.key = AblyTests.commonAppSetup().key
+
+                client.auth.authorize(nil, options: authOptions) { tokenDetails, error in
+                    expect(error).to(beNil())
+                    guard let tokenDetails = tokenDetails else {
+                        fail("TokenDetails is nil"); done(); return
                     }
+                    expect(tokenDetails.token).toNot(beNil())
+                    expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+
+                    guard let transport = client.internal.transport as? TestProxyTransport else {
+                        fail("TestProxyTransport is not set"); done(); return
+                    }
+                    expect(transport.protocolMessagesReceived.filter { $0.action == .connected }).to(haveCount(1))
+                    done()
+                }
+            }
+            client.connect()
+        }
+
+        expect(connections) == 2
+        expect(connectionsConnected) == 1
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+    }
+
+    // RTC8b1 - part 1
+    func test__033__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_the_new_token_once_the_connection_has_moved_to_the_CONNECTED_state() {
+        let options = AblyTests.clientOptions()
+        options.autoConnect = false
+        let testToken = getTestToken()
+        options.token = testToken
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            let authOptions = ARTAuthOptions()
+            authOptions.key = AblyTests.commonAppSetup().key
+
+            client.auth.authorize(nil, options: authOptions) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    fail("TokenDetails is nil"); done(); return
+                }
+                expect(tokenDetails.token).toNot(equal(testToken))
+                done()
+            }
+        }
+
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+    }
+
+    // RTC8b1 - part 2
+    func test__034__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_an_error_if_the_connection_moves_to_the_FAILED_state() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.useTokenAuth = true
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.internal.setTransport(TestProxyTransport.self)
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            client.connect()
+        }
+
+        let hook = client.auth.internal.testSuite_injectIntoMethod(after: #selector(client.auth.internal._authorize(_:options:callback:))) {
+            guard let transport = client.internal.transport as? TestProxyTransport else {
+                fail("TestProxyTransport is not set"); return
+            }
+            transport.simulateIncomingError()
+        }
+        defer { hook.remove() }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+
+            client.connection.once(.failed) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("ErrorInfo is nil"); partialDone(); return
+                }
+                expect(error.message).to(contain("Fail test"))
+                partialDone()
+            }
+
+            client.auth.authorize(nil, options: nil) { tokenDetails, error in
+                guard let error = error else {
+                    fail("ErrorInfo is nil"); partialDone(); return
+                }
+                expect((error as NSError).code) == URLError.cancelled.rawValue
+                expect(client.connection.errorReason?.localizedDescription).to(contain("Fail test"))
+                expect(tokenDetails).to(beNil())
+                partialDone()
+            }
+        }
+
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.failed))
+    }
+
+    // RTC8b1 - part 3
+    func test__035__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_an_error_if_the_connection_moves_to_the_SUSPENDED_state() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.useTokenAuth = true
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.internal.setTransport(TestProxyTransport.self)
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            client.connect()
+        }
+
+        let hook = client.auth.internal.testSuite_injectIntoMethod(after: #selector(client.auth.internal._authorize(_:options:callback:))) {
+            client.internal.onSuspended()
+        }
+        defer { hook.remove() }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+
+            client.connection.once(.suspended) { _ in
+                partialDone()
+            }
+
+            client.auth.authorize(nil, options: nil) { tokenDetails, error in
+                guard let error = error else {
+                    fail("ErrorInfo is nil"); partialDone(); return
+                }
+                expect((error as NSError).code) == URLError.cancelled.rawValue
+                expect(tokenDetails).to(beNil())
+                partialDone()
+            }
+        }
+
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.suspended))
+    }
+
+    // RTC8b1 - part 4
+    func skipped__test__036__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_an_error_if_the_connection_moves_to_the_CLOSED_state() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.useTokenAuth = true
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            client.connect()
+        }
+
+        let hook = client.auth.internal.testSuite_injectIntoMethod(after: #selector(client.auth.internal._authorize(_:options:callback:))) {
+            delay(0) {
+                client.close()
+            }
+        }
+        defer { hook.remove() }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+
+            client.connection.once(.closed) { _ in
+                partialDone()
+            }
+
+            client.auth.authorize(nil, options: nil) { tokenDetails, error in
+                guard let error = error else {
+                    fail("Error is nil"); partialDone(); return
+                }
+                expect((error as NSError).code) == URLError.cancelled.rawValue
+                expect(tokenDetails).to(beNil())
+                partialDone()
+            }
+        }
+
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closed))
+    }
+
+    // RTC8c - part 1
+    func test__037__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_connection_is_in_the_SUSPENDED_state_when_auth_authorize_is_called__after_obtaining_a_token_the_library_should_move_to_the_CONNECTING_state_and_initiate_a_connection_attempt_using_the_new_token() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let testToken = getTestToken()
+        options.token = testToken
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.internal.setTransport(TestProxyTransport.self)
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            client.connect()
+        }
+
+        client.internal.onSuspended()
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.suspended), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(3, done: done)
+
+            client.connection.once(.connecting) { stateChange in
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.suspended))
+                expect(stateChange.reason).to(beNil())
+                partialDone()
+            }
+
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
+                expect(stateChange.reason).to(beNil())
+                partialDone()
+            }
+
+            client.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    fail("TokenDetails is nil"); partialDone(); return
+                }
+
+                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+                expect(tokenDetails.token).toNot(equal(testToken))
+
+                guard let transport = client.internal.transport as? TestProxyTransport else {
+                    fail("TestProxyTransport is not set"); partialDone(); return
+                }
+                expect(transport.protocolMessagesSent.filter { $0.action == .auth }).to(haveCount(0))
+                expect(transport.protocolMessagesReceived.filter { $0.action == .connected }).to(haveCount(1)) // New transport
+                partialDone()
+            }
+        }
+    }
+
+    // RTC8c - part 2
+    func test__038__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_connection_is_in_the_CLOSED_state_when_auth_authorize_is_called__after_obtaining_a_token_the_library_should_move_to_the_CONNECTING_state_and_initiate_a_connection_attempt_using_the_new_token() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let testToken = getTestToken()
+        options.token = testToken
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.internal.setTransport(TestProxyTransport.self)
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            client.connect()
+        }
+
+        client.close()
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.closed), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(3, done: done)
+
+            client.connection.once(.connecting) { stateChange in
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.closed))
+                expect(stateChange.reason).to(beNil())
+                partialDone()
+            }
+
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
+                expect(stateChange.reason).to(beNil())
+                partialDone()
+            }
+
+            client.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    fail("TokenDetails is nil"); partialDone(); return
+                }
+
+                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+                expect(tokenDetails.token).toNot(equal(testToken))
+
+                guard let transport = client.internal.transport as? TestProxyTransport else {
+                    fail("TestProxyTransport is not set"); partialDone(); return
+                }
+                expect(transport.protocolMessagesSent.filter { $0.action == .auth }).to(haveCount(0))
+                expect(transport.protocolMessagesReceived.filter { $0.action == .connected }).to(haveCount(1)) // New transport
+                partialDone()
+            }
+        }
+    }
+
+    // RTC8c - part 3
+    func test__039__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_connection_is_in_the_DISCONNECTED_state_when_auth_authorize_is_called__after_obtaining_a_token_the_library_should_move_to_the_CONNECTING_state_and_initiate_a_connection_attempt_using_the_new_token() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let testToken = getTestToken()
+        options.token = testToken
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.internal.setTransport(TestProxyTransport.self)
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            client.connect()
+        }
+
+        client.internal.onDisconnected()
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.disconnected), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(3, done: done)
+
+            client.connection.once(.connecting) { stateChange in
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.disconnected))
+                expect(stateChange.reason).to(beNil())
+                partialDone()
+            }
+
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
+                expect(stateChange.reason).to(beNil())
+                partialDone()
+            }
+
+            client.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    fail("TokenDetails is nil"); partialDone(); return
+                }
+
+                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+                expect(tokenDetails.token).toNot(equal(testToken))
+
+                guard let transport = client.internal.transport as? TestProxyTransport else {
+                    fail("TestProxyTransport is not set"); partialDone(); return
+                }
+                expect(transport.protocolMessagesSent.filter { $0.action == .auth }).to(haveCount(0))
+                expect(transport.protocolMessagesReceived.filter { $0.action == .connected }).to(haveCount(1)) // New transport
+                partialDone()
+            }
+        }
+    }
+
+    // RTC8c - part 4
+    func test__040__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_connection_is_in_the_FAILED_state_when_auth_authorize_is_called__after_obtaining_a_token_the_library_should_move_to_the_CONNECTING_state_and_initiate_a_connection_attempt_using_the_new_token() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let testToken = getTestToken()
+        options.token = testToken
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.internal.setTransport(TestProxyTransport.self)
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            client.connect()
+        }
+
+        client.internal.onError(AblyTests.newErrorProtocolMessage())
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.failed), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(3, done: done)
+
+            client.connection.once(.connecting) { stateChange in
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.failed))
+                expect(stateChange.reason).to(beNil())
+                partialDone()
+            }
+
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
+                expect(stateChange.reason).to(beNil())
+                partialDone()
+            }
+
+            client.auth.authorize(nil, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    fail("TokenDetails is nil"); partialDone(); return
+                }
+
+                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+                expect(tokenDetails.token).toNot(equal(testToken))
+
+                guard let transport = client.internal.transport as? TestProxyTransport else {
+                    fail("TestProxyTransport is not set"); partialDone(); return
+                }
+                expect(transport.protocolMessagesSent.filter { $0.action == .auth }).to(haveCount(0))
+                expect(transport.protocolMessagesReceived.filter { $0.action == .connected }).to(haveCount(1)) // New transport
+                partialDone()
+            }
+        }
+    }
+
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    // https://github.com/ably/ably-cocoa/issues/577
+    func skipped__test__005__RealtimeClient__background_behaviour() {
+        waitUntil(timeout: testTimeout) { done in
+            URLSession.shared.dataTask(with: URL(string: "https://ably.io")!) { _, _, _ in
+                let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+                realtime.channels.get("foo").attach { error in
+                    expect(error).to(beNil())
+                    realtime.close()
+                    done()
+                }
+            }.resume()
+        }
+    }
+
+    func test__006__RealtimeClient__should_accept_acks_with_different_order() {
+        let realtime = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        let channel = realtime.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+        guard let transport = realtime.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            transport.setListenerBeforeProcessingIncomingMessage { pm in
+                if pm.action == .ack, let msgSerial = pm.msgSerial {
+                    switch msgSerial.intValue {
+                    case 0:
+                        pm.msgSerial = 3
+                    case 1:
+                        pm.msgSerial = 2
+                    case 2:
+                        pm.msgSerial = 1
+                    default:
+                        pm.msgSerial = 0
+                    }
+                }
+            }
+
+            let partialDone = AblyTests.splitDone(4, done: done)
+            channel.publish("test1", data: nil) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+            channel.publish("test2", data: nil) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+            channel.publish("test3", data: nil) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+            channel.publish("test4", data: nil) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
+    }
+
+    func test__007__RealtimeClient__transport_should_guarantee_the_incoming_message_order() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.dispose(); realtime.close() }
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.on(.connected) { _ in
+                done()
+            }
+        }
+        guard let webSocketTransport = realtime.internal.transport as? ARTWebSocketTransport else {
+            fail("should be using a WebSocket transport"); return
+        }
+
+        var result: [Int] = []
+        let expectedOrder = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(expectedOrder.count, done: done)
+
+            realtime.internal.testSuite_getArgument(from: NSSelectorFromString("ack:"), at: 0) { object in
+                guard let value = (object as? ARTProtocolMessage)?.msgSerial?.intValue else {
+                    return
+                }
+                result.append(value)
+                partialDone()
+            }
+
+            for i in expectedOrder {
+                let message = ARTProtocolMessage()
+                message.action = .ack
+                message.msgSerial = i as NSNumber
+                webSocketTransport.webSocket(webSocketTransport.websocket!, didReceiveMessage: message)
+            }
+        }
+
+        expect(result).to(equal(expectedOrder))
+    }
+
+    func test__008__RealtimeClient__subscriber_should_receive_messages_in_the_same_order_in_which_they_have_been_sent() {
+        let options = AblyTests.commonAppSetup()
+        let realtime1 = ARTRealtime(options: options)
+        let realtime2 = ARTRealtime(options: options)
+        defer {
+            realtime1.dispose(); realtime1.close()
+            realtime2.dispose(); realtime2.close()
+        }
+
+        let subscribeChannel = realtime1.channels.get("testing")
+        let sendChannel = realtime2.channels.get("testing")
+
+        waitUntil(timeout: testTimeout) { done in
+            subscribeChannel.attach { _ in
+                done()
+            }
+        }
+
+        let expectedResults = [Int](1 ... 50)
+
+        waitUntil(timeout: testTimeout) { done in
+            var index = 0
+            subscribeChannel.subscribe { message in
+                let value = expectedResults[index]
+                let receivedValue = message.name
+                expect(receivedValue).to(equal(String(value)))
+                index += 1
+                if receivedValue == String(describing: expectedResults.last!) {
+                    done()
+                }
+            }
+            for i in expectedResults {
+                sendChannel.publish(String(i), data: nil)
+            }
+        }
+    }
+
+    // Issue https://github.com/ably/ably-cocoa/issues/640
+    func test__009__RealtimeClient__should_dispatch_in_user_queue_when_removing_an_observer() {
+        class Foo {
+            init() {
+                AblyManager.sharedClient.channels.get("foo").subscribe { _ in
+                    // keep reference
+                    self.update()
+                }
+            }
+
+            func update() {}
+
+            deinit {
+                AblyManager.sharedClient.channels.get("foo").unsubscribe()
+            }
+        }
+
+        var foo: Foo? = Foo()
+        expect(foo).toNot(beNil())
+        foo = nil
+        AblyManager.sharedClient.channels.get("foo").unsubscribe()
+    }
+
+    func test__010__RealtimeClient__should_never_register_any_connection_listeners_for_internal_use_with_the_public_EventEmitter() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        client.connect()
+        client.close() // Before it connects; this registers a listener on the internal event emitter.
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connecting))
+        client.connection.off()
+        // If we didn't have a separate internal event emitter, the line above would unregister
+        // the listener, and the next lines would fail, because we would never move to
+        // CLOSED, because we do that on the internal event listener registered when
+        // we called close().
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connecting)) // Still connecting...
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.closed), timeout: testTimeout)
+    }
+
+    func test__011__RealtimeClient__should_never_register_any_message_and_channel_listeners_for_internal_use_with_the_public_EventEmitter() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { _ in
+                done()
+            }
+        }
+        if channel.state != .attached {
+            fail("Channel is not attached")
+            return
+        }
+
+        client.internal.onDisconnected()
+        expect(client.connection.state).to(equal(.disconnected))
+
+        // If we now send a message through the channel, it will be queued and the channel
+        // should register a listener in the connection's _internal_ event emitter.
+        // If we call client.connection.off(), reconnect, and never get the message ACK,
+        // we probably weren't using the internal event emitter but the public one.
+
+        client.connection.off()
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish("test", data: nil) { err in
+                expect(err).to(beNil())
+                done()
+            }
+            client.connect()
+        }
+    }
+
+    func skipped__test__012__RealtimeClient__moves_to_DISCONNECTED_on_an_unexpected_normal_WebSocket_close() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        var received = false
+        client.channels.get("test").subscribe { _ in
+            received = true
+        }
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+
+        let ws = (client.internal.transport! as! ARTWebSocketTransport).websocket!
+        ws.close(withCode: 1000, reason: "test")
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.disconnected), timeout: testTimeout)
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+
+        client.channels.get("test").publish(nil, data: "test")
+
+        expect(received).toEventually(beTrue(), timeout: testTimeout)
+    }
+
+    // RSL1i
+
+    func test__041__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_the_publish_and_indicate_an_error() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        let channel = client.channels.get(channelName)
+        let messages = buildMessagesThatExceedMaxMessageSize()
+
+        waitUntil(timeout: testTimeout, action: { done in
+            // Wait for connected so that maxMessageSize is loaded from connection details
+            client.connection.once(.connected) { _ in
+                channel.publish(messages, callback: { err in
+                    expect(err?.code).to(equal(ARTErrorCode.maxMessageLengthExceeded.intValue))
+                    done()
                 })
             }
-            
-            func test__042__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_also_presence_messages__enter_() {
-                let options = AblyTests.commonAppSetup()
-                options.clientId = clientId
-                let client = ARTRealtime(options: options)
-                let channel = client.channels.get(channelName)
-                
-                waitUntil(timeout: testTimeout, action: { done in
-                    client.connection.once(.connected) { _ in
-                        channel.presence.enter(presenceData, callback: { err in
-                            expect(err?.code).to(equal(ARTErrorCode.maxMessageLengthExceeded.intValue))
-                            done()
-                        })
-                    }
+        })
+    }
+
+    func test__042__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_also_presence_messages__enter_() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = clientId
+        let client = ARTRealtime(options: options)
+        let channel = client.channels.get(channelName)
+
+        waitUntil(timeout: testTimeout, action: { done in
+            client.connection.once(.connected) { _ in
+                channel.presence.enter(presenceData, callback: { err in
+                    expect(err?.code).to(equal(ARTErrorCode.maxMessageLengthExceeded.intValue))
+                    done()
                 })
             }
-            
-            func test__043__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_also_presence_messages__leave_() {
-                let options = AblyTests.commonAppSetup()
-                options.clientId = clientId
-                let client = ARTRealtime(options: options)
-                let channel = client.channels.get(channelName)
-                
-                waitUntil(timeout: testTimeout, action: { done in
-                    client.connection.once(.connected) { _ in
-                        channel.presence.leave(presenceData, callback: { err in
-                            expect(err?.code).to(equal(ARTErrorCode.maxMessageLengthExceeded.intValue))
-                            done()
-                        })
-                    }
+        })
+    }
+
+    func test__043__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_also_presence_messages__leave_() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = clientId
+        let client = ARTRealtime(options: options)
+        let channel = client.channels.get(channelName)
+
+        waitUntil(timeout: testTimeout, action: { done in
+            client.connection.once(.connected) { _ in
+                channel.presence.leave(presenceData, callback: { err in
+                    expect(err?.code).to(equal(ARTErrorCode.maxMessageLengthExceeded.intValue))
+                    done()
                 })
             }
-            
-            func test__044__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_also_presence_messages__update_() {
-                let options = AblyTests.commonAppSetup()
-                options.clientId = clientId
-                let client = ARTRealtime(options: options)
-                let channel = client.channels.get(channelName)
-                
-                waitUntil(timeout: testTimeout, action: { done in
-                    client.connection.once(.connected) { _ in
-                        channel.presence.update(presenceData, callback: { err in
-                            expect(err?.code).to(equal(ARTErrorCode.maxMessageLengthExceeded.intValue))
-                            done()
-                        })
-                    }
+        })
+    }
+
+    func test__044__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_also_presence_messages__update_() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = clientId
+        let client = ARTRealtime(options: options)
+        let channel = client.channels.get(channelName)
+
+        waitUntil(timeout: testTimeout, action: { done in
+            client.connection.once(.connected) { _ in
+                channel.presence.update(presenceData, callback: { err in
+                    expect(err?.code).to(equal(ARTErrorCode.maxMessageLengthExceeded.intValue))
+                    done()
                 })
             }
-            
-            func test__045__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_also_presence_messages__updateClient_() {
-                let options = AblyTests.commonAppSetup()
-                options.clientId = clientId
-                let client = ARTRealtime(options: options)
-                let channel = client.channels.get(channelName)
-                
-                waitUntil(timeout: testTimeout, action: { done in
-                    client.connection.once(.connected) { _ in
-                        channel.presence.updateClient(clientId, data: presenceData, callback: { err in
-                            expect(err?.code).to(equal(ARTErrorCode.maxMessageLengthExceeded.intValue))
-                            done()
-                        })
-                    }
+        })
+    }
+
+    func test__045__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_also_presence_messages__updateClient_() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = clientId
+        let client = ARTRealtime(options: options)
+        let channel = client.channels.get(channelName)
+
+        waitUntil(timeout: testTimeout, action: { done in
+            client.connection.once(.connected) { _ in
+                channel.presence.updateClient(clientId, data: presenceData, callback: { err in
+                    expect(err?.code).to(equal(ARTErrorCode.maxMessageLengthExceeded.intValue))
+                    done()
                 })
             }
-            
-            func test__046__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_also_presence_messages__leaveClient_() {
-                let options = AblyTests.commonAppSetup()
-                options.clientId = clientId
-                let client = ARTRealtime(options: options)
-                let channel = client.channels.get(channelName)
-                
-                waitUntil(timeout: testTimeout, action: { done in
-                    client.connection.once(.connected) { _ in
-                        channel.presence.leaveClient(clientId, data: presenceData, callback: { err in
-                            expect(err?.code).to(equal(ARTErrorCode.maxMessageLengthExceeded.intValue))
-                            done()
-                        })
-                    }
+        })
+    }
+
+    func test__046__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_also_presence_messages__leaveClient_() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = clientId
+        let client = ARTRealtime(options: options)
+        let channel = client.channels.get(channelName)
+
+        waitUntil(timeout: testTimeout, action: { done in
+            client.connection.once(.connected) { _ in
+                channel.presence.leaveClient(clientId, data: presenceData, callback: { err in
+                    expect(err?.code).to(equal(ARTErrorCode.maxMessageLengthExceeded.intValue))
+                    done()
                 })
             }
+        })
+    }
 }

--- a/Spec/RealtimeClient.swift
+++ b/Spec/RealtimeClient.swift
@@ -1,6 +1,6 @@
 import Ably
 import Nimble
-import Quick
+import XCTest
 
 private let query: ARTStatsQuery = {
     let query = ARTStatsQuery()

--- a/Spec/RealtimeClient.swift
+++ b/Spec/RealtimeClient.swift
@@ -11,7 +11,7 @@ import Nimble
             private let presenceData = buildStringThatExceedMaxMessageSize()
             private let clientId = "testMessageSizeClientId"
 
-class RealtimeClient: QuickSpec {
+class RealtimeClient: XCTestCase {
 
     func checkError(_ errorInfo: ARTErrorInfo?, withAlternative message: String) {
         if let error = errorInfo {
@@ -40,11 +40,9 @@ override class var defaultTestSuite : XCTestSuite {
             class AblyManager {
                 static let sharedClient = ARTRealtime(options: { $0.autoConnect = false; return $0 }(ARTClientOptions(key: "xxxx:xxxx")))
             }
-
-    override func spec() {
-        describe("RealtimeClient") {
+        
             // G4
-            it("All WebSocket connections should include the current API version") {
+            func test__001__RealtimeClient__All_WebSocket_connections_should_include_the_current_API_version() {
                 let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                 defer { client.dispose(); client.close() }
                 let channel = client.channels.get("test")
@@ -63,8 +61,8 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTC1
-            context("options") {
-                it("should support the same options as the Rest client") {
+            
+                func test__013__RealtimeClient__options__should_support_the_same_options_as_the_Rest_client() {
                     let options = AblyTests.commonAppSetup() //Same as Rest
                     options.clientId = "client_string"
 
@@ -91,19 +89,19 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 
                 //RTC1a
-                it("should echoMessages option be true by default") {
+                func test__014__RealtimeClient__options__should_echoMessages_option_be_true_by_default() {
                     let options = ARTClientOptions()
                     expect(options.echoMessages) == true
                 }
                 
                 //RTC1b
-                it("should autoConnect option be true by default") {
+                func test__015__RealtimeClient__options__should_autoConnect_option_be_true_by_default() {
                     let options = ARTClientOptions()
                     expect(options.autoConnect) == true
                 }
 
                 //RTC1c
-                it("should attempt to recover the connection state if recover string is assigned") {
+                func test__016__RealtimeClient__options__should_attempt_to_recover_the_connection_state_if_recover_string_is_assigned() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "client_string"
 
@@ -155,7 +153,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 //RTC1d
-                it("should modify the realtime endpoint host if realtimeHost is assigned") {
+                func test__017__RealtimeClient__options__should_modify_the_realtime_endpoint_host_if_realtimeHost_is_assigned() {
                     let options = ARTClientOptions(key: "secret:key")
                     options.realtimeHost = "fake.ably.io"
                     options.autoConnect = false
@@ -181,7 +179,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 
                 //RTC1e
-                it("should modify both the REST and realtime endpoint if environment string is assigned") {
+                func test__018__RealtimeClient__options__should_modify_both_the_REST_and_realtime_endpoint_if_environment_string_is_assigned() {
                     let options = AblyTests.commonAppSetup()
                     
                     let oldRestHost = options.restHost
@@ -198,7 +196,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 
                 //RTC1f
-                it("url should contains transport params") {
+                func test__019__RealtimeClient__options__url_should_contains_transport_params() {
                     let options = AblyTests.commonAppSetup()
                     options.transportParams = [
                         "tpBool": .init(bool: true),
@@ -235,10 +233,9 @@ override class var defaultTestSuite : XCTestSuite {
                         client.connect()
                     }
                 }
-            }
 
             // RTC2
-            it("should have access to the underlying Connection object") {
+            func test__002__RealtimeClient__should_have_access_to_the_underlying_Connection_object() {
                 let options = AblyTests.commonAppSetup()
                 options.autoConnect = false
                 let client = ARTRealtime(options: options)
@@ -246,7 +243,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTC3
-            it("should provide access to the underlying Channels object") {
+            func test__003__RealtimeClient__should_provide_access_to_the_underlying_Channels_object() {
                 let options = AblyTests.commonAppSetup()
                 options.autoConnect = false
 
@@ -260,10 +257,10 @@ override class var defaultTestSuite : XCTestSuite {
                 expect(client.channels.get("test")).toNot(beNil())
             }
 
-            context("Auth object") {
+            
 
                 // RTC4
-                it("should provide access to the Auth object") {
+                func test__020__RealtimeClient__Auth_object__should_provide_access_to_the_Auth_object() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.close() }
@@ -271,7 +268,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTC4a
-                it("clientId may be populated when the connection is established") {
+                func test__021__RealtimeClient__Auth_object__clientId_may_be_populated_when_the_connection_is_established() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "client_string"
                     let client = ARTRealtime(options: options)
@@ -295,12 +292,11 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
-            context("stats") {
+            
 
                 // RTC5a
-                it("should present an async interface") {
+                func test__022__RealtimeClient__stats__should_present_an_async_interface() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.close() }
                     // Async
@@ -316,7 +312,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTC5b
-                xit("should accept all the same params as RestClient") {
+                func skipped__test__023__RealtimeClient__stats__should_accept_all_the_same_params_as_RestClient() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.close() }
                     var paginatedResult: ARTPaginatedResult<AnyObject>?
@@ -358,11 +354,10 @@ override class var defaultTestSuite : XCTestSuite {
                         }.toNot(throwError() { err in fail("\(err)"); done() })
                     }
                 }
-            }
 
-            context("time") {
+            
                 // RTC6a
-                it("should present an async interface") {
+                func test__024__RealtimeClient__time__should_present_an_async_interface() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.close() }
                     // Async
@@ -374,10 +369,9 @@ override class var defaultTestSuite : XCTestSuite {
                         })
                     }
                 }
-            }
 
             // RTC7
-            it("should use the configured timeouts specified") {
+            func test__004__RealtimeClient__should_use_the_configured_timeouts_specified() {
                 let options = AblyTests.commonAppSetup()
                 options.suspendedRetryTimeout = 6.0
 
@@ -425,10 +419,10 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTC8
-            context("Auth#authorize should upgrade the connection with current token") {
+            
 
                 // RTC8a
-                it("in the CONNECTED state and auth#authorize is called, the client must obtain a new token, send an AUTH ProtocolMessage with an auth attribute") {
+                func test__025__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__in_the_CONNECTED_state_and_auth_authorize_is_called__the_client_must_obtain_a_new_token__send_an_AUTH_ProtocolMessage_with_an_auth_attribute() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     options.useTokenAuth = true
@@ -484,7 +478,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTC8a1 - part 1
-                it("when the authentication token change is successful, then the client should receive a new CONNECTED ProtocolMessage") {
+                func test__026__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_authentication_token_change_is_successful__then_the_client_should_receive_a_new_CONNECTED_ProtocolMessage() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let testToken = getTestToken()
@@ -544,7 +538,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTC8a1 - part 2
-                it("performs an upgrade of capabilities without any loss of continuity or connectivity during the upgrade process") {
+                func test__027__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__performs_an_upgrade_of_capabilities_without_any_loss_of_continuity_or_connectivity_during_the_upgrade_process() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let testToken = getTestToken(capability: "{\"test\":[\"subscribe\"]}")
@@ -635,7 +629,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTC8a1 - part 3
-                it("when capabilities are downgraded, client should receive an ERROR ProtocolMessage with a channel property") {
+                func test__028__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_capabilities_are_downgraded__client_should_receive_an_ERROR_ProtocolMessage_with_a_channel_property() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let testToken = getTestToken()
@@ -696,7 +690,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTC8a2
-                it("when the authentication token change fails, client should receive an ERROR ProtocolMessage triggering the connection to transition to the FAILED state") {
+                func test__029__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_authentication_token_change_fails__client_should_receive_an_ERROR_ProtocolMessage_triggering_the_connection_to_transition_to_the_FAILED_state() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     options.clientId = "ios"
@@ -746,7 +740,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(authError).to(beIdenticalTo(connectionError))
                 }
 
-                it("authorize call should complete with an error if the request fails") {
+                func test__030__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_an_error_if_the_request_fails() {
                     let options = AblyTests.clientOptions()
                     let testToken = getTestToken()
                     options.token = testToken
@@ -788,7 +782,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTC8a3
-                it("authorize call should be indicated as completed with the new token or error only once realtime has responded to the AUTH with either a CONNECTED or ERROR respectively") {
+                func test__031__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_be_indicated_as_completed_with_the_new_token_or_error_only_once_realtime_has_responded_to_the_AUTH_with_either_a_CONNECTED_or_ERROR_respectively() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     options.useTokenAuth = true
@@ -822,7 +816,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTC8b
-                it("when connection is CONNECTING, all current connection attempts should be halted, and after obtaining a new token the library should immediately initiate a connection attempt using the new token") {
+                func test__032__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_connection_is_CONNECTING__all_current_connection_attempts_should_be_halted__and_after_obtaining_a_new_token_the_library_should_immediately_initiate_a_connection_attempt_using_the_new_token() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     options.useTokenAuth = true
@@ -874,7 +868,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTC8b1 - part 1
-                it("authorize call should complete with the new token once the connection has moved to the CONNECTED state") {
+                func test__033__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_the_new_token_once_the_connection_has_moved_to_the_CONNECTED_state() {
                     let options = AblyTests.clientOptions()
                     options.autoConnect = false
                     let testToken = getTestToken()
@@ -900,7 +894,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTC8b1 - part 2
-                it("authorize call should complete with an error if the connection moves to the FAILED state") {
+                func test__034__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_an_error_if_the_connection_moves_to_the_FAILED_state() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     options.useTokenAuth = true
@@ -950,7 +944,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTC8b1 - part 3
-                it("authorize call should complete with an error if the connection moves to the SUSPENDED state") {
+                func test__035__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_an_error_if_the_connection_moves_to_the_SUSPENDED_state() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     options.useTokenAuth = true
@@ -992,7 +986,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTC8b1 - part 4
-                xit("authorize call should complete with an error if the connection moves to the CLOSED state") {
+                func skipped__test__036__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_an_error_if_the_connection_moves_to_the_CLOSED_state() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     options.useTokenAuth = true
@@ -1035,7 +1029,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTC8c - part 1
-                it("when the connection is in the SUSPENDED state when auth#authorize is called, after obtaining a token the library should move to the CONNECTING state and initiate a connection attempt using the new token") {
+                func test__037__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_connection_is_in_the_SUSPENDED_state_when_auth_authorize_is_called__after_obtaining_a_token_the_library_should_move_to_the_CONNECTING_state_and_initiate_a_connection_attempt_using_the_new_token() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let testToken = getTestToken()
@@ -1090,7 +1084,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTC8c - part 2
-                it("when the connection is in the CLOSED state when auth#authorize is called, after obtaining a token the library should move to the CONNECTING state and initiate a connection attempt using the new token") {
+                func test__038__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_connection_is_in_the_CLOSED_state_when_auth_authorize_is_called__after_obtaining_a_token_the_library_should_move_to_the_CONNECTING_state_and_initiate_a_connection_attempt_using_the_new_token() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let testToken = getTestToken()
@@ -1145,7 +1139,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTC8c - part 3
-                it("when the connection is in the DISCONNECTED state when auth#authorize is called, after obtaining a token the library should move to the CONNECTING state and initiate a connection attempt using the new token") {
+                func test__039__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_connection_is_in_the_DISCONNECTED_state_when_auth_authorize_is_called__after_obtaining_a_token_the_library_should_move_to_the_CONNECTING_state_and_initiate_a_connection_attempt_using_the_new_token() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let testToken = getTestToken()
@@ -1200,7 +1194,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTC8c - part 4
-                it("when the connection is in the FAILED state when auth#authorize is called, after obtaining a token the library should move to the CONNECTING state and initiate a connection attempt using the new token") {
+                func test__040__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__when_the_connection_is_in_the_FAILED_state_when_auth_authorize_is_called__after_obtaining_a_token_the_library_should_move_to_the_CONNECTING_state_and_initiate_a_connection_attempt_using_the_new_token() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let testToken = getTestToken()
@@ -1253,11 +1247,10 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
             // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
             // https://github.com/ably/ably-cocoa/issues/577
-            xit("background behaviour") {
+            func skipped__test__005__RealtimeClient__background_behaviour() {
                 waitUntil(timeout: testTimeout) { done in
                   URLSession.shared.dataTask(with: URL(string:"https://ably.io")!) { _ , _ , _  in
                         let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
@@ -1270,7 +1263,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
             }
 
-            it("should accept acks with different order") {
+            func test__006__RealtimeClient__should_accept_acks_with_different_order() {
                 let realtime = AblyTests.newRealtime(AblyTests.commonAppSetup())
                 defer { realtime.dispose(); realtime.close() }
                 let channel = realtime.channels.get("foo")
@@ -1320,7 +1313,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
             }
 
-            it("transport should guarantee the incoming message order") {
+            func test__007__RealtimeClient__transport_should_guarantee_the_incoming_message_order() {
                 let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                 defer { realtime.dispose(); realtime.close() }
                 waitUntil(timeout: testTimeout) { done in
@@ -1357,7 +1350,7 @@ override class var defaultTestSuite : XCTestSuite {
                 expect(result).to(equal(expectedOrder))
             }
             
-            it("subscriber should receive messages in the same order in which they have been sent") {
+            func test__008__RealtimeClient__subscriber_should_receive_messages_in_the_same_order_in_which_they_have_been_sent() {
                 let options = AblyTests.commonAppSetup()
                 let realtime1 = ARTRealtime(options: options)
                 let realtime2 = ARTRealtime(options: options)
@@ -1395,7 +1388,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // Issue https://github.com/ably/ably-cocoa/issues/640
-            it("should dispatch in user queue when removing an observer") {
+            func test__009__RealtimeClient__should_dispatch_in_user_queue_when_removing_an_observer() {
                 class Foo {
                     init() {
                         AblyManager.sharedClient.channels.get("foo").subscribe { _ in
@@ -1416,7 +1409,7 @@ override class var defaultTestSuite : XCTestSuite {
                 AblyManager.sharedClient.channels.get("foo").unsubscribe()
             }
 
-            it("should never register any connection listeners for internal use with the public EventEmitter") {
+            func test__010__RealtimeClient__should_never_register_any_connection_listeners_for_internal_use_with_the_public_EventEmitter() {
                 let options = AblyTests.commonAppSetup()
                 options.autoConnect = false
                 let client = ARTRealtime(options: options)
@@ -1434,7 +1427,7 @@ override class var defaultTestSuite : XCTestSuite {
                 expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.closed), timeout: testTimeout)
             }
 
-            it("should never register any message and channel listeners for internal use with the public EventEmitter") {
+            func test__011__RealtimeClient__should_never_register_any_message_and_channel_listeners_for_internal_use_with_the_public_EventEmitter() {
                 let options = AblyTests.commonAppSetup()
                 let client = ARTRealtime(options: options)
                 defer { client.dispose(); client.close() }
@@ -1469,7 +1462,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
             }
             
-            xit("moves to DISCONNECTED on an unexpected normal WebSocket close") {
+            func skipped__test__012__RealtimeClient__moves_to_DISCONNECTED_on_an_unexpected_normal_WebSocket_close() {
                 let options = AblyTests.commonAppSetup()
                 let client = ARTRealtime(options: options)
                 defer { client.dispose(); client.close() }
@@ -1491,12 +1484,11 @@ override class var defaultTestSuite : XCTestSuite {
                 
                 expect(received).toEventually(beTrue(), timeout: testTimeout)
             }
-        }
         
         // RSL1i
-        context("If the total size of message(s) exceeds the maxMessageSize") {
+        
             
-            it("the client library should reject the publish and indicate an error") {
+            func test__041__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_the_publish_and_indicate_an_error() {
                 let options = AblyTests.commonAppSetup()
                 let client = ARTRealtime(options: options)
                 let channel = client.channels.get(channelName)
@@ -1513,7 +1505,7 @@ override class var defaultTestSuite : XCTestSuite {
                 })
             }
             
-            it("the client library should reject also presence messages (enter)") {
+            func test__042__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_also_presence_messages__enter_() {
                 let options = AblyTests.commonAppSetup()
                 options.clientId = clientId
                 let client = ARTRealtime(options: options)
@@ -1529,7 +1521,7 @@ override class var defaultTestSuite : XCTestSuite {
                 })
             }
             
-            it("the client library should reject also presence messages (leave)") {
+            func test__043__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_also_presence_messages__leave_() {
                 let options = AblyTests.commonAppSetup()
                 options.clientId = clientId
                 let client = ARTRealtime(options: options)
@@ -1545,7 +1537,7 @@ override class var defaultTestSuite : XCTestSuite {
                 })
             }
             
-            it("the client library should reject also presence messages (update)") {
+            func test__044__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_also_presence_messages__update_() {
                 let options = AblyTests.commonAppSetup()
                 options.clientId = clientId
                 let client = ARTRealtime(options: options)
@@ -1561,7 +1553,7 @@ override class var defaultTestSuite : XCTestSuite {
                 })
             }
             
-            it("the client library should reject also presence messages (updateClient)") {
+            func test__045__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_also_presence_messages__updateClient_() {
                 let options = AblyTests.commonAppSetup()
                 options.clientId = clientId
                 let client = ARTRealtime(options: options)
@@ -1577,7 +1569,7 @@ override class var defaultTestSuite : XCTestSuite {
                 })
             }
             
-            it("the client library should reject also presence messages (leaveClient)") {
+            func test__046__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_also_presence_messages__leaveClient_() {
                 let options = AblyTests.commonAppSetup()
                 options.clientId = clientId
                 let client = ARTRealtime(options: options)
@@ -1592,6 +1584,4 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 })
             }
-        }
-    }
 }

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -1,7 +1,7 @@
 import Ably
 import Aspects
 import Nimble
-import Quick
+import XCTest
 
 private let attachResumeExpectedValues: [ARTRealtimeChannelState: Bool] = [
     .initialized: false,

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -1,4430 +1,4381 @@
 import Ably
-import Quick
-import Nimble
 import Aspects
+import Nimble
+import Quick
 
+private let attachResumeExpectedValues: [ARTRealtimeChannelState: Bool] = [
+    .initialized: false,
+    .attached: true,
+    .detaching: false,
+    .failed: false,
+]
+private var rtl6c2TestsClient: ARTRealtime!
+private var rtl6c2TestsChannel: ARTRealtimeChannel!
 
-                    private let attachResumeExpectedValues: [ARTRealtimeChannelState: Bool] = [
-                        .initialized: false,
-                        .attached: true,
-                        .detaching: false,
-                        .failed: false,
-                    ]
-                        private var rtl6c2TestsClient: ARTRealtime!
-                        private var rtl6c2TestsChannel: ARTRealtimeChannel!
-
-                        private func rtl16c2TestsPublish(_ done: @escaping () -> ()) {
-                            rtl6c2TestsChannel.publish(nil, data: "message") { error in
-                                expect(error).to(beNil())
-                                expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                                done()
-                            }
-                        }
-                        private var options: ARTClientOptions!
-                        private var rtl6c4TestsClient: ARTRealtime!
-                        private var rtl6c4TestsChannel: ARTRealtimeChannel!
-
-                        private let previousConnectionStateTtl = ARTDefault.connectionStateTtl()
-
-                        private func setupDependencies() {
-                            if (options == nil) {
-                                options = AblyTests.commonAppSetup()
-                                options.suspendedRetryTimeout = 0.3
-                                options.autoConnect = false
-                            }
-                        }
-
-                        private func rtl6c4TestsPublish(_ done: @escaping () -> ()) {
-                            rtl6c4TestsChannel.publish(nil, data: "message") { error in
-                                expect(error).toNot(beNil())
-                                done()
-                            }
-                        }
-                    /*
-                     This test makes a deep assumption about the content of these two files,
-                     specifically the format of the first message in the items array.
-                     */
-                    private func testHandlesDecodingErrorInFixture(_ cryptoFixtureFileName: String) {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        options.logHandler = ARTLog(capturingOutput: true)
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-                        
-                        let (keyData, ivData, messages) = AblyTests.loadCryptoTestData(cryptoFixtureFileName)
-                        let testMessage = messages[0]
-                        
-                        let cipherParams = ARTCipherParams(algorithm: "aes", key: keyData as ARTCipherKeyCompatible, iv: ivData)
-                        let channelOptions = ARTRealtimeChannelOptions(cipher: cipherParams)
-                        let channel = client.channels.get("test", options: channelOptions)
-                        
-                        let transport = client.internal.transport as! TestProxyTransport
-                        
-                        transport.setListenerBeforeProcessingOutgoingMessage({ protocolMessage in
-                            if protocolMessage.action == .message {
-                                expect(protocolMessage.messages![0].data as? String).to(equal(testMessage.encrypted.data))
-                                expect(protocolMessage.messages![0].encoding).to(equal(testMessage.encrypted.encoding))
-                            }
-                        })
-                        
-                        transport.setBeforeIncomingMessageModifier({ protocolMessage in
-                            if protocolMessage.action == .message {
-                                expect(protocolMessage.messages![0].data as? NSObject).to(equal(AblyTests.base64ToData(testMessage.encrypted.data) as NSObject?))
-                                expect(protocolMessage.messages![0].encoding).to(equal("utf-8/cipher+aes-\(cryptoFixtureFileName.suffix(3))-cbc"))
-                                
-                                // Force an error decoding a message
-                                protocolMessage.messages![0].encoding = "bad_encoding_type"
-                            }
-                            return protocolMessage
-                        })
-                        
-                        waitUntil(timeout: testTimeout) { done in
-                            let partlyDone = AblyTests.splitDone(2, done: done)
-                            
-                            channel.subscribe(testMessage.encoded.name) { message in
-                                expect(message.data as? NSObject).to(equal(AblyTests.base64ToData(testMessage.encrypted.data) as NSObject?))
-                                
-                                let logs = options.logHandler.captured
-                                let line = logs.reduce("") { $0 + "; " + $1.toString() } //Reduce in one line
-                                
-                                expect(line).to(contain("Failed to decode data: unknown encoding: 'bad_encoding_type'"))
-                                
-                                partlyDone()
-                            }
-                            
-                            channel.on(.update) { stateChange in
-                                guard let error = stateChange.reason else {
-                                    return
-                                }
-                                expect(error.message).to(contain("Failed to decode data: unknown encoding: 'bad_encoding_type'"))
-                                expect(error).to(beIdenticalTo(channel.errorReason))
-                                partlyDone()
-                            }
-                            
-                            channel.publish(testMessage.encoded.name, data: testMessage.encoded.data)
-                        }
-                    }
-                    
-                    private func testWithUntilAttach(_ untilAttach: Bool) {
-                        let options = AblyTests.commonAppSetup()
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-
-                        let testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                        client.internal.rest.httpExecutor = testHTTPExecutor
-
-                        let query = ARTRealtimeHistoryQuery()
-                        query.untilAttach = untilAttach
-
-                        channel.attach()
-                        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            expect {
-                                try channel.history(query) { _, errorInfo in
-                                    expect(errorInfo).to(beNil())
-                                    done()
-                                }
-                            }.toNot(throwError() { err in fail("\(err)"); done() })
-                        }
-
-                        let queryString = testHTTPExecutor.requests.last!.url!.query
-
-                        if query.untilAttach {
-                            expect(queryString).to(contain("fromSerial=\(channel.internal.attachSerial!)"))
-                        }
-                        else {
-                            expect(queryString).toNot(contain("fromSerial"))
-                        }
-                    }
-
-class RealtimeClientChannel: XCTestCase {
-
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = attachResumeExpectedValues
-    let _ = rtl6c2TestsClient
-    let _ = rtl6c2TestsChannel
-    let _ = options
-    let _ = rtl6c4TestsClient
-    let _ = rtl6c4TestsChannel
-    let _ = previousConnectionStateTtl
-
-    return super.defaultTestSuite
+private func rtl16c2TestsPublish(_ done: @escaping () -> Void) {
+    rtl6c2TestsChannel.publish(nil, data: "message") { error in
+        expect(error).to(beNil())
+        expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+        done()
+    }
 }
 
+private var options: ARTClientOptions!
+private var rtl6c4TestsClient: ARTRealtime!
+private var rtl6c4TestsChannel: ARTRealtimeChannel!
 
-                    class TotalMessages {
-                        static let expected = 50
-                        static var succeeded = 0
-                        static var failed = 0
-                        fileprivate init() {}
+private let previousConnectionStateTtl = ARTDefault.connectionStateTtl()
+
+private func setupDependencies() {
+    if options == nil {
+        options = AblyTests.commonAppSetup()
+        options.suspendedRetryTimeout = 0.3
+        options.autoConnect = false
+    }
+}
+
+private func rtl6c4TestsPublish(_ done: @escaping () -> Void) {
+    rtl6c4TestsChannel.publish(nil, data: "message") { error in
+        expect(error).toNot(beNil())
+        done()
+    }
+}
+
+/*
+ This test makes a deep assumption about the content of these two files,
+ specifically the format of the first message in the items array.
+ */
+private func testHandlesDecodingErrorInFixture(_ cryptoFixtureFileName: String) {
+    let options = AblyTests.commonAppSetup()
+    options.autoConnect = false
+    options.logHandler = ARTLog(capturingOutput: true)
+    let client = ARTRealtime(options: options)
+    client.internal.setTransport(TestProxyTransport.self)
+    client.connect()
+    defer { client.dispose(); client.close() }
+
+    let (keyData, ivData, messages) = AblyTests.loadCryptoTestData(cryptoFixtureFileName)
+    let testMessage = messages[0]
+
+    let cipherParams = ARTCipherParams(algorithm: "aes", key: keyData as ARTCipherKeyCompatible, iv: ivData)
+    let channelOptions = ARTRealtimeChannelOptions(cipher: cipherParams)
+    let channel = client.channels.get("test", options: channelOptions)
+
+    let transport = client.internal.transport as! TestProxyTransport
+
+    transport.setListenerBeforeProcessingOutgoingMessage { protocolMessage in
+        if protocolMessage.action == .message {
+            expect(protocolMessage.messages![0].data as? String).to(equal(testMessage.encrypted.data))
+            expect(protocolMessage.messages![0].encoding).to(equal(testMessage.encrypted.encoding))
+        }
+    }
+
+    transport.setBeforeIncomingMessageModifier { protocolMessage in
+        if protocolMessage.action == .message {
+            expect(protocolMessage.messages![0].data as? NSObject).to(equal(AblyTests.base64ToData(testMessage.encrypted.data) as NSObject?))
+            expect(protocolMessage.messages![0].encoding).to(equal("utf-8/cipher+aes-\(cryptoFixtureFileName.suffix(3))-cbc"))
+
+            // Force an error decoding a message
+            protocolMessage.messages![0].encoding = "bad_encoding_type"
+        }
+        return protocolMessage
+    }
+
+    waitUntil(timeout: testTimeout) { done in
+        let partlyDone = AblyTests.splitDone(2, done: done)
+
+        channel.subscribe(testMessage.encoded.name) { message in
+            expect(message.data as? NSObject).to(equal(AblyTests.base64ToData(testMessage.encrypted.data) as NSObject?))
+
+            let logs = options.logHandler.captured
+            let line = logs.reduce("") { $0 + "; " + $1.toString() } // Reduce in one line
+
+            expect(line).to(contain("Failed to decode data: unknown encoding: 'bad_encoding_type'"))
+
+            partlyDone()
+        }
+
+        channel.on(.update) { stateChange in
+            guard let error = stateChange.reason else {
+                return
+            }
+            expect(error.message).to(contain("Failed to decode data: unknown encoding: 'bad_encoding_type'"))
+            expect(error).to(beIdenticalTo(channel.errorReason))
+            partlyDone()
+        }
+
+        channel.publish(testMessage.encoded.name, data: testMessage.encoded.data)
+    }
+}
+
+private func testWithUntilAttach(_ untilAttach: Bool) {
+    let options = AblyTests.commonAppSetup()
+    let client = ARTRealtime(options: options)
+    defer { client.dispose(); client.close() }
+    let channel = client.channels.get("test")
+
+    let testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+    client.internal.rest.httpExecutor = testHTTPExecutor
+
+    let query = ARTRealtimeHistoryQuery()
+    query.untilAttach = untilAttach
+
+    channel.attach()
+    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+    waitUntil(timeout: testTimeout) { done in
+        expect {
+            try channel.history(query) { _, errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }.toNot(throwError { err in fail("\(err)"); done() })
+    }
+
+    let queryString = testHTTPExecutor.requests.last!.url!.query
+
+    if query.untilAttach {
+        expect(queryString).to(contain("fromSerial=\(channel.internal.attachSerial!)"))
+    } else {
+        expect(queryString).toNot(contain("fromSerial"))
+    }
+}
+
+class RealtimeClientChannel: XCTestCase {
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = attachResumeExpectedValues
+        _ = rtl6c2TestsClient
+        _ = rtl6c2TestsChannel
+        _ = options
+        _ = rtl6c4TestsClient
+        _ = rtl6c4TestsChannel
+        _ = previousConnectionStateTtl
+
+        return super.defaultTestSuite
+    }
+
+    class TotalMessages {
+        static let expected = 50
+        static var succeeded = 0
+        static var failed = 0
+        fileprivate init() {}
+    }
+
+    // RTL1
+    func skipped__test__001__Channel__should_process_all_incoming_messages_and_presence_messages_as_soon_as_a_Channel_becomes_attached() {
+        let options = AblyTests.commonAppSetup()
+        let client1 = AblyTests.newRealtime(options)
+        defer { client1.dispose(); client1.close() }
+        let channel1 = client1.channels.get("room")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel1.presence.enterClient("Client 1", data: nil) { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+
+        options.clientId = "Client 2"
+        let client2 = AblyTests.newRealtime(options)
+        defer { client2.dispose(); client2.close() }
+        let channel2 = client2.channels.get("room")
+
+        channel2.subscribe("Client 1") { message in
+            expect(message.data as? String).to(equal("message"))
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel2.on(.attached) { _ in
+                expect(channel2.state).to(equal(ARTRealtimeChannelState.attached))
+                done()
+            }
+            channel2.attach()
+
+            expect(channel2.presence.syncComplete).to(beFalse())
+            expect(channel1.internal.presenceMap.members).to(haveCount(1))
+            expect(channel2.internal.presenceMap.members).to(haveCount(0))
+        }
+
+        expect(channel2.presence.syncComplete).toEventually(beTrue(), timeout: testTimeout)
+
+        expect(channel1.internal.presenceMap.members).to(haveCount(1))
+        expect(channel2.internal.presenceMap.members).toEventually(haveCount(1), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel1.publish("message", data: nil) { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel2.presence.enter(nil) { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+
+        expect(channel1.internal.presenceMap.members).toEventually(haveCount(2), timeout: testTimeout)
+        expect(channel1.internal.presenceMap.members.keys).to(allPass { $0!.hasPrefix("\(channel1.internal.connectionId):Client") || $0!.hasPrefix("\(channel2.internal.connectionId):Client") })
+        expect(channel1.internal.presenceMap.members.values).to(allPass { $0!.action == .present })
+
+        expect(channel2.internal.presenceMap.members).toEventually(haveCount(2), timeout: testTimeout)
+        expect(channel2.internal.presenceMap.members.keys).to(allPass { $0!.hasPrefix("\(channel1.internal.connectionId):Client") || $0!.hasPrefix("\(channel2.internal.connectionId):Client") })
+        expect(channel2.internal.presenceMap.members["\(channel1.internal.connectionId):Client 1"]!.action).to(equal(ARTPresenceAction.present))
+        expect(channel2.internal.presenceMap.members["\(channel2.internal.connectionId):Client 2"]!.action).to(equal(ARTPresenceAction.present))
+    }
+
+    // RTL2
+
+    // RTL2a
+    func test__003__Channel__EventEmitter__channel_states_and_events__should_implement_the_EventEmitter_and_emit_events_for_state_changes() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+        expect(channel.internal.statesEventEmitter).to(beAKindOf(ARTEventEmitter<ARTEvent, ARTChannelStateChange>.self))
+
+        var channelOnMethodCalled = false
+        channel.internal.testSuite_injectIntoMethod(after: #selector(ARTEventEmitter<ARTEvent, ARTChannelStateChange>.on(_:))) {
+            channelOnMethodCalled = true
+        }
+
+        // The `channel.on` should use `statesEventEmitter`
+        var statesEventEmitterOnMethodCalled = false
+        channel.internal.statesEventEmitter.testSuite_injectIntoMethod(after: #selector(ARTEventEmitter<ARTEvent, ARTChannelStateChange>.on(_:))) {
+            statesEventEmitterOnMethodCalled = true
+        }
+
+        var emitCounter = 0
+        channel.internal.statesEventEmitter.testSuite_injectIntoMethod(after: #selector(ARTEventEmitter<ARTEvent, ARTChannelStateChange>.emit(_:with:))) {
+            emitCounter += 1
+        }
+
+        var states = [channel.state]
+        waitUntil(timeout: testTimeout) { done in
+            channel.on { stateChange in
+                expect(stateChange.previous).to(equal(states.last))
+                expect(channel.state).to(equal(stateChange.current))
+                states += [stateChange.current]
+
+                switch stateChange.current {
+                case .attached:
+                    expect(stateChange.event).to(equal(ARTChannelEvent.attached))
+                    expect(stateChange.reason).to(beNil())
+                    channel.detach()
+                case .detached:
+                    expect(stateChange.event).to(equal(ARTChannelEvent.detached))
+                    guard let error = stateChange.reason else {
+                        fail("Detach state change reason is nil"); done(); return
                     }
-        
+                    expect(error.message).to(contain("channel has detached"))
+                    done()
+                default:
+                    break
+                }
+            }
+            channel.attach()
+        }
 
-            // RTL1
-            func skipped__test__001__Channel__should_process_all_incoming_messages_and_presence_messages_as_soon_as_a_Channel_becomes_attached() {
-                let options = AblyTests.commonAppSetup()
-                let client1 = AblyTests.newRealtime(options)
-                defer { client1.dispose(); client1.close() }
-                let channel1 = client1.channels.get("room")
+        expect(channelOnMethodCalled).to(beTrue())
+        expect(statesEventEmitterOnMethodCalled).to(beTrue())
+        expect(emitCounter).to(equal(4))
 
-                waitUntil(timeout: testTimeout) { done in
-                    channel1.presence.enterClient("Client 1", data: nil) { errorInfo in
-                        expect(errorInfo).to(beNil())
-                        done()
+        if states.count != 5 {
+            fail("Expecting 5 states; got \(states)")
+            return
+        }
+
+        expect(states[0].rawValue).to(equal(ARTRealtimeChannelState.initialized.rawValue), description: "Should be INITIALIZED state")
+        expect(states[1].rawValue).to(equal(ARTRealtimeChannelState.attaching.rawValue), description: "Should be ATTACHING state")
+        expect(states[2].rawValue).to(equal(ARTRealtimeChannelState.attached.rawValue), description: "Should be ATTACHED state")
+        expect(states[3].rawValue).to(equal(ARTRealtimeChannelState.detaching.rawValue), description: "Should be DETACHING state")
+        expect(states[4].rawValue).to(equal(ARTRealtimeChannelState.detached.rawValue), description: "Should be DETACHED state")
+    }
+
+    // RTL2a
+    func test__004__Channel__EventEmitter__channel_states_and_events__should_implement_the_EventEmitter_and_emit_events_for_FAILED_state_changes() {
+        let options = AblyTests.clientOptions()
+        options.token = getTestToken(capability: "{\"secret\":[\"subscribe\"]}")
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.on { stateChange in
+                expect(channel.state).to(equal(stateChange.current))
+                switch stateChange.current {
+                case .attaching:
+                    expect(stateChange.event).to(equal(ARTChannelEvent.attaching))
+                    expect(stateChange.reason).to(beNil())
+                    expect(stateChange.previous).to(equal(ARTRealtimeChannelState.initialized))
+                case .failed:
+                    guard let reason = stateChange.reason else {
+                        fail("Reason is nil"); done(); return
                     }
+                    expect(stateChange.event).to(equal(ARTChannelEvent.failed))
+                    expect(reason.code) == ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue
+                    expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attaching))
+                    done()
+                default:
+                    break
                 }
+            }
+            channel.attach()
+        }
+    }
 
-                options.clientId = "Client 2"
-                let client2 = AblyTests.newRealtime(options)
-                defer { client2.dispose(); client2.close() }
-                let channel2 = client2.channels.get("room")
+    // RTL2a
+    func test__005__Channel__EventEmitter__channel_states_and_events__should_implement_the_EventEmitter_and_emit_events_for_SUSPENDED_state_changes() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
 
-                channel2.subscribe("Client 1") { message in
-                    expect(message.data as? String).to(equal("message"))
-                }
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
 
-                waitUntil(timeout: testTimeout) { done in
-                    channel2.on(.attached) { stateChange in
-                        expect(channel2.state).to(equal(ARTRealtimeChannelState.attached))
-                        done()
-                    }
-                    channel2.attach()
+        client.simulateSuspended(beforeSuspension: { done in
+            channel.once(.suspended) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attached))
+                expect(stateChange.event).to(equal(ARTChannelEvent.suspended))
+                expect(channel.state).to(equal(stateChange.current))
+                done()
+            }
+        })
+    }
 
-                    expect(channel2.presence.syncComplete).to(beFalse())
-                    expect(channel1.internal.presenceMap.members).to(haveCount(1))
-                    expect(channel2.internal.presenceMap.members).to(haveCount(0))
-                }
+    // RTL2g
+    func test__006__Channel__EventEmitter__channel_states_and_events__can_emit_an_UPDATE_event() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
 
-                expect(channel2.presence.syncComplete).toEventually(beTrue(), timeout: testTimeout)
+        channel.on(.attached) { _ in
+            fail("Should not emit Attached again")
+        }
+        defer {
+            channel.off()
+        }
 
-                expect(channel1.internal.presenceMap.members).to(haveCount(1))
-                expect(channel2.internal.presenceMap.members).toEventually(haveCount(1), timeout: testTimeout)
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel1.publish("message", data: nil) { errorInfo in
-                        expect(errorInfo).to(beNil())
-                        done()
-                    }
-                }
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel2.presence.enter(nil) { errorInfo in
-                        expect(errorInfo).to(beNil())
-                        done()
-                    }
-                }
-                
-                expect(channel1.internal.presenceMap.members).toEventually(haveCount(2), timeout: testTimeout)
-                expect(channel1.internal.presenceMap.members.keys).to(allPass({ $0!.hasPrefix("\(channel1.internal.connectionId):Client") || $0!.hasPrefix("\(channel2.internal.connectionId):Client") }))
-                expect(channel1.internal.presenceMap.members.values).to(allPass({ $0!.action == .present }))
-
-                expect(channel2.internal.presenceMap.members).toEventually(haveCount(2), timeout: testTimeout)
-                expect(channel2.internal.presenceMap.members.keys).to(allPass({ $0!.hasPrefix("\(channel1.internal.connectionId):Client") || $0!.hasPrefix("\(channel2.internal.connectionId):Client") }))
-                expect(channel2.internal.presenceMap.members["\(channel1.internal.connectionId):Client 1"]!.action).to(equal(ARTPresenceAction.present))
-                expect(channel2.internal.presenceMap.members["\(channel2.internal.connectionId):Client 2"]!.action).to(equal(ARTPresenceAction.present))
+        waitUntil(timeout: testTimeout) { done in
+            channel.on(.update) { stateChange in
+                expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+                expect(stateChange.previous).to(equal(channel.state))
+                expect(stateChange.current).to(equal(channel.state))
+                expect(stateChange.event).to(equal(ARTChannelEvent.update))
+                expect(stateChange.resumed).to(beFalse())
+                expect(stateChange.reason).to(beNil())
+                done()
             }
 
-            // RTL2
-            
+            let attachedMessage = ARTProtocolMessage()
+            attachedMessage.action = .attached
+            attachedMessage.channel = channel.name
+            client.internal.transport?.receive(attachedMessage)
+        }
+    }
 
-                // RTL2a
-                func test__003__Channel__EventEmitter__channel_states_and_events__should_implement_the_EventEmitter_and_emit_events_for_state_changes() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
+    // RTL2g + https://github.com/ably/ably-cocoa/issues/1088
+    func test__007__Channel__EventEmitter__channel_states_and_events__should_not_emit_detached_event_on_an_already_detached_channel() {
+        let options = AblyTests.commonAppSetup()
+        options.logLevel = .debug
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
 
-                    let channel = client.channels.get("test")
-                    expect(channel.internal.statesEventEmitter).to(beAKindOf(ARTEventEmitter<ARTEvent, ARTChannelStateChange>.self))
+        channel.on { stateChange in
+            expect(stateChange.current).toNot(equal(stateChange.previous))
+        }
+        defer {
+            channel.off()
+        }
 
-                    var channelOnMethodCalled = false
-                    channel.internal.testSuite_injectIntoMethod(after: #selector(ARTEventEmitter<ARTEvent, ARTChannelStateChange>.on(_:))) {
-                        channelOnMethodCalled = true
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
 
-                    // The `channel.on` should use `statesEventEmitter`
-                    var statesEventEmitterOnMethodCalled = false
-                    channel.internal.statesEventEmitter.testSuite_injectIntoMethod(after: #selector(ARTEventEmitter<ARTEvent, ARTChannelStateChange>.on(_:))) {
-                        statesEventEmitterOnMethodCalled = true
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            channel.detach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
 
-                    var emitCounter = 0
-                    channel.internal.statesEventEmitter.testSuite_injectIntoMethod(after: #selector(ARTEventEmitter<ARTEvent, ARTChannelStateChange>.emit(_:with:))) {
-                        emitCounter += 1
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.closed) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            client.close()
+        }
+    }
 
-                    var states = [channel.state]
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.on { stateChange in
-                            expect(stateChange.previous).to(equal(states.last))
-                            expect(channel.state).to(equal(stateChange.current))
-                            states += [stateChange.current]
+    // RTL2b
+    func test__008__Channel__EventEmitter__channel_states_and_events__state_attribute_should_be_the_current_state_of_the_channel() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
 
-                            switch stateChange.current {
-                            case .attached:
-                                expect(stateChange.event).to(equal(ARTChannelEvent.attached))
-                                expect(stateChange.reason).to(beNil())
-                                channel.detach()
-                            case .detached:
-                                expect(stateChange.event).to(equal(ARTChannelEvent.detached))
-                                guard let error = stateChange.reason else {
-                                    fail("Detach state change reason is nil"); done(); return
-                                }
-                                expect(error.message).to(contain("channel has detached"))
-                                done()
-                            default:
-                                break
-                            }
-                        }
-                        channel.attach()
-                    }
+        let channel = client.channels.get("test")
+        expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
 
-                    expect(channelOnMethodCalled).to(beTrue())
-                    expect(statesEventEmitterOnMethodCalled).to(beTrue())
-                    expect(emitCounter).to(equal(4))
+        channel.attach()
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+    }
 
-                    if states.count != 5 {
-                        fail("Expecting 5 states; got \(states)")
-                        return
-                    }
+    // RTL2c
+    func test__009__Channel__EventEmitter__channel_states_and_events__should_contain_an_ErrorInfo_object_with_details_when_an_error_occurs() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
 
-                    expect(states[0].rawValue).to(equal(ARTRealtimeChannelState.initialized.rawValue), description: "Should be INITIALIZED state")
-                    expect(states[1].rawValue).to(equal(ARTRealtimeChannelState.attaching.rawValue), description: "Should be ATTACHING state")
-                    expect(states[2].rawValue).to(equal(ARTRealtimeChannelState.attached.rawValue), description: "Should be ATTACHED state")
-                    expect(states[3].rawValue).to(equal(ARTRealtimeChannelState.detaching.rawValue), description: "Should be DETACHING state")
-                    expect(states[4].rawValue).to(equal(ARTRealtimeChannelState.detached.rawValue), description: "Should be DETACHED state")
+        let pmError = AblyTests.newErrorProtocolMessage()
+        waitUntil(timeout: testTimeout) { done in
+            channel.on(.failed) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Error is nil"); done(); return
                 }
+                expect(error).to(equal(pmError.error))
+                expect(channel.errorReason).to(equal(pmError.error))
+                done()
+            }
+            AblyTests.queue.async {
+                channel.internal.onError(pmError)
+            }
+        }
+    }
 
-                // RTL2a
-                func test__004__Channel__EventEmitter__channel_states_and_events__should_implement_the_EventEmitter_and_emit_events_for_FAILED_state_changes() {
-                    let options = AblyTests.clientOptions()
-                    options.token = getTestToken(capability: "{\"secret\":[\"subscribe\"]}")
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
+    // RTL2d
+    func test__010__Channel__EventEmitter__channel_states_and_events__a_ChannelStateChange_is_emitted_as_the_first_argument_for_every_channel_state_change() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.on { stateChange in
-                            expect(channel.state).to(equal(stateChange.current))
-                            switch stateChange.current {
-                            case .attaching:
-                                expect(stateChange.event).to(equal(ARTChannelEvent.attaching))
-                                expect(stateChange.reason).to(beNil())
-                                expect(stateChange.previous).to(equal(ARTRealtimeChannelState.initialized))
-                            case .failed:
-                                guard let reason = stateChange.reason else {
-                                    fail("Reason is nil"); done(); return
-                                }
-                                expect(stateChange.event).to(equal(ARTChannelEvent.failed))
-                                expect(reason.code) == ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue
-                                expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attaching))
-                                done()
-                            default:
-                                break
-                            }
-                        }
-                        channel.attach()
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            channel.on { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(stateChange.current).to(equal(channel.state))
+                expect(stateChange.previous).toNot(equal(channel.state))
+
+                if stateChange.current == .attached {
+                    done()
                 }
+            }
+            channel.attach()
+        }
+        channel.off()
 
-                // RTL2a
-                func test__005__Channel__EventEmitter__channel_states_and_events__should_implement_the_EventEmitter_and_emit_events_for_SUSPENDED_state_changes() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.failed) { stateChange in
+                expect(stateChange.reason).toNot(beNil())
+                expect(stateChange.current).to(equal(ARTRealtimeChannelState.failed))
+                expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attached))
+                done()
+            }
+            AblyTests.queue.async {
+                channel.internal.onError(AblyTests.newErrorProtocolMessage())
+            }
+        }
+    }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
+    // RTL2f
+    func test__011__Channel__EventEmitter__channel_states_and_events__ChannelStateChange_will_contain_a_resumed_boolean_attribute_with_value__true__if_the_bit_flag_RESUMED_was_included() {
+        let options = AblyTests.commonAppSetup()
+        options.tokenDetails = getTestTokenDetails(ttl: 5.0)
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
 
-                    client.simulateSuspended(beforeSuspension: { done in
-                        channel.once(.suspended) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attached))
-                            expect(stateChange.event).to(equal(ARTChannelEvent.suspended))
-                            expect(channel.state).to(equal(stateChange.current))
-                            done()
-                        }
-                    })
+        waitUntil(timeout: testTimeout) { done in
+            channel.on { stateChange in
+                switch stateChange.current {
+                case .attached:
+                    expect(stateChange.resumed).to(beFalse())
+                default:
+                    expect(stateChange.resumed).to(beFalse())
                 }
-
-                // RTL2g
-                func test__006__Channel__EventEmitter__channel_states_and_events__can_emit_an_UPDATE_event() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    channel.on(.attached) { _ in
-                        fail("Should not emit Attached again")
-                    }
-                    defer {
-                        channel.off()
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.on(.update) { stateChange in
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
-                            expect(stateChange.previous).to(equal(channel.state))
-                            expect(stateChange.current).to(equal(channel.state))
-                            expect(stateChange.event).to(equal(ARTChannelEvent.update))
-                            expect(stateChange.resumed).to(beFalse())
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-
-                        let attachedMessage = ARTProtocolMessage()
-                        attachedMessage.action = .attached
-                        attachedMessage.channel = channel.name
-                        client.internal.transport?.receive(attachedMessage)
-                    }
+            }
+            client.connection.once(.disconnected) { stateChange in
+                channel.off()
+                guard let error = stateChange.reason else {
+                    fail("Error is nil"); done(); return
                 }
-
-                // RTL2g + https://github.com/ably/ably-cocoa/issues/1088
-                func test__007__Channel__EventEmitter__channel_states_and_events__should_not_emit_detached_event_on_an_already_detached_channel() {
-                    let options = AblyTests.commonAppSetup()
-                    options.logLevel = .debug
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("foo")
-
-                    channel.on { stateChange in
-                        expect(stateChange.current).toNot(equal(stateChange.previous))
-                    }
-                    defer {
-                        channel.off()
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.detach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.closed) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                        client.close()
-                    }
-                }
-
-                // RTL2b
-                func test__008__Channel__EventEmitter__channel_states_and_events__state_attribute_should_be_the_current_state_of_the_channel() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
-
-                    channel.attach()
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-                }
-
-                // RTL2c
-                func test__009__Channel__EventEmitter__channel_states_and_events__should_contain_an_ErrorInfo_object_with_details_when_an_error_occurs() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    let pmError = AblyTests.newErrorProtocolMessage()
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.on(.failed) { stateChange in
-                            guard let error = stateChange.reason else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error).to(equal(pmError.error))
-                            expect(channel.errorReason).to(equal(pmError.error))
-                            done()
-                        }
-                        AblyTests.queue.async {
-                            channel.internal.onError(pmError)
-                        }
-                    }
-                }
-
-                // RTL2d
-                func test__010__Channel__EventEmitter__channel_states_and_events__a_ChannelStateChange_is_emitted_as_the_first_argument_for_every_channel_state_change() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.on { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            expect(stateChange.current).to(equal(channel.state))
-                            expect(stateChange.previous).toNot(equal(channel.state))
-
-                            if stateChange.current == .attached {
-                                done()
-                            }
-                        }
-                        channel.attach()
-                    }
-                    channel.off()
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.once(.failed) { stateChange in
-                            expect(stateChange.reason).toNot(beNil())
-                            expect(stateChange.current).to(equal(ARTRealtimeChannelState.failed))
-                            expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attached))
-                            done()
-                        }
-                        AblyTests.queue.async {
-                            channel.internal.onError(AblyTests.newErrorProtocolMessage())
-                        }
-                    }
-                }
-
-                // RTL2f
-                func test__011__Channel__EventEmitter__channel_states_and_events__ChannelStateChange_will_contain_a_resumed_boolean_attribute_with_value__true__if_the_bit_flag_RESUMED_was_included() {
-                    let options = AblyTests.commonAppSetup()
-                    options.tokenDetails = getTestTokenDetails(ttl: 5.0)
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.on { stateChange in
-                            switch stateChange.current {
-                            case .attached:
-                                expect(stateChange.resumed).to(beFalse())
-                            default:
-                                expect(stateChange.resumed).to(beFalse())
-                            }
-                        }
-                        client.connection.once(.disconnected) { stateChange in
-                            channel.off()
-                            guard let error = stateChange.reason else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.code) == ARTErrorCode.tokenExpired.intValue
-
-                            channel.on { stateChange in
-                                if (stateChange.current == .attached) {
-                                    expect(stateChange.resumed).to(beTrue())
-                                    expect(stateChange.reason).to(beNil())
-                                    expect(stateChange.current).to(equal(ARTRealtimeChannelState.attached))
-                                    expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attached))
-                                    done()
-                                }
-                            }
-                        }
-                        channel.attach()
-                    }
-                }
-
-                // RTL2f, TR4i
-                func test__012__Channel__EventEmitter__channel_states_and_events__bit_flag_RESUMED_was_included() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.once(.attached) { stateChange in
-                            expect(stateChange.resumed).to(beFalse())
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                        channel.attach()
-                    }
-
-                    let attachedMessage = ARTProtocolMessage()
-                    attachedMessage.action = .attached
-                    attachedMessage.channel = channel.name
-                    attachedMessage.flags = 4 //Resumed
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.once(.update) { stateChange in
-                            expect(stateChange.resumed).to(beTrue())
-                            expect(stateChange.reason).to(beNil())
-                            expect(stateChange.current).to(equal(ARTRealtimeChannelState.attached))
-                            expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attached))
-                            done()
-                        }
-                        client.internal.transport?.receive(attachedMessage)
-                    }
-                }
-
-            // RTL3
-            
-
-                // RTL3a
-                
-
-                    func test__017__Channel__connection_state__changes_to_FAILED__ATTACHING_channel_should_transition_to_FAILED() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("test")
-                        channel.attach()
-                        let transport = client.internal.transport as! TestProxyTransport
-                        transport.actionsIgnored += [.attached]
-
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let pmError = AblyTests.newErrorProtocolMessage()
-                            channel.once(.failed) { stateChange in
-                                guard let error = stateChange.reason else {
-                                    fail("Reason error is nil"); done(); return
-                                }
-                                expect(error).to(equal(pmError.error))
-                                expect(channel.errorReason).to(beIdenticalTo(error))
-                                done()
-                            }
-                            client.internal.onError(pmError)
-                        }
-
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-                    }
-
-                    func test__018__Channel__connection_state__changes_to_FAILED__ATTACHED_channel_should_transition_to_FAILED() {
-                        let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("test")
-                        channel.attach()
-                        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let pmError = AblyTests.newErrorProtocolMessage()
-                            channel.once(.failed) { stateChange in
-                                guard let error = stateChange.reason else {
-                                    fail("Reason error is nil"); done(); return
-                                }
-                                expect(error).to(equal(pmError.error))
-                                expect(channel.errorReason).to(equal(error))
-                                done()
-                            }
-                            client.internal.onError(pmError)
-                        }
-
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-                    }
-                    
-                    func test__019__Channel__connection_state__changes_to_FAILED__channel_being_released_waiting_for_DETACH_shouldn_t_crash__issue__918_() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-                        
-                        // Force the callback on .release below to be triggered by our
-                        // forced FAILED message, not by a DETACHED.
-                        let transport = client.internal.transport as! TestProxyTransport
-                        transport.actionsIgnored += [.detached]
-                        
-                        for i in (0..<100) { // We need a few channels to trigger iterator invalidation.
-                            let channel = client.channels.get("test\(i)")
-                            channel.attach() // No need to wait; ATTACHING state is good enough.
-                            expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attaching), timeout: testTimeout)
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            
-                            client.channels.release("test0") { _ in
-                                partialDone()
-                            }
-                            
-                            AblyTests.queue.async {
-                                let pmError = AblyTests.newErrorProtocolMessage()
-                                client.internal.onError(pmError)
-                                partialDone()
-                            }
-                        }
-                    }
-
-                    // TO3g
-                    func test__020__Channel__connection_state__changes_to_FAILED__should_immediately_fail_if_not_in_the_connected_state() {
-                        let options = AblyTests.commonAppSetup()
-                        options.queueMessages = false
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("foo")
-                        waitUntil(timeout: testTimeout) { done in
-                            expect(client.connection.state).to(equal(.initialized))
-                            channel.publish(nil, data: "message") { error in
-                                expect(error?.code).to(equal(ARTErrorCode.invalidTransportHandle.intValue))
-                                expect(error?.message).to(contain("Invalid operation"))
-                                done()
-                            }
-                        }
-                        expect(channel.state).to(equal(.initialized))
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connect()
-                            expect(client.connection.state).to(equal(.connecting))
-                            channel.publish(nil, data: "message") { error in
-                                expect(error?.code).to(equal(ARTErrorCode.invalidTransportHandle.intValue))
-                                expect(error?.message).to(contain("Invalid operation"))
-                                done()
-                            }
-                        }
-                        expect(channel.state).toEventually(equal(.attached), timeout: testTimeout)
-                    }
-
-                    // TO3g and https://github.com/ably/ably-cocoa/issues/1004
-                    func test__021__Channel__connection_state__changes_to_FAILED__should_keep_the_channels_attached_when_client_reconnected_successfully_and_queue_messages_is_disabled() {
-                        let options = AblyTests.commonAppSetup()
-                        options.queueMessages = false
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.internal.setReachabilityClass(TestReachability.self)
-                        let channel = client.channels.get("foo")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.connected) { _ in
-                                done()
-                            }
-                            client.connect()
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "message") { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        expect(channel.state).to(equal(.attached))
-                        channel.on { stateChange in
-                            if stateChange.current != .attached {
-                                fail("Channel state should not change")
-                            }
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.disconnected) { stateChange in
-                                expect(stateChange.reason?.message).to(satisfyAnyOf(contain("unreachable host"), contain("network is down")))
-                                done()
-                            }
-                            client.simulateNoInternetConnection()
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.connected) { stateChange in
-                                expect(stateChange.previous).to(equal(.connecting))
-                                done()
-                            }
-                            client.simulateRestoreInternetConnection()
-                        }
-
-                        channel.off()
-                        expect(channel.state).to(equal(.attached))
-                    }
-
-                // RTL3b
-                
-
-                    func test__022__Channel__connection_state__changes_to_CLOSED__ATTACHING_channel_should_transition_to_DETACHED() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-                        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-
-                        let channel = client.channels.get("test")
-                        channel.attach()
-                        let transport = client.internal.transport as! TestProxyTransport
-                        transport.actionsIgnored += [.attached]
-
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-                        client.close()
-                        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closing))
-                        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
-                        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closed))
-                    }
-
-                    func test__023__Channel__connection_state__changes_to_CLOSED__ATTACHED_channel_should_transition_to_DETACHED() {
-                        let options = AblyTests.commonAppSetup()
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("test")
-                        channel.attach()
-
-                        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-                        client.close()
-                        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closing))
-                        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
-                        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closed))
-                    }
-
-                // RTL3c
-                
-
-                    func test__024__Channel__connection_state__changes_to_SUSPENDED__ATTACHING_channel_should_transition_to_SUSPENDED() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("test")
-                        channel.attach()
-                        let transport = client.internal.transport as! TestProxyTransport
-                        transport.actionsIgnored += [.attached]
-
-                        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-                        client.internal.onSuspended()
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.suspended))
-                    }
-
-                    func test__025__Channel__connection_state__changes_to_SUSPENDED__ATTACHED_channel_should_transition_to_SUSPENDED() {
-                        let options = AblyTests.commonAppSetup()
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("test")
-                        channel.attach()
-                        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-                        client.internal.onSuspended()
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.suspended))
-                    }
-                    
-                    func test__026__Channel__connection_state__changes_to_SUSPENDED__channel_being_released_waiting_for_DETACH_shouldn_t_crash__issue__918_() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-                        
-                        // Force the callback on .release below to be triggered by our
-                        // forced SUSPENDED message, not by a DETACHED.
-                        let transport = client.internal.transport as! TestProxyTransport
-                        transport.actionsIgnored += [.detached]
-                        
-                        for i in (0..<100) { // We need a few channels to trigger iterator invalidation.
-                            let channel = client.channels.get("test\(i)")
-                            channel.attach() // No need to wait; ATTACHING state is good enough.
-                            expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attaching), timeout: testTimeout)
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            
-                            client.channels.release("test0") { _ in
-                                partialDone()
-                            }
-                            
-                            AblyTests.queue.async {
-                                client.internal.onSuspended()
-                                partialDone()
-                            }
-                        }
-                    }
-
-                // RTL3d
-                func test__013__Channel__connection_state__if_the_connection_state_enters_the_CONNECTED_state__then_a_SUSPENDED_channel_will_initiate_an_attach_operation() {
-                    let options = AblyTests.commonAppSetup()
-                    options.suspendedRetryTimeout = 1.0
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.once(.suspended) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                        delay(0) {
-                            client.internal.onSuspended()
-                        }
-                    }
-
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-                }
-
-                // RTL3d
-                func test__014__Channel__connection_state__if_the_attach_operation_for_the_channel_times_out_and_the_channel_returns_to_the_SUSPENDED_state() {
-                    let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    client.simulateSuspended(beforeSuspension: { done in
-                        channel.once(.suspended) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                    })
-                }
-
-                // RTL3d - https://github.com/ably/ably-cocoa/issues/881
-                func test__015__Channel__connection_state__should_attach_successfully_and_remain_attached_when_the_connection_state_without_a_successful_recovery_gets_CONNECTED() {
-                    let options = AblyTests.commonAppSetup()
-                    options.disconnectedRetryTimeout = 0.5
-                    options.suspendedRetryTimeout = 3.0
-                    options.channelRetryTimeout = 0.5
-                    options.autoConnect = false
-
-                    let client = ARTRealtime(options: options)
-                    client.internal.setTransport(TestProxyTransport.self)
-                    client.internal.setReachabilityClass(TestReachability.self)
-                    defer {
-                        client.simulateRestoreInternetConnection()
-                        client.dispose()
-                        client.close()
-                    }
-
-                    // Move to SUSPENDED
-                    let ttlHookToken = client.overrideConnectionStateTTL(3.0)
-                    defer { ttlHookToken.remove() }
-
-                    let channel = client.channels.get("foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.once(.suspended) { stateChange in
-                            guard let error = stateChange.reason else {
-                                fail("SUSPENDED reason should not be nil"); done(); return
-                            }
-                            expect(error.message).to(satisfyAnyOf(contain("network is down"), contain("unreachable host")))
-                            done()
-                        }
-                        client.simulateNoInternetConnection()
-                    }
-
-                    AblyTests.queue.async {
-                        // Do not resume
-                        client.simulateLostConnectionAndState()
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason?.code).to(equal(ARTErrorCode.unableToRecoverConnectionExpired.intValue)) //didn't resumed
-                            done()
-                        }
-                        client.simulateRestoreInternetConnection(after: 1.0)
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.once(.attached) { stateChange in
-                            expect(stateChange.resumed).to(beFalse())
-                            expect(stateChange.reason).to(beNil())
-                            channel.on(.suspended) { _ in
-                                fail("Should not reach SUSPENDED state")
-                            }
-                            delay(3.0) {
-                                // Wait some seconds to see if the channel doesn't change to SUSPENDED again
-                                done()
-                            }
-                        }
-                    }
-                    channel.off()
-                }
-
-                // RTL3e
-                func test__016__Channel__connection_state__if_the_connection_state_enters_the_DISCONNECTED_state__it_will_have_no_effect_on_the_channel_states() {
-                    let options = AblyTests.commonAppSetup()
-                    options.token = getTestToken(ttl: 5.0)
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-
-                    channel.once(.detached) { stateChange in
-                        fail("Should not reach the DETACHED state")
-                    }
-                    defer {
-                        channel.off()
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.disconnected) { _ in
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
-                            done()
-                        }
-                    }
-                }
-
-            // RTL4
-            
-
-                // RTL4a
-                func test__027__Channel__attach__if_already_ATTACHED_or_ATTACHING_nothing_is_done() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-
-                    channel.attach { errorInfo in
-                        expect(errorInfo).to(beNil())
-                    }
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-
-                    channel.attach { errorInfo in
-                        expect(errorInfo).to(beNil())
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
-                    }
-
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
-                            done()
-                        }
-                    }
-                }
-
-                // RTL4e
-                func test__028__Channel__attach__if_the_user_does_not_have_sufficient_permissions_to_attach__then_the_channel_will_transition_to_FAILED_and_set_the_errorReason() {
-                    let options = AblyTests.commonAppSetup()
-                    options.token = getTestToken(key: options.key!, capability: "{\"restricted\":[\"*\"]}")
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channel.once(.failed) { stateChange in
-                            expect(stateChange.reason?.code) == ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue
-                            partialDone()
-                        }
-                        channel.attach { error in
-                            guard let error = error else {
-                                fail("Error is nil"); partialDone(); return
-                            }
-                            expect(error.code) == ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue
-                            partialDone()
-                        }
-                    }
-
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-                    expect(channel.errorReason?.code) == ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue
-                }
-
-                // RTL4g
-                func test__029__Channel__attach__if_the_channel_is_in_the_FAILED_state__the_attach_request_sets_its_errorReason_to_null__and_proceeds_with_a_channel_attach() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    channel.attach()
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                    let errorMsg = AblyTests.newErrorProtocolMessage()
-                    errorMsg.channel = channel.name
-                    client.internal.onError(errorMsg)
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-                    expect(channel.errorReason).toNot(beNil())
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
-                    expect(channel.errorReason).to(beNil())
-                }
-
-                // RTL4b
-                
-
-                    func test__039__Channel__attach__results_in_an_error_if_the_connection_state_is__CLOSING() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-
-                        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                        let transport = client.internal.transport as! TestProxyTransport
-                        transport.actionsIgnored += [.closed]
-
-                        let channel = client.channels.get("test")
-
-                        client.close()
-                        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closing))
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach { error in
-                                expect(error).toNot(beNil())
-                                done()
-                            }
-                        }
-                    }
-
-                    func test__040__Channel__attach__results_in_an_error_if_the_connection_state_is__CLOSED() {
-                        let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("test")
-
-                        client.close()
-                        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.closed), timeout: testTimeout)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach { error in
-                                expect(error).toNot(beNil())
-                                done()
-                            }
-                        }
-                    }
-
-                    func test__041__Channel__attach__results_in_an_error_if_the_connection_state_is__SUSPENDED() {
-                        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("test")
-                        client.internal.onSuspended()
-                        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.suspended))
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach { error in
-                                expect(error).toNot(beNil())
-                                done()
-                            }
-                        }
-                    }
-
-                    func test__042__Channel__attach__results_in_an_error_if_the_connection_state_is__FAILED() {
-                        let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("test")
-                        client.internal.onError(AblyTests.newErrorProtocolMessage())
-                        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.failed))
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach { error in
-                                expect(error).toNot(beNil())
-                                done()
-                            }
-                        }
-                    }
-
-                // RTL4i
-                
-                    func test__043__Channel__attach__happens_when_connection_is_CONNECTED_if_it_s_currently__INITIALIZED() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("test")
-                        expect(client.connection.state).to(equal(.initialized))
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.on(.attached) { stateChange in
-                                expect(client.connection.state).to(equal(.connected))
-                                expect(stateChange.reason).to(beNil())
-                                done()
-                            }
-
-                            client.connect()
-                        }
-                        expect(channel.state).to(equal(.attached))
-                    }
-
-                    func test__044__Channel__attach__happens_when_connection_is_CONNECTED_if_it_s_currently__CONNECTING() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connect()
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connecting))
-
-                            channel.attach { error in
-                                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-                    }
-
-                    func skipped__test__045__Channel__attach__happens_when_connection_is_CONNECTED_if_it_s_currently__DISCONNECTED() {
-                        let options = AblyTests.commonAppSetup()
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("test")
-
-                        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.internal.onDisconnected()
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.disconnected))
-
-                            channel.attach { error in
-                                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-                    }
-
-                // RTL4c
-                func test__030__Channel__attach__should_send_an_ATTACH_ProtocolMessage__change_state_to_ATTACHING_and_change_state_to_ATTACHED_after_confirmation() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    client.internal.setTransport(TestProxyTransport.self)
-                    client.connect()
-                    defer { client.dispose(); client.close() }
-
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                    let transport = client.internal.transport as! TestProxyTransport
-
-                    let channel = client.channels.get("test")
-                    channel.attach()
-
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-                    expect(transport.protocolMessagesSent.filter({ $0.action == .attach })).to(haveCount(1))
-
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-                    expect(transport.protocolMessagesReceived.filter({ $0.action == .attached })).to(haveCount(1))
-                }
-
-                // RTL4e
-                func test__031__Channel__attach__should_transition_the_channel_state_to_FAILED_if_the_user_does_not_have_sufficient_permissions() {
-                    let options = AblyTests.clientOptions()
-                    options.token = getTestToken(capability: "{ \"main\":[\"subscribe\"] }")
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-                    channel.attach()
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.once(.failed) { stateChange in
-                            guard let error = stateChange.reason else {
-                                fail("Reason error is nil"); done(); return
-                            }
-                            expect(error.code).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
-                            done()
-                        }
-                    }
-
-                    expect(channel.errorReason!.code).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-                }
-
-                // RTL4f
-                func test__032__Channel__attach__should_transition_the_channel_state_to_SUSPENDED_if_ATTACHED_ProtocolMessage_is_not_received() {
-                    let options = AblyTests.commonAppSetup()
-                    options.channelRetryTimeout = 1.0
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-
-                    let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                    defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                    ARTDefault.setRealtimeRequestTimeout(1.0)
-
-                    guard let transport = client.internal.transport as? TestProxyTransport else {
-                        fail("TestProxyTransport is not set"); return
-                    }
-                    transport.actionsIgnored += [.attached]
-
-                    let channel = client.channels.get("test")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach { errorInfo in
-                            expect(errorInfo).toNot(beNil())
-                            expect(errorInfo).to(equal(channel.errorReason))
-                            done()
-                        }
-                    }
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.suspended), timeout: testTimeout)
-                    expect(channel.errorReason).toNot(beNil())
-
-                    transport.actionsIgnored = []
-                    // Automatically re-attached
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channel.once(.attaching) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            partialDone()
-                        }
-                        channel.once(.attached) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            partialDone()
-                        }
-                    }
-                }
-
-                func test__033__Channel__attach__if_called_with_a_callback_should_call_it_once_attached() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
-                            done()
-                        }
-                    }
-                }
-
-                func test__034__Channel__attach__if_called_with_a_callback_and_already_attaching_should_call_the_callback_once_attached() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach()
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-                        channel.attach { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
-                            done()
-                        }
-                    }
-                }
-
-                func test__035__Channel__attach__if_called_with_a_callback_and_already_attached_should_call_the_callback_with_nil_error() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-
-                    channel.attach()
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            done()
-                        }
-                    }
-                }
-
-                // RTL4h
-                func test__036__Channel__attach__if_the_channel_is_in_a_pending_state_ATTACHING__do_the_attach_operation_after_the_completion_of_the_pending_request() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("foo")
-
-                    var attachedCount = 0
-                    channel.on(.attached) { stateChange in
+                expect(error.code) == ARTErrorCode.tokenExpired.intValue
+
+                channel.on { stateChange in
+                    if stateChange.current == .attached {
+                        expect(stateChange.resumed).to(beTrue())
                         expect(stateChange.reason).to(beNil())
-                        attachedCount += 1
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channel.once(.attaching) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            expect(stateChange.current).to(equal(ARTRealtimeChannelState.attaching))
-                            expect(stateChange.previous).to(equal(ARTRealtimeChannelState.initialized))
-                            channel.attach()
-                            partialDone()
-                        }
-                        channel.once(.attached) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            partialDone()
-                        }
-                        channel.attach()
-                    }
-
-                    expect(attachedCount).toEventually(equal(1), timeout: testTimeout)
-                }
-
-                // RTL4h
-                func test__037__Channel__attach__if_the_channel_is_in_a_pending_state_DETACHING__do_the_attach_operation_after_the_completion_of_the_pending_request() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(4, done: done)
-                        channel.once(.detaching) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            expect(stateChange.current).to(equal(ARTRealtimeChannelState.detaching))
-                            expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attached))
-                            channel.attach()
-                            partialDone()
-                        }
-                        channel.once(.detached) { stateChange in
-                            expect(stateChange.reason?.message).to(contain("channel has detached"))
-                            expect(stateChange.current).to(equal(ARTRealtimeChannelState.detached))
-                            expect(stateChange.previous).to(equal(ARTRealtimeChannelState.detaching))
-                            partialDone()
-                        }
-                        channel.once(.attaching) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            expect(stateChange.current).to(equal(ARTRealtimeChannelState.attaching))
-                            expect(stateChange.previous).to(equal(ARTRealtimeChannelState.detached))
-                            partialDone()
-                        }
-                        channel.once(.attached) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            expect(stateChange.current).to(equal(ARTRealtimeChannelState.attached))
-                            expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attaching))
-                            partialDone()
-                        }
-                        channel.detach()
+                        expect(stateChange.current).to(equal(ARTRealtimeChannelState.attached))
+                        expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attached))
+                        done()
                     }
                 }
+            }
+            channel.attach()
+        }
+    }
 
-                func test__038__Channel__attach__a_channel_in_DETACHING_can_actually_move_back_to_ATTACHED_if_it_fails_to_detach() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
+    // RTL2f, TR4i
+    func test__012__Channel__EventEmitter__channel_states_and_events__bit_flag_RESUMED_was_included() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
 
-                    let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                    defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                    ARTDefault.setRealtimeRequestTimeout(1.0)
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.attached) { stateChange in
+                expect(stateChange.resumed).to(beFalse())
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            channel.attach()
+        }
 
-                    guard let transport = client.internal.transport as? TestProxyTransport else {
-                        fail("TestProxyTransport is not set"); return
-                    }
+        let attachedMessage = ARTProtocolMessage()
+        attachedMessage.action = .attached
+        attachedMessage.channel = channel.name
+        attachedMessage.flags = 4 // Resumed
 
-                    // Force timeout
-                    transport.actionsIgnored = [.detached]
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.update) { stateChange in
+                expect(stateChange.resumed).to(beTrue())
+                expect(stateChange.reason).to(beNil())
+                expect(stateChange.current).to(equal(ARTRealtimeChannelState.attached))
+                expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attached))
+                done()
+            }
+            client.internal.transport?.receive(attachedMessage)
+        }
+    }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.detach() { error in
-                            guard let error = error else {
-                                fail("Reason error is nil"); return
-                            }
-                            expect(error.message).to(contain("timed out"))
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
-                            done()
-                        }
-                    }
+    // RTL3
+
+    // RTL3a
+
+    func test__017__Channel__connection_state__changes_to_FAILED__ATTACHING_channel_should_transition_to_FAILED() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+        channel.attach()
+        let transport = client.internal.transport as! TestProxyTransport
+        transport.actionsIgnored += [.attached]
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+
+        waitUntil(timeout: testTimeout) { done in
+            let pmError = AblyTests.newErrorProtocolMessage()
+            channel.once(.failed) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Reason error is nil"); done(); return
                 }
+                expect(error).to(equal(pmError.error))
+                expect(channel.errorReason).to(beIdenticalTo(error))
+                done()
+            }
+            client.internal.onError(pmError)
+        }
 
-                // RTL4j
-                
+        expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+    }
 
-                    func test__046__Channel__attach__attach_resume__should_pass_attach_resume_flag_in_attach_message() {
-                        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("foo")
+    func test__018__Channel__connection_state__changes_to_FAILED__ATTACHED_channel_should_transition_to_FAILED() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
 
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach() { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
+        let channel = client.channels.get("test")
+        channel.attach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
 
-                        guard let transport = client.internal.transport as? TestProxyTransport else {
-                            fail("Expecting TestProxyTransport"); return
-                        }
+        waitUntil(timeout: testTimeout) { done in
+            let pmError = AblyTests.newErrorProtocolMessage()
+            channel.once(.failed) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Reason error is nil"); done(); return
+                }
+                expect(error).to(equal(pmError.error))
+                expect(channel.errorReason).to(equal(error))
+                done()
+            }
+            client.internal.onError(pmError)
+        }
 
-                        let channelOptions = ARTRealtimeChannelOptions()
-                        channelOptions.modes = [.publish]
+        expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+    }
 
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.setOptions(channelOptions) { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
+    func test__019__Channel__connection_state__changes_to_FAILED__channel_being_released_waiting_for_DETACH_shouldn_t_crash__issue__918_() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
 
-                        let attachMessages = transport.protocolMessagesSent.filter({ $0.action == .attach })
-                        expect(attachMessages).to(haveCount(2))
+        // Force the callback on .release below to be triggered by our
+        // forced FAILED message, not by a DETACHED.
+        let transport = client.internal.transport as! TestProxyTransport
+        transport.actionsIgnored += [.detached]
 
-                        guard let firstAttach = attachMessages.first else {
-                            fail("First ATTACH message is missing"); return
-                        }
-                        expect(firstAttach.flags).to(equal(0))
+        for i in 0 ..< 100 { // We need a few channels to trigger iterator invalidation.
+            let channel = client.channels.get("test\(i)")
+            channel.attach() // No need to wait; ATTACHING state is good enough.
+            expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attaching), timeout: testTimeout)
+        }
 
-                        guard let lastAttach = attachMessages.last else {
-                            fail("Last ATTACH message is missing"); return
-                        }
-                        expect(lastAttach.flags & Int64(ARTProtocolMessageFlag.attachResume.rawValue)).to(beGreaterThan(0)) //true
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
 
-                    // RTL4j1
-                    func test__047__Channel__attach__attach_resume__should_have_correct_AttachResume_value() {
-                        let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("foo")
+            client.channels.release("test0") { _ in
+                partialDone()
+            }
 
-                        // Initialized
-                        expect(channel.internal.attachResume).to(equal(attachResumeExpectedValues[channel.state]))
+            AblyTests.queue.async {
+                let pmError = AblyTests.newErrorProtocolMessage()
+                client.internal.onError(pmError)
+                partialDone()
+            }
+        }
+    }
 
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.once(.failed) { stateChange in
-                                done()
-                            }
-                            AblyTests.queue.async {
-                                channel.internal.onError(AblyTests.newErrorProtocolMessage())
-                            }
-                        }
+    // TO3g
+    func test__020__Channel__connection_state__changes_to_FAILED__should_immediately_fail_if_not_in_the_connected_state() {
+        let options = AblyTests.commonAppSetup()
+        options.queueMessages = false
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            expect(client.connection.state).to(equal(.initialized))
+            channel.publish(nil, data: "message") { error in
+                expect(error?.code).to(equal(ARTErrorCode.invalidTransportHandle.intValue))
+                expect(error?.message).to(contain("Invalid operation"))
+                done()
+            }
+        }
+        expect(channel.state).to(equal(.initialized))
+        waitUntil(timeout: testTimeout) { done in
+            client.connect()
+            expect(client.connection.state).to(equal(.connecting))
+            channel.publish(nil, data: "message") { error in
+                expect(error?.code).to(equal(ARTErrorCode.invalidTransportHandle.intValue))
+                expect(error?.message).to(contain("Invalid operation"))
+                done()
+            }
+        }
+        expect(channel.state).toEventually(equal(.attached), timeout: testTimeout)
+    }
 
-                        // Failed
-                        expect(channel.internal.attachResume).to(equal(attachResumeExpectedValues[channel.state]))
+    // TO3g and https://github.com/ably/ably-cocoa/issues/1004
+    func test__021__Channel__connection_state__changes_to_FAILED__should_keep_the_channels_attached_when_client_reconnected_successfully_and_queue_messages_is_disabled() {
+        let options = AblyTests.commonAppSetup()
+        options.queueMessages = false
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.internal.setTransport(TestProxyTransport.self)
+        client.internal.setReachabilityClass(TestReachability.self)
+        let channel = client.channels.get("foo")
 
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach() { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                done()
+            }
+            client.connect()
+        }
 
-                        // Attached
-                        expect(channel.internal.attachResume).to(equal(attachResumeExpectedValues[channel.state]))
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
 
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.once(.detaching) { stateChange in
-                                // Detaching
-                                expect(channel.internal.attachResume).to(equal(attachResumeExpectedValues[channel.state]))
-                                done()
-                            }
-                            channel.detach()
-                        }
-                    }
+        expect(channel.state).to(equal(.attached))
+        channel.on { stateChange in
+            if stateChange.current != .attached {
+                fail("Channel state should not change")
+            }
+        }
 
-                    // RTL4j2
-                    func test__048__Channel__attach__attach_resume__should_encode_correctly_the_AttachResume_flag() {
-                        let options = AblyTests.commonAppSetup()
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.disconnected) { stateChange in
+                expect(stateChange.reason?.message).to(satisfyAnyOf(contain("unreachable host"), contain("network is down")))
+                done()
+            }
+            client.simulateNoInternetConnection()
+        }
 
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.previous).to(equal(.connecting))
+                done()
+            }
+            client.simulateRestoreInternetConnection()
+        }
 
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish("test", data: nil) { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
+        channel.off()
+        expect(channel.state).to(equal(.attached))
+    }
 
-                        let channelOptions = ARTRealtimeChannelOptions()
-                        channelOptions.params = ["rewind": "1"]
+    // RTL3b
 
-                        let client1 = ARTRealtime(options: options)
-                        defer { client1.dispose(); client1.close() }
-                        let channelWithAttachResume = client1.channels.get("foo", options: channelOptions)
-                        channelWithAttachResume.internal.attachResume = true
-                        waitUntil(timeout: testTimeout) { done in
-                            channelWithAttachResume.subscribe { message in
-                                fail("Should not receive the previously-published message")
-                            }
-                            channelWithAttachResume.attach { error in
-                                expect(error).to(beNil())
-                            }
-                            delay(2.0) {
-                                // Wait some seconds to confirm that the message is not received
-                                done()
-                            }
-                        }
+    func test__022__Channel__connection_state__changes_to_CLOSED__ATTACHING_channel_should_transition_to_DETACHED() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
 
-                        channelOptions.modes = [.subscribe]
-                        let client2 = ARTRealtime(options: options)
-                        defer { client2.dispose(); client2.close() }
-                        let channelWithoutAttachResume = client2.channels.get("foo", options: channelOptions)
-                        waitUntil(timeout: testTimeout) { done in
-                            channelWithoutAttachResume.subscribe { message in
-                                expect(message.name).to(equal("test"))
-                                done()
-                            }
-                            channelWithoutAttachResume.attach()
-                        }
-                    }
+        let channel = client.channels.get("test")
+        channel.attach()
+        let transport = client.internal.transport as! TestProxyTransport
+        transport.actionsIgnored += [.attached]
 
-            
-                // RTL5a
-                func test__049__Channel__detach__if_state_is_INITIALIZED_or_DETACHED_nothing_is_done() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+        client.close()
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closing))
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closed))
+    }
 
+    func test__023__Channel__connection_state__changes_to_CLOSED__ATTACHED_channel_should_transition_to_DETACHED() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+        channel.attach()
+
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+        client.close()
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closing))
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closed))
+    }
+
+    // RTL3c
+
+    func test__024__Channel__connection_state__changes_to_SUSPENDED__ATTACHING_channel_should_transition_to_SUSPENDED() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+        channel.attach()
+        let transport = client.internal.transport as! TestProxyTransport
+        transport.actionsIgnored += [.attached]
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+        client.internal.onSuspended()
+        expect(channel.state).to(equal(ARTRealtimeChannelState.suspended))
+    }
+
+    func test__025__Channel__connection_state__changes_to_SUSPENDED__ATTACHED_channel_should_transition_to_SUSPENDED() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+        channel.attach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+        client.internal.onSuspended()
+        expect(channel.state).to(equal(ARTRealtimeChannelState.suspended))
+    }
+
+    func test__026__Channel__connection_state__changes_to_SUSPENDED__channel_being_released_waiting_for_DETACH_shouldn_t_crash__issue__918_() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        // Force the callback on .release below to be triggered by our
+        // forced SUSPENDED message, not by a DETACHED.
+        let transport = client.internal.transport as! TestProxyTransport
+        transport.actionsIgnored += [.detached]
+
+        for i in 0 ..< 100 { // We need a few channels to trigger iterator invalidation.
+            let channel = client.channels.get("test\(i)")
+            channel.attach() // No need to wait; ATTACHING state is good enough.
+            expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attaching), timeout: testTimeout)
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+
+            client.channels.release("test0") { _ in
+                partialDone()
+            }
+
+            AblyTests.queue.async {
+                client.internal.onSuspended()
+                partialDone()
+            }
+        }
+    }
+
+    // RTL3d
+    func test__013__Channel__connection_state__if_the_connection_state_enters_the_CONNECTED_state__then_a_SUSPENDED_channel_will_initiate_an_attach_operation() {
+        let options = AblyTests.commonAppSetup()
+        options.suspendedRetryTimeout = 1.0
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.suspended) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            delay(0) {
+                client.internal.onSuspended()
+            }
+        }
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+    }
+
+    // RTL3d
+    func test__014__Channel__connection_state__if_the_attach_operation_for_the_channel_times_out_and_the_channel_returns_to_the_SUSPENDED_state() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        client.simulateSuspended(beforeSuspension: { done in
+            channel.once(.suspended) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+        })
+    }
+
+    // RTL3d - https://github.com/ably/ably-cocoa/issues/881
+    func test__015__Channel__connection_state__should_attach_successfully_and_remain_attached_when_the_connection_state_without_a_successful_recovery_gets_CONNECTED() {
+        let options = AblyTests.commonAppSetup()
+        options.disconnectedRetryTimeout = 0.5
+        options.suspendedRetryTimeout = 3.0
+        options.channelRetryTimeout = 0.5
+        options.autoConnect = false
+
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.internal.setReachabilityClass(TestReachability.self)
+        defer {
+            client.simulateRestoreInternetConnection()
+            client.dispose()
+            client.close()
+        }
+
+        // Move to SUSPENDED
+        let ttlHookToken = client.overrideConnectionStateTTL(3.0)
+        defer { ttlHookToken.remove() }
+
+        let channel = client.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+            client.connect()
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.suspended) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("SUSPENDED reason should not be nil"); done(); return
+                }
+                expect(error.message).to(satisfyAnyOf(contain("network is down"), contain("unreachable host")))
+                done()
+            }
+            client.simulateNoInternetConnection()
+        }
+
+        AblyTests.queue.async {
+            // Do not resume
+            client.simulateLostConnectionAndState()
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason?.code).to(equal(ARTErrorCode.unableToRecoverConnectionExpired.intValue)) // didn't resumed
+                done()
+            }
+            client.simulateRestoreInternetConnection(after: 1.0)
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.attached) { stateChange in
+                expect(stateChange.resumed).to(beFalse())
+                expect(stateChange.reason).to(beNil())
+                channel.on(.suspended) { _ in
+                    fail("Should not reach SUSPENDED state")
+                }
+                delay(3.0) {
+                    // Wait some seconds to see if the channel doesn't change to SUSPENDED again
+                    done()
+                }
+            }
+        }
+        channel.off()
+    }
+
+    // RTL3e
+    func test__016__Channel__connection_state__if_the_connection_state_enters_the_DISCONNECTED_state__it_will_have_no_effect_on_the_channel_states() {
+        let options = AblyTests.commonAppSetup()
+        options.token = getTestToken(ttl: 5.0)
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        channel.once(.detached) { _ in
+            fail("Should not reach the DETACHED state")
+        }
+        defer {
+            channel.off()
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.disconnected) { _ in
+                expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+                done()
+            }
+        }
+    }
+
+    // RTL4
+
+    // RTL4a
+    func test__027__Channel__attach__if_already_ATTACHED_or_ATTACHING_nothing_is_done() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        channel.attach { errorInfo in
+            expect(errorInfo).to(beNil())
+        }
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+
+        channel.attach { errorInfo in
+            expect(errorInfo).to(beNil())
+            expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+        }
+
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { errorInfo in
+                expect(errorInfo).to(beNil())
+                expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+                done()
+            }
+        }
+    }
+
+    // RTL4e
+    func test__028__Channel__attach__if_the_user_does_not_have_sufficient_permissions_to_attach__then_the_channel_will_transition_to_FAILED_and_set_the_errorReason() {
+        let options = AblyTests.commonAppSetup()
+        options.token = getTestToken(key: options.key!, capability: "{\"restricted\":[\"*\"]}")
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.once(.failed) { stateChange in
+                expect(stateChange.reason?.code) == ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue
+                partialDone()
+            }
+            channel.attach { error in
+                guard let error = error else {
+                    fail("Error is nil"); partialDone(); return
+                }
+                expect(error.code) == ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue
+                partialDone()
+            }
+        }
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+        expect(channel.errorReason?.code) == ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue
+    }
+
+    // RTL4g
+    func test__029__Channel__attach__if_the_channel_is_in_the_FAILED_state__the_attach_request_sets_its_errorReason_to_null__and_proceeds_with_a_channel_attach() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        channel.attach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        let errorMsg = AblyTests.newErrorProtocolMessage()
+        errorMsg.channel = channel.name
+        client.internal.onError(errorMsg)
+        expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+        expect(channel.errorReason).toNot(beNil())
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+        expect(channel.errorReason).to(beNil())
+    }
+
+    // RTL4b
+
+    func test__039__Channel__attach__results_in_an_error_if_the_connection_state_is__CLOSING() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        let transport = client.internal.transport as! TestProxyTransport
+        transport.actionsIgnored += [.closed]
+
+        let channel = client.channels.get("test")
+
+        client.close()
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closing))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).toNot(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__040__Channel__attach__results_in_an_error_if_the_connection_state_is__CLOSED() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        client.close()
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.closed), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).toNot(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__041__Channel__attach__results_in_an_error_if_the_connection_state_is__SUSPENDED() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+        client.internal.onSuspended()
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.suspended))
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).toNot(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__042__Channel__attach__results_in_an_error_if_the_connection_state_is__FAILED() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+        client.internal.onError(AblyTests.newErrorProtocolMessage())
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.failed))
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).toNot(beNil())
+                done()
+            }
+        }
+    }
+
+    // RTL4i
+
+    func test__043__Channel__attach__happens_when_connection_is_CONNECTED_if_it_s_currently__INITIALIZED() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+        expect(client.connection.state).to(equal(.initialized))
+        waitUntil(timeout: testTimeout) { done in
+            channel.on(.attached) { stateChange in
+                expect(client.connection.state).to(equal(.connected))
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+
+            client.connect()
+        }
+        expect(channel.state).to(equal(.attached))
+    }
+
+    func test__044__Channel__attach__happens_when_connection_is_CONNECTED_if_it_s_currently__CONNECTING() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connect()
+            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connecting))
+
+            channel.attach { error in
+                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    func skipped__test__045__Channel__attach__happens_when_connection_is_CONNECTED_if_it_s_currently__DISCONNECTED() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            client.internal.onDisconnected()
+            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.disconnected))
+
+            channel.attach { error in
+                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RTL4c
+    func test__030__Channel__attach__should_send_an_ATTACH_ProtocolMessage__change_state_to_ATTACHING_and_change_state_to_ATTACHED_after_confirmation() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        let transport = client.internal.transport as! TestProxyTransport
+
+        let channel = client.channels.get("test")
+        channel.attach()
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+        expect(transport.protocolMessagesSent.filter { $0.action == .attach }).to(haveCount(1))
+
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+        expect(transport.protocolMessagesReceived.filter { $0.action == .attached }).to(haveCount(1))
+    }
+
+    // RTL4e
+    func test__031__Channel__attach__should_transition_the_channel_state_to_FAILED_if_the_user_does_not_have_sufficient_permissions() {
+        let options = AblyTests.clientOptions()
+        options.token = getTestToken(capability: "{ \"main\":[\"subscribe\"] }")
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+        channel.attach()
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.failed) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Reason error is nil"); done(); return
+                }
+                expect(error.code).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
+                done()
+            }
+        }
+
+        expect(channel.errorReason!.code).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
+        expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+    }
+
+    // RTL4f
+    func test__032__Channel__attach__should_transition_the_channel_state_to_SUSPENDED_if_ATTACHED_ProtocolMessage_is_not_received() {
+        let options = AblyTests.commonAppSetup()
+        options.channelRetryTimeout = 1.0
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(1.0)
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+        transport.actionsIgnored += [.attached]
+
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { errorInfo in
+                expect(errorInfo).toNot(beNil())
+                expect(errorInfo).to(equal(channel.errorReason))
+                done()
+            }
+        }
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.suspended), timeout: testTimeout)
+        expect(channel.errorReason).toNot(beNil())
+
+        transport.actionsIgnored = []
+        // Automatically re-attached
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.once(.attaching) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                partialDone()
+            }
+            channel.once(.attached) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                partialDone()
+            }
+        }
+    }
+
+    func test__033__Channel__attach__if_called_with_a_callback_should_call_it_once_attached() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { errorInfo in
+                expect(errorInfo).to(beNil())
+                expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+                done()
+            }
+        }
+    }
+
+    func test__034__Channel__attach__if_called_with_a_callback_and_already_attaching_should_call_the_callback_once_attached() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach()
+            expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+            channel.attach { errorInfo in
+                expect(errorInfo).to(beNil())
+                expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+                done()
+            }
+        }
+    }
+
+    func test__035__Channel__attach__if_called_with_a_callback_and_already_attached_should_call_the_callback_with_nil_error() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        channel.attach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RTL4h
+    func test__036__Channel__attach__if_the_channel_is_in_a_pending_state_ATTACHING__do_the_attach_operation_after_the_completion_of_the_pending_request() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+
+        var attachedCount = 0
+        channel.on(.attached) { stateChange in
+            expect(stateChange.reason).to(beNil())
+            attachedCount += 1
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.once(.attaching) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(stateChange.current).to(equal(ARTRealtimeChannelState.attaching))
+                expect(stateChange.previous).to(equal(ARTRealtimeChannelState.initialized))
+                channel.attach()
+                partialDone()
+            }
+            channel.once(.attached) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                partialDone()
+            }
+            channel.attach()
+        }
+
+        expect(attachedCount).toEventually(equal(1), timeout: testTimeout)
+    }
+
+    // RTL4h
+    func test__037__Channel__attach__if_the_channel_is_in_a_pending_state_DETACHING__do_the_attach_operation_after_the_completion_of_the_pending_request() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(4, done: done)
+            channel.once(.detaching) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(stateChange.current).to(equal(ARTRealtimeChannelState.detaching))
+                expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attached))
+                channel.attach()
+                partialDone()
+            }
+            channel.once(.detached) { stateChange in
+                expect(stateChange.reason?.message).to(contain("channel has detached"))
+                expect(stateChange.current).to(equal(ARTRealtimeChannelState.detached))
+                expect(stateChange.previous).to(equal(ARTRealtimeChannelState.detaching))
+                partialDone()
+            }
+            channel.once(.attaching) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(stateChange.current).to(equal(ARTRealtimeChannelState.attaching))
+                expect(stateChange.previous).to(equal(ARTRealtimeChannelState.detached))
+                partialDone()
+            }
+            channel.once(.attached) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(stateChange.current).to(equal(ARTRealtimeChannelState.attached))
+                expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attaching))
+                partialDone()
+            }
+            channel.detach()
+        }
+    }
+
+    func test__038__Channel__attach__a_channel_in_DETACHING_can_actually_move_back_to_ATTACHED_if_it_fails_to_detach() {
+        let options = AblyTests.commonAppSetup()
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(1.0)
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        // Force timeout
+        transport.actionsIgnored = [.detached]
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.detach { error in
+                guard let error = error else {
+                    fail("Reason error is nil"); return
+                }
+                expect(error.message).to(contain("timed out"))
+                expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+                done()
+            }
+        }
+    }
+
+    // RTL4j
+
+    func test__046__Channel__attach__attach_resume__should_pass_attach_resume_flag_in_attach_message() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("Expecting TestProxyTransport"); return
+        }
+
+        let channelOptions = ARTRealtimeChannelOptions()
+        channelOptions.modes = [.publish]
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.setOptions(channelOptions) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        let attachMessages = transport.protocolMessagesSent.filter { $0.action == .attach }
+        expect(attachMessages).to(haveCount(2))
+
+        guard let firstAttach = attachMessages.first else {
+            fail("First ATTACH message is missing"); return
+        }
+        expect(firstAttach.flags).to(equal(0))
+
+        guard let lastAttach = attachMessages.last else {
+            fail("Last ATTACH message is missing"); return
+        }
+        expect(lastAttach.flags & Int64(ARTProtocolMessageFlag.attachResume.rawValue)).to(beGreaterThan(0)) // true
+    }
+
+    // RTL4j1
+    func test__047__Channel__attach__attach_resume__should_have_correct_AttachResume_value() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+
+        // Initialized
+        expect(channel.internal.attachResume).to(equal(attachResumeExpectedValues[channel.state]))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.failed) { _ in
+                done()
+            }
+            AblyTests.queue.async {
+                channel.internal.onError(AblyTests.newErrorProtocolMessage())
+            }
+        }
+
+        // Failed
+        expect(channel.internal.attachResume).to(equal(attachResumeExpectedValues[channel.state]))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        // Attached
+        expect(channel.internal.attachResume).to(equal(attachResumeExpectedValues[channel.state]))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.detaching) { _ in
+                // Detaching
+                expect(channel.internal.attachResume).to(equal(attachResumeExpectedValues[channel.state]))
+                done()
+            }
+            channel.detach()
+        }
+    }
+
+    // RTL4j2
+    func test__048__Channel__attach__attach_resume__should_encode_correctly_the_AttachResume_flag() {
+        let options = AblyTests.commonAppSetup()
+
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish("test", data: nil) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        let channelOptions = ARTRealtimeChannelOptions()
+        channelOptions.params = ["rewind": "1"]
+
+        let client1 = ARTRealtime(options: options)
+        defer { client1.dispose(); client1.close() }
+        let channelWithAttachResume = client1.channels.get("foo", options: channelOptions)
+        channelWithAttachResume.internal.attachResume = true
+        waitUntil(timeout: testTimeout) { done in
+            channelWithAttachResume.subscribe { _ in
+                fail("Should not receive the previously-published message")
+            }
+            channelWithAttachResume.attach { error in
+                expect(error).to(beNil())
+            }
+            delay(2.0) {
+                // Wait some seconds to confirm that the message is not received
+                done()
+            }
+        }
+
+        channelOptions.modes = [.subscribe]
+        let client2 = ARTRealtime(options: options)
+        defer { client2.dispose(); client2.close() }
+        let channelWithoutAttachResume = client2.channels.get("foo", options: channelOptions)
+        waitUntil(timeout: testTimeout) { done in
+            channelWithoutAttachResume.subscribe { message in
+                expect(message.name).to(equal("test"))
+                done()
+            }
+            channelWithoutAttachResume.attach()
+        }
+    }
+
+    // RTL5a
+    func test__049__Channel__detach__if_state_is_INITIALIZED_or_DETACHED_nothing_is_done() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
+        channel.detach { errorInfo in
+            expect(errorInfo).to(beNil())
+        }
+        expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
+
+        channel.attach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attaching), timeout: testTimeout)
+
+        channel.detach { errorInfo in
+            expect(errorInfo).to(beNil())
+            expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
+        }
+
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.detach { errorInfo in
+                expect(errorInfo).to(beNil())
+                expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
+                done()
+            }
+        }
+    }
+
+    // RTL5i
+    func test__050__Channel__detach__if_the_channel_is_in_a_pending_state_DETACHING__do_the_detach_operation_after_the_completion_of_the_pending_request() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        var detachedCount = 0
+        channel.on(.detached) { _ in
+            detachedCount += 1
+        }
+
+        var detachingCount = 0
+        channel.on(.detaching) { _ in
+            detachingCount += 1
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.once(.detaching) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(stateChange.current).to(equal(ARTRealtimeChannelState.detaching))
+                expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attached))
+                channel.detach()
+                partialDone()
+            }
+            channel.once(.detached) { stateChange in
+                expect(stateChange.current).to(equal(ARTRealtimeChannelState.detached))
+                expect(stateChange.previous).to(equal(ARTRealtimeChannelState.detaching))
+                partialDone()
+            }
+            channel.detach()
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            delay(1.0) {
+                expect(detachedCount) == 1
+                expect(detachingCount) == 1
+                done()
+            }
+        }
+
+        channel.off()
+    }
+
+    // RTL5i
+    func test__051__Channel__detach__if_the_channel_is_in_a_pending_state_ATTACHING__do_the_detach_operation_after_the_completion_of_the_pending_request() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(3, done: done)
+            channel.once(.attaching) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(stateChange.current).to(equal(ARTRealtimeChannelState.attaching))
+                expect(stateChange.previous).to(equal(ARTRealtimeChannelState.initialized))
+                channel.detach()
+                partialDone()
+            }
+            channel.once(.attached) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(stateChange.current).to(equal(ARTRealtimeChannelState.attached))
+                expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attaching))
+                partialDone()
+            }
+            channel.once(.detaching) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(stateChange.current).to(equal(ARTRealtimeChannelState.detaching))
+                expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attached))
+                partialDone()
+            }
+            channel.attach()
+        }
+    }
+
+    // RTL5b
+    func test__052__Channel__detach__results_in_an_error_if_the_connection_state_is_FAILED() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+        client.internal.onError(AblyTests.newErrorProtocolMessage())
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.failed))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.detach { errorInfo in
+                expect(errorInfo!.code).to(equal(ARTErrorCode.channelOperationFailed.intValue))
+                done()
+            }
+        }
+    }
+
+    // RTL5d
+    func test__053__Channel__detach__should_send_a_DETACH_ProtocolMessage__change_state_to_DETACHING_and_change_state_to_DETACHED_after_confirmation() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        let transport = client.internal.transport as! TestProxyTransport
+
+        let channel = client.channels.get("test")
+        channel.attach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+        channel.detach()
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.detaching))
+        expect(transport.protocolMessagesSent.filter { $0.action == .detach }).to(haveCount(1))
+
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
+        expect(transport.protocolMessagesReceived.filter { $0.action == .detached }).to(haveCount(1))
+    }
+
+    // RTL5e
+    func test__054__Channel__detach__if_called_with_a_callback_should_call_it_once_detached() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        channel.attach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.detach { errorInfo in
+                expect(errorInfo).to(beNil())
+                expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
+                done()
+            }
+        }
+    }
+
+    // RTL5e
+    func test__055__Channel__detach__if_called_with_a_callback_and_already_detaching_should_call_the_callback_once_detached() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        channel.attach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.detach()
+            expect(channel.state).to(equal(ARTRealtimeChannelState.detaching))
+            channel.detach { errorInfo in
+                expect(errorInfo).to(beNil())
+                expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
+                done()
+            }
+        }
+    }
+
+    // RTL5e
+    func test__056__Channel__detach__if_called_with_a_callback_and_already_detached_should_should_call_the_callback_with_nil_error() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        channel.attach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+        channel.detach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.detach { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RTL5f
+    func test__057__Channel__detach__if_a_DETACHED_is_not_received_within_the_default_realtime_request_timeout__the_detach_request_should_be_treated_as_though_it_has_failed_and_the_channel_will_return_to_its_previous_state() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        let transport = client.internal.transport as! TestProxyTransport
+        transport.actionsIgnored += [.detached]
+
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(1.0)
+
+        let channel = client.channels.get("test")
+        channel.attach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        var callbackCalled = false
+        channel.detach { error in
+            guard let error = error else {
+                fail("Error is nil"); return
+            }
+            expect(error.message).to(contain("timed out"))
+            expect(error).to(equal(channel.errorReason))
+            callbackCalled = true
+        }
+        let start = NSDate()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+        expect(channel.errorReason).toNot(beNil())
+        expect(callbackCalled).toEventually(beTrue(), timeout: testTimeout)
+        let end = NSDate()
+        expect(start.addingTimeInterval(1.0)).to(beCloseTo(end, within: 0.5))
+    }
+
+    // RTL5g
+
+    func test__059__Channel__detach__results_in_an_error_if_the_connection_state_is__CLOSING() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        let transport = client.internal.transport as! TestProxyTransport
+        transport.actionsIgnored += [.closed]
+
+        let channel = client.channels.get("test")
+        channel.attach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        client.close()
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closing))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.detach { error in
+                expect(error).toNot(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__060__Channel__detach__results_in_an_error_if_the_connection_state_is__FAILED() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+        channel.attach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        client.internal.onError(AblyTests.newErrorProtocolMessage())
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.failed))
+        waitUntil(timeout: testTimeout) { done in
+            channel.detach { error in
+                expect(error).toNot(beNil())
+                done()
+            }
+        }
+    }
+
+    // RTL5h
+
+    func test__061__Channel__detach__happens_when_channel_is_ATTACHED_if_connection_is_currently__INITIALIZED() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach()
+            expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.initialized))
+
+            channel.detach { error in
+                expect(error).to(beNil())
+                done()
+            }
+
+            client.connect()
+        }
+    }
+
+    func test__062__Channel__detach__happens_when_channel_is_ATTACHED_if_connection_is_currently__CONNECTING() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connect()
+            channel.attach()
+            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connecting))
+            expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+
+            channel.detach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__063__Channel__detach__happens_when_channel_is_ATTACHED_if_connection_is_currently__DISCONNECTED() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            client.internal.onDisconnected()
+            channel.attach()
+            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.disconnected))
+            expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+
+            channel.detach { error in
+                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RTL5j
+    func test__058__Channel__detach__if_the_channel_state_is_SUSPENDED__the__detach__request_transitions_the_channel_immediately_to_the_DETACHED_state() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        channel.internal.setSuspended(ARTStatus.state(.ok))
+        expect(channel.state).to(equal(ARTRealtimeChannelState.suspended))
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.once(.detached) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(stateChange.current).to(equal(ARTRealtimeChannelState.detached))
+                expect(stateChange.previous).to(equal(ARTRealtimeChannelState.suspended))
+                partialDone()
+            }
+            channel.detach { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
+    }
+
+    // RTL6
+
+    // RTL6a
+    func test__064__Channel__publish__should_encode_messages_in_the_same_way_as_the_RestChannel() {
+        let data = ["value": 1]
+
+        let rest = ARTRest(options: AblyTests.commonAppSetup())
+        let restChannel = rest.channels.get("test")
+
+        var restEncodedMessage: ARTMessage?
+        restChannel.internal.testSuite_getReturnValue(from: NSSelectorFromString("encodeMessageIfNeeded:error:")) { value in
+            restEncodedMessage = value as? ARTMessage
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            restChannel.publish(nil, data: data) { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.close() }
+        let realtimeChannel = realtime.channels.get("test")
+        realtimeChannel.attach()
+        expect(realtimeChannel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        var realtimeEncodedMessage: ARTMessage?
+        realtimeChannel.internal.testSuite_getReturnValue(from: NSSelectorFromString("encodeMessageIfNeeded:error:")) { value in
+            realtimeEncodedMessage = value as? ARTMessage
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtimeChannel.publish(nil, data: data) { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+
+        expect(restEncodedMessage!.data as? NSObject).to(equal(realtimeEncodedMessage!.data as? NSObject))
+        expect(restEncodedMessage!.data).toNot(beNil())
+        expect(realtimeEncodedMessage!.data).toNot(beNil())
+        expect(restEncodedMessage!.encoding).to(equal(realtimeEncodedMessage!.encoding))
+        expect(restEncodedMessage!.encoding).toNot(beNil())
+        expect(realtimeEncodedMessage!.encoding).toNot(beNil())
+    }
+
+    // RTL6b
+
+    func test__067__Channel__publish__should_invoke_callback__when_the_message_is_successfully_delivered() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let error = stateChange.reason
+                expect(error).to(beNil())
+                if state == .connected {
                     let channel = client.channels.get("test")
-
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
-                    channel.detach { errorInfo in
-                        expect(errorInfo).to(beNil())
-                    }
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
-
-                    channel.attach()
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attaching), timeout: testTimeout)
-
-                    channel.detach { errorInfo in
-                        expect(errorInfo).to(beNil())
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
-                    }
-
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.detach { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
-                            done()
-                        }
-                    }
-                }
-
-                // RTL5i
-                func test__050__Channel__detach__if_the_channel_is_in_a_pending_state_DETACHING__do_the_detach_operation_after_the_completion_of_the_pending_request() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    var detachedCount = 0
-                    channel.on(.detached) { _ in
-                        detachedCount += 1
-                    }
-
-                    var detachingCount = 0
-                    channel.on(.detaching) { _ in
-                        detachingCount += 1
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channel.once(.detaching) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            expect(stateChange.current).to(equal(ARTRealtimeChannelState.detaching))
-                            expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attached))
-                            channel.detach()
-                            partialDone()
-                        }
-                        channel.once(.detached) { stateChange in
-                            expect(stateChange.current).to(equal(ARTRealtimeChannelState.detached))
-                            expect(stateChange.previous).to(equal(ARTRealtimeChannelState.detaching))
-                            partialDone()
-                        }
-                        channel.detach()
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        delay(1.0) {
-                            expect(detachedCount) == 1
-                            expect(detachingCount) == 1
-                            done()
-                        }
-                    }
-
-                    channel.off()
-                }
-
-                // RTL5i
-                func test__051__Channel__detach__if_the_channel_is_in_a_pending_state_ATTACHING__do_the_detach_operation_after_the_completion_of_the_pending_request() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("foo")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(3, done: done)
-                        channel.once(.attaching) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            expect(stateChange.current).to(equal(ARTRealtimeChannelState.attaching))
-                            expect(stateChange.previous).to(equal(ARTRealtimeChannelState.initialized))
-                            channel.detach()
-                            partialDone()
-                        }
-                        channel.once(.attached) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            expect(stateChange.current).to(equal(ARTRealtimeChannelState.attached))
-                            expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attaching))
-                            partialDone()
-                        }
-                        channel.once(.detaching) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            expect(stateChange.current).to(equal(ARTRealtimeChannelState.detaching))
-                            expect(stateChange.previous).to(equal(ARTRealtimeChannelState.attached))
-                            partialDone()
-                        }
-                        channel.attach()
-                    }
-                }
-
-                // RTL5b
-                func test__052__Channel__detach__results_in_an_error_if_the_connection_state_is_FAILED() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-                    client.internal.onError(AblyTests.newErrorProtocolMessage())
-                    expect(client.connection.state).to(equal(ARTRealtimeConnectionState.failed))
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.detach() { errorInfo in
-                            expect(errorInfo!.code).to(equal(ARTErrorCode.channelOperationFailed.intValue))
-                            done()
-                        }
-                    }
-                }
-
-                // RTL5d
-                func test__053__Channel__detach__should_send_a_DETACH_ProtocolMessage__change_state_to_DETACHING_and_change_state_to_DETACHED_after_confirmation() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    client.internal.setTransport(TestProxyTransport.self)
-                    client.connect()
-                    defer { client.dispose(); client.close() }
-
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                    let transport = client.internal.transport as! TestProxyTransport
-
-                    let channel = client.channels.get("test")
-                    channel.attach()
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-                    channel.detach()
-
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.detaching))
-                    expect(transport.protocolMessagesSent.filter({ $0.action == .detach })).to(haveCount(1))
-
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
-                    expect(transport.protocolMessagesReceived.filter({ $0.action == .detached })).to(haveCount(1))
-                }
-
-                // RTL5e
-                func test__054__Channel__detach__if_called_with_a_callback_should_call_it_once_detached() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-
-                    channel.attach()
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.detach { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
-                            done()
-                        }
-                    }
-                }
-
-                // RTL5e
-                func test__055__Channel__detach__if_called_with_a_callback_and_already_detaching_should_call_the_callback_once_detached() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-
-                    channel.attach()
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.detach()
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.detaching))
-                        channel.detach { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
-                            done()
-                        }
-                    }
-                }
-
-                // RTL5e
-                func test__056__Channel__detach__if_called_with_a_callback_and_already_detached_should_should_call_the_callback_with_nil_error() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-
-                    channel.attach()
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-                    channel.detach()
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.detach { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            done()
-                        }
-                    }
-                }
-
-                // RTL5f
-                func test__057__Channel__detach__if_a_DETACHED_is_not_received_within_the_default_realtime_request_timeout__the_detach_request_should_be_treated_as_though_it_has_failed_and_the_channel_will_return_to_its_previous_state() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    client.internal.setTransport(TestProxyTransport.self)
-                    client.connect()
-                    defer { client.dispose(); client.close() }
-
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                    let transport = client.internal.transport as! TestProxyTransport
-                    transport.actionsIgnored += [.detached]
-
-                    let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                    defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                    ARTDefault.setRealtimeRequestTimeout(1.0)
-
-                    let channel = client.channels.get("test")
-                    channel.attach()
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                    var callbackCalled = false
-                    channel.detach { error in
-                        guard let error = error else {
-                            fail("Error is nil"); return
-                        }
-                        expect(error.message).to(contain("timed out"))
-                        expect(error).to(equal(channel.errorReason))
-                        callbackCalled = true
-                    }
-                    let start = NSDate()
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-                    expect(channel.errorReason).toNot(beNil())
-                    expect(callbackCalled).toEventually(beTrue(), timeout: testTimeout)
-                    let end = NSDate()
-                    expect(start.addingTimeInterval(1.0)).to(beCloseTo(end, within: 0.5))
-                }
-
-                // RTL5g
-                
-
-                    func test__059__Channel__detach__results_in_an_error_if_the_connection_state_is__CLOSING() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-
-                        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                        let transport = client.internal.transport as! TestProxyTransport
-                        transport.actionsIgnored += [.closed]
-
-                        let channel = client.channels.get("test")
-                        channel.attach()
-                        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                        client.close()
-                        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closing))
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.detach { error in
-                                expect(error).toNot(beNil())
-                                done()
-                            }
-                        }
-                    }
-
-                    func test__060__Channel__detach__results_in_an_error_if_the_connection_state_is__FAILED() {
-                        let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("test")
-                        channel.attach()
-                        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                        client.internal.onError(AblyTests.newErrorProtocolMessage())
-                        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.failed))
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.detach { error in
-                                expect(error).toNot(beNil())
-                                done()
-                            }
-                        }
-                    }
-
-                // RTL5h
-                
-                    func test__061__Channel__detach__happens_when_channel_is_ATTACHED_if_connection_is_currently__INITIALIZED() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("test")
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach()
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.initialized))
-
-                            channel.detach { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-
-                            client.connect()
-                        }
-                    }
-
-                    func test__062__Channel__detach__happens_when_channel_is_ATTACHED_if_connection_is_currently__CONNECTING() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connect()
-                            channel.attach()
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connecting))
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-
-                            channel.detach { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-                    }
-
-                    func test__063__Channel__detach__happens_when_channel_is_ATTACHED_if_connection_is_currently__DISCONNECTED() {
-                        let options = AblyTests.commonAppSetup()
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("test")
-
-                        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.internal.onDisconnected()
-                            channel.attach()
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.disconnected))
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-
-                            channel.detach { error in
-                                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-                    }
-
-                // RTL5j
-                func test__058__Channel__detach__if_the_channel_state_is_SUSPENDED__the__detach__request_transitions_the_channel_immediately_to_the_DETACHED_state() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("foo")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    channel.internal.setSuspended(ARTStatus.state(.ok))
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.suspended))
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channel.once(.detached) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            expect(stateChange.current).to(equal(ARTRealtimeChannelState.detached))
-                            expect(stateChange.previous).to(equal(ARTRealtimeChannelState.suspended))
-                            partialDone()
-                        }
-                        channel.detach() { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                    }
-
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
-                }
-
-            // RTL6
-            
-
-                // RTL6a
-                func test__064__Channel__publish__should_encode_messages_in_the_same_way_as_the_RestChannel() {
-                    let data = ["value":1]
-
-                    let rest = ARTRest(options: AblyTests.commonAppSetup())
-                    let restChannel = rest.channels.get("test")
-
-                    var restEncodedMessage: ARTMessage?
-                    restChannel.internal.testSuite_getReturnValue(from: NSSelectorFromString("encodeMessageIfNeeded:error:")) { value in
-                        restEncodedMessage = value as? ARTMessage
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        restChannel.publish(nil, data: data) { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            done()
-                        }
-                    }
-
-                    let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { realtime.close() }
-                    let realtimeChannel = realtime.channels.get("test")
-                    realtimeChannel.attach()
-                    expect(realtimeChannel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                    var realtimeEncodedMessage: ARTMessage?
-                    realtimeChannel.internal.testSuite_getReturnValue(from: NSSelectorFromString("encodeMessageIfNeeded:error:")) { value in
-                        realtimeEncodedMessage = value as? ARTMessage
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        realtimeChannel.publish(nil, data: data) { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            done()
-                        }
-                    }
-
-                    expect(restEncodedMessage!.data as? NSObject).to(equal(realtimeEncodedMessage!.data as? NSObject))
-                    expect(restEncodedMessage!.data).toNot(beNil())
-                    expect(realtimeEncodedMessage!.data).toNot(beNil())
-                    expect(restEncodedMessage!.encoding).to(equal(realtimeEncodedMessage!.encoding))
-                    expect(restEncodedMessage!.encoding).toNot(beNil())
-                    expect(realtimeEncodedMessage!.encoding).toNot(beNil())
-                }
-
-                // RTL6b
-                
-
-                    func test__067__Channel__publish__should_invoke_callback__when_the_message_is_successfully_delivered() {
-                        let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.on { stateChange in
-                                let state = stateChange.current
-                                let error = stateChange.reason
-                                expect(error).to(beNil())
-                                if state == .connected {
-                                    let channel = client.channels.get("test")
-                                    channel.on { stateChange in
-                                        if stateChange.current == .attached {
-                                            channel.publish(nil, data: "message") { errorInfo in
-                                                expect(errorInfo).to(beNil())
-                                                done()
-                                            }
-                                        }
-                                    }
-                                    channel.attach()
-                                }
-                            }
-                        }
-                    }
-
-                    func test__068__Channel__publish__should_invoke_callback__upon_failure() {
-                        let options = AblyTests.commonAppSetup()
-                        options.token = getTestToken(key: options.key, capability: "{ \"\(options.channelNamePrefix!)-test\":[\"subscribe\"] }")
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.on { stateChange in
-                                let state = stateChange.current
-                                let error = stateChange.reason
-                                expect(error).to(beNil())
-                                if state == .connected {
-                                    let channel = client.channels.get("test")
-                                    channel.on { stateChange in
-                                        if stateChange.current == .attached {
-                                            channel.publish(nil, data: "message") { errorInfo in
-                                                expect(errorInfo).toNot(beNil())
-                                                guard let errorInfo = errorInfo else {
-                                                    XCTFail("ErrorInfo is nil"); done(); return
-                                                }
-                                                // Unable to perform channel operation
-                                                expect(errorInfo.code).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
-                                                done()
-                                            }
-                                        }
-                                    }
-                                    channel.attach()
-                                }
-                            }
-                        }
-                    }
-
-                    func test__069__Channel__publish__should_invoke_callback__for_all_messages_published() {
-                        let options = AblyTests.commonAppSetup()
-                        options.token = getTestToken(key: options.key, capability: "{ \"\(options.channelNamePrefix!)-channelToSucceed\":[\"subscribe\", \"publish\"], \"\(options.channelNamePrefix!)-channelToFail\":[\"subscribe\"] }")
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-
-                        TotalMessages.succeeded = 0
-                        TotalMessages.failed = 0
-
-                        let channelToSucceed = client.channels.get("channelToSucceed")
-                        channelToSucceed.on { stateChange in
-                            if stateChange.current == .attached {
-                                for index in 1...TotalMessages.expected {
-                                    channelToSucceed.publish(nil, data: "message\(index)") { errorInfo in
-                                        if errorInfo == nil {
-                                            TotalMessages.succeeded += 1
-                                            expect(index).to(equal(TotalMessages.succeeded), description: "Callback was invoked with an invalid sequence")
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        channelToSucceed.attach()
-
-                        let channelToFail = client.channels.get("channelToFail")
-                        channelToFail.on { stateChange in
-                            if stateChange.current == .attached {
-                                for index in 1...TotalMessages.expected {
-                                    channelToFail.publish(nil, data: "message\(index)") { errorInfo in
-                                        if errorInfo != nil {
-                                            TotalMessages.failed += 1
-                                            expect(index).to(equal(TotalMessages.failed), description: "Callback was invoked with an invalid sequence")
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        channelToFail.attach()
-
-                        expect(TotalMessages.succeeded).toEventually(equal(TotalMessages.expected), timeout: testTimeout)
-                        expect(TotalMessages.failed).toEventually(equal(TotalMessages.expected), timeout: testTimeout)
-                    }
-
-                // RTL6c
-                
-
-                    // RTL6c1
-                    
-                        func test__071__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__ATTACHED_then_the_messages_should_be_published_immediately() {
-                            let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                            defer { client.dispose(); client.close() }
-                            let channel = client.channels.get("test")
-                            channel.attach()
-
-                            expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-
-                            waitUntil(timeout: testTimeout) { done in
-                                channel.publish(nil, data: "message") { error in
-                                    expect(error).to(beNil())
-                                    done()
-                                }
-                                expect((client.internal.transport as! TestProxyTransport).protocolMessagesSent.filter({ $0.action == .message })).to(haveCount(1))
-                            }
-                        }
-
-                        func test__072__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__INITIALIZED_then_the_messages_should_be_published_immediately() {
-                            let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                            defer { client.dispose(); client.close() }
-                            waitUntil(timeout: testTimeout) { done in
-                                client.connection.once(.connected) { _ in
-                                    done()
-                                }
-                            }
-                            let channel = client.channels.get("test")
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-
-                            waitUntil(timeout: testTimeout) { done in
-                                channel.publish(nil, data: "message") { error in
-                                    expect(error).to(beNil())
-                                    done()
-                                }
-                                expect((client.internal.transport as! TestProxyTransport).protocolMessagesSent.filter({ $0.action == .message })).to(haveCount(1))
-                            }
-
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
-                        }
-
-                        func test__073__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__DETACHED_then_the_messages_should_be_published_immediately() {
-                            let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                            defer { client.dispose(); client.close() }
-                            let channel = client.channels.get("test")
-                            waitUntil(timeout: testTimeout) { done in
-                                channel.attach() { _ in
-                                    done()
-                                }
-                            }
-                            waitUntil(timeout: testTimeout) { done in
-                                channel.detach() { _ in
-                                    done()
-                                }
-                            }
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-
-                            waitUntil(timeout: testTimeout) { done in
-                                channel.publish(nil, data: "message") { error in
-                                    expect(error).to(beNil())
-                                    done()
-                                }
-                                expect((client.internal.transport as! TestProxyTransport).protocolMessagesSent.filter({ $0.action == .message })).to(haveCount(1))
-                            }
-
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
-                        }
-
-                        func test__074__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__ATTACHING_then_the_messages_should_be_published_immediately() {
-                            let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                            defer { client.dispose(); client.close() }
-                            let channel = client.channels.get("test")
-                            waitUntil(timeout: testTimeout) { done in
-                                client.connection.once(.connected) { _ in
-                                    done()
-                                }
-                            }
-                            channel.attach()
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-                            guard let transport = client.internal.transport as? TestProxyTransport else {
-                                fail("Expecting TestProxyTransport"); return
-                            }
-                            transport.actionsIgnored += [.attached]
-
-                            waitUntil(timeout: testTimeout) { done in
-                                channel.publish(nil, data: "message") { error in
-                                    expect(error).to(beNil())
-                                    done()
-                                }
-                                expect((client.internal.transport as! TestProxyTransport).protocolMessagesSent.filter({ $0.action == .message })).to(haveCount(1))
-                            }
-
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-                        }
-
-                        func test__075__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__DETACHING_then_the_messages_should_be_published_immediately() {
-                            let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                            defer { client.dispose(); client.close() }
-                            let channel = client.channels.get("test")
-                            waitUntil(timeout: testTimeout) { done in
-                                channel.attach() { _ in
-                                    done()
-                                }
-                            }
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                            channel.detach()
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.detaching))
-                            guard let transport = client.internal.transport as? TestProxyTransport else {
-                                fail("Expecting TestProxyTransport"); return
-                            }
-                            transport.actionsIgnored += [.detached]
-
-                            waitUntil(timeout: testTimeout) { done in
-                                channel.publish(nil, data: "message") { error in
-                                    expect(error).to(beNil())
-                                    done()
-                                }
-                                expect((client.internal.transport as! TestProxyTransport).protocolMessagesSent.filter({ $0.action == .message })).to(haveCount(1))
-                            }
-
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.detaching))
-                        }
-
-                    // RTL6c2
-                    
-
-                        func beforeEach__Channel__publish__Connection_state_conditions__the_message() {
-                            let options = AblyTests.commonAppSetup()
-                            options.useTokenAuth = true
-                            options.autoConnect = false
-                            rtl6c2TestsClient = AblyTests.newRealtime(options)
-                            rtl6c2TestsChannel = rtl6c2TestsClient.channels.get("test")
-                            expect(rtl6c2TestsClient.internal.options.queueMessages).to(beTrue())
-                        }
-                        func afterEach__Channel__publish__Connection_state_conditions__the_message() { rtl6c2TestsClient.close() }
-
-                        
-                            func test__076__Channel__publish__Connection_state_conditions__the_message__should_be_queued_and_delivered_as_soon_as_the_connection_state_returns_to_CONNECTED_if_the_connection_is__INITIALIZED() {
-beforeEach__Channel__publish__Connection_state_conditions__the_message()
-
-                                waitUntil(timeout: testTimeout) { done in
-                                    expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.initialized))
-                                    rtl16c2TestsPublish(done)
-                                    rtl6c2TestsClient.connect()
-                                    expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
-                                }
-
-afterEach__Channel__publish__Connection_state_conditions__the_message()
-
-                            }
-
-                            func test__077__Channel__publish__Connection_state_conditions__the_message__should_be_queued_and_delivered_as_soon_as_the_connection_state_returns_to_CONNECTED_if_the_connection_is__CONNECTING() {
-beforeEach__Channel__publish__Connection_state_conditions__the_message()
-
-                                waitUntil(timeout: testTimeout) { done in
-                                    rtl6c2TestsClient.connect()
-                                    expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.connecting))
-                                    rtl16c2TestsPublish(done)
-                                    expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
-                                }
-
-afterEach__Channel__publish__Connection_state_conditions__the_message()
-
-                            }
-
-                            func test__078__Channel__publish__Connection_state_conditions__the_message__should_be_queued_and_delivered_as_soon_as_the_connection_state_returns_to_CONNECTED_if_the_connection_is__DISCONNECTED() {
-beforeEach__Channel__publish__Connection_state_conditions__the_message()
-
-                                rtl6c2TestsClient.connect()
-                                expect(rtl6c2TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                                rtl6c2TestsClient.internal.onDisconnected()
-
-                                waitUntil(timeout: testTimeout) { done in
-                                    expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.disconnected))
-                                    rtl16c2TestsPublish(done)
-                                    expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
-                                }
-
-afterEach__Channel__publish__Connection_state_conditions__the_message()
-
-                            }
-
-                        
-                            func test__079__Channel__publish__Connection_state_conditions__the_message__should_NOT_be_queued_instead_it_should_be_published_if_the_channel_is__INITIALIZED() {
-beforeEach__Channel__publish__Connection_state_conditions__the_message()
-
-                                rtl6c2TestsClient.connect()
-                                expect(rtl6c2TestsChannel.state).to(equal(ARTRealtimeChannelState.initialized))
-
-                                expect(rtl6c2TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-
-                                waitUntil(timeout: testTimeout) { done in
-                                    rtl16c2TestsPublish(done)
-                                    expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(0))
-                                    expect((rtl6c2TestsClient.internal.transport as! TestProxyTransport).protocolMessagesSent.filter({ $0.action == .message })).to(haveCount(1))
-                                }
-
-afterEach__Channel__publish__Connection_state_conditions__the_message()
-
-                            }
-
-                            func test__080__Channel__publish__Connection_state_conditions__the_message__should_NOT_be_queued_instead_it_should_be_published_if_the_channel_is__ATTACHING() {
-beforeEach__Channel__publish__Connection_state_conditions__the_message()
-
-                                rtl6c2TestsClient.connect()
-                                expect(rtl6c2TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-
-                                waitUntil(timeout: testTimeout) { done in
-                                    rtl6c2TestsChannel.attach()
-                                    expect(rtl6c2TestsChannel.state).to(equal(ARTRealtimeChannelState.attaching))
-                                    rtl16c2TestsPublish(done)
-                                    expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(0))
-                                    expect((rtl6c2TestsClient.internal.transport as! TestProxyTransport).protocolMessagesSent.filter({ $0.action == .message })).to(haveCount(1))
-                                }
-
-afterEach__Channel__publish__Connection_state_conditions__the_message()
-
-                            }
-
-                            func test__081__Channel__publish__Connection_state_conditions__the_message__should_NOT_be_queued_instead_it_should_be_published_if_the_channel_is__ATTACHED() {
-beforeEach__Channel__publish__Connection_state_conditions__the_message()
-
-                                waitUntil(timeout: testTimeout) { done in
-                                    rtl6c2TestsChannel.attach() { error in
-                                        expect(error).to(beNil())
-                                        done()
-                                    }
-                                    rtl6c2TestsClient.connect()
-                                }
-
-                                waitUntil(timeout: testTimeout) { done in
-                                    let tokenParams = ARTTokenParams()
-                                    tokenParams.ttl = 5.0
-                                    rtl6c2TestsClient.auth.authorize(tokenParams, options: nil) { tokenDetails, error in
-                                        expect(error).to(beNil())
-                                        expect(tokenDetails).toNot(beNil())
-                                        done()
-                                    }
-                                }
-
-                                waitUntil(timeout: testTimeout) { done in
-                                    rtl6c2TestsClient.connection.once(.disconnected) { _ in
-                                        done()
-                                    }
-                                }
-
-                                expect(rtl6c2TestsChannel.state).to(equal(ARTRealtimeChannelState.attached))
-
-                                waitUntil(timeout: testTimeout) { done in
-                                    rtl16c2TestsPublish(done)
-                                    expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
-                                }
-
-afterEach__Channel__publish__Connection_state_conditions__the_message()
-
-                            }
-
-                    // RTL6c4
-                    
-
-                        func beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the() {
-                            setupDependencies()
-                            ARTDefault.setConnectionStateTtl(0.3)
-                            rtl6c4TestsClient = AblyTests.newRealtime(options)
-                            rtl6c4TestsChannel = rtl6c4TestsClient.channels.get("test")
-                        }
-                        func afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the() {
-                            rtl6c4TestsClient.close()
-                            ARTDefault.setConnectionStateTtl(previousConnectionStateTtl)
-                        }
-
-                        func test__082__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__connection_is_SUSPENDED() {
-beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
-
-                            rtl6c4TestsClient.connect()
-                            expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                            rtl6c4TestsClient.internal.onSuspended()
-                            expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.suspended), timeout: testTimeout)
-                            waitUntil(timeout: testTimeout) { done in
-                                rtl6c4TestsPublish(done)
-                            }
-
-afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
-
-                        }
-
-                        func test__083__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__connection_is_CLOSING() {
-beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
-
-                            rtl6c4TestsClient.connect()
-                            expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                            rtl6c4TestsClient.close()
-                            expect(rtl6c4TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.closing))
-                            waitUntil(timeout: testTimeout) { done in
-                                rtl6c4TestsPublish(done)
-                            }
-
-afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
-
-                        }
-
-                        func test__084__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__connection_is_CLOSED() {
-beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
-
-                            rtl6c4TestsClient.connect()
-                            expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                            rtl6c4TestsClient.close()
-                            expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.closed), timeout: testTimeout)
-                            waitUntil(timeout: testTimeout) { done in
-                                rtl6c4TestsPublish(done)
-                            }
-
-afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
-
-                        }
-
-                        func test__085__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__connection_is_FAILED() {
-beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
-
-                            rtl6c4TestsClient.connect()
-                            expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                            rtl6c4TestsClient.internal.onError(AblyTests.newErrorProtocolMessage())
-                            expect(rtl6c4TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.failed))
-                            waitUntil(timeout: testTimeout) { done in
-                                rtl6c4TestsPublish(done)
-                            }
-
-afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
-
-                        }
-
-                        func test__086__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__channel_is_SUSPENDED() {
-beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
-
-                            rtl6c4TestsClient.connect()
-                            rtl6c4TestsChannel.attach()
-                            expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-                            rtl6c4TestsChannel.internal.setSuspended(ARTStatus.state(.ok))
-                            expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.suspended), timeout: testTimeout)
-                            waitUntil(timeout: testTimeout) { done in
-                                rtl6c4TestsPublish(done)
-                            }
-
-afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
-
-                        }
-
-                        func test__087__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__channel_is_FAILED() {
-beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
-
-                            rtl6c4TestsClient.connect()
-                            rtl6c4TestsChannel.attach()
-                            expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-                            let protocolError = AblyTests.newErrorProtocolMessage()
-                            rtl6c4TestsChannel.internal.onError(protocolError)
-                            expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.failed), timeout: testTimeout)
-                            waitUntil(timeout: testTimeout) { done in
-                                rtl6c4TestsPublish(done)
-                            }
-
-afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
-
-                        }
-
-                    // RTL6c5
-                    func test__070__Channel__publish__Connection_state_conditions__publish_should_not_trigger_an_implicit_attach() {
-                        let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-                        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                        let channel = client.channels.get("test")
-                        waitUntil(timeout: testTimeout) { done in
-                            let protocolError = AblyTests.newErrorProtocolMessage()
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
-                            channel.publish(nil, data: "message") { error in
-                                expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-
-                                channel.publish(nil, data: "message") { error in
-                                    expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-                                    expect(error).toNot(beNil())
-                                    done()
-                                }
-                            }
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
-                            AblyTests.queue.async {
-                                channel.internal.onError(protocolError)
-                            }
-                        }
-                    }
-
-                // RTL6d
-                
-
-                    func test__088__Channel__publish__message_bundling__Messages_are_delivered_using_a_single_ProtocolMessage_where_possible_by_bundling_in_all_messages_for_that_channel() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-
-                        // Test that the initially queued messages are sent together.
-
-                        let messagesSent = 3
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(messagesSent, done: done)
-                            for i in 1...messagesSent {
-                                channel.publish("initial", data: "message\(i)") { error in
-                                    expect(error).to(beNil())
-                                    partialDone()
-                                }
-                            }
-                            client.connect()
-                        }
-
-                        let transport = client.internal.transport as! TestProxyTransport
-                        let protocolMessages = transport.protocolMessagesSent.filter{ $0.action == .message }
-                        expect(protocolMessages).to(haveCount(1))
-                        if protocolMessages.count != 1 {
-                            return
-                        }
-                        expect(protocolMessages[0].messages).to(haveCount(messagesSent))
-
-                        // Test that publishing an array of messages sends them together.
-
-                        // TODO: limit the total number of messages bundled per ProtocolMessage
-                        let maxMessages = 50
-
-                        var messages = [ARTMessage]()
-                        for i in 1...maxMessages {
-                            messages.append(ARTMessage(name: "total number of messages", data: "message\(i)"))
-                        }
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(messages) { error in
-                                expect(error).to(beNil())
-                                let transport = client.internal.transport as! TestProxyTransport
-                                let protocolMessages = transport.protocolMessagesSent.filter{ $0.action == .message }
-                                expect(protocolMessages).to(haveCount(2))
-                                if protocolMessages.count != 2 {
-                                    done(); return
-                                }
-                                expect(protocolMessages[1].messages).to(haveCount(maxMessages))
-                                done()
-                            }
-                        }
-                    }
-
-                    // RTL6d1
-                    func test__089__Channel__publish__message_bundling__The_resulting_ProtocolMessage_must_not_exceed_the_maxMessageSize() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test-maxMessageSize")
-                        // This amount of messages would be beyond maxMessageSize, if bundled together
-                        let messagesToBeSent = 2000
-
-                        // Call publish before connecting, so messages are queued
-                        waitUntil(timeout: testTimeout.multiplied(by: 6)) { done in
-                            let partialDone = AblyTests.splitDone(messagesToBeSent, done: done)
-                            for i in 1...messagesToBeSent {
-                                channel.publish("initial initial\(i)", data: "message message\(i)") { error in
-                                    expect(error).to(beNil())
-                                    partialDone()
-                                }
-                            }
-                            client.connect()
-                        }
-
-                        let transport = client.internal.transport as! TestProxyTransport
-                        let protocolMessages = transport.protocolMessagesSent.filter{ $0.action == .message }
-                        // verify that messages are not bundled in a single protocol message
-                        expect(protocolMessages.count).to(beGreaterThan(1))
-                        // verify that all the messages have been sent
-                        let messagesSent = protocolMessages.compactMap{$0.messages?.count}.reduce(0, +)
-                        expect(messagesSent).to(equal(messagesToBeSent))
-                    }
-
-                    // RTL6d2
-                    
-
-                        func test__092__Channel__publish__message_bundling__Messages_with_differing_clientId_values_must_not_be_bundled_together__messages_with_different__non_empty__clientIds_are_posted_via_different_protocol_messages() {
-                            let options = AblyTests.commonAppSetup()
-                            options.autoConnect = false
-                            let client = AblyTests.newRealtime(options)
-                            defer { client.dispose(); client.close() }
-                            let channel = client.channels.get("test-message-bundling-prevention")
-                            let clientIDs = ["client1", "client2", "client3"]
-
-                            waitUntil(timeout: testTimeout) { done in
-                                let partialDone = AblyTests.splitDone(clientIDs.count, done: done)
-                                for (i, el) in clientIDs.enumerated() {
-                                    channel.publish("name\(i)", data: "data\(i)", clientId: el) { error in
-                                        expect(error).to(beNil())
-                                        partialDone()
-                                    }
-                                }
-                                client.connect()
-                            }
-
-                            let transport = client.internal.transport as! TestProxyTransport
-                            let protocolMessages = transport.protocolMessagesSent.filter{ $0.action == .message }
-                            expect(protocolMessages.count).to(equal(clientIDs.count))
-                        }
-
-                        func test__093__Channel__publish__message_bundling__Messages_with_differing_clientId_values_must_not_be_bundled_together__messages_with_mixed_empty_non_empty_clientIds_are_posted_via_different_protocol_messages() {
-                            let options = AblyTests.commonAppSetup()
-                            options.autoConnect = false
-                            let client = AblyTests.newRealtime(options)
-                            defer { client.dispose(); client.close() }
-                            let channel = client.channels.get("test-message-bundling-prevention")
-
-                            waitUntil(timeout: testTimeout) { done in
-                                let partialDone = AblyTests.splitDone(2, done: done)
-                                channel.publish("name1", data: "data1", clientId: "clientID1") { error in
-                                    expect(error).to(beNil())
-                                    partialDone()
-                                }
-                                channel.publish("name2", data: "data2") { error in
-                                    expect(error).to(beNil())
-                                    partialDone()
-                                }
-                                client.connect()
-                            }
-
-                            let transport = client.internal.transport as! TestProxyTransport
-                            let protocolMessages = transport.protocolMessagesSent.filter{ $0.action == .message }
-                            expect(protocolMessages.count).to(equal(2))
-                        }
-
-                        func test__094__Channel__publish__message_bundling__Messages_with_differing_clientId_values_must_not_be_bundled_together__messages_bundled_by_the_user_are_posted_in_a_single_protocol_message_even_if_they_have_mixed_clientIds() {
-                            let options = AblyTests.commonAppSetup()
-                            options.autoConnect = false
-                            let client = AblyTests.newRealtime(options)
-                            defer { client.dispose(); client.close() }
-                            let channel = client.channels.get("test-message-bundling-prevention")
-                            var messages = [ARTMessage]()
-                            for i in 1...3 {
-                                messages.append(ARTMessage(name: "name\(i)", data: "data\(i)", clientId: "clientId\(i)"))
-                            }
-
-                            waitUntil(timeout: testTimeout) { done in
-                                channel.publish(messages) { error in
-                                    expect(error).to(beNil())
-                                    done()
-                                }
-                                client.connect()
-                            }
-
-                            let transport = client.internal.transport as! TestProxyTransport
-                            let protocolMessages = transport.protocolMessagesSent.filter{ $0.action == .message }
-                            expect(protocolMessages.count).to(equal(1))
-                        }
-
-                    
-                    // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                    func skipped__test__090__Channel__publish__message_bundling__should_only_bundle_messages_when_it_respects_all_of_the_constraints() {
-                        let defaultMaxMessageSize = ARTDefault.maxMessageSize()
-                        ARTDefault.setMaxMessageSize(256)
-                        defer { ARTDefault.setMaxMessageSize(defaultMaxMessageSize) }
-
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-                        let channelOne = client.channels.get("bundlingOne")
-                        let channelTwo = client.channels.get("bundlingTwo")
-
-                        channelTwo.publish("2a", data: ["expectedBundle": 0])
-                        channelOne.publish("a", data: ["expectedBundle": 1])
-                        channelOne.publish([
-                            ARTMessage(name: "b", data: ["expectedBundle": 1]),
-                            ARTMessage(name: "c", data: ["expectedBundle": 1])
-                        ])
-                        channelOne.publish("d", data: ["expectedBundle": 1])
-                        channelTwo.publish("2b", data: ["expectedBundle": 2])
-                        channelOne.publish("e", data: ["expectedBundle": 3])
-                        channelOne.publish([ARTMessage(name: "f", data: ["expectedBundle": 3])])
-                        // RTL6d2
-                        channelOne.publish("g", data: ["expectedBundle": 4], clientId: "foo")
-                        channelOne.publish("h", data: ["expectedBundle": 4], clientId: "foo")
-                        channelOne.publish("i", data: ["expectedBundle": 5], clientId: "bar")
-                        channelOne.publish("j", data: ["expectedBundle": 6])
-                        // RTL6d1
-                        channelOne.publish("k", data: ["expectedBundle": 7, "moreData": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"])
-                        channelOne.publish("l", data: ["expectedBundle": 8])
-                        // RTL6d7
-                        channelOne.publish([ARTMessage(id: "bundle_m", name: "m", data: ["expectedBundle": 9])])
-                        channelOne.publish("z_last", data: ["expectedBundle": 10])
-
-                        let expectationMessageBundling = XCTestExpectation(description: "message-bundling")
-
-                        AblyTests.queue.async {
-                            let queue: [ARTQueuedMessage] = client.internal.queuedMessages as! [ARTQueuedMessage]
-                            for i in 0...10 {
-                                for message in queue[i].msg.messages! {
-                                    let decodedMessage = channelOne.internal.dataEncoder.decode(message.data, encoding: message.encoding)
-
-                                    guard let data = (decodedMessage.data as? [String: Any]) else {
-                                        fail("Unexpected data type"); continue
-                                    }
-
-                                    expect(data["expectedBundle"] as? Int).to(equal(i))
-                                }
-                            }
-
-                            expectationMessageBundling.fulfill()
-                        }
-
-                        AblyTests.wait(for: [expectationMessageBundling], timeout: testTimeout)
-
-                        let expectationMessageFinalOrder = XCTestExpectation(description: "final-order")
-
-                        // RTL6d6
-                        var currentName = ""
-                        channelOne.subscribe { message in
-                            expect(currentName) < message.name! //Check final ordering preserved
-                            currentName = message.name!
-                            if currentName == "z_last" {
-                                expectationMessageFinalOrder.fulfill()
-                            }
-                        }
-                        client.connect()
-
-                        AblyTests.wait(for: [expectationMessageFinalOrder], timeout: testTimeout)
-                    }
-
-                    func test__091__Channel__publish__message_bundling__should_publish_only_once_on_multiple_explicit_publish_requests_for_a_given_message_with_client_supplied_ids() {
-                        let options = AblyTests.commonAppSetup()
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("idempotentRealtimePublishing")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.once(.attached) { stateChange in
-                                expect(stateChange.reason).to(beNil())
-                                done()
-                            }
-                        }
-
-                        let expectationEvent0 = XCTestExpectation(description: "event0")
-                        let expectationEnd = XCTestExpectation(description: "end")
-
-                        var event0Msgs: [ARTMessage] = []
-                        channel.subscribe("event0") { message in
-                            event0Msgs.append(message)
-                            expectationEvent0.fulfill()
-                        }
-
-                        channel.subscribe("end") { message in
-                            expect(event0Msgs).to(haveCount(1))
-                            expectationEnd.fulfill()
-                        }
-
-                        channel.publish([ARTMessage(id: "some_msg_id", name: "event0", data: "")])
-                        channel.publish([ARTMessage(id: "some_msg_id", name: "event0", data: "")])
-                        channel.publish([ARTMessage(id: "some_msg_id", name: "event0", data: "")])
-                        channel.publish("end", data: nil)
-
-                        AblyTests.wait(for: [expectationEvent0, expectationEnd])
-                    }
-
-                // RTL6e
-                
-
-                    // RTL6e1
-                    func test__095__Channel__publish__Unidentified_clients_using_Basic_Auth__should_have_the_provided_clientId_on_received_message_when_it_was_published_with_clientId() {
-                        let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-
-                        expect(client.auth.clientId).to(beNil())
-
-                        let channel = client.channels.get("test")
-
-                        var resultClientId: String?
-
-                        let message = ARTMessage(name: nil, data: "message")
-                        message.clientId = "client_string"
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            channel.subscribe() { message in
-                                resultClientId = message.clientId
-                                partialDone()
-                            }
-                            channel.publish([message]) { errorInfo in
-                                expect(errorInfo).to(beNil())
-                                partialDone()
-                            }
-                        }
-
-                        expect(resultClientId).toEventually(equal(message.clientId), timeout: testTimeout)
-                    }
-
-                // RTL6f
-                func test__065__Channel__publish__Message_connectionId_should_match_the_current_Connection_id_for_all_published_messages() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.subscribe() { message in
-                            expect(message.connectionId).to(equal(client.connection.id))
-                            done()
-                        }
-                        channel.publish(nil, data: "message")
-                    }
-                }
-
-                // RTL6i
-                
-
-                    func test__096__Channel__publish__expect_either__an_array_of_Message_objects() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-                        typealias JSONObject = NSDictionary
-
-                        var result = [JSONObject]()
-                        channel.subscribe { message in
-                            result.append(message.data as! JSONObject)
-                        }
-
-                        let messages = [ARTMessage(name: nil, data: ["key":1]), ARTMessage(name: nil, data: ["key":2])]
-                        channel.publish(messages)
-
-                        let transport = client.internal.transport as! TestProxyTransport
-
-                        expect(transport.protocolMessagesSent.filter{ $0.action == .message }).toEventually(haveCount(1), timeout: testTimeout)
-                        expect(result).toEventually(equal(messages.map{ $0.data as! JSONObject }), timeout: testTimeout)
-                    }
-
-                    func test__097__Channel__publish__expect_either__a_name_string_and_data_payload() {
-                        let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-
-                        let expectedResult = "string_data"
-                        var result: String?
-
-                        channel.subscribe("event") { message in
-                            result = message.data as? String
-                        }
-
-                        channel.publish("event", data: expectedResult, callback: nil)
-
-                        expect(result).toEventually(equal(expectedResult), timeout: testTimeout)
-                    }
-
-                    func test__098__Channel__publish__expect_either__allows_name_to_be_null() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-
-                        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                        let expectedObject = ["data": "message", "connectionId": client.connection.id!]
-
-                        var resultMessage: ARTMessage?
-                        channel.subscribe { message in
-                            resultMessage = message
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: expectedObject["data"]) { errorInfo in
+                    channel.on { stateChange in
+                        if stateChange.current == .attached {
+                            channel.publish(nil, data: "message") { errorInfo in
                                 expect(errorInfo).to(beNil())
                                 done()
                             }
                         }
-
-                        let transport = client.internal.transport as! TestProxyTransport
-                        
-                        let rawProtoMsgsSent: [NSDictionary] = transport.rawDataSent.toMsgPackArray()
-                        let rawMessagesSent = rawProtoMsgsSent.filter({ $0["action"] as! UInt == ARTProtocolMessageAction.message.rawValue })
-                        let messagesList = rawMessagesSent[0]["messages"] as! NSArray
-                        let resultObject = messagesList[0] as! [String: String]
-
-                        expect(resultObject).to(equal(expectedObject))
-
-                        expect(resultMessage).toNotEventually(beNil(), timeout: testTimeout)
-                        expect(resultMessage!.name).to(beNil())
-                        expect(resultMessage!.data as? String).to(equal(expectedObject["data"]))
                     }
-
-                    func test__099__Channel__publish__expect_either__allows_data_to_be_null() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-
-                        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                        let expectedObject = ["name": "click", "connectionId": client.connection.id!]
-
-                        var resultMessage: ARTMessage?
-                        channel.subscribe(expectedObject["name"]!) { message in
-                            resultMessage = message
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(expectedObject["name"], data: nil) { errorInfo in
-                                expect(errorInfo).to(beNil())
-                                done()
-                            }
-                        }
-
-                        let transport = client.internal.transport as! TestProxyTransport
-
-                        let rawProtoMsgsSent: [NSDictionary] = transport.rawDataSent.toMsgPackArray()
-                        let rawMessagesSent = rawProtoMsgsSent.filter({ $0["action"] as! UInt == ARTProtocolMessageAction.message.rawValue })
-                        let messagesList = rawMessagesSent[0]["messages"] as! NSArray
-                        let resultObject = messagesList[0] as! NSDictionary
-
-                        expect(resultObject).to(equal(expectedObject as NSDictionary))
-
-                        expect(resultMessage).toNotEventually(beNil(), timeout: testTimeout)
-                        expect(resultMessage!.name).to(equal(expectedObject["name"]))
-                        expect(resultMessage!.data).to(beNil())
-                    }
-
-                    func test__100__Channel__publish__expect_either__allows_name_and_data_to_be_assigned() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-
-                        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                        let expectedObject = ["name": "click", "data": "message", "connectionId": client.connection.id!]
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(expectedObject["name"], data: expectedObject["data"]) { errorInfo in
-                                expect(errorInfo).to(beNil())
-                                done()
-                            }
-                        }
-
-                        let transport = client.internal.transport as! TestProxyTransport
-
-                        let rawProtoMsgsSent: [NSDictionary] = transport.rawDataSent.toMsgPackArray()
-                        let rawMessagesSent = rawProtoMsgsSent.filter({ $0["action"] as! UInt == ARTProtocolMessageAction.message.rawValue })
-                        let messagesList = rawMessagesSent[0]["messages"] as! NSArray
-                        let resultObject = messagesList[0] as! NSDictionary
-
-                        expect(resultObject).to(equal(expectedObject as NSDictionary))
-                    }
-
-                // RTL6g
-                
-
-                    // RTL6g1
-                    
-
-                        // RTL6g1a & RTL6g1b
-                        func test__105__Channel__publish__Identified_clients_with_clientId__When_publishing_a_Message_with_clientId_set_to_null__should_be_unnecessary_to_set_clientId_of_the_Message_before_publishing_and_have_clientId_value_set_for_the_Message_when_received() {
-                            let options = AblyTests.commonAppSetup()
-                            options.clientId = "client_string"
-                            options.autoConnect = false
-                            let client = ARTRealtime(options: options)
-                            client.internal.setTransport(TestProxyTransport.self)
-                            client.connect()
-                            defer { client.dispose(); client.close() }
-                            let channel = client.channels.get("test")
-
-                            let message = ARTMessage(name: nil, data: "message")
-                            expect(message.clientId).to(beNil())
-
-                            waitUntil(timeout: testTimeout) { done in
-                                channel.subscribe() { message in
-                                    expect(message.clientId).to(equal(options.clientId))
-                                    done()
-                                }
-                                channel.publish([message])
-                            }
-
-                            let transport = client.internal.transport as! TestProxyTransport
-
-                            let messageSent = transport.protocolMessagesSent.filter({ $0.action == .message })[0]
-                            expect(messageSent.messages![0].clientId).to(beNil())
-
-                            let messageReceived = transport.protocolMessagesReceived.filter({ $0.action == .message })[0]
-                            expect(messageReceived.messages![0].clientId).to(equal(options.clientId))
-                        }
-
-                    // RTL6g2
-                    func test__101__Channel__publish__Identified_clients_with_clientId__when_publishing_a_Message_with_the_clientId_attribute_value_set_to_the_identified_client_s_clientId() {
-                        let options = AblyTests.commonAppSetup()
-                        options.clientId = "john"
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-
-                        let message = ARTMessage(name: nil, data: "message", clientId: options.clientId!)
-                        var resultClientId: String?
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            channel.subscribe() { message in
-                                resultClientId = message.clientId
-                                partialDone()
-                            }
-                            channel.publish([message]) { error in
-                                expect(error).to(beNil())
-                                partialDone()
-                            }
-                        }
-
-                        expect(resultClientId).toEventually(equal(message.clientId), timeout: testTimeout)
-                    }
-
-                    // RTL6g3
-                    func test__102__Channel__publish__Identified_clients_with_clientId__when_publishing_a_Message_with_a_different_clientId_attribute_value_from_the_identified_client_s_clientId__it_should_reject_that_publish_operation_immediately() {
-                        let options = AblyTests.commonAppSetup()
-                        options.clientId = "john"
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish([ARTMessage(name: nil, data: "message", clientId: "tester")]) { error in
-                                expect(error?.code).to(equal(Int(ARTState.mismatchedClientId.rawValue)))
-                                done()
-                            }
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish([ARTMessage(name: nil, data: "message")]) { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-                    }
-
-                    // RTL6g4
-                    func test__103__Channel__publish__Identified_clients_with_clientId__message_should_be_published_following_authentication_and_received_back_with_the_clientId_intact() {
-                        let options = AblyTests.clientOptions()
-                        options.authCallback = { tokenParams, completion in
-                            getTestTokenDetails(clientId: "john", completion: completion)
-                        }
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-                        let message = ARTMessage(name: nil, data: "message", clientId: "john")
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            channel.subscribe() { received in
-                                expect(received.clientId).to(equal(message.clientId))
-                                partialDone()
-                            }
-                            channel.publish([message]) { error in
-                                expect(error).to(beNil())
-                                partialDone()
-                            }
-                        }
-                    }
-
-                    // RTL6g4
-                    func test__104__Channel__publish__Identified_clients_with_clientId__message_should_be_rejected_by_the_Ably_service_and_the_message_error_should_contain_the_server_error() {
-                        let options = AblyTests.clientOptions()
-                        options.authCallback = { tokenParams, completion in
-                            getTestTokenDetails(clientId: "john", completion: completion)
-                        }
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-                        let message = ARTMessage(name: nil, data: "message", clientId: "tester")
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish([message]) { error in
-                                expect(error!.code).to(equal(ARTErrorCode.invalidClientId.intValue))
-                                done()
-                            }
-                        }
-                    }
-
-                // RTL6h
-                func test__066__Channel__publish__should_provide_an_optional_argument_that_allows_the_clientId_value_to_be_specified() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channel.subscribe { message in
-                            expect(message.name).to(equal("event"))
-                            expect(message.data as? NSObject).to(equal("data" as NSObject?))
-                            expect(message.clientId).to(equal("foo"))
-                            partialDone()
-                        }
-                        channel.publish("event", data: "data", clientId: "foo") { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            partialDone()
-                        }
-                    }
+                    channel.attach()
                 }
+            }
+        }
+    }
 
-            // RTL7
-            
+    func test__068__Channel__publish__should_invoke_callback__upon_failure() {
+        let options = AblyTests.commonAppSetup()
+        options.token = getTestToken(key: options.key, capability: "{ \"\(options.channelNamePrefix!)-test\":[\"subscribe\"] }")
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
 
-                // RTL7a
-                func test__106__Channel__subscribe__with_no_arguments_subscribes_a_listener_to_all_messages() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let error = stateChange.reason
+                expect(error).to(beNil())
+                if state == .connected {
                     let channel = client.channels.get("test")
-
-                    class Test {
-                        static var counter = 0
-                        fileprivate init() {}
-                    }
-
-                    channel.subscribe { message in
-                        expect(message.data as? String).to(equal("message"))
-                        Test.counter += 1
-                    }
-
-                    channel.publish(nil, data: "message")
-                    channel.publish("eventA", data: "message")
-                    channel.publish("eventB", data: "message")
-
-                    expect(Test.counter).toEventually(equal(3), timeout: testTimeout)
-                }
-
-                // RTL7b
-                func test__107__Channel__subscribe__with_a_single_name_argument_subscribes_a_listener_to_only_messages_whose_name_member_matches_the_string_name() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-
-                    class Test {
-                        static var counter = 0
-                        fileprivate init() {}
-                    }
-
-                    channel.subscribe("eventA") { message in
-                        expect(message.name).to(equal("eventA"))
-                        expect(message.data as? String).to(equal("message"))
-                        Test.counter += 1
-                    }
-
-                    channel.publish(nil, data: "message")
-                    channel.publish("eventA", data: "message")
-                    channel.publish("eventB", data: "message")
-                    channel.publish("eventA", data: "message")
-
-                    expect(Test.counter).toEventually(equal(2), timeout: testTimeout)
-                }
-
-                func test__108__Channel__subscribe__with_a_attach_callback_should_subscribe_and_call_the_callback_when_attached() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-
-                    let publishedMessage = ARTMessage(name: "foo", data: "bar")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
-
-                        channel.subscribe(attachCallback: { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
-                            channel.publish([publishedMessage])
-                        }) { message in
-                            expect(message.name).to(equal(publishedMessage.name))
-                            expect(message.data as? NSObject).to(equal(publishedMessage.data as? NSObject))
-                            done()
-                        }
-
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-                    }
-                }
-
-                // RTL7c
-                func test__109__Channel__subscribe__should_implicitly_attach_the_channel() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-
-                    channel.subscribe { _ in }
-
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-                }
-
-                // RTL7c
-                func test__110__Channel__subscribe__should_result_in_an_error_if_channel_is_in_the_FAILED_state() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-                    channel.internal.onError(AblyTests.newErrorProtocolMessage())
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.subscribe(attachCallback: { errorInfo in
-                            expect(errorInfo).toNot(beNil())
-
-                            channel.subscribe("foo", onAttach: { errorInfo in
+                    channel.on { stateChange in
+                        if stateChange.current == .attached {
+                            channel.publish(nil, data: "message") { errorInfo in
                                 expect(errorInfo).toNot(beNil())
-                                done()
-                            }) { _ in }
-                        }) { _ in }
-                    }
-                }
-
-                // RTL7d
-                
-                    
-                    func test__112__Channel__subscribe__should_deliver_the_message_even_if_there_is_an_error_while_decoding__using_crypto_data_128() {
-                        testHandlesDecodingErrorInFixture("crypto-data-128")
-                    }
-                    
-                    func test__113__Channel__subscribe__should_deliver_the_message_even_if_there_is_an_error_while_decoding__using_crypto_data_256() {
-                        testHandlesDecodingErrorInFixture("crypto-data-256")
-                    }
-
-                
-
-                    // RTL7e
-                    func test__114__Channel__subscribe__message_cannot_be_decoded_or_decrypted__should_deliver_with_encoding_attribute_set_indicating_the_residual_encoding_and_error_should_be_emitted() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        options.logHandler = ARTLog(capturingOutput: true)
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-
-                        let channelOptions = ARTRealtimeChannelOptions(cipher: ["key":ARTCrypto.generateRandomKey()] as ARTCipherParamsCompatible)
-                        let channel = client.channels.get("test", options: channelOptions)
-
-                        let expectedMessage = ["key":1]
-                        let expectedData = try! JSONSerialization.data(withJSONObject: expectedMessage, options: JSONSerialization.WritingOptions(rawValue: 0))
-
-                        let transport = client.internal.transport as! TestProxyTransport
-
-                        transport.setBeforeIncomingMessageModifier({ protocolMessage in
-                            if protocolMessage.action == .message {
-                                let messageReceived = protocolMessage.messages![0]
-                                // Replacement: `json/utf-8/cipher+aes-256-cbc/base64` to `invalid/cipher+aes-256-cbc/base64`
-                                let newEncoding = "invalid" + messageReceived.encoding!["json/utf-8".endIndex...]
-                                messageReceived.encoding = newEncoding
-                            }
-                            return protocolMessage
-                        })
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.subscribe { message in
-                                // Last decoding failed: NSData -> JSON object, so...
-                                expect(message.data as? NSData).to(equal(expectedData as NSData?))
-                                expect(message.encoding).to(equal("invalid"))
-
-                                let logs = options.logHandler.captured
-                                let line = logs.reduce("") { $0 + "; " + $1.toString() } //Reduce in one line
-                                expect(line).to(contain("Failed to decode data: unknown encoding: 'invalid'"))
-
-                                expect(channel.errorReason!.message).to(contain("Failed to decode data: unknown encoding: 'invalid'"))
-
+                                guard let errorInfo = errorInfo else {
+                                    XCTFail("ErrorInfo is nil"); done(); return
+                                }
+                                // Unable to perform channel operation
+                                expect(errorInfo.code).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
                                 done()
                             }
-                            
-                            channel.publish(nil, data: expectedMessage)
                         }
                     }
+                    channel.attach()
+                }
+            }
+        }
+    }
 
-                // RTL7f
-                func test__111__Channel__subscribe__should_exist_ensuring_published_messages_are_not_echoed_back_to_the_subscriber_when_echoMessages_is_false() {
-                    let options = AblyTests.commonAppSetup()
-                    let client1 = ARTRealtime(options: options)
-                    defer { client1.close() }
+    func test__069__Channel__publish__should_invoke_callback__for_all_messages_published() {
+        let options = AblyTests.commonAppSetup()
+        options.token = getTestToken(key: options.key, capability: "{ \"\(options.channelNamePrefix!)-channelToSucceed\":[\"subscribe\", \"publish\"], \"\(options.channelNamePrefix!)-channelToFail\":[\"subscribe\"] }")
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
 
-                    options.echoMessages = false
-                    let client2 = ARTRealtime(options: options)
-                    defer { client2.close() }
+        TotalMessages.succeeded = 0
+        TotalMessages.failed = 0
 
-                    let channel1 = client1.channels.get("test")
-                    let channel2 = client2.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel1.attach { err in
-                            expect(err).to(beNil())
-                            channel1.subscribe { message in
-                                expect(message.data as? String).to(equal("message"))
-                                delay(1.0) { done() }
-                            }
-
-                            channel2.subscribe { message in
-                                fail("Shouldn't receive the message")
-                            }
-
-                            channel2.publish(nil, data: "message")
+        let channelToSucceed = client.channels.get("channelToSucceed")
+        channelToSucceed.on { stateChange in
+            if stateChange.current == .attached {
+                for index in 1 ... TotalMessages.expected {
+                    channelToSucceed.publish(nil, data: "message\(index)") { errorInfo in
+                        if errorInfo == nil {
+                            TotalMessages.succeeded += 1
+                            expect(index).to(equal(TotalMessages.succeeded), description: "Callback was invoked with an invalid sequence")
                         }
                     }
                 }
+            }
+        }
+        channelToSucceed.attach()
 
-            // RTL8
-            
-
-                // RTL8a
-                func test__115__Channel__unsubscribe__with_no_arguments_unsubscribes_the_provided_listener_to_all_messages_if_subscribed() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let listener = channel.subscribe { message in
-                            fail("Listener shouldn't exist")
-                            done()
-                        }
-
-                        channel.unsubscribe(listener)
-
-                        channel.publish(nil, data: "message") { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            done()
+        let channelToFail = client.channels.get("channelToFail")
+        channelToFail.on { stateChange in
+            if stateChange.current == .attached {
+                for index in 1 ... TotalMessages.expected {
+                    channelToFail.publish(nil, data: "message\(index)") { errorInfo in
+                        if errorInfo != nil {
+                            TotalMessages.failed += 1
+                            expect(index).to(equal(TotalMessages.failed), description: "Callback was invoked with an invalid sequence")
                         }
                     }
                 }
-
-                // RTL8b
-                func test__116__Channel__unsubscribe__with_a_single_name_argument_unsubscribes_the_provided_listener_if_previously_subscribed_with_a_name_specific_subscription() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let eventAListener = channel.subscribe("eventA") { message in
-                            fail("Listener shouldn't exist")
-                            done()
-                        }
-
-                        channel.unsubscribe("eventA", listener: eventAListener)
-
-                        channel.publish("eventA", data: "message") { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            done()
-                        }
-                    }
-                }
-
-            // RTL10
-            
-                // RTL10a 
-                func test__117__Channel__history__should_support_all_the_same_params_as_Rest() {
-                    let options = AblyTests.commonAppSetup()
-
-                    let rest = ARTRest(options: options)
-
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.close() }
-
-                    let channelRest = rest.channels.get("test")
-                    let channelRealtime = realtime.channels.get("test")
-
-                    var restChannelHistoryMethodWasCalled = false
-
-                    let hookRest = channelRest.testSuite_injectIntoMethod(after: #selector(ARTRestChannel.history(_:callback:))) {
-                        restChannelHistoryMethodWasCalled = true
-                    }
-                    defer { hookRest.remove() }
-
-                    let hookRealtime = channelRealtime.testSuite_injectIntoMethod(after: #selector(ARTRestChannel.history(_:callback:))) {
-                        restChannelHistoryMethodWasCalled = true
-                    }
-                    defer { hookRealtime.remove() }
-
-                    let queryRealtime = ARTRealtimeHistoryQuery()
-                    queryRealtime.start = NSDate() as Date
-                    queryRealtime.end = NSDate() as Date
-                    queryRealtime.direction = .forwards
-                    queryRealtime.limit = 50
-
-                    let queryRest = queryRealtime as ARTDataQuery
-
-                    waitUntil(timeout: testTimeout) { done in
-                        expect {
-                            try channelRest.history(queryRest) { _, _ in
-                                done()
-                            }
-                        }.toNot(throwError() { err in fail("\(err)"); done() })
-                    }
-                    expect(restChannelHistoryMethodWasCalled).to(beTrue())
-                    restChannelHistoryMethodWasCalled = false
-
-                    waitUntil(timeout: testTimeout) { done in
-                        expect {
-                            try channelRealtime.history(queryRealtime) { _, _ in
-                                done()
-                            }
-                        }.toNot(throwError() { err in fail("\(err)"); done() })
-                    }
-                    expect(restChannelHistoryMethodWasCalled).to(beTrue())
-                }
-
-                // RTL10b
-                
-
-                    func test__123__Channel__history__supports_the_param_untilAttach__should_be_false_as_default() {
-                        let query = ARTRealtimeHistoryQuery()
-                        expect(query.untilAttach).to(equal(false))
-                    }
-
-                    func test__124__Channel__history__supports_the_param_untilAttach__should_invoke_an_error_when_the_untilAttach_is_specified_and_the_channel_is_not_attached() {
-                        let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-
-                        let query = ARTRealtimeHistoryQuery()
-                        query.untilAttach = true
-
-                        do {
-                            try channel.history(query, callback: { _, _ in })
-                        }
-                        catch let error as NSError {
-                            if error.code != ARTRealtimeHistoryError.notAttached.rawValue {
-                                fail("Shouldn't raise a global error, got \(error)")
-                            }
-                            return
-                        }
-                        fail("Should raise an error")
-                    }
-                    
-                    func test__125__Channel__history__supports_the_param_untilAttach__where_value_is_true__should_pass_the_querystring_param_fromSerial_with_the_serial_number_assigned_to_the_channel() {
-                        testWithUntilAttach(true)
-                    }
-                    
-                    func test__126__Channel__history__supports_the_param_untilAttach__where_value_is_false__should_pass_the_querystring_param_fromSerial_with_the_serial_number_assigned_to_the_channel() {
-                        testWithUntilAttach(true)
-                    }
-
-                    func test__127__Channel__history__supports_the_param_untilAttach__should_retrieve_messages_prior_to_the_moment_that_the_channel_was_attached() {
-                        let options = AblyTests.commonAppSetup()
-                        let client1 = ARTRealtime(options: options)
-                        defer { client1.close() }
-
-                        options.autoConnect = false
-                        let client2 = ARTRealtime(options: options)
-                        defer { client2.close() }
-
-                        let channel1 = client1.channels.get("test")
-                        channel1.attach()
-                        expect(channel1.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                        var messages = [ARTMessage]()
-                        for i in 0..<20 {
-                            messages.append(ARTMessage(name: nil, data: "message \(i)"))
-                        }
-                        waitUntil(timeout: testTimeout) { done in
-                            channel1.publish(messages) { errorInfo in
-                                expect(errorInfo).to(beNil())
-                                done()
-                            }
-                        }
-
-                        client2.connect()
-                        let channel2 = client2.channels.get("test")
-                        channel2.attach()
-                        expect(channel2.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                        var counter = 20
-                        channel2.subscribe { message in
-                            expect(message.data as? String).to(equal("message \(counter)"))
-                            counter += 1
-                        }
-
-                        messages = [ARTMessage]()
-                        for i in 20..<40 {
-                            messages.append(ARTMessage(name: nil, data: "message \(i)"))
-                        }
-                        waitUntil(timeout: testTimeout) { done in
-                            channel1.publish(messages) { errorInfo in
-                                expect(errorInfo).to(beNil())
-                                done()
-                            }
-                        }
-
-                        let query = ARTRealtimeHistoryQuery()
-                        query.untilAttach = true
-
-                        waitUntil(timeout: testTimeout) { done in
-                            expect {
-                                try channel2.history(query) { result, error in
-                                    expect(error).to(beNil())
-                                    guard let result = result else {
-                                        fail("Result is empty"); done(); return
-                                    }
-                                    expect(result.items).to(haveCount(20))
-                                    expect(result.hasNext).to(beFalse())
-                                    expect(result.items.first?.data as? String).to(equal("message 19"))
-                                    expect(result.items.last?.data as? String).to(equal("message 0"))
-                                    done()
-                                }
-                            }.toNot(throwError() { err in fail("\(err)"); done() })
-                        }
-                    }
-
-                // RTL10c
-                func test__118__Channel__history__should_return_a_PaginatedResult_page() {
-                    let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { realtime.close() }
-                    let channel = realtime.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: "message") { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.history { result, error in
-                            expect(error).to(beNil())
-                            expect(result).to(beAKindOf(ARTPaginatedResult<ARTMessage>.self))
-                            guard let result = result else {
-                                fail("Result is empty"); done(); return
-                            }
-                            expect(result.items).to(haveCount(1))
-                            expect(result.hasNext).to(beFalse())
-                            let messages = result.items 
-                            expect(messages[0].data as? String).to(equal("message"))
-                            done()
-                        }
-                    }
-                }
-
-                // RTL10d
-                func test__119__Channel__history__should_retrieve_all_available_messages() {
-                    let options = AblyTests.commonAppSetup()
-                    let client1 = ARTRealtime(options: options)
-                    defer { client1.close() }
-
-                    let client2 = ARTRealtime(options: options)
-                    defer { client2.close() }
-
-                    let channel1 = client1.channels.get("test")
-                    channel1.attach()
-                    expect(channel1.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                    var messages = [ARTMessage]()
-                    for i in 0..<20 {
-                        messages.append(ARTMessage(name: nil, data: "message \(i)"))
-                    }
-                    waitUntil(timeout: testTimeout) { done in
-                        channel1.publish(messages) { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            done()
-                        }
-                    }
-
-                    let channel2 = client2.channels.get("test")
-                    channel2.attach()
-                    expect(channel2.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                    let query = ARTRealtimeHistoryQuery()
-                    query.limit = 10
-
-                    waitUntil(timeout: testTimeout) { done in
-                        expect {
-                            try channel2.history(query) { result, errorInfo in
-                                expect(result!.items).to(haveCount(10))
-                                expect(result!.hasNext).to(beTrue())
-                                expect(result!.isLast).to(beFalse())
-                                expect((result!.items.first! ).data as? String).to(equal("message 19"))
-                                expect((result!.items.last! ).data as? String).to(equal("message 10"))
-
-                                result!.next { result, errorInfo in
-                                    expect(result!.items).to(haveCount(10))
-                                    expect(result!.hasNext).to(beFalse())
-                                    expect(result!.isLast).to(beTrue())
-                                    expect((result!.items.first! ).data as? String).to(equal("message 9"))
-                                    expect((result!.items.last! ).data as? String).to(equal("message 0"))
-                                    done()
-                                }
-                            }
-                        }.toNot(throwError() { err in fail("\(err)"); done() })
-                    }
-                }
-
-                // RTL12
-                func test__120__Channel__history__attached_channel_may_receive_an_additional_ATTACHED_ProtocolMessage() {
-                    let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    channel.on(.attached) { _ in
-                        fail("Should not be called")
-                    }
-                    defer {
-                        channel.off()
-                    }
-
-                    var hook: AspectToken?
-                    waitUntil(timeout: testTimeout) { done in
-                        let attachedMessage = ARTProtocolMessage()
-                        attachedMessage.action = .attached
-                        attachedMessage.channel = channel.name
-
-                        hook = channel.internal.testSuite_injectIntoMethod(after: #selector(channel.internal.onChannelMessage(_:))) {
-                            done()
-                        }
-
-                        // Inject additional ATTACHED action without an error
-                        client.internal.transport?.receive(attachedMessage)
-                    }
-                    hook!.remove()
-                    expect(channel.errorReason).to(beNil())
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let attachedMessageWithError = AblyTests.newErrorProtocolMessage()
-                        attachedMessageWithError.action = .attached
-                        attachedMessageWithError.channel = channel.name
-
-                        channel.once(.update) { stateChange in
-                            expect(stateChange.event).to(equal(ARTChannelEvent.update))
-                            expect(stateChange.reason).to(beIdenticalTo(attachedMessageWithError.error))
-                            expect(channel.errorReason).to(beIdenticalTo(stateChange.reason))
-                            done()
-                        }
-
-                        // Inject additional ATTACHED action with an error
-                        client.internal.transport?.receive(attachedMessageWithError)
-                    }
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
-                }
-
-                // RTL13
-                
-
-                    // RTL13a
-                    func test__128__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__the_channel_is_in_the_ATTACHED_states__an_attempt_to_reattach_the_channel_should_be_made_immediately_by_sending_a_new_ATTACH_message_and_the_channel_should_transition_to_the_ATTACHING_state_with_the_error_emitted_in_the_ChannelStateChange_event() {
-                        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("foo")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach() { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
-
-                        guard let transport = client.internal.transport as? TestProxyTransport else {
-                            fail("TestProxyTransport is not set"); return
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let detachedMessageWithError = AblyTests.newErrorProtocolMessage()
-                            detachedMessageWithError.action = .detached
-                            detachedMessageWithError.channel = channel.name
-
-                            channel.once(.attaching) { stateChange in
-                                guard let error = stateChange.reason  else {
-                                    fail("Reason error is nil"); done(); return
-                                }
-                                expect(error).to(beIdenticalTo(detachedMessageWithError.error))
-                                expect(channel.errorReason).to(beNil())
-                                done()
-                            }
-
-                            transport.receive(detachedMessageWithError)
-                        }
-
-                        expect(transport.protocolMessagesSent.filter{ $0.action == .attach }).to(haveCount(2))
-                    }
-
-                    // RTL13a
-                    func test__129__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__the_channel_is_in_the_SUSPENDED_state__an_attempt_to_reattach_the_channel_should_be_made_immediately_by_sending_a_new_ATTACH_message_and_the_channel_should_transition_to_the_ATTACHING_state_with_the_error_emitted_in_the_ChannelStateChange_event() {
-                        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.connected) { stateChange in
-                                expect(stateChange.reason).to(beNil())
-                                done()
-                            }
-                        }
-
-                        guard let transport = client.internal.transport as? TestProxyTransport else {
-                            fail("TestProxyTransport is not set"); return
-                        }
-
-                        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                        ARTDefault.setRealtimeRequestTimeout(1.0)
-
-                        let channel = client.channels.get("foo")
-
-                        // Timeout
-                        transport.actionsIgnored += [.attached]
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.once(.suspended) { stateChange in
-                                expect(stateChange.reason?.message).to(contain("timed out"))
-                                done()
-                            }
-                            channel.attach()
-                        }
-
-                        transport.actionsIgnored = []
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let detachedMessageWithError = AblyTests.newErrorProtocolMessage()
-                            detachedMessageWithError.action = .detached
-                            detachedMessageWithError.channel = channel.name
-
-                            channel.once(.attaching) { stateChange in
-                                guard let error = stateChange.reason  else {
-                                    fail("Reason error is nil"); done(); return
-                                }
-                                expect(error).to(beIdenticalTo(detachedMessageWithError.error))
-                                expect(channel.errorReason).to(beNil())
-                                done()
-                            }
-
-                            transport.receive(detachedMessageWithError)
-                        }
-                        
-                        expect(transport.protocolMessagesSent.filter{ $0.action == .attach }).to(haveCount(2))
-                    }
-
-                    // RTL13b
-                    func test__130__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__if_the_attempt_to_re_attach_fails_the_channel_will_transition_to_the_SUSPENDED_state_and_the_error_will_be_emitted_in_the_ChannelStateChange_event() {
-                        let options = AblyTests.commonAppSetup()
-                        options.channelRetryTimeout = 1.0
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("foo")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        guard let transport = client.internal.transport as? TestProxyTransport else {
-                            fail("TestProxyTransport is not set"); return
-                        }
-
-                        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                        ARTDefault.setRealtimeRequestTimeout(1.0)
-                        transport.actionsIgnored = [.attached]
-
-                        let detachedMessageWithError = AblyTests.newErrorProtocolMessage()
-                        detachedMessageWithError.action = .detached
-                        detachedMessageWithError.channel = channel.name
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.once(.attaching) { stateChange in
-                                guard let error = stateChange.reason  else {
-                                    fail("Reason error is nil"); done(); return
-                                }
-                                expect(error).to(beIdenticalTo(detachedMessageWithError.error))
-                                expect(channel.errorReason).to(beNil())
-                                done()
-                            }
-
-                            transport.receive(detachedMessageWithError)
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.once(.suspended) { stateChange in
-                                guard let error = stateChange.reason  else {
-                                    fail("Reason error is nil"); done(); return
-                                }
-                                expect(error.message).to(contain("timed out"))
-                                expect(channel.errorReason).to(beIdenticalTo(error))
-                                done()
-                            }
-                        }
-
-                        let start = NSDate()
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.once(.attaching) { _ in
-                                let end = NSDate()
-                                expect(start.addingTimeInterval(options.channelRetryTimeout)).to(beCloseTo(end, within: 0.5))
-                                done()
-                            }
-                        }
-                    }
-
-                    // RTL13b
-                    func test__131__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__if_the_channel_was_already_in_the_ATTACHING_state__the_channel_will_transition_to_the_SUSPENDED_state_and_the_error_will_be_emitted_in_the_ChannelStateChange_event() {
-                        let options = AblyTests.commonAppSetup()
-                        options.channelRetryTimeout = 1.0
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("foo")
-
-                        let detachedMessageWithError = AblyTests.newErrorProtocolMessage()
-                        detachedMessageWithError.action = .detached
-                        detachedMessageWithError.channel = channel.name
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            channel.once(.attaching) { stateChange in
-                                expect(stateChange.reason).to(beNil())
-                                client.internal.transport?.receive(detachedMessageWithError)
-                                partialDone()
-                            }
-                            channel.once(.suspended) { stateChange in
-                                guard let error = stateChange.reason  else {
-                                    fail("Reason error is nil"); partialDone(); return
-                                }
-                                expect(error).to(beIdenticalTo(detachedMessageWithError.error))
-                                expect(channel.errorReason).to(beNil())
-
-                                // Check retry
-                                let start = NSDate()
-                                channel.once(.attached) { stateChange in
-                                    let end = NSDate()
-                                    expect(start).to(beCloseTo(end, within: 1.5))
-                                    expect(stateChange.reason).to(beNil())
-                                    partialDone()
-                                }
-                            }
-                            channel.attach()
-                        }
-                    }
-
-                    // RTL13c
-                    func test__132__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__if_the_connection_is_no_longer_CONNECTED__then_the_automatic_attempts_to_re_attach_the_channel_must_be_cancelled() {
-                        let options = AblyTests.commonAppSetup()
-                        options.channelRetryTimeout = 1.0
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("foo")
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-                        guard let transport = client.internal.transport as? TestProxyTransport else {
-                            fail("TestProxyTransport is not set"); return
-                        }
-
-                        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                        ARTDefault.setRealtimeRequestTimeout(1.0)
-
-                        transport.actionsIgnored = [.attached]
-                        let detachedMessageWithError = AblyTests.newErrorProtocolMessage()
-                        detachedMessageWithError.action = .detached
-                        detachedMessageWithError.channel = channel.name
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.once(.attaching) { stateChange in
-                                guard let error = stateChange.reason  else {
-                                    fail("Reason error is nil"); done(); return
-                                }
-                                expect(error).to(beIdenticalTo(detachedMessageWithError.error))
-                                expect(channel.errorReason).to(beNil())
-                                done()
-                            }
-                            transport.receive(detachedMessageWithError)
-                        }
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.once(.suspended) { stateChange in
-                                guard let error = stateChange.reason  else {
-                                    fail("Reason error is nil"); done(); return
-                                }
-                                expect(error.message).to(contain("timed out"))
-                                expect(channel.errorReason).to(beIdenticalTo(error))
-                                done()
-                            }
-                        }
-
-                        channel.once(.attaching) { _ in
-                            fail("Should cancel the re-attach")
-                        }
-
-                        client.simulateSuspended(beforeSuspension: { done in
-                            channel.once(.suspended) { _ in
-                                done()
-                            }
-                        })
-                    }
-
-                // RTL14
-                func test__121__Channel__history__If_an_ERROR_ProtocolMessage_is_received_for_this_channel_then_the_channel_should_immediately_transition_to_the_FAILED_state__the_errorReason_should_be_set_and_an_error_should_be_emitted_on_the_channel() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("foo")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let errorProtocolMessage = AblyTests.newErrorProtocolMessage()
-                        errorProtocolMessage.action = .error
-                        errorProtocolMessage.channel = channel.name
-
-                        channel.once(.failed) { stateChange in
-                            guard let error = stateChange.reason else {
-                                fail("Reason error is nil"); done(); return
-                            }
-                            expect(error).to(beIdenticalTo(errorProtocolMessage.error))
-                            expect(channel.errorReason).to(beIdenticalTo(error))
-                            done()
-                        }
-
-                        client.internal.transport?.receive(errorProtocolMessage)
-                    }
-
+            }
+        }
+        channelToFail.attach()
+
+        expect(TotalMessages.succeeded).toEventually(equal(TotalMessages.expected), timeout: testTimeout)
+        expect(TotalMessages.failed).toEventually(equal(TotalMessages.expected), timeout: testTimeout)
+    }
+
+    // RTL6c
+
+    // RTL6c1
+
+    func test__071__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__ATTACHED_then_the_messages_should_be_published_immediately() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        channel.attach()
+
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { error in
+                expect(error).to(beNil())
+                done()
+            }
+            expect((client.internal.transport as! TestProxyTransport).protocolMessagesSent.filter { $0.action == .message }).to(haveCount(1))
+        }
+    }
+
+    func test__072__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__INITIALIZED_then_the_messages_should_be_published_immediately() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                done()
+            }
+        }
+        let channel = client.channels.get("test")
+        expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { error in
+                expect(error).to(beNil())
+                done()
+            }
+            expect((client.internal.transport as! TestProxyTransport).protocolMessagesSent.filter { $0.action == .message }).to(haveCount(1))
+        }
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
+    }
+
+    func test__073__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__DETACHED_then_the_messages_should_be_published_immediately() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { _ in
+                done()
+            }
+        }
+        waitUntil(timeout: testTimeout) { done in
+            channel.detach { _ in
+                done()
+            }
+        }
+        expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { error in
+                expect(error).to(beNil())
+                done()
+            }
+            expect((client.internal.transport as! TestProxyTransport).protocolMessagesSent.filter { $0.action == .message }).to(haveCount(1))
+        }
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
+    }
+
+    func test__074__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__ATTACHING_then_the_messages_should_be_published_immediately() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                done()
+            }
+        }
+        channel.attach()
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("Expecting TestProxyTransport"); return
+        }
+        transport.actionsIgnored += [.attached]
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { error in
+                expect(error).to(beNil())
+                done()
+            }
+            expect((client.internal.transport as! TestProxyTransport).protocolMessagesSent.filter { $0.action == .message }).to(haveCount(1))
+        }
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+    }
+
+    func test__075__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__DETACHING_then_the_messages_should_be_published_immediately() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { _ in
+                done()
+            }
+        }
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+        channel.detach()
+        expect(channel.state).to(equal(ARTRealtimeChannelState.detaching))
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("Expecting TestProxyTransport"); return
+        }
+        transport.actionsIgnored += [.detached]
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { error in
+                expect(error).to(beNil())
+                done()
+            }
+            expect((client.internal.transport as! TestProxyTransport).protocolMessagesSent.filter { $0.action == .message }).to(haveCount(1))
+        }
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.detaching))
+    }
+
+    // RTL6c2
+
+    func beforeEach__Channel__publish__Connection_state_conditions__the_message() {
+        let options = AblyTests.commonAppSetup()
+        options.useTokenAuth = true
+        options.autoConnect = false
+        rtl6c2TestsClient = AblyTests.newRealtime(options)
+        rtl6c2TestsChannel = rtl6c2TestsClient.channels.get("test")
+        expect(rtl6c2TestsClient.internal.options.queueMessages).to(beTrue())
+    }
+
+    func afterEach__Channel__publish__Connection_state_conditions__the_message() { rtl6c2TestsClient.close() }
+
+    func test__076__Channel__publish__Connection_state_conditions__the_message__should_be_queued_and_delivered_as_soon_as_the_connection_state_returns_to_CONNECTED_if_the_connection_is__INITIALIZED() {
+        beforeEach__Channel__publish__Connection_state_conditions__the_message()
+
+        waitUntil(timeout: testTimeout) { done in
+            expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.initialized))
+            rtl16c2TestsPublish(done)
+            rtl6c2TestsClient.connect()
+            expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
+        }
+
+        afterEach__Channel__publish__Connection_state_conditions__the_message()
+    }
+
+    func test__077__Channel__publish__Connection_state_conditions__the_message__should_be_queued_and_delivered_as_soon_as_the_connection_state_returns_to_CONNECTED_if_the_connection_is__CONNECTING() {
+        beforeEach__Channel__publish__Connection_state_conditions__the_message()
+
+        waitUntil(timeout: testTimeout) { done in
+            rtl6c2TestsClient.connect()
+            expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.connecting))
+            rtl16c2TestsPublish(done)
+            expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
+        }
+
+        afterEach__Channel__publish__Connection_state_conditions__the_message()
+    }
+
+    func test__078__Channel__publish__Connection_state_conditions__the_message__should_be_queued_and_delivered_as_soon_as_the_connection_state_returns_to_CONNECTED_if_the_connection_is__DISCONNECTED() {
+        beforeEach__Channel__publish__Connection_state_conditions__the_message()
+
+        rtl6c2TestsClient.connect()
+        expect(rtl6c2TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        rtl6c2TestsClient.internal.onDisconnected()
+
+        waitUntil(timeout: testTimeout) { done in
+            expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.disconnected))
+            rtl16c2TestsPublish(done)
+            expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
+        }
+
+        afterEach__Channel__publish__Connection_state_conditions__the_message()
+    }
+
+    func test__079__Channel__publish__Connection_state_conditions__the_message__should_NOT_be_queued_instead_it_should_be_published_if_the_channel_is__INITIALIZED() {
+        beforeEach__Channel__publish__Connection_state_conditions__the_message()
+
+        rtl6c2TestsClient.connect()
+        expect(rtl6c2TestsChannel.state).to(equal(ARTRealtimeChannelState.initialized))
+
+        expect(rtl6c2TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            rtl16c2TestsPublish(done)
+            expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(0))
+            expect((rtl6c2TestsClient.internal.transport as! TestProxyTransport).protocolMessagesSent.filter { $0.action == .message }).to(haveCount(1))
+        }
+
+        afterEach__Channel__publish__Connection_state_conditions__the_message()
+    }
+
+    func test__080__Channel__publish__Connection_state_conditions__the_message__should_NOT_be_queued_instead_it_should_be_published_if_the_channel_is__ATTACHING() {
+        beforeEach__Channel__publish__Connection_state_conditions__the_message()
+
+        rtl6c2TestsClient.connect()
+        expect(rtl6c2TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            rtl6c2TestsChannel.attach()
+            expect(rtl6c2TestsChannel.state).to(equal(ARTRealtimeChannelState.attaching))
+            rtl16c2TestsPublish(done)
+            expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(0))
+            expect((rtl6c2TestsClient.internal.transport as! TestProxyTransport).protocolMessagesSent.filter { $0.action == .message }).to(haveCount(1))
+        }
+
+        afterEach__Channel__publish__Connection_state_conditions__the_message()
+    }
+
+    func test__081__Channel__publish__Connection_state_conditions__the_message__should_NOT_be_queued_instead_it_should_be_published_if_the_channel_is__ATTACHED() {
+        beforeEach__Channel__publish__Connection_state_conditions__the_message()
+
+        waitUntil(timeout: testTimeout) { done in
+            rtl6c2TestsChannel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+            rtl6c2TestsClient.connect()
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let tokenParams = ARTTokenParams()
+            tokenParams.ttl = 5.0
+            rtl6c2TestsClient.auth.authorize(tokenParams, options: nil) { tokenDetails, error in
+                expect(error).to(beNil())
+                expect(tokenDetails).toNot(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            rtl6c2TestsClient.connection.once(.disconnected) { _ in
+                done()
+            }
+        }
+
+        expect(rtl6c2TestsChannel.state).to(equal(ARTRealtimeChannelState.attached))
+
+        waitUntil(timeout: testTimeout) { done in
+            rtl16c2TestsPublish(done)
+            expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
+        }
+
+        afterEach__Channel__publish__Connection_state_conditions__the_message()
+    }
+
+    // RTL6c4
+
+    func beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the() {
+        setupDependencies()
+        ARTDefault.setConnectionStateTtl(0.3)
+        rtl6c4TestsClient = AblyTests.newRealtime(options)
+        rtl6c4TestsChannel = rtl6c4TestsClient.channels.get("test")
+    }
+
+    func afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the() {
+        rtl6c4TestsClient.close()
+        ARTDefault.setConnectionStateTtl(previousConnectionStateTtl)
+    }
+
+    func test__082__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__connection_is_SUSPENDED() {
+        beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
+        rtl6c4TestsClient.connect()
+        expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        rtl6c4TestsClient.internal.onSuspended()
+        expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.suspended), timeout: testTimeout)
+        waitUntil(timeout: testTimeout) { done in
+            rtl6c4TestsPublish(done)
+        }
+
+        afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+    }
+
+    func test__083__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__connection_is_CLOSING() {
+        beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
+        rtl6c4TestsClient.connect()
+        expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        rtl6c4TestsClient.close()
+        expect(rtl6c4TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.closing))
+        waitUntil(timeout: testTimeout) { done in
+            rtl6c4TestsPublish(done)
+        }
+
+        afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+    }
+
+    func test__084__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__connection_is_CLOSED() {
+        beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
+        rtl6c4TestsClient.connect()
+        expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        rtl6c4TestsClient.close()
+        expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.closed), timeout: testTimeout)
+        waitUntil(timeout: testTimeout) { done in
+            rtl6c4TestsPublish(done)
+        }
+
+        afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+    }
+
+    func test__085__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__connection_is_FAILED() {
+        beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
+        rtl6c4TestsClient.connect()
+        expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        rtl6c4TestsClient.internal.onError(AblyTests.newErrorProtocolMessage())
+        expect(rtl6c4TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.failed))
+        waitUntil(timeout: testTimeout) { done in
+            rtl6c4TestsPublish(done)
+        }
+
+        afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+    }
+
+    func test__086__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__channel_is_SUSPENDED() {
+        beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
+        rtl6c4TestsClient.connect()
+        rtl6c4TestsChannel.attach()
+        expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+        rtl6c4TestsChannel.internal.setSuspended(ARTStatus.state(.ok))
+        expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.suspended), timeout: testTimeout)
+        waitUntil(timeout: testTimeout) { done in
+            rtl6c4TestsPublish(done)
+        }
+
+        afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+    }
+
+    func test__087__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__channel_is_FAILED() {
+        beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
+        rtl6c4TestsClient.connect()
+        rtl6c4TestsChannel.attach()
+        expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+        let protocolError = AblyTests.newErrorProtocolMessage()
+        rtl6c4TestsChannel.internal.onError(protocolError)
+        expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.failed), timeout: testTimeout)
+        waitUntil(timeout: testTimeout) { done in
+            rtl6c4TestsPublish(done)
+        }
+
+        afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+    }
+
+    // RTL6c5
+    func test__070__Channel__publish__Connection_state_conditions__publish_should_not_trigger_an_implicit_attach() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            let protocolError = AblyTests.newErrorProtocolMessage()
+            expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
+            channel.publish(nil, data: "message") { error in
+                expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+
+                channel.publish(nil, data: "message") { error in
                     expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-                }
-
-                // RTL16
-                
-
-                    // RTL16a
-                    
-                        func test__133__Channel__history__Channel_options__setOptions__should_send_an_ATTACH_message_with_params___modes_if_the_channel_is_attached() {
-                            let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                            defer { client.dispose(); client.close() }
-                            let channel = client.channels.get("foo")
-
-                            waitUntil(timeout: testTimeout) { done in
-                                channel.attach() { error in
-                                    expect(error).to(beNil())
-                                    done()
-                                }
-                            }
-
-                            guard let transport = client.internal.transport as? TestProxyTransport else {
-                                fail("Expecting TestProxyTransport"); return
-                            }
-
-                            let channelOptions = ARTRealtimeChannelOptions()
-                            channelOptions.modes = [.subscribe, .publish]
-                            channelOptions.params = [
-                                "delta": "vcdiff"
-                            ]
-
-                            waitUntil(timeout: testTimeout) { done in
-                                channel.setOptions(channelOptions) { error in
-                                    expect(error).to(beNil())
-                                    done()
-                                }
-                            }
-
-                            expect(channel.options?.modes).to(equal(channelOptions.modes))
-                            expect(channel.options?.params).to(equal(channelOptions.params))
-
-                            let attachMessages = transport.protocolMessagesSent.filter({ $0.action == .attach })
-                            expect(attachMessages).to(haveCount(2))
-                            guard let lastAttach = attachMessages.last else {
-                                fail("Last ATTACH message is missing"); return
-                            }
-                            expect(lastAttach.flags & Int64(ARTChannelMode.publish.rawValue)).to(beGreaterThan(0)) //true
-                            expect(lastAttach.flags & Int64(ARTChannelMode.subscribe.rawValue)).to(beGreaterThan(0)) //true
-                            expect(lastAttach.params).to(equal(channelOptions.params))
-
-                            let attachedMessages = transport.protocolMessagesReceived.filter({ $0.action == .attached })
-                            expect(attachMessages).to(haveCount(2))
-                            guard let lastAttached = attachedMessages.last else {
-                                fail("Last ATTACH message is missing"); return
-                            }
-                            expect(lastAttached.flags & Int64(ARTChannelMode.publish.rawValue)).to(beGreaterThan(0)) //true
-                            expect(lastAttached.flags & Int64(ARTChannelMode.subscribe.rawValue)).to(beGreaterThan(0)) //true
-                            expect(lastAttached.params).to(equal(channelOptions.params))
-                        }
-
-                        func test__134__Channel__history__Channel_options__setOptions__should_send_an_ATTACH_message_with_params___modes_if_the_channel_is_attaching() {
-                            let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                            defer { client.dispose(); client.close() }
-
-                            waitUntil(timeout: testTimeout) { done in
-                                client.connection.once(.connected) { _ in
-                                    done()
-                                }
-                            }
-
-                            guard let transport = client.internal.transport as? TestProxyTransport else {
-                                fail("Expecting TestProxyTransport"); return
-                            }
-
-                            let channelOptions = ARTRealtimeChannelOptions()
-                            channelOptions.modes = [.subscribe]
-                            channelOptions.params = [
-                                "delta": "vcdiff"
-                            ]
-
-                            let channel = client.channels.get("foo")
-                            waitUntil(timeout: testTimeout) { done in
-                                let partialDone = AblyTests.splitDone(3, done: done)
-                                channel.once(.attaching) { _ in
-                                    channel.setOptions(channelOptions) { error in
-                                        expect(error).to(beNil())
-                                        partialDone()
-                                    }
-                                }
-                                channel.once(.attached) { _ in
-                                    partialDone()
-                                }
-                                channel.once(.update) { _ in
-                                    partialDone()
-                                }
-                                channel.attach()
-                            }
-
-                            let subscribeFlag = Int64(ARTChannelMode.subscribe.rawValue)
-
-                            let attachMessages = transport.protocolMessagesSent.filter({ $0.action == .attach })
-                            expect(attachMessages).to(haveCount(2))
-                            guard let lastAttach = attachMessages.last else {
-                                fail("Last ATTACH message is missing"); return
-                            }
-                            expect(lastAttach.flags & subscribeFlag).to(equal(subscribeFlag))
-                            expect(lastAttach.params).to(equal(channelOptions.params))
-
-                            let attachedMessages = transport.protocolMessagesReceived.filter({ $0.action == .attached })
-                            expect(attachedMessages).to(haveCount(2))
-                            guard let lastAttached = attachedMessages.last else {
-                                fail("Last ATTACH message is missing"); return
-                            }
-                            expect(lastAttached.flags & subscribeFlag).to(equal(subscribeFlag))
-                            expect(lastAttached.params).to(equal(channelOptions.params))
-                        }
-
-                        func test__135__Channel__history__Channel_options__setOptions__should_success_immediately_if_channel_is_not_attaching_or_attached() {
-                            let options = AblyTests.commonAppSetup()
-                            options.autoConnect = false
-                            let client = AblyTests.newRealtime(options)
-                            defer { client.dispose(); client.close() }
-                            let channel = client.channels.get("foo")
-
-                            let channelOptions = ARTRealtimeChannelOptions()
-                            channelOptions.modes = [.subscribe]
-                            channelOptions.params = [
-                                "delta": "vcdiff"
-                            ]
-
-                            channel.setOptions(channelOptions) { error in
-                                expect(error).to(beNil())
-                            }
-
-                            expect(channel.state).to(equal(.initialized))
-                            expect(channel.options?.modes).to(equal(channelOptions.modes))
-                            expect(channel.options?.params).to(equal(channelOptions.params))
-                        }
-
-                        func test__136__Channel__history__Channel_options__setOptions__should_fail_if_the_attach_moves_to_FAILED() {
-                            let options = AblyTests.commonAppSetup()
-                            options.token = getTestToken(capability: "{\"secret\":[\"subscribe\"]}") //access denied
-                            let client = AblyTests.newRealtime(options)
-                            defer { client.dispose(); client.close() }
-                            let channel = client.channels.get("foo")
-
-                            waitUntil(timeout: testTimeout) { done in
-                                client.connection.once(.connected) { _ in
-                                    done()
-                                }
-                            }
-
-                            guard let transport = client.internal.transport as? TestProxyTransport else {
-                                fail("Expecting TestProxyTransport"); return
-                            }
-
-                            let channelOptions = ARTRealtimeChannelOptions()
-                            channelOptions.modes = [.subscribe]
-                            channelOptions.params = [
-                                "delta": "vcdiff"
-                            ]
-
-                            waitUntil(timeout: testTimeout) { done in
-                                let partialDone = AblyTests.splitDone(2, done: done)
-                                channel.once(.failed) { stateChange in
-                                    expect(stateChange.reason?.code).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
-                                    partialDone()
-                                }
-                                channel.attach()
-                                channel.setOptions(channelOptions) { error in
-                                    expect(error?.code).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
-                                    partialDone()
-                                }
-                            }
-
-                            let subscribeFlag = Int64(ARTChannelMode.subscribe.rawValue)
-
-                            let attachMessages = transport.protocolMessagesSent.filter({ $0.action == .attach })
-                            expect(attachMessages).to(haveCount(2))
-                            guard let lastAttach = attachMessages.last else {
-                                fail("Last ATTACH message is missing"); return
-                            }
-                            expect(lastAttach.flags & subscribeFlag).to(equal(subscribeFlag))
-                            expect(lastAttach.params).to(equal(channelOptions.params))
-
-                            let attachedMessages = transport.protocolMessagesReceived.filter({ $0.action == .attached })
-                            expect(attachedMessages).to(beEmpty())
-                        }
-
-                        func test__137__Channel__history__Channel_options__setOptions__should_fail_if_the_attach_moves_to_DETACHED() {
-                            let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                            defer { client.dispose(); client.close() }
-                            let channel = client.channels.get("foo")
-
-                            waitUntil(timeout: testTimeout) { done in
-                                client.connection.once(.connected) { _ in
-                                    done()
-                                }
-                            }
-
-                            guard let transport = client.internal.transport as? TestProxyTransport else {
-                                fail("Expecting TestProxyTransport"); return
-                            }
-
-                            let channelOptions = ARTRealtimeChannelOptions()
-                            channelOptions.modes = [.subscribe]
-                            channelOptions.params = [
-                                "delta": "vcdiff"
-                            ]
-
-                            // Convert ATTACHED to DETACHED
-                            transport.setBeforeIncomingMessageModifier({ protocolMessage in
-                                if protocolMessage.action == .attached {
-                                    protocolMessage.action = .detached
-                                    protocolMessage.error = .create(withCode: ARTErrorCode.internalError.intValue, status: 500, message: "internal error")
-                                    transport.setBeforeIncomingMessageModifier(nil)
-                                }
-                                return protocolMessage
-                            })
-
-                            waitUntil(timeout: testTimeout) { done in
-                                let partialDone = AblyTests.splitDone(2, done: done)
-                                channel.attach() { _ in
-                                    partialDone()
-                                }
-                                channel.setOptions(channelOptions) { error in
-                                    expect(error?.code).to(equal(ARTErrorCode.internalError.intValue))
-                                    partialDone()
-                                }
-                            }
-
-                            let subscribeFlag = Int64(ARTChannelMode.subscribe.rawValue)
-
-                            let attachMessages = transport.protocolMessagesSent.filter({ $0.action == .attach })
-                            expect(attachMessages).to(haveCount(2))
-                            guard let lastAttach = attachMessages.last else {
-                                fail("Last ATTACH message is missing"); return
-                            }
-                            expect(lastAttach.flags & subscribeFlag).to(equal(subscribeFlag))
-                            expect(lastAttach.params).to(equal(channelOptions.params))
-                        }
-
-                // RTL17
-                func test__122__Channel__history__should_not_emit_messages_to_subscribers_if_the_channel_is_in_any_state_other_than_ATTACHED() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.close(); client.dispose() }
-                    let channel = client.channels.get("foo")
-
-                    let m1 = ARTMessage(name: "m1", data: "d1")
-                    let m2 = ARTMessage(name: "m2", data: "d2")
-
-                    var subscribeEmittedCount = 0
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channel.once(.attached) { _ in
-                            channel.subscribe { message in
-                                expect(channel.state).to(equal(.attached))
-                                expect(message.name).to(equal(m1.name))
-                                subscribeEmittedCount += 1
-                                partialDone()
-                            }
-                            channel.publish([m1]) { error in
-                                expect(error).to(beNil())
-                                partialDone()
-                            }
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channel.subscribe { message in
-                            fail("not supposed to receive messages when channel state is \(channel.state)")
-                        }
-                        channel.detach()
-                        channel.publish([m2]) { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                        delay(3.0) {
-                            // Wait some seconds to see if the channel doesn't emit a message
-                            partialDone()
-                        }
-                    }
-
-                    channel.unsubscribe()
-                    expect(subscribeEmittedCount) == 1
-                }
-
-            
-                func test__138__Channel__crypto__if_configured_for_encryption__channels_encrypt_and_decrypt_messages__data() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-
-                    let clientSender = ARTRealtime(options: options)
-                    clientSender.internal.setTransport(TestProxyTransport.self)
-                    defer { clientSender.close() }
-                    clientSender.connect()
-
-                    let clientReceiver = ARTRealtime(options: options)
-                    clientReceiver.internal.setTransport(TestProxyTransport.self)
-                    defer { clientReceiver.close() }
-                    clientReceiver.connect()
-
-                    let key = ARTCrypto.generateRandomKey()
-                    let sender = clientSender.channels.get("test", options: ARTRealtimeChannelOptions(cipherKey: key as ARTCipherKeyCompatible))
-                    let receiver = clientReceiver.channels.get("test", options: ARTRealtimeChannelOptions(cipherKey: key as ARTCipherKeyCompatible))
-
-                    var received = [ARTMessage]()
-
-                    waitUntil(timeout: testTimeout) { done in
-                        receiver.attach { _ in
-                            receiver.subscribe { message in
-                                receiver.unsubscribe()
-                                received.append(message)
-                                done()
-                            }
-
-                            sender.publish("first", data: "first data")
-                        }
-                    }
-                    if received.count != 1 {
-                        fail("should have received one message")
-                        return
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        receiver.detach { _ in
-                            sender.publish("second", data: "second data") { _ in done() }
-                        }
-                    }
-                    if receiver.state != .detached {
-                        fail("receiver should be detached")
-                        return
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        receiver.attach { _ in
-                            receiver.subscribe { message in
-                                received.append(message)
-                                done()
-                            }
-                            sender.publish("third", data: "third data")
-                        }
-                    }
-                    if received.count != 2 {
-                        fail("should've received two messages")
-                        return
-                    }
-
-                    expect(received[0].name).to(equal("first"))
-                    expect(received[0].data as? NSString).to(equal("first data"))
-                    expect(received[1].name).to(equal("third"))
-                    expect(received[1].data as? NSString).to(equal("third data"))
-
-                    let senderTransport = clientSender.internal.transport as! TestProxyTransport
-                    let senderMessages = senderTransport.protocolMessagesSent.filter({ $0.action == .message })
-                    for protocolMessage in senderMessages {
-                        for message in protocolMessage.messages! {
-                            expect(message.data! as? String).toNot(equal("\(message.name!) data"))
-                            expect(message.encoding).to(equal("utf-8/cipher+aes-256-cbc/base64"))
-                        }
-                    }
-
-                    let receiverTransport = clientReceiver.internal.transport as! TestProxyTransport
-                    let receiverMessages = receiverTransport.protocolMessagesReceived.filter({ $0.action == .message })
-                    for protocolMessage in receiverMessages {
-                        for message in protocolMessage.messages! {
-                            expect(message.data! as? NSObject).toNot(equal("\(message.name!) data" as NSObject?))
-                            expect(message.encoding).to(equal("utf-8/cipher+aes-256-cbc"))
-                        }
-                    }
-                }
-
-            // https://github.com/ably/ably-cocoa/issues/614
-            func test__002__Channel__should_not_crash_when_an_ATTACH_request_is_responded_with_a_DETACHED() {
-                let options = AblyTests.commonAppSetup()
-                let client = AblyTests.newRealtime(options)
-                defer { client.dispose(); client.close() }
-                let channel = client.channels.get("foo")
-
-                let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                ARTDefault.setRealtimeRequestTimeout(1.0)
-
-                guard let transport = client.internal.transport as? TestProxyTransport else {
-                    fail("TestProxyTransport is not set"); return
-                }
-
-                transport.setBeforeIncomingMessageModifier({ protocolMessage in
-                    if protocolMessage.action == .attached {
-                        protocolMessage.action = .detached
-                        protocolMessage.error = ARTErrorInfo.create(withCode: ARTErrorCode.internalError.intValue, status: 500, message: "fake error message text")
-                    }
-                    return protocolMessage
-                })
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.attach { error in
-                        guard let error = error else {
-                            fail("Error is nil"); done(); return
-                        }
-                        expect(error.statusCode) == 500
-                        done()
-                    }
+                    expect(error).toNot(beNil())
+                    done()
                 }
             }
-        
-        
-            
-            // TM2a
-            func test__139__message_attributes__if_the_message_does_not_contain_an_id__it_should_be_set_to_protocolMsgId_index() {
-                let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                defer { client.dispose(); client.close() }
-                let p = ARTProtocolMessage()
-                p.id = "protocolId"
-                let m = ARTMessage(name: nil, data: "message without ID")
-                p.messages = [m]
-                let channel = client.channels.get(NSUUID().uuidString)
-                waitUntil(timeout: testTimeout) { done in
-                    channel.attach { _ in
-                        done()
-                    }
-                }
-                waitUntil(timeout: testTimeout) { done in
-                    channel.subscribe { message in
-                        expect(message.id).to(equal("protocolId:0"))
-                        done()
-                    }
-                    AblyTests.queue.async {
-                        channel.internal.onMessage(p)
-                    }
+            expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
+            AblyTests.queue.async {
+                channel.internal.onError(protocolError)
+            }
+        }
+    }
+
+    // RTL6d
+
+    func test__088__Channel__publish__message_bundling__Messages_are_delivered_using_a_single_ProtocolMessage_where_possible_by_bundling_in_all_messages_for_that_channel() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        // Test that the initially queued messages are sent together.
+
+        let messagesSent = 3
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(messagesSent, done: done)
+            for i in 1 ... messagesSent {
+                channel.publish("initial", data: "message\(i)") { error in
+                    expect(error).to(beNil())
+                    partialDone()
                 }
             }
+            client.connect()
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+        let protocolMessages = transport.protocolMessagesSent.filter { $0.action == .message }
+        expect(protocolMessages).to(haveCount(1))
+        if protocolMessages.count != 1 {
+            return
+        }
+        expect(protocolMessages[0].messages).to(haveCount(messagesSent))
+
+        // Test that publishing an array of messages sends them together.
+
+        // TODO: limit the total number of messages bundled per ProtocolMessage
+        let maxMessages = 50
+
+        var messages = [ARTMessage]()
+        for i in 1 ... maxMessages {
+            messages.append(ARTMessage(name: "total number of messages", data: "message\(i)"))
+        }
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(messages) { error in
+                expect(error).to(beNil())
+                let transport = client.internal.transport as! TestProxyTransport
+                let protocolMessages = transport.protocolMessagesSent.filter { $0.action == .message }
+                expect(protocolMessages).to(haveCount(2))
+                if protocolMessages.count != 2 {
+                    done(); return
+                }
+                expect(protocolMessages[1].messages).to(haveCount(maxMessages))
+                done()
+            }
+        }
+    }
+
+    // RTL6d1
+    func test__089__Channel__publish__message_bundling__The_resulting_ProtocolMessage_must_not_exceed_the_maxMessageSize() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test-maxMessageSize")
+        // This amount of messages would be beyond maxMessageSize, if bundled together
+        let messagesToBeSent = 2000
+
+        // Call publish before connecting, so messages are queued
+        waitUntil(timeout: testTimeout.multiplied(by: 6)) { done in
+            let partialDone = AblyTests.splitDone(messagesToBeSent, done: done)
+            for i in 1 ... messagesToBeSent {
+                channel.publish("initial initial\(i)", data: "message message\(i)") { error in
+                    expect(error).to(beNil())
+                    partialDone()
+                }
+            }
+            client.connect()
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+        let protocolMessages = transport.protocolMessagesSent.filter { $0.action == .message }
+        // verify that messages are not bundled in a single protocol message
+        expect(protocolMessages.count).to(beGreaterThan(1))
+        // verify that all the messages have been sent
+        let messagesSent = protocolMessages.compactMap { $0.messages?.count }.reduce(0, +)
+        expect(messagesSent).to(equal(messagesToBeSent))
+    }
+
+    // RTL6d2
+
+    func test__092__Channel__publish__message_bundling__Messages_with_differing_clientId_values_must_not_be_bundled_together__messages_with_different__non_empty__clientIds_are_posted_via_different_protocol_messages() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test-message-bundling-prevention")
+        let clientIDs = ["client1", "client2", "client3"]
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(clientIDs.count, done: done)
+            for (i, el) in clientIDs.enumerated() {
+                channel.publish("name\(i)", data: "data\(i)", clientId: el) { error in
+                    expect(error).to(beNil())
+                    partialDone()
+                }
+            }
+            client.connect()
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+        let protocolMessages = transport.protocolMessagesSent.filter { $0.action == .message }
+        expect(protocolMessages.count).to(equal(clientIDs.count))
+    }
+
+    func test__093__Channel__publish__message_bundling__Messages_with_differing_clientId_values_must_not_be_bundled_together__messages_with_mixed_empty_non_empty_clientIds_are_posted_via_different_protocol_messages() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test-message-bundling-prevention")
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.publish("name1", data: "data1", clientId: "clientID1") { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+            channel.publish("name2", data: "data2") { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+            client.connect()
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+        let protocolMessages = transport.protocolMessagesSent.filter { $0.action == .message }
+        expect(protocolMessages.count).to(equal(2))
+    }
+
+    func test__094__Channel__publish__message_bundling__Messages_with_differing_clientId_values_must_not_be_bundled_together__messages_bundled_by_the_user_are_posted_in_a_single_protocol_message_even_if_they_have_mixed_clientIds() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test-message-bundling-prevention")
+        var messages = [ARTMessage]()
+        for i in 1 ... 3 {
+            messages.append(ARTMessage(name: "name\(i)", data: "data\(i)", clientId: "clientId\(i)"))
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(messages) { error in
+                expect(error).to(beNil())
+                done()
+            }
+            client.connect()
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+        let protocolMessages = transport.protocolMessagesSent.filter { $0.action == .message }
+        expect(protocolMessages.count).to(equal(1))
+    }
+
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    func skipped__test__090__Channel__publish__message_bundling__should_only_bundle_messages_when_it_respects_all_of_the_constraints() {
+        let defaultMaxMessageSize = ARTDefault.maxMessageSize()
+        ARTDefault.setMaxMessageSize(256)
+        defer { ARTDefault.setMaxMessageSize(defaultMaxMessageSize) }
+
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channelOne = client.channels.get("bundlingOne")
+        let channelTwo = client.channels.get("bundlingTwo")
+
+        channelTwo.publish("2a", data: ["expectedBundle": 0])
+        channelOne.publish("a", data: ["expectedBundle": 1])
+        channelOne.publish([
+            ARTMessage(name: "b", data: ["expectedBundle": 1]),
+            ARTMessage(name: "c", data: ["expectedBundle": 1]),
+        ])
+        channelOne.publish("d", data: ["expectedBundle": 1])
+        channelTwo.publish("2b", data: ["expectedBundle": 2])
+        channelOne.publish("e", data: ["expectedBundle": 3])
+        channelOne.publish([ARTMessage(name: "f", data: ["expectedBundle": 3])])
+        // RTL6d2
+        channelOne.publish("g", data: ["expectedBundle": 4], clientId: "foo")
+        channelOne.publish("h", data: ["expectedBundle": 4], clientId: "foo")
+        channelOne.publish("i", data: ["expectedBundle": 5], clientId: "bar")
+        channelOne.publish("j", data: ["expectedBundle": 6])
+        // RTL6d1
+        channelOne.publish("k", data: ["expectedBundle": 7, "moreData": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"])
+        channelOne.publish("l", data: ["expectedBundle": 8])
+        // RTL6d7
+        channelOne.publish([ARTMessage(id: "bundle_m", name: "m", data: ["expectedBundle": 9])])
+        channelOne.publish("z_last", data: ["expectedBundle": 10])
+
+        let expectationMessageBundling = XCTestExpectation(description: "message-bundling")
+
+        AblyTests.queue.async {
+            let queue: [ARTQueuedMessage] = client.internal.queuedMessages as! [ARTQueuedMessage]
+            for i in 0 ... 10 {
+                for message in queue[i].msg.messages! {
+                    let decodedMessage = channelOne.internal.dataEncoder.decode(message.data, encoding: message.encoding)
+
+                    guard let data = (decodedMessage.data as? [String: Any]) else {
+                        fail("Unexpected data type"); continue
+                    }
+
+                    expect(data["expectedBundle"] as? Int).to(equal(i))
+                }
+            }
+
+            expectationMessageBundling.fulfill()
+        }
+
+        AblyTests.wait(for: [expectationMessageBundling], timeout: testTimeout)
+
+        let expectationMessageFinalOrder = XCTestExpectation(description: "final-order")
+
+        // RTL6d6
+        var currentName = ""
+        channelOne.subscribe { message in
+            expect(currentName) < message.name! // Check final ordering preserved
+            currentName = message.name!
+            if currentName == "z_last" {
+                expectationMessageFinalOrder.fulfill()
+            }
+        }
+        client.connect()
+
+        AblyTests.wait(for: [expectationMessageFinalOrder], timeout: testTimeout)
+    }
+
+    func test__091__Channel__publish__message_bundling__should_publish_only_once_on_multiple_explicit_publish_requests_for_a_given_message_with_client_supplied_ids() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("idempotentRealtimePublishing")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.attached) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+        }
+
+        let expectationEvent0 = XCTestExpectation(description: "event0")
+        let expectationEnd = XCTestExpectation(description: "end")
+
+        var event0Msgs: [ARTMessage] = []
+        channel.subscribe("event0") { message in
+            event0Msgs.append(message)
+            expectationEvent0.fulfill()
+        }
+
+        channel.subscribe("end") { _ in
+            expect(event0Msgs).to(haveCount(1))
+            expectationEnd.fulfill()
+        }
+
+        channel.publish([ARTMessage(id: "some_msg_id", name: "event0", data: "")])
+        channel.publish([ARTMessage(id: "some_msg_id", name: "event0", data: "")])
+        channel.publish([ARTMessage(id: "some_msg_id", name: "event0", data: "")])
+        channel.publish("end", data: nil)
+
+        AblyTests.wait(for: [expectationEvent0, expectationEnd])
+    }
+
+    // RTL6e
+
+    // RTL6e1
+    func test__095__Channel__publish__Unidentified_clients_using_Basic_Auth__should_have_the_provided_clientId_on_received_message_when_it_was_published_with_clientId() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        expect(client.auth.clientId).to(beNil())
+
+        let channel = client.channels.get("test")
+
+        var resultClientId: String?
+
+        let message = ARTMessage(name: nil, data: "message")
+        message.clientId = "client_string"
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.subscribe { message in
+                resultClientId = message.clientId
+                partialDone()
+            }
+            channel.publish([message]) { errorInfo in
+                expect(errorInfo).to(beNil())
+                partialDone()
+            }
+        }
+
+        expect(resultClientId).toEventually(equal(message.clientId), timeout: testTimeout)
+    }
+
+    // RTL6f
+    func test__065__Channel__publish__Message_connectionId_should_match_the_current_Connection_id_for_all_published_messages() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.subscribe { message in
+                expect(message.connectionId).to(equal(client.connection.id))
+                done()
+            }
+            channel.publish(nil, data: "message")
+        }
+    }
+
+    // RTL6i
+
+    func test__096__Channel__publish__expect_either__an_array_of_Message_objects() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        typealias JSONObject = NSDictionary
+
+        var result = [JSONObject]()
+        channel.subscribe { message in
+            result.append(message.data as! JSONObject)
+        }
+
+        let messages = [ARTMessage(name: nil, data: ["key": 1]), ARTMessage(name: nil, data: ["key": 2])]
+        channel.publish(messages)
+
+        let transport = client.internal.transport as! TestProxyTransport
+
+        expect(transport.protocolMessagesSent.filter { $0.action == .message }).toEventually(haveCount(1), timeout: testTimeout)
+        expect(result).toEventually(equal(messages.map { $0.data as! JSONObject }), timeout: testTimeout)
+    }
+
+    func test__097__Channel__publish__expect_either__a_name_string_and_data_payload() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        let expectedResult = "string_data"
+        var result: String?
+
+        channel.subscribe("event") { message in
+            result = message.data as? String
+        }
+
+        channel.publish("event", data: expectedResult, callback: nil)
+
+        expect(result).toEventually(equal(expectedResult), timeout: testTimeout)
+    }
+
+    func test__098__Channel__publish__expect_either__allows_name_to_be_null() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        let expectedObject = ["data": "message", "connectionId": client.connection.id!]
+
+        var resultMessage: ARTMessage?
+        channel.subscribe { message in
+            resultMessage = message
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: expectedObject["data"]) { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+
+        let rawProtoMsgsSent: [NSDictionary] = transport.rawDataSent.toMsgPackArray()
+        let rawMessagesSent = rawProtoMsgsSent.filter { $0["action"] as! UInt == ARTProtocolMessageAction.message.rawValue }
+        let messagesList = rawMessagesSent[0]["messages"] as! NSArray
+        let resultObject = messagesList[0] as! [String: String]
+
+        expect(resultObject).to(equal(expectedObject))
+
+        expect(resultMessage).toNotEventually(beNil(), timeout: testTimeout)
+        expect(resultMessage!.name).to(beNil())
+        expect(resultMessage!.data as? String).to(equal(expectedObject["data"]))
+    }
+
+    func test__099__Channel__publish__expect_either__allows_data_to_be_null() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        let expectedObject = ["name": "click", "connectionId": client.connection.id!]
+
+        var resultMessage: ARTMessage?
+        channel.subscribe(expectedObject["name"]!) { message in
+            resultMessage = message
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(expectedObject["name"], data: nil) { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+
+        let rawProtoMsgsSent: [NSDictionary] = transport.rawDataSent.toMsgPackArray()
+        let rawMessagesSent = rawProtoMsgsSent.filter { $0["action"] as! UInt == ARTProtocolMessageAction.message.rawValue }
+        let messagesList = rawMessagesSent[0]["messages"] as! NSArray
+        let resultObject = messagesList[0] as! NSDictionary
+
+        expect(resultObject).to(equal(expectedObject as NSDictionary))
+
+        expect(resultMessage).toNotEventually(beNil(), timeout: testTimeout)
+        expect(resultMessage!.name).to(equal(expectedObject["name"]))
+        expect(resultMessage!.data).to(beNil())
+    }
+
+    func test__100__Channel__publish__expect_either__allows_name_and_data_to_be_assigned() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        let expectedObject = ["name": "click", "data": "message", "connectionId": client.connection.id!]
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(expectedObject["name"], data: expectedObject["data"]) { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+
+        let rawProtoMsgsSent: [NSDictionary] = transport.rawDataSent.toMsgPackArray()
+        let rawMessagesSent = rawProtoMsgsSent.filter { $0["action"] as! UInt == ARTProtocolMessageAction.message.rawValue }
+        let messagesList = rawMessagesSent[0]["messages"] as! NSArray
+        let resultObject = messagesList[0] as! NSDictionary
+
+        expect(resultObject).to(equal(expectedObject as NSDictionary))
+    }
+
+    // RTL6g
+
+    // RTL6g1
+
+    // RTL6g1a & RTL6g1b
+    func test__105__Channel__publish__Identified_clients_with_clientId__When_publishing_a_Message_with_clientId_set_to_null__should_be_unnecessary_to_set_clientId_of_the_Message_before_publishing_and_have_clientId_value_set_for_the_Message_when_received() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "client_string"
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        let message = ARTMessage(name: nil, data: "message")
+        expect(message.clientId).to(beNil())
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.subscribe { message in
+                expect(message.clientId).to(equal(options.clientId))
+                done()
+            }
+            channel.publish([message])
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+
+        let messageSent = transport.protocolMessagesSent.filter { $0.action == .message }[0]
+        expect(messageSent.messages![0].clientId).to(beNil())
+
+        let messageReceived = transport.protocolMessagesReceived.filter { $0.action == .message }[0]
+        expect(messageReceived.messages![0].clientId).to(equal(options.clientId))
+    }
+
+    // RTL6g2
+    func test__101__Channel__publish__Identified_clients_with_clientId__when_publishing_a_Message_with_the_clientId_attribute_value_set_to_the_identified_client_s_clientId() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        let message = ARTMessage(name: nil, data: "message", clientId: options.clientId!)
+        var resultClientId: String?
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.subscribe { message in
+                resultClientId = message.clientId
+                partialDone()
+            }
+            channel.publish([message]) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
+
+        expect(resultClientId).toEventually(equal(message.clientId), timeout: testTimeout)
+    }
+
+    // RTL6g3
+    func test__102__Channel__publish__Identified_clients_with_clientId__when_publishing_a_Message_with_a_different_clientId_attribute_value_from_the_identified_client_s_clientId__it_should_reject_that_publish_operation_immediately() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish([ARTMessage(name: nil, data: "message", clientId: "tester")]) { error in
+                expect(error?.code).to(equal(Int(ARTState.mismatchedClientId.rawValue)))
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish([ARTMessage(name: nil, data: "message")]) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RTL6g4
+    func test__103__Channel__publish__Identified_clients_with_clientId__message_should_be_published_following_authentication_and_received_back_with_the_clientId_intact() {
+        let options = AblyTests.clientOptions()
+        options.authCallback = { _, completion in
+            getTestTokenDetails(clientId: "john", completion: completion)
+        }
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        let message = ARTMessage(name: nil, data: "message", clientId: "john")
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.subscribe { received in
+                expect(received.clientId).to(equal(message.clientId))
+                partialDone()
+            }
+            channel.publish([message]) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
+    }
+
+    // RTL6g4
+    func test__104__Channel__publish__Identified_clients_with_clientId__message_should_be_rejected_by_the_Ably_service_and_the_message_error_should_contain_the_server_error() {
+        let options = AblyTests.clientOptions()
+        options.authCallback = { _, completion in
+            getTestTokenDetails(clientId: "john", completion: completion)
+        }
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        let message = ARTMessage(name: nil, data: "message", clientId: "tester")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish([message]) { error in
+                expect(error!.code).to(equal(ARTErrorCode.invalidClientId.intValue))
+                done()
+            }
+        }
+    }
+
+    // RTL6h
+    func test__066__Channel__publish__should_provide_an_optional_argument_that_allows_the_clientId_value_to_be_specified() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.subscribe { message in
+                expect(message.name).to(equal("event"))
+                expect(message.data as? NSObject).to(equal("data" as NSObject?))
+                expect(message.clientId).to(equal("foo"))
+                partialDone()
+            }
+            channel.publish("event", data: "data", clientId: "foo") { errorInfo in
+                expect(errorInfo).to(beNil())
+                partialDone()
+            }
+        }
+    }
+
+    // RTL7
+
+    // RTL7a
+    func test__106__Channel__subscribe__with_no_arguments_subscribes_a_listener_to_all_messages() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        class Test {
+            static var counter = 0
+            fileprivate init() {}
+        }
+
+        channel.subscribe { message in
+            expect(message.data as? String).to(equal("message"))
+            Test.counter += 1
+        }
+
+        channel.publish(nil, data: "message")
+        channel.publish("eventA", data: "message")
+        channel.publish("eventB", data: "message")
+
+        expect(Test.counter).toEventually(equal(3), timeout: testTimeout)
+    }
+
+    // RTL7b
+    func test__107__Channel__subscribe__with_a_single_name_argument_subscribes_a_listener_to_only_messages_whose_name_member_matches_the_string_name() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        class Test {
+            static var counter = 0
+            fileprivate init() {}
+        }
+
+        channel.subscribe("eventA") { message in
+            expect(message.name).to(equal("eventA"))
+            expect(message.data as? String).to(equal("message"))
+            Test.counter += 1
+        }
+
+        channel.publish(nil, data: "message")
+        channel.publish("eventA", data: "message")
+        channel.publish("eventB", data: "message")
+        channel.publish("eventA", data: "message")
+
+        expect(Test.counter).toEventually(equal(2), timeout: testTimeout)
+    }
+
+    func test__108__Channel__subscribe__with_a_attach_callback_should_subscribe_and_call_the_callback_when_attached() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        let publishedMessage = ARTMessage(name: "foo", data: "bar")
+
+        waitUntil(timeout: testTimeout) { done in
+            expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
+
+            channel.subscribe(attachCallback: { errorInfo in
+                expect(errorInfo).to(beNil())
+                expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+                channel.publish([publishedMessage])
+            }) { message in
+                expect(message.name).to(equal(publishedMessage.name))
+                expect(message.data as? NSObject).to(equal(publishedMessage.data as? NSObject))
+                done()
+            }
+
+            expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+        }
+    }
+
+    // RTL7c
+    func test__109__Channel__subscribe__should_implicitly_attach_the_channel() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        channel.subscribe { _ in }
+
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+    }
+
+    // RTL7c
+    func test__110__Channel__subscribe__should_result_in_an_error_if_channel_is_in_the_FAILED_state() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+        channel.internal.onError(AblyTests.newErrorProtocolMessage())
+        expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.subscribe(attachCallback: { errorInfo in
+                expect(errorInfo).toNot(beNil())
+
+                channel.subscribe("foo", onAttach: { errorInfo in
+                    expect(errorInfo).toNot(beNil())
+                    done()
+                }) { _ in }
+            }) { _ in }
+        }
+    }
+
+    // RTL7d
+
+    func test__112__Channel__subscribe__should_deliver_the_message_even_if_there_is_an_error_while_decoding__using_crypto_data_128() {
+        testHandlesDecodingErrorInFixture("crypto-data-128")
+    }
+
+    func test__113__Channel__subscribe__should_deliver_the_message_even_if_there_is_an_error_while_decoding__using_crypto_data_256() {
+        testHandlesDecodingErrorInFixture("crypto-data-256")
+    }
+
+    // RTL7e
+    func test__114__Channel__subscribe__message_cannot_be_decoded_or_decrypted__should_deliver_with_encoding_attribute_set_indicating_the_residual_encoding_and_error_should_be_emitted() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.logHandler = ARTLog(capturingOutput: true)
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        let channelOptions = ARTRealtimeChannelOptions(cipher: ["key": ARTCrypto.generateRandomKey()] as ARTCipherParamsCompatible)
+        let channel = client.channels.get("test", options: channelOptions)
+
+        let expectedMessage = ["key": 1]
+        let expectedData = try! JSONSerialization.data(withJSONObject: expectedMessage, options: JSONSerialization.WritingOptions(rawValue: 0))
+
+        let transport = client.internal.transport as! TestProxyTransport
+
+        transport.setBeforeIncomingMessageModifier { protocolMessage in
+            if protocolMessage.action == .message {
+                let messageReceived = protocolMessage.messages![0]
+                // Replacement: `json/utf-8/cipher+aes-256-cbc/base64` to `invalid/cipher+aes-256-cbc/base64`
+                let newEncoding = "invalid" + messageReceived.encoding!["json/utf-8".endIndex...]
+                messageReceived.encoding = newEncoding
+            }
+            return protocolMessage
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.subscribe { message in
+                // Last decoding failed: NSData -> JSON object, so...
+                expect(message.data as? NSData).to(equal(expectedData as NSData?))
+                expect(message.encoding).to(equal("invalid"))
+
+                let logs = options.logHandler.captured
+                let line = logs.reduce("") { $0 + "; " + $1.toString() } // Reduce in one line
+                expect(line).to(contain("Failed to decode data: unknown encoding: 'invalid'"))
+
+                expect(channel.errorReason!.message).to(contain("Failed to decode data: unknown encoding: 'invalid'"))
+
+                done()
+            }
+
+            channel.publish(nil, data: expectedMessage)
+        }
+    }
+
+    // RTL7f
+    func test__111__Channel__subscribe__should_exist_ensuring_published_messages_are_not_echoed_back_to_the_subscriber_when_echoMessages_is_false() {
+        let options = AblyTests.commonAppSetup()
+        let client1 = ARTRealtime(options: options)
+        defer { client1.close() }
+
+        options.echoMessages = false
+        let client2 = ARTRealtime(options: options)
+        defer { client2.close() }
+
+        let channel1 = client1.channels.get("test")
+        let channel2 = client2.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel1.attach { err in
+                expect(err).to(beNil())
+                channel1.subscribe { message in
+                    expect(message.data as? String).to(equal("message"))
+                    delay(1.0) { done() }
+                }
+
+                channel2.subscribe { _ in
+                    fail("Shouldn't receive the message")
+                }
+
+                channel2.publish(nil, data: "message")
+            }
+        }
+    }
+
+    // RTL8
+
+    // RTL8a
+    func test__115__Channel__unsubscribe__with_no_arguments_unsubscribes_the_provided_listener_to_all_messages_if_subscribed() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            let listener = channel.subscribe { _ in
+                fail("Listener shouldn't exist")
+                done()
+            }
+
+            channel.unsubscribe(listener)
+
+            channel.publish(nil, data: "message") { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RTL8b
+    func test__116__Channel__unsubscribe__with_a_single_name_argument_unsubscribes_the_provided_listener_if_previously_subscribed_with_a_name_specific_subscription() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            let eventAListener = channel.subscribe("eventA") { _ in
+                fail("Listener shouldn't exist")
+                done()
+            }
+
+            channel.unsubscribe("eventA", listener: eventAListener)
+
+            channel.publish("eventA", data: "message") { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RTL10
+
+    // RTL10a
+    func test__117__Channel__history__should_support_all_the_same_params_as_Rest() {
+        let options = AblyTests.commonAppSetup()
+
+        let rest = ARTRest(options: options)
+
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.close() }
+
+        let channelRest = rest.channels.get("test")
+        let channelRealtime = realtime.channels.get("test")
+
+        var restChannelHistoryMethodWasCalled = false
+
+        let hookRest = channelRest.testSuite_injectIntoMethod(after: #selector(ARTRestChannel.history(_:callback:))) {
+            restChannelHistoryMethodWasCalled = true
+        }
+        defer { hookRest.remove() }
+
+        let hookRealtime = channelRealtime.testSuite_injectIntoMethod(after: #selector(ARTRestChannel.history(_:callback:))) {
+            restChannelHistoryMethodWasCalled = true
+        }
+        defer { hookRealtime.remove() }
+
+        let queryRealtime = ARTRealtimeHistoryQuery()
+        queryRealtime.start = NSDate() as Date
+        queryRealtime.end = NSDate() as Date
+        queryRealtime.direction = .forwards
+        queryRealtime.limit = 50
+
+        let queryRest = queryRealtime as ARTDataQuery
+
+        waitUntil(timeout: testTimeout) { done in
+            expect {
+                try channelRest.history(queryRest) { _, _ in
+                    done()
+                }
+            }.toNot(throwError { err in fail("\(err)"); done() })
+        }
+        expect(restChannelHistoryMethodWasCalled).to(beTrue())
+        restChannelHistoryMethodWasCalled = false
+
+        waitUntil(timeout: testTimeout) { done in
+            expect {
+                try channelRealtime.history(queryRealtime) { _, _ in
+                    done()
+                }
+            }.toNot(throwError { err in fail("\(err)"); done() })
+        }
+        expect(restChannelHistoryMethodWasCalled).to(beTrue())
+    }
+
+    // RTL10b
+
+    func test__123__Channel__history__supports_the_param_untilAttach__should_be_false_as_default() {
+        let query = ARTRealtimeHistoryQuery()
+        expect(query.untilAttach).to(equal(false))
+    }
+
+    func test__124__Channel__history__supports_the_param_untilAttach__should_invoke_an_error_when_the_untilAttach_is_specified_and_the_channel_is_not_attached() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        let query = ARTRealtimeHistoryQuery()
+        query.untilAttach = true
+
+        do {
+            try channel.history(query, callback: { _, _ in })
+        } catch let error as NSError {
+            if error.code != ARTRealtimeHistoryError.notAttached.rawValue {
+                fail("Shouldn't raise a global error, got \(error)")
+            }
+            return
+        }
+        fail("Should raise an error")
+    }
+
+    func test__125__Channel__history__supports_the_param_untilAttach__where_value_is_true__should_pass_the_querystring_param_fromSerial_with_the_serial_number_assigned_to_the_channel() {
+        testWithUntilAttach(true)
+    }
+
+    func test__126__Channel__history__supports_the_param_untilAttach__where_value_is_false__should_pass_the_querystring_param_fromSerial_with_the_serial_number_assigned_to_the_channel() {
+        testWithUntilAttach(true)
+    }
+
+    func test__127__Channel__history__supports_the_param_untilAttach__should_retrieve_messages_prior_to_the_moment_that_the_channel_was_attached() {
+        let options = AblyTests.commonAppSetup()
+        let client1 = ARTRealtime(options: options)
+        defer { client1.close() }
+
+        options.autoConnect = false
+        let client2 = ARTRealtime(options: options)
+        defer { client2.close() }
+
+        let channel1 = client1.channels.get("test")
+        channel1.attach()
+        expect(channel1.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        var messages = [ARTMessage]()
+        for i in 0 ..< 20 {
+            messages.append(ARTMessage(name: nil, data: "message \(i)"))
+        }
+        waitUntil(timeout: testTimeout) { done in
+            channel1.publish(messages) { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+
+        client2.connect()
+        let channel2 = client2.channels.get("test")
+        channel2.attach()
+        expect(channel2.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        var counter = 20
+        channel2.subscribe { message in
+            expect(message.data as? String).to(equal("message \(counter)"))
+            counter += 1
+        }
+
+        messages = [ARTMessage]()
+        for i in 20 ..< 40 {
+            messages.append(ARTMessage(name: nil, data: "message \(i)"))
+        }
+        waitUntil(timeout: testTimeout) { done in
+            channel1.publish(messages) { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+
+        let query = ARTRealtimeHistoryQuery()
+        query.untilAttach = true
+
+        waitUntil(timeout: testTimeout) { done in
+            expect {
+                try channel2.history(query) { result, error in
+                    expect(error).to(beNil())
+                    guard let result = result else {
+                        fail("Result is empty"); done(); return
+                    }
+                    expect(result.items).to(haveCount(20))
+                    expect(result.hasNext).to(beFalse())
+                    expect(result.items.first?.data as? String).to(equal("message 19"))
+                    expect(result.items.last?.data as? String).to(equal("message 0"))
+                    done()
+                }
+            }.toNot(throwError { err in fail("\(err)"); done() })
+        }
+    }
+
+    // RTL10c
+    func test__118__Channel__history__should_return_a_PaginatedResult_page() {
+        let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { realtime.close() }
+        let channel = realtime.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.history { result, error in
+                expect(error).to(beNil())
+                expect(result).to(beAKindOf(ARTPaginatedResult<ARTMessage>.self))
+                guard let result = result else {
+                    fail("Result is empty"); done(); return
+                }
+                expect(result.items).to(haveCount(1))
+                expect(result.hasNext).to(beFalse())
+                let messages = result.items
+                expect(messages[0].data as? String).to(equal("message"))
+                done()
+            }
+        }
+    }
+
+    // RTL10d
+    func test__119__Channel__history__should_retrieve_all_available_messages() {
+        let options = AblyTests.commonAppSetup()
+        let client1 = ARTRealtime(options: options)
+        defer { client1.close() }
+
+        let client2 = ARTRealtime(options: options)
+        defer { client2.close() }
+
+        let channel1 = client1.channels.get("test")
+        channel1.attach()
+        expect(channel1.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        var messages = [ARTMessage]()
+        for i in 0 ..< 20 {
+            messages.append(ARTMessage(name: nil, data: "message \(i)"))
+        }
+        waitUntil(timeout: testTimeout) { done in
+            channel1.publish(messages) { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+
+        let channel2 = client2.channels.get("test")
+        channel2.attach()
+        expect(channel2.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        let query = ARTRealtimeHistoryQuery()
+        query.limit = 10
+
+        waitUntil(timeout: testTimeout) { done in
+            expect {
+                try channel2.history(query) { result, _ in
+                    expect(result!.items).to(haveCount(10))
+                    expect(result!.hasNext).to(beTrue())
+                    expect(result!.isLast).to(beFalse())
+                    expect((result!.items.first!).data as? String).to(equal("message 19"))
+                    expect((result!.items.last!).data as? String).to(equal("message 10"))
+
+                    result!.next { result, _ in
+                        expect(result!.items).to(haveCount(10))
+                        expect(result!.hasNext).to(beFalse())
+                        expect(result!.isLast).to(beTrue())
+                        expect((result!.items.first!).data as? String).to(equal("message 9"))
+                        expect((result!.items.last!).data as? String).to(equal("message 0"))
+                        done()
+                    }
+                }
+            }.toNot(throwError { err in fail("\(err)"); done() })
+        }
+    }
+
+    // RTL12
+    func test__120__Channel__history__attached_channel_may_receive_an_additional_ATTACHED_ProtocolMessage() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        channel.on(.attached) { _ in
+            fail("Should not be called")
+        }
+        defer {
+            channel.off()
+        }
+
+        var hook: AspectToken?
+        waitUntil(timeout: testTimeout) { done in
+            let attachedMessage = ARTProtocolMessage()
+            attachedMessage.action = .attached
+            attachedMessage.channel = channel.name
+
+            hook = channel.internal.testSuite_injectIntoMethod(after: #selector(channel.internal.onChannelMessage(_:))) {
+                done()
+            }
+
+            // Inject additional ATTACHED action without an error
+            client.internal.transport?.receive(attachedMessage)
+        }
+        hook!.remove()
+        expect(channel.errorReason).to(beNil())
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+
+        waitUntil(timeout: testTimeout) { done in
+            let attachedMessageWithError = AblyTests.newErrorProtocolMessage()
+            attachedMessageWithError.action = .attached
+            attachedMessageWithError.channel = channel.name
+
+            channel.once(.update) { stateChange in
+                expect(stateChange.event).to(equal(ARTChannelEvent.update))
+                expect(stateChange.reason).to(beIdenticalTo(attachedMessageWithError.error))
+                expect(channel.errorReason).to(beIdenticalTo(stateChange.reason))
+                done()
+            }
+
+            // Inject additional ATTACHED action with an error
+            client.internal.transport?.receive(attachedMessageWithError)
+        }
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+    }
+
+    // RTL13
+
+    // RTL13a
+    func test__128__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__the_channel_is_in_the_ATTACHED_states__an_attempt_to_reattach_the_channel_should_be_made_immediately_by_sending_a_new_ATTACH_message_and_the_channel_should_transition_to_the_ATTACHING_state_with_the_error_emitted_in_the_ChannelStateChange_event() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let detachedMessageWithError = AblyTests.newErrorProtocolMessage()
+            detachedMessageWithError.action = .detached
+            detachedMessageWithError.channel = channel.name
+
+            channel.once(.attaching) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Reason error is nil"); done(); return
+                }
+                expect(error).to(beIdenticalTo(detachedMessageWithError.error))
+                expect(channel.errorReason).to(beNil())
+                done()
+            }
+
+            transport.receive(detachedMessageWithError)
+        }
+
+        expect(transport.protocolMessagesSent.filter { $0.action == .attach }).to(haveCount(2))
+    }
+
+    // RTL13a
+    func test__129__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__the_channel_is_in_the_SUSPENDED_state__an_attempt_to_reattach_the_channel_should_be_made_immediately_by_sending_a_new_ATTACH_message_and_the_channel_should_transition_to_the_ATTACHING_state_with_the_error_emitted_in_the_ChannelStateChange_event() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+        }
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(1.0)
+
+        let channel = client.channels.get("foo")
+
+        // Timeout
+        transport.actionsIgnored += [.attached]
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.suspended) { stateChange in
+                expect(stateChange.reason?.message).to(contain("timed out"))
+                done()
+            }
+            channel.attach()
+        }
+
+        transport.actionsIgnored = []
+
+        waitUntil(timeout: testTimeout) { done in
+            let detachedMessageWithError = AblyTests.newErrorProtocolMessage()
+            detachedMessageWithError.action = .detached
+            detachedMessageWithError.channel = channel.name
+
+            channel.once(.attaching) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Reason error is nil"); done(); return
+                }
+                expect(error).to(beIdenticalTo(detachedMessageWithError.error))
+                expect(channel.errorReason).to(beNil())
+                done()
+            }
+
+            transport.receive(detachedMessageWithError)
+        }
+
+        expect(transport.protocolMessagesSent.filter { $0.action == .attach }).to(haveCount(2))
+    }
+
+    // RTL13b
+    func test__130__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__if_the_attempt_to_re_attach_fails_the_channel_will_transition_to_the_SUSPENDED_state_and_the_error_will_be_emitted_in_the_ChannelStateChange_event() {
+        let options = AblyTests.commonAppSetup()
+        options.channelRetryTimeout = 1.0
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(1.0)
+        transport.actionsIgnored = [.attached]
+
+        let detachedMessageWithError = AblyTests.newErrorProtocolMessage()
+        detachedMessageWithError.action = .detached
+        detachedMessageWithError.channel = channel.name
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.attaching) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Reason error is nil"); done(); return
+                }
+                expect(error).to(beIdenticalTo(detachedMessageWithError.error))
+                expect(channel.errorReason).to(beNil())
+                done()
+            }
+
+            transport.receive(detachedMessageWithError)
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.suspended) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Reason error is nil"); done(); return
+                }
+                expect(error.message).to(contain("timed out"))
+                expect(channel.errorReason).to(beIdenticalTo(error))
+                done()
+            }
+        }
+
+        let start = NSDate()
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.attaching) { _ in
+                let end = NSDate()
+                expect(start.addingTimeInterval(options.channelRetryTimeout)).to(beCloseTo(end, within: 0.5))
+                done()
+            }
+        }
+    }
+
+    // RTL13b
+    func test__131__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__if_the_channel_was_already_in_the_ATTACHING_state__the_channel_will_transition_to_the_SUSPENDED_state_and_the_error_will_be_emitted_in_the_ChannelStateChange_event() {
+        let options = AblyTests.commonAppSetup()
+        options.channelRetryTimeout = 1.0
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+
+        let detachedMessageWithError = AblyTests.newErrorProtocolMessage()
+        detachedMessageWithError.action = .detached
+        detachedMessageWithError.channel = channel.name
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.once(.attaching) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                client.internal.transport?.receive(detachedMessageWithError)
+                partialDone()
+            }
+            channel.once(.suspended) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Reason error is nil"); partialDone(); return
+                }
+                expect(error).to(beIdenticalTo(detachedMessageWithError.error))
+                expect(channel.errorReason).to(beNil())
+
+                // Check retry
+                let start = NSDate()
+                channel.once(.attached) { stateChange in
+                    let end = NSDate()
+                    expect(start).to(beCloseTo(end, within: 1.5))
+                    expect(stateChange.reason).to(beNil())
+                    partialDone()
+                }
+            }
+            channel.attach()
+        }
+    }
+
+    // RTL13c
+    func test__132__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__if_the_connection_is_no_longer_CONNECTED__then_the_automatic_attempts_to_re_attach_the_channel_must_be_cancelled() {
+        let options = AblyTests.commonAppSetup()
+        options.channelRetryTimeout = 1.0
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(1.0)
+
+        transport.actionsIgnored = [.attached]
+        let detachedMessageWithError = AblyTests.newErrorProtocolMessage()
+        detachedMessageWithError.action = .detached
+        detachedMessageWithError.channel = channel.name
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.attaching) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Reason error is nil"); done(); return
+                }
+                expect(error).to(beIdenticalTo(detachedMessageWithError.error))
+                expect(channel.errorReason).to(beNil())
+                done()
+            }
+            transport.receive(detachedMessageWithError)
+        }
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.suspended) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Reason error is nil"); done(); return
+                }
+                expect(error.message).to(contain("timed out"))
+                expect(channel.errorReason).to(beIdenticalTo(error))
+                done()
+            }
+        }
+
+        channel.once(.attaching) { _ in
+            fail("Should cancel the re-attach")
+        }
+
+        client.simulateSuspended(beforeSuspension: { done in
+            channel.once(.suspended) { _ in
+                done()
+            }
+        })
+    }
+
+    // RTL14
+    func test__121__Channel__history__If_an_ERROR_ProtocolMessage_is_received_for_this_channel_then_the_channel_should_immediately_transition_to_the_FAILED_state__the_errorReason_should_be_set_and_an_error_should_be_emitted_on_the_channel() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let errorProtocolMessage = AblyTests.newErrorProtocolMessage()
+            errorProtocolMessage.action = .error
+            errorProtocolMessage.channel = channel.name
+
+            channel.once(.failed) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Reason error is nil"); done(); return
+                }
+                expect(error).to(beIdenticalTo(errorProtocolMessage.error))
+                expect(channel.errorReason).to(beIdenticalTo(error))
+                done()
+            }
+
+            client.internal.transport?.receive(errorProtocolMessage)
+        }
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+    }
+
+    // RTL16
+
+    // RTL16a
+
+    func test__133__Channel__history__Channel_options__setOptions__should_send_an_ATTACH_message_with_params___modes_if_the_channel_is_attached() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("Expecting TestProxyTransport"); return
+        }
+
+        let channelOptions = ARTRealtimeChannelOptions()
+        channelOptions.modes = [.subscribe, .publish]
+        channelOptions.params = [
+            "delta": "vcdiff",
+        ]
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.setOptions(channelOptions) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        expect(channel.options?.modes).to(equal(channelOptions.modes))
+        expect(channel.options?.params).to(equal(channelOptions.params))
+
+        let attachMessages = transport.protocolMessagesSent.filter { $0.action == .attach }
+        expect(attachMessages).to(haveCount(2))
+        guard let lastAttach = attachMessages.last else {
+            fail("Last ATTACH message is missing"); return
+        }
+        expect(lastAttach.flags & Int64(ARTChannelMode.publish.rawValue)).to(beGreaterThan(0)) // true
+        expect(lastAttach.flags & Int64(ARTChannelMode.subscribe.rawValue)).to(beGreaterThan(0)) // true
+        expect(lastAttach.params).to(equal(channelOptions.params))
+
+        let attachedMessages = transport.protocolMessagesReceived.filter { $0.action == .attached }
+        expect(attachMessages).to(haveCount(2))
+        guard let lastAttached = attachedMessages.last else {
+            fail("Last ATTACH message is missing"); return
+        }
+        expect(lastAttached.flags & Int64(ARTChannelMode.publish.rawValue)).to(beGreaterThan(0)) // true
+        expect(lastAttached.flags & Int64(ARTChannelMode.subscribe.rawValue)).to(beGreaterThan(0)) // true
+        expect(lastAttached.params).to(equal(channelOptions.params))
+    }
+
+    func test__134__Channel__history__Channel_options__setOptions__should_send_an_ATTACH_message_with_params___modes_if_the_channel_is_attaching() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                done()
+            }
+        }
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("Expecting TestProxyTransport"); return
+        }
+
+        let channelOptions = ARTRealtimeChannelOptions()
+        channelOptions.modes = [.subscribe]
+        channelOptions.params = [
+            "delta": "vcdiff",
+        ]
+
+        let channel = client.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(3, done: done)
+            channel.once(.attaching) { _ in
+                channel.setOptions(channelOptions) { error in
+                    expect(error).to(beNil())
+                    partialDone()
+                }
+            }
+            channel.once(.attached) { _ in
+                partialDone()
+            }
+            channel.once(.update) { _ in
+                partialDone()
+            }
+            channel.attach()
+        }
+
+        let subscribeFlag = Int64(ARTChannelMode.subscribe.rawValue)
+
+        let attachMessages = transport.protocolMessagesSent.filter { $0.action == .attach }
+        expect(attachMessages).to(haveCount(2))
+        guard let lastAttach = attachMessages.last else {
+            fail("Last ATTACH message is missing"); return
+        }
+        expect(lastAttach.flags & subscribeFlag).to(equal(subscribeFlag))
+        expect(lastAttach.params).to(equal(channelOptions.params))
+
+        let attachedMessages = transport.protocolMessagesReceived.filter { $0.action == .attached }
+        expect(attachedMessages).to(haveCount(2))
+        guard let lastAttached = attachedMessages.last else {
+            fail("Last ATTACH message is missing"); return
+        }
+        expect(lastAttached.flags & subscribeFlag).to(equal(subscribeFlag))
+        expect(lastAttached.params).to(equal(channelOptions.params))
+    }
+
+    func test__135__Channel__history__Channel_options__setOptions__should_success_immediately_if_channel_is_not_attaching_or_attached() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+
+        let channelOptions = ARTRealtimeChannelOptions()
+        channelOptions.modes = [.subscribe]
+        channelOptions.params = [
+            "delta": "vcdiff",
+        ]
+
+        channel.setOptions(channelOptions) { error in
+            expect(error).to(beNil())
+        }
+
+        expect(channel.state).to(equal(.initialized))
+        expect(channel.options?.modes).to(equal(channelOptions.modes))
+        expect(channel.options?.params).to(equal(channelOptions.params))
+    }
+
+    func test__136__Channel__history__Channel_options__setOptions__should_fail_if_the_attach_moves_to_FAILED() {
+        let options = AblyTests.commonAppSetup()
+        options.token = getTestToken(capability: "{\"secret\":[\"subscribe\"]}") // access denied
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                done()
+            }
+        }
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("Expecting TestProxyTransport"); return
+        }
+
+        let channelOptions = ARTRealtimeChannelOptions()
+        channelOptions.modes = [.subscribe]
+        channelOptions.params = [
+            "delta": "vcdiff",
+        ]
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.once(.failed) { stateChange in
+                expect(stateChange.reason?.code).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
+                partialDone()
+            }
+            channel.attach()
+            channel.setOptions(channelOptions) { error in
+                expect(error?.code).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
+                partialDone()
+            }
+        }
+
+        let subscribeFlag = Int64(ARTChannelMode.subscribe.rawValue)
+
+        let attachMessages = transport.protocolMessagesSent.filter { $0.action == .attach }
+        expect(attachMessages).to(haveCount(2))
+        guard let lastAttach = attachMessages.last else {
+            fail("Last ATTACH message is missing"); return
+        }
+        expect(lastAttach.flags & subscribeFlag).to(equal(subscribeFlag))
+        expect(lastAttach.params).to(equal(channelOptions.params))
+
+        let attachedMessages = transport.protocolMessagesReceived.filter { $0.action == .attached }
+        expect(attachedMessages).to(beEmpty())
+    }
+
+    func test__137__Channel__history__Channel_options__setOptions__should_fail_if_the_attach_moves_to_DETACHED() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                done()
+            }
+        }
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("Expecting TestProxyTransport"); return
+        }
+
+        let channelOptions = ARTRealtimeChannelOptions()
+        channelOptions.modes = [.subscribe]
+        channelOptions.params = [
+            "delta": "vcdiff",
+        ]
+
+        // Convert ATTACHED to DETACHED
+        transport.setBeforeIncomingMessageModifier { protocolMessage in
+            if protocolMessage.action == .attached {
+                protocolMessage.action = .detached
+                protocolMessage.error = .create(withCode: ARTErrorCode.internalError.intValue, status: 500, message: "internal error")
+                transport.setBeforeIncomingMessageModifier(nil)
+            }
+            return protocolMessage
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.attach { _ in
+                partialDone()
+            }
+            channel.setOptions(channelOptions) { error in
+                expect(error?.code).to(equal(ARTErrorCode.internalError.intValue))
+                partialDone()
+            }
+        }
+
+        let subscribeFlag = Int64(ARTChannelMode.subscribe.rawValue)
+
+        let attachMessages = transport.protocolMessagesSent.filter { $0.action == .attach }
+        expect(attachMessages).to(haveCount(2))
+        guard let lastAttach = attachMessages.last else {
+            fail("Last ATTACH message is missing"); return
+        }
+        expect(lastAttach.flags & subscribeFlag).to(equal(subscribeFlag))
+        expect(lastAttach.params).to(equal(channelOptions.params))
+    }
+
+    // RTL17
+    func test__122__Channel__history__should_not_emit_messages_to_subscribers_if_the_channel_is_in_any_state_other_than_ATTACHED() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.close(); client.dispose() }
+        let channel = client.channels.get("foo")
+
+        let m1 = ARTMessage(name: "m1", data: "d1")
+        let m2 = ARTMessage(name: "m2", data: "d2")
+
+        var subscribeEmittedCount = 0
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.once(.attached) { _ in
+                channel.subscribe { message in
+                    expect(channel.state).to(equal(.attached))
+                    expect(message.name).to(equal(m1.name))
+                    subscribeEmittedCount += 1
+                    partialDone()
+                }
+                channel.publish([m1]) { error in
+                    expect(error).to(beNil())
+                    partialDone()
+                }
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.subscribe { _ in
+                fail("not supposed to receive messages when channel state is \(channel.state)")
+            }
+            channel.detach()
+            channel.publish([m2]) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+            delay(3.0) {
+                // Wait some seconds to see if the channel doesn't emit a message
+                partialDone()
+            }
+        }
+
+        channel.unsubscribe()
+        expect(subscribeEmittedCount) == 1
+    }
+
+    func test__138__Channel__crypto__if_configured_for_encryption__channels_encrypt_and_decrypt_messages__data() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+
+        let clientSender = ARTRealtime(options: options)
+        clientSender.internal.setTransport(TestProxyTransport.self)
+        defer { clientSender.close() }
+        clientSender.connect()
+
+        let clientReceiver = ARTRealtime(options: options)
+        clientReceiver.internal.setTransport(TestProxyTransport.self)
+        defer { clientReceiver.close() }
+        clientReceiver.connect()
+
+        let key = ARTCrypto.generateRandomKey()
+        let sender = clientSender.channels.get("test", options: ARTRealtimeChannelOptions(cipherKey: key as ARTCipherKeyCompatible))
+        let receiver = clientReceiver.channels.get("test", options: ARTRealtimeChannelOptions(cipherKey: key as ARTCipherKeyCompatible))
+
+        var received = [ARTMessage]()
+
+        waitUntil(timeout: testTimeout) { done in
+            receiver.attach { _ in
+                receiver.subscribe { message in
+                    receiver.unsubscribe()
+                    received.append(message)
+                    done()
+                }
+
+                sender.publish("first", data: "first data")
+            }
+        }
+        if received.count != 1 {
+            fail("should have received one message")
+            return
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            receiver.detach { _ in
+                sender.publish("second", data: "second data") { _ in done() }
+            }
+        }
+        if receiver.state != .detached {
+            fail("receiver should be detached")
+            return
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            receiver.attach { _ in
+                receiver.subscribe { message in
+                    received.append(message)
+                    done()
+                }
+                sender.publish("third", data: "third data")
+            }
+        }
+        if received.count != 2 {
+            fail("should've received two messages")
+            return
+        }
+
+        expect(received[0].name).to(equal("first"))
+        expect(received[0].data as? NSString).to(equal("first data"))
+        expect(received[1].name).to(equal("third"))
+        expect(received[1].data as? NSString).to(equal("third data"))
+
+        let senderTransport = clientSender.internal.transport as! TestProxyTransport
+        let senderMessages = senderTransport.protocolMessagesSent.filter { $0.action == .message }
+        for protocolMessage in senderMessages {
+            for message in protocolMessage.messages! {
+                expect(message.data! as? String).toNot(equal("\(message.name!) data"))
+                expect(message.encoding).to(equal("utf-8/cipher+aes-256-cbc/base64"))
+            }
+        }
+
+        let receiverTransport = clientReceiver.internal.transport as! TestProxyTransport
+        let receiverMessages = receiverTransport.protocolMessagesReceived.filter { $0.action == .message }
+        for protocolMessage in receiverMessages {
+            for message in protocolMessage.messages! {
+                expect(message.data! as? NSObject).toNot(equal("\(message.name!) data" as NSObject?))
+                expect(message.encoding).to(equal("utf-8/cipher+aes-256-cbc"))
+            }
+        }
+    }
+
+    // https://github.com/ably/ably-cocoa/issues/614
+    func test__002__Channel__should_not_crash_when_an_ATTACH_request_is_responded_with_a_DETACHED() {
+        let options = AblyTests.commonAppSetup()
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(1.0)
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        transport.setBeforeIncomingMessageModifier { protocolMessage in
+            if protocolMessage.action == .attached {
+                protocolMessage.action = .detached
+                protocolMessage.error = ARTErrorInfo.create(withCode: ARTErrorCode.internalError.intValue, status: 500, message: "fake error message text")
+            }
+            return protocolMessage
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error.statusCode) == 500
+                done()
+            }
+        }
+    }
+
+    // TM2a
+    func test__139__message_attributes__if_the_message_does_not_contain_an_id__it_should_be_set_to_protocolMsgId_index() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let p = ARTProtocolMessage()
+        p.id = "protocolId"
+        let m = ARTMessage(name: nil, data: "message without ID")
+        p.messages = [m]
+        let channel = client.channels.get(NSUUID().uuidString)
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { _ in
+                done()
+            }
+        }
+        waitUntil(timeout: testTimeout) { done in
+            channel.subscribe { message in
+                expect(message.id).to(equal("protocolId:0"))
+                done()
+            }
+            AblyTests.queue.async {
+                channel.internal.onMessage(p)
+            }
+        }
+    }
 }

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -141,7 +141,7 @@ import Aspects
                         }
                     }
 
-class RealtimeClientChannel: QuickSpec {
+class RealtimeClientChannel: XCTestCase {
 
 // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
 override class var defaultTestSuite : XCTestSuite {
@@ -163,11 +163,10 @@ override class var defaultTestSuite : XCTestSuite {
                         static var failed = 0
                         fileprivate init() {}
                     }
-    override func spec() {
-        describe("Channel") {
+        
 
             // RTL1
-            xit("should process all incoming messages and presence messages as soon as a Channel becomes attached") {
+            func skipped__test__001__Channel__should_process_all_incoming_messages_and_presence_messages_as_soon_as_a_Channel_becomes_attached() {
                 let options = AblyTests.commonAppSetup()
                 let client1 = AblyTests.newRealtime(options)
                 defer { client1.dispose(); client1.close() }
@@ -231,10 +230,10 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTL2
-            context("EventEmitter, channel states and events") {
+            
 
                 // RTL2a
-                it("should implement the EventEmitter and emit events for state changes") {
+                func test__003__Channel__EventEmitter__channel_states_and_events__should_implement_the_EventEmitter_and_emit_events_for_state_changes() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -300,7 +299,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL2a
-                it("should implement the EventEmitter and emit events for FAILED state changes") {
+                func test__004__Channel__EventEmitter__channel_states_and_events__should_implement_the_EventEmitter_and_emit_events_for_FAILED_state_changes() {
                     let options = AblyTests.clientOptions()
                     options.token = getTestToken(capability: "{\"secret\":[\"subscribe\"]}")
                     let client = ARTRealtime(options: options)
@@ -332,7 +331,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL2a
-                it("should implement the EventEmitter and emit events for SUSPENDED state changes") {
+                func test__005__Channel__EventEmitter__channel_states_and_events__should_implement_the_EventEmitter_and_emit_events_for_SUSPENDED_state_changes() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -356,7 +355,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL2g
-                it("can emit an UPDATE event") {
+                func test__006__Channel__EventEmitter__channel_states_and_events__can_emit_an_UPDATE_event() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("foo")
@@ -393,7 +392,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL2g + https://github.com/ably/ably-cocoa/issues/1088
-                it("should not emit detached event on an already detached channel") {
+                func test__007__Channel__EventEmitter__channel_states_and_events__should_not_emit_detached_event_on_an_already_detached_channel() {
                     let options = AblyTests.commonAppSetup()
                     options.logLevel = .debug
                     let client = ARTRealtime(options: options)
@@ -431,7 +430,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL2b
-                it("state attribute should be the current state of the channel") {
+                func test__008__Channel__EventEmitter__channel_states_and_events__state_attribute_should_be_the_current_state_of_the_channel() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -444,7 +443,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL2c
-                it("should contain an ErrorInfo object with details when an error occurs") {
+                func test__009__Channel__EventEmitter__channel_states_and_events__should_contain_an_ErrorInfo_object_with_details_when_an_error_occurs() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -466,7 +465,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL2d
-                it("a ChannelStateChange is emitted as the first argument for every channel state change") {
+                func test__010__Channel__EventEmitter__channel_states_and_events__a_ChannelStateChange_is_emitted_as_the_first_argument_for_every_channel_state_change() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -499,7 +498,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL2f
-                it("ChannelStateChange will contain a resumed boolean attribute with value @true@ if the bit flag RESUMED was included") {
+                func test__011__Channel__EventEmitter__channel_states_and_events__ChannelStateChange_will_contain_a_resumed_boolean_attribute_with_value__true__if_the_bit_flag_RESUMED_was_included() {
                     let options = AblyTests.commonAppSetup()
                     options.tokenDetails = getTestTokenDetails(ttl: 5.0)
                     let client = ARTRealtime(options: options)
@@ -537,7 +536,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL2f, TR4i
-                it("bit flag RESUMED was included") {
+                func test__012__Channel__EventEmitter__channel_states_and_events__bit_flag_RESUMED_was_included() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.dispose(); client.close() }
@@ -569,15 +568,13 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTL3
-            context("connection state") {
+            
 
                 // RTL3a
-                context("changes to FAILED") {
+                
 
-                    it("ATTACHING channel should transition to FAILED") {
+                    func test__017__Channel__connection_state__changes_to_FAILED__ATTACHING_channel_should_transition_to_FAILED() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = ARTRealtime(options: options)
@@ -608,7 +605,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
                     }
 
-                    it("ATTACHED channel should transition to FAILED") {
+                    func test__018__Channel__connection_state__changes_to_FAILED__ATTACHED_channel_should_transition_to_FAILED() {
                         let client = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
 
@@ -632,7 +629,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
                     }
                     
-                    it("channel being released waiting for DETACH shouldn't crash (issue #918)") {
+                    func test__019__Channel__connection_state__changes_to_FAILED__channel_being_released_waiting_for_DETACH_shouldn_t_crash__issue__918_() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = ARTRealtime(options: options)
@@ -667,7 +664,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // TO3g
-                    it("should immediately fail if not in the connected state") {
+                    func test__020__Channel__connection_state__changes_to_FAILED__should_immediately_fail_if_not_in_the_connected_state() {
                         let options = AblyTests.commonAppSetup()
                         options.queueMessages = false
                         options.autoConnect = false
@@ -696,7 +693,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // TO3g and https://github.com/ably/ably-cocoa/issues/1004
-                    it("should keep the channels attached when client reconnected successfully and queue messages is disabled") {
+                    func test__021__Channel__connection_state__changes_to_FAILED__should_keep_the_channels_attached_when_client_reconnected_successfully_and_queue_messages_is_disabled() {
                         let options = AblyTests.commonAppSetup()
                         options.queueMessages = false
                         options.autoConnect = false
@@ -747,12 +744,10 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(channel.state).to(equal(.attached))
                     }
 
-                }
-
                 // RTL3b
-                context("changes to CLOSED") {
+                
 
-                    it("ATTACHING channel should transition to DETACHED") {
+                    func test__022__Channel__connection_state__changes_to_CLOSED__ATTACHING_channel_should_transition_to_DETACHED() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = ARTRealtime(options: options)
@@ -773,7 +768,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closed))
                     }
 
-                    it("ATTACHED channel should transition to DETACHED") {
+                    func test__023__Channel__connection_state__changes_to_CLOSED__ATTACHED_channel_should_transition_to_DETACHED() {
                         let options = AblyTests.commonAppSetup()
                         let client = ARTRealtime(options: options)
                         defer { client.dispose(); client.close() }
@@ -787,12 +782,11 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
                         expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closed))
                     }
-                }
 
                 // RTL3c
-                context("changes to SUSPENDED") {
+                
 
-                    it("ATTACHING channel should transition to SUSPENDED") {
+                    func test__024__Channel__connection_state__changes_to_SUSPENDED__ATTACHING_channel_should_transition_to_SUSPENDED() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = ARTRealtime(options: options)
@@ -811,7 +805,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(channel.state).to(equal(ARTRealtimeChannelState.suspended))
                     }
 
-                    it("ATTACHED channel should transition to SUSPENDED") {
+                    func test__025__Channel__connection_state__changes_to_SUSPENDED__ATTACHED_channel_should_transition_to_SUSPENDED() {
                         let options = AblyTests.commonAppSetup()
                         let client = ARTRealtime(options: options)
                         defer { client.dispose(); client.close() }
@@ -823,7 +817,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(channel.state).to(equal(ARTRealtimeChannelState.suspended))
                     }
                     
-                    it("channel being released waiting for DETACH shouldn't crash (issue #918)") {
+                    func test__026__Channel__connection_state__changes_to_SUSPENDED__channel_being_released_waiting_for_DETACH_shouldn_t_crash__issue__918_() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = ARTRealtime(options: options)
@@ -856,10 +850,8 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
                 // RTL3d
-                it("if the connection state enters the CONNECTED state, then a SUSPENDED channel will initiate an attach operation") {
+                func test__013__Channel__connection_state__if_the_connection_state_enters_the_CONNECTED_state__then_a_SUSPENDED_channel_will_initiate_an_attach_operation() {
                     let options = AblyTests.commonAppSetup()
                     options.suspendedRetryTimeout = 1.0
                     let client = ARTRealtime(options: options)
@@ -888,7 +880,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL3d
-                it("if the attach operation for the channel times out and the channel returns to the SUSPENDED state") {
+                func test__014__Channel__connection_state__if_the_attach_operation_for_the_channel_times_out_and_the_channel_returns_to_the_SUSPENDED_state() {
                     let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -909,7 +901,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL3d - https://github.com/ably/ably-cocoa/issues/881
-                it("should attach successfully and remain attached when the connection state without a successful recovery gets CONNECTED") {
+                func test__015__Channel__connection_state__should_attach_successfully_and_remain_attached_when_the_connection_state_without_a_successful_recovery_gets_CONNECTED() {
                     let options = AblyTests.commonAppSetup()
                     options.disconnectedRetryTimeout = 0.5
                     options.suspendedRetryTimeout = 3.0
@@ -979,7 +971,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL3e
-                it("if the connection state enters the DISCONNECTED state, it will have no effect on the channel states") {
+                func test__016__Channel__connection_state__if_the_connection_state_enters_the_DISCONNECTED_state__it_will_have_no_effect_on_the_channel_states() {
                     let options = AblyTests.commonAppSetup()
                     options.token = getTestToken(ttl: 5.0)
                     let client = ARTRealtime(options: options)
@@ -1009,13 +1001,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTL4
-            describe("attach") {
+            
 
                 // RTL4a
-                it("if already ATTACHED or ATTACHING nothing is done") {
+                func test__027__Channel__attach__if_already_ATTACHED_or_ATTACHING_nothing_is_done() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -1043,7 +1033,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL4e
-                it("if the user does not have sufficient permissions to attach, then the channel will transition to FAILED and set the errorReason") {
+                func test__028__Channel__attach__if_the_user_does_not_have_sufficient_permissions_to_attach__then_the_channel_will_transition_to_FAILED_and_set_the_errorReason() {
                     let options = AblyTests.commonAppSetup()
                     options.token = getTestToken(key: options.key!, capability: "{\"restricted\":[\"*\"]}")
                     let client = ARTRealtime(options: options)
@@ -1070,7 +1060,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL4g
-                it("if the channel is in the FAILED state, the attach request sets its errorReason to null, and proceeds with a channel attach") {
+                func test__029__Channel__attach__if_the_channel_is_in_the_FAILED_state__the_attach_request_sets_its_errorReason_to_null__and_proceeds_with_a_channel_attach() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -1096,9 +1086,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL4b
-                context("results in an error if the connection state is") {
+                
 
-                    it("CLOSING") {
+                    func test__039__Channel__attach__results_in_an_error_if_the_connection_state_is__CLOSING() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = ARTRealtime(options: options)
@@ -1123,7 +1113,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("CLOSED") {
+                    func test__040__Channel__attach__results_in_an_error_if_the_connection_state_is__CLOSED() {
                         let client = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
 
@@ -1140,7 +1130,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("SUSPENDED") {
+                    func test__041__Channel__attach__results_in_an_error_if_the_connection_state_is__SUSPENDED() {
                         let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
 
@@ -1155,7 +1145,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("FAILED") {
+                    func test__042__Channel__attach__results_in_an_error_if_the_connection_state_is__FAILED() {
                         let client = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
 
@@ -1170,11 +1160,9 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
                 // RTL4i
-                context("happens when connection is CONNECTED if it's currently") {
-                    it("INITIALIZED") {
+                
+                    func test__043__Channel__attach__happens_when_connection_is_CONNECTED_if_it_s_currently__INITIALIZED() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = ARTRealtime(options: options)
@@ -1194,7 +1182,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(channel.state).to(equal(.attached))
                     }
 
-                    it("CONNECTING") {
+                    func test__044__Channel__attach__happens_when_connection_is_CONNECTED_if_it_s_currently__CONNECTING() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = ARTRealtime(options: options)
@@ -1214,7 +1202,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    xit("DISCONNECTED") {
+                    func skipped__test__045__Channel__attach__happens_when_connection_is_CONNECTED_if_it_s_currently__DISCONNECTED() {
                         let options = AblyTests.commonAppSetup()
                         let client = ARTRealtime(options: options)
                         defer { client.dispose(); client.close() }
@@ -1234,10 +1222,9 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                         }
                     }
-                }
 
                 // RTL4c
-                it("should send an ATTACH ProtocolMessage, change state to ATTACHING and change state to ATTACHED after confirmation") {
+                func test__030__Channel__attach__should_send_an_ATTACH_ProtocolMessage__change_state_to_ATTACHING_and_change_state_to_ATTACHED_after_confirmation() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -1259,7 +1246,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL4e
-                it("should transition the channel state to FAILED if the user does not have sufficient permissions") {
+                func test__031__Channel__attach__should_transition_the_channel_state_to_FAILED_if_the_user_does_not_have_sufficient_permissions() {
                     let options = AblyTests.clientOptions()
                     options.token = getTestToken(capability: "{ \"main\":[\"subscribe\"] }")
                     let client = ARTRealtime(options: options)
@@ -1283,7 +1270,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL4f
-                it("should transition the channel state to SUSPENDED if ATTACHED ProtocolMessage is not received") {
+                func test__032__Channel__attach__should_transition_the_channel_state_to_SUSPENDED_if_ATTACHED_ProtocolMessage_is_not_received() {
                     let options = AblyTests.commonAppSetup()
                     options.channelRetryTimeout = 1.0
                     let client = AblyTests.newRealtime(options)
@@ -1326,7 +1313,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("if called with a callback should call it once attached") {
+                func test__033__Channel__attach__if_called_with_a_callback_should_call_it_once_attached() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -1341,7 +1328,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("if called with a callback and already attaching should call the callback once attached") {
+                func test__034__Channel__attach__if_called_with_a_callback_and_already_attaching_should_call_the_callback_once_attached() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -1358,7 +1345,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("if called with a callback and already attached should call the callback with nil error") {
+                func test__035__Channel__attach__if_called_with_a_callback_and_already_attached_should_call_the_callback_with_nil_error() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -1376,7 +1363,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL4h
-                it("if the channel is in a pending state ATTACHING, do the attach operation after the completion of the pending request") {
+                func test__036__Channel__attach__if_the_channel_is_in_a_pending_state_ATTACHING__do_the_attach_operation_after_the_completion_of_the_pending_request() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.dispose(); client.close() }
@@ -1408,7 +1395,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL4h
-                it("if the channel is in a pending state DETACHING, do the attach operation after the completion of the pending request") {
+                func test__037__Channel__attach__if_the_channel_is_in_a_pending_state_DETACHING__do_the_attach_operation_after_the_completion_of_the_pending_request() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.dispose(); client.close() }
@@ -1451,7 +1438,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("a channel in DETACHING can actually move back to ATTACHED if it fails to detach") {
+                func test__038__Channel__attach__a_channel_in_DETACHING_can_actually_move_back_to_ATTACHED_if_it_fails_to_detach() {
                     let options = AblyTests.commonAppSetup()
                     let client = AblyTests.newRealtime(options)
                     defer { client.dispose(); client.close() }
@@ -1487,9 +1474,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL4j
-                context("attach resume") {
+                
 
-                    it("should pass attach resume flag in attach message") {
+                    func test__046__Channel__attach__attach_resume__should_pass_attach_resume_flag_in_attach_message() {
                         let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
                         let channel = client.channels.get("foo")
@@ -1530,7 +1517,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTL4j1
-                    it("should have correct AttachResume value") {
+                    func test__047__Channel__attach__attach_resume__should_have_correct_AttachResume_value() {
                         let client = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
                         let channel = client.channels.get("foo")
@@ -1571,7 +1558,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTL4j2
-                    it("should encode correctly the AttachResume flag") {
+                    func test__048__Channel__attach__attach_resume__should_encode_correctly_the_AttachResume_flag() {
                         let options = AblyTests.commonAppSetup()
 
                         let client = ARTRealtime(options: options)
@@ -1618,13 +1605,9 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
-            }
-
-            describe("detach") {
+            
                 // RTL5a
-                it("if state is INITIALIZED or DETACHED nothing is done") {
+                func test__049__Channel__detach__if_state_is_INITIALIZED_or_DETACHED_nothing_is_done() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -1656,7 +1639,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL5i
-                it("if the channel is in a pending state DETACHING, do the detach operation after the completion of the pending request") {
+                func test__050__Channel__detach__if_the_channel_is_in_a_pending_state_DETACHING__do_the_detach_operation_after_the_completion_of_the_pending_request() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.dispose(); client.close() }
@@ -1707,7 +1690,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL5i
-                it("if the channel is in a pending state ATTACHING, do the detach operation after the completion of the pending request") {
+                func test__051__Channel__detach__if_the_channel_is_in_a_pending_state_ATTACHING__do_the_detach_operation_after_the_completion_of_the_pending_request() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.dispose(); client.close() }
@@ -1739,7 +1722,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL5b
-                it("results in an error if the connection state is FAILED") {
+                func test__052__Channel__detach__results_in_an_error_if_the_connection_state_is_FAILED() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -1756,7 +1739,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL5d
-                it("should send a DETACH ProtocolMessage, change state to DETACHING and change state to DETACHED after confirmation") {
+                func test__053__Channel__detach__should_send_a_DETACH_ProtocolMessage__change_state_to_DETACHING_and_change_state_to_DETACHED_after_confirmation() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -1780,7 +1763,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL5e
-                it("if called with a callback should call it once detached") {
+                func test__054__Channel__detach__if_called_with_a_callback_should_call_it_once_detached() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -1799,7 +1782,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL5e
-                it("if called with a callback and already detaching should call the callback once detached") {
+                func test__055__Channel__detach__if_called_with_a_callback_and_already_detaching_should_call_the_callback_once_detached() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -1820,7 +1803,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL5e
-                it("if called with a callback and already detached should should call the callback with nil error") {
+                func test__056__Channel__detach__if_called_with_a_callback_and_already_detached_should_should_call_the_callback_with_nil_error() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -1840,7 +1823,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL5f
-                it("if a DETACHED is not received within the default realtime request timeout, the detach request should be treated as though it has failed and the channel will return to its previous state") {
+                func test__057__Channel__detach__if_a_DETACHED_is_not_received_within_the_default_realtime_request_timeout__the_detach_request_should_be_treated_as_though_it_has_failed_and_the_channel_will_return_to_its_previous_state() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -1878,9 +1861,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL5g
-                context("results in an error if the connection state is") {
+                
 
-                    it("CLOSING") {
+                    func test__059__Channel__detach__results_in_an_error_if_the_connection_state_is__CLOSING() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = ARTRealtime(options: options)
@@ -1907,7 +1890,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("FAILED") {
+                    func test__060__Channel__detach__results_in_an_error_if_the_connection_state_is__FAILED() {
                         let client = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
 
@@ -1925,11 +1908,9 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
                 // RTL5h
-                context("happens when channel is ATTACHED if connection is currently") {
-                    it("INITIALIZED") {
+                
+                    func test__061__Channel__detach__happens_when_channel_is_ATTACHED_if_connection_is_currently__INITIALIZED() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = ARTRealtime(options: options)
@@ -1950,7 +1931,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("CONNECTING") {
+                    func test__062__Channel__detach__happens_when_channel_is_ATTACHED_if_connection_is_currently__CONNECTING() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = ARTRealtime(options: options)
@@ -1971,7 +1952,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("DISCONNECTED") {
+                    func test__063__Channel__detach__happens_when_channel_is_ATTACHED_if_connection_is_currently__DISCONNECTED() {
                         let options = AblyTests.commonAppSetup()
                         let client = ARTRealtime(options: options)
                         defer { client.dispose(); client.close() }
@@ -1993,10 +1974,9 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                         }
                     }
-                }
 
                 // RTL5j
-                it("if the channel state is SUSPENDED, the @detach@ request transitions the channel immediately to the DETACHED state") {
+                func test__058__Channel__detach__if_the_channel_state_is_SUSPENDED__the__detach__request_transitions_the_channel_immediately_to_the_DETACHED_state() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("foo")
@@ -2028,13 +2008,11 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
                 }
 
-            }
-
             // RTL6
-            describe("publish") {
+            
 
                 // RTL6a
-                it("should encode messages in the same way as the RestChannel") {
+                func test__064__Channel__publish__should_encode_messages_in_the_same_way_as_the_RestChannel() {
                     let data = ["value":1]
 
                     let rest = ARTRest(options: AblyTests.commonAppSetup())
@@ -2079,9 +2057,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL6b
-                context("should invoke callback") {
+                
 
-                    it("when the message is successfully delivered") {
+                    func test__067__Channel__publish__should_invoke_callback__when_the_message_is_successfully_delivered() {
                         let client = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
 
@@ -2106,7 +2084,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("upon failure") {
+                    func test__068__Channel__publish__should_invoke_callback__upon_failure() {
                         let options = AblyTests.commonAppSetup()
                         options.token = getTestToken(key: options.key, capability: "{ \"\(options.channelNamePrefix!)-test\":[\"subscribe\"] }")
                         let client = ARTRealtime(options: options)
@@ -2138,7 +2116,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("for all messages published") {
+                    func test__069__Channel__publish__should_invoke_callback__for_all_messages_published() {
                         let options = AblyTests.commonAppSetup()
                         options.token = getTestToken(key: options.key, capability: "{ \"\(options.channelNamePrefix!)-channelToSucceed\":[\"subscribe\", \"publish\"], \"\(options.channelNamePrefix!)-channelToFail\":[\"subscribe\"] }")
                         let client = ARTRealtime(options: options)
@@ -2181,14 +2159,12 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(TotalMessages.failed).toEventually(equal(TotalMessages.expected), timeout: testTimeout)
                     }
 
-                }
-
                 // RTL6c
-                context("Connection state conditions") {
+                
 
                     // RTL6c1
-                    context("if the connection is CONNECTED and the channel is") {
-                        it("ATTACHED then the messages should be published immediately") {
+                    
+                        func test__071__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__ATTACHED_then_the_messages_should_be_published_immediately() {
                             let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                             defer { client.dispose(); client.close() }
                             let channel = client.channels.get("test")
@@ -2206,7 +2182,7 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                         }
 
-                        it("INITIALIZED then the messages should be published immediately") {
+                        func test__072__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__INITIALIZED_then_the_messages_should_be_published_immediately() {
                             let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                             defer { client.dispose(); client.close() }
                             waitUntil(timeout: testTimeout) { done in
@@ -2229,7 +2205,7 @@ override class var defaultTestSuite : XCTestSuite {
                             expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
                         }
 
-                        it("DETACHED then the messages should be published immediately") {
+                        func test__073__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__DETACHED_then_the_messages_should_be_published_immediately() {
                             let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                             defer { client.dispose(); client.close() }
                             let channel = client.channels.get("test")
@@ -2257,7 +2233,7 @@ override class var defaultTestSuite : XCTestSuite {
                             expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
                         }
 
-                        it("ATTACHING then the messages should be published immediately") {
+                        func test__074__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__ATTACHING_then_the_messages_should_be_published_immediately() {
                             let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                             defer { client.dispose(); client.close() }
                             let channel = client.channels.get("test")
@@ -2284,7 +2260,7 @@ override class var defaultTestSuite : XCTestSuite {
                             expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
                         }
 
-                        it("DETACHING then the messages should be published immediately") {
+                        func test__075__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__DETACHING_then_the_messages_should_be_published_immediately() {
                             let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                             defer { client.dispose(); client.close() }
                             let channel = client.channels.get("test")
@@ -2311,12 +2287,11 @@ override class var defaultTestSuite : XCTestSuite {
 
                             expect(channel.state).to(equal(ARTRealtimeChannelState.detaching))
                         }
-                    }
 
                     // RTL6c2
-                    context("the message") {
+                    
 
-                        beforeEach {
+                        func beforeEach__Channel__publish__Connection_state_conditions__the_message() {
                             let options = AblyTests.commonAppSetup()
                             options.useTokenAuth = true
                             options.autoConnect = false
@@ -2324,28 +2299,40 @@ override class var defaultTestSuite : XCTestSuite {
                             rtl6c2TestsChannel = rtl6c2TestsClient.channels.get("test")
                             expect(rtl6c2TestsClient.internal.options.queueMessages).to(beTrue())
                         }
-                        afterEach { rtl6c2TestsClient.close() }
+                        func afterEach__Channel__publish__Connection_state_conditions__the_message() { rtl6c2TestsClient.close() }
 
-                        context("should be queued and delivered as soon as the connection state returns to CONNECTED if the connection is") {
-                            it("INITIALIZED") {
+                        
+                            func test__076__Channel__publish__Connection_state_conditions__the_message__should_be_queued_and_delivered_as_soon_as_the_connection_state_returns_to_CONNECTED_if_the_connection_is__INITIALIZED() {
+beforeEach__Channel__publish__Connection_state_conditions__the_message()
+
                                 waitUntil(timeout: testTimeout) { done in
                                     expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.initialized))
                                     rtl16c2TestsPublish(done)
                                     rtl6c2TestsClient.connect()
                                     expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
                                 }
+
+afterEach__Channel__publish__Connection_state_conditions__the_message()
+
                             }
 
-                            it("CONNECTING") {
+                            func test__077__Channel__publish__Connection_state_conditions__the_message__should_be_queued_and_delivered_as_soon_as_the_connection_state_returns_to_CONNECTED_if_the_connection_is__CONNECTING() {
+beforeEach__Channel__publish__Connection_state_conditions__the_message()
+
                                 waitUntil(timeout: testTimeout) { done in
                                     rtl6c2TestsClient.connect()
                                     expect(rtl6c2TestsClient.connection.state).to(equal(ARTRealtimeConnectionState.connecting))
                                     rtl16c2TestsPublish(done)
                                     expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
                                 }
+
+afterEach__Channel__publish__Connection_state_conditions__the_message()
+
                             }
 
-                            it("DISCONNECTED") {
+                            func test__078__Channel__publish__Connection_state_conditions__the_message__should_be_queued_and_delivered_as_soon_as_the_connection_state_returns_to_CONNECTED_if_the_connection_is__DISCONNECTED() {
+beforeEach__Channel__publish__Connection_state_conditions__the_message()
+
                                 rtl6c2TestsClient.connect()
                                 expect(rtl6c2TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
                                 rtl6c2TestsClient.internal.onDisconnected()
@@ -2355,11 +2342,15 @@ override class var defaultTestSuite : XCTestSuite {
                                     rtl16c2TestsPublish(done)
                                     expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
                                 }
-                            }
-                        }
 
-                        context("should NOT be queued instead it should be published if the channel is") {
-                            it("INITIALIZED") {
+afterEach__Channel__publish__Connection_state_conditions__the_message()
+
+                            }
+
+                        
+                            func test__079__Channel__publish__Connection_state_conditions__the_message__should_NOT_be_queued_instead_it_should_be_published_if_the_channel_is__INITIALIZED() {
+beforeEach__Channel__publish__Connection_state_conditions__the_message()
+
                                 rtl6c2TestsClient.connect()
                                 expect(rtl6c2TestsChannel.state).to(equal(ARTRealtimeChannelState.initialized))
 
@@ -2370,9 +2361,14 @@ override class var defaultTestSuite : XCTestSuite {
                                     expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(0))
                                     expect((rtl6c2TestsClient.internal.transport as! TestProxyTransport).protocolMessagesSent.filter({ $0.action == .message })).to(haveCount(1))
                                 }
+
+afterEach__Channel__publish__Connection_state_conditions__the_message()
+
                             }
 
-                            it("ATTACHING") {
+                            func test__080__Channel__publish__Connection_state_conditions__the_message__should_NOT_be_queued_instead_it_should_be_published_if_the_channel_is__ATTACHING() {
+beforeEach__Channel__publish__Connection_state_conditions__the_message()
+
                                 rtl6c2TestsClient.connect()
                                 expect(rtl6c2TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
 
@@ -2383,9 +2379,14 @@ override class var defaultTestSuite : XCTestSuite {
                                     expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(0))
                                     expect((rtl6c2TestsClient.internal.transport as! TestProxyTransport).protocolMessagesSent.filter({ $0.action == .message })).to(haveCount(1))
                                 }
+
+afterEach__Channel__publish__Connection_state_conditions__the_message()
+
                             }
 
-                            it("ATTACHED") {
+                            func test__081__Channel__publish__Connection_state_conditions__the_message__should_NOT_be_queued_instead_it_should_be_published_if_the_channel_is__ATTACHED() {
+beforeEach__Channel__publish__Connection_state_conditions__the_message()
+
                                 waitUntil(timeout: testTimeout) { done in
                                     rtl6c2TestsChannel.attach() { error in
                                         expect(error).to(beNil())
@@ -2416,25 +2417,28 @@ override class var defaultTestSuite : XCTestSuite {
                                     rtl16c2TestsPublish(done)
                                     expect(rtl6c2TestsClient.internal.queuedMessages).to(haveCount(1))
                                 }
+
+afterEach__Channel__publish__Connection_state_conditions__the_message()
+
                             }
-                        }
-                    }
 
                     // RTL6c4
-                    context("will result in an error if the") {
+                    
 
-                        beforeEach {
+                        func beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the() {
                             setupDependencies()
                             ARTDefault.setConnectionStateTtl(0.3)
                             rtl6c4TestsClient = AblyTests.newRealtime(options)
                             rtl6c4TestsChannel = rtl6c4TestsClient.channels.get("test")
                         }
-                        afterEach {
+                        func afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the() {
                             rtl6c4TestsClient.close()
                             ARTDefault.setConnectionStateTtl(previousConnectionStateTtl)
                         }
 
-                        it("connection is SUSPENDED") {
+                        func test__082__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__connection_is_SUSPENDED() {
+beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
                             rtl6c4TestsClient.connect()
                             expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
                             rtl6c4TestsClient.internal.onSuspended()
@@ -2442,9 +2446,14 @@ override class var defaultTestSuite : XCTestSuite {
                             waitUntil(timeout: testTimeout) { done in
                                 rtl6c4TestsPublish(done)
                             }
+
+afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
                         }
 
-                        it("connection is CLOSING") {
+                        func test__083__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__connection_is_CLOSING() {
+beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
                             rtl6c4TestsClient.connect()
                             expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
                             rtl6c4TestsClient.close()
@@ -2452,9 +2461,14 @@ override class var defaultTestSuite : XCTestSuite {
                             waitUntil(timeout: testTimeout) { done in
                                 rtl6c4TestsPublish(done)
                             }
+
+afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
                         }
 
-                        it("connection is CLOSED") {
+                        func test__084__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__connection_is_CLOSED() {
+beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
                             rtl6c4TestsClient.connect()
                             expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
                             rtl6c4TestsClient.close()
@@ -2462,9 +2476,14 @@ override class var defaultTestSuite : XCTestSuite {
                             waitUntil(timeout: testTimeout) { done in
                                 rtl6c4TestsPublish(done)
                             }
+
+afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
                         }
 
-                        it("connection is FAILED") {
+                        func test__085__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__connection_is_FAILED() {
+beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
                             rtl6c4TestsClient.connect()
                             expect(rtl6c4TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
                             rtl6c4TestsClient.internal.onError(AblyTests.newErrorProtocolMessage())
@@ -2472,9 +2491,14 @@ override class var defaultTestSuite : XCTestSuite {
                             waitUntil(timeout: testTimeout) { done in
                                 rtl6c4TestsPublish(done)
                             }
+
+afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
                         }
 
-                        it("channel is SUSPENDED") {
+                        func test__086__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__channel_is_SUSPENDED() {
+beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
                             rtl6c4TestsClient.connect()
                             rtl6c4TestsChannel.attach()
                             expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
@@ -2483,9 +2507,14 @@ override class var defaultTestSuite : XCTestSuite {
                             waitUntil(timeout: testTimeout) { done in
                                 rtl6c4TestsPublish(done)
                             }
+
+afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
                         }
 
-                        it("channel is FAILED") {
+                        func test__087__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the__channel_is_FAILED() {
+beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
                             rtl6c4TestsClient.connect()
                             rtl6c4TestsChannel.attach()
                             expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
@@ -2495,11 +2524,13 @@ override class var defaultTestSuite : XCTestSuite {
                             waitUntil(timeout: testTimeout) { done in
                                 rtl6c4TestsPublish(done)
                             }
+
+afterEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the()
+
                         }
-                    }
 
                     // RTL6c5
-                    it("publish should not trigger an implicit attach") {
+                    func test__070__Channel__publish__Connection_state_conditions__publish_should_not_trigger_an_implicit_attach() {
                         let client = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
                         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
@@ -2522,12 +2553,11 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                         }
                     }
-                }
 
                 // RTL6d
-                context("message bundling") {
+                
 
-                    it("Messages are delivered using a single ProtocolMessage where possible by bundling in all messages for that channel") {
+                    func test__088__Channel__publish__message_bundling__Messages_are_delivered_using_a_single_ProtocolMessage_where_possible_by_bundling_in_all_messages_for_that_channel() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = AblyTests.newRealtime(options)
@@ -2581,7 +2611,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTL6d1
-                    it("The resulting ProtocolMessage must not exceed the maxMessageSize") {
+                    func test__089__Channel__publish__message_bundling__The_resulting_ProtocolMessage_must_not_exceed_the_maxMessageSize() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = AblyTests.newRealtime(options)
@@ -2612,9 +2642,9 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTL6d2
-                    context("Messages with differing clientId values must not be bundled together") {
+                    
 
-                        it("messages with different (non empty) clientIds are posted via different protocol messages") {
+                        func test__092__Channel__publish__message_bundling__Messages_with_differing_clientId_values_must_not_be_bundled_together__messages_with_different__non_empty__clientIds_are_posted_via_different_protocol_messages() {
                             let options = AblyTests.commonAppSetup()
                             options.autoConnect = false
                             let client = AblyTests.newRealtime(options)
@@ -2638,7 +2668,7 @@ override class var defaultTestSuite : XCTestSuite {
                             expect(protocolMessages.count).to(equal(clientIDs.count))
                         }
 
-                        it("messages with mixed empty/non empty clientIds are posted via different protocol messages") {
+                        func test__093__Channel__publish__message_bundling__Messages_with_differing_clientId_values_must_not_be_bundled_together__messages_with_mixed_empty_non_empty_clientIds_are_posted_via_different_protocol_messages() {
                             let options = AblyTests.commonAppSetup()
                             options.autoConnect = false
                             let client = AblyTests.newRealtime(options)
@@ -2663,7 +2693,7 @@ override class var defaultTestSuite : XCTestSuite {
                             expect(protocolMessages.count).to(equal(2))
                         }
 
-                        it("messages bundled by the user are posted in a single protocol message even if they have mixed clientIds") {
+                        func test__094__Channel__publish__message_bundling__Messages_with_differing_clientId_values_must_not_be_bundled_together__messages_bundled_by_the_user_are_posted_in_a_single_protocol_message_even_if_they_have_mixed_clientIds() {
                             let options = AblyTests.commonAppSetup()
                             options.autoConnect = false
                             let client = AblyTests.newRealtime(options)
@@ -2686,11 +2716,10 @@ override class var defaultTestSuite : XCTestSuite {
                             let protocolMessages = transport.protocolMessagesSent.filter{ $0.action == .message }
                             expect(protocolMessages.count).to(equal(1))
                         }
-                    }
 
                     
                     // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                    xit("should only bundle messages when it respects all of the constraints") {
+                    func skipped__test__090__Channel__publish__message_bundling__should_only_bundle_messages_when_it_respects_all_of_the_constraints() {
                         let defaultMaxMessageSize = ARTDefault.maxMessageSize()
                         ARTDefault.setMaxMessageSize(256)
                         defer { ARTDefault.setMaxMessageSize(defaultMaxMessageSize) }
@@ -2761,7 +2790,7 @@ override class var defaultTestSuite : XCTestSuite {
                         AblyTests.wait(for: [expectationMessageFinalOrder], timeout: testTimeout)
                     }
 
-                    it("should publish only once on multiple explicit publish requests for a given message with client-supplied ids") {
+                    func test__091__Channel__publish__message_bundling__should_publish_only_once_on_multiple_explicit_publish_requests_for_a_given_message_with_client_supplied_ids() {
                         let options = AblyTests.commonAppSetup()
                         let client = ARTRealtime(options: options)
                         defer { client.dispose(); client.close() }
@@ -2796,13 +2825,11 @@ override class var defaultTestSuite : XCTestSuite {
                         AblyTests.wait(for: [expectationEvent0, expectationEnd])
                     }
 
-                }
-
                 // RTL6e
-                context("Unidentified clients using Basic Auth") {
+                
 
                     // RTL6e1
-                    it("should have the provided clientId on received message when it was published with clientId") {
+                    func test__095__Channel__publish__Unidentified_clients_using_Basic_Auth__should_have_the_provided_clientId_on_received_message_when_it_was_published_with_clientId() {
                         let client = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
 
@@ -2830,10 +2857,8 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(resultClientId).toEventually(equal(message.clientId), timeout: testTimeout)
                     }
 
-                }
-
                 // RTL6f
-                it("Message#connectionId should match the current Connection#id for all published messages") {
+                func test__065__Channel__publish__Message_connectionId_should_match_the_current_Connection_id_for_all_published_messages() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -2848,9 +2873,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL6i
-                context("expect either") {
+                
 
-                    it("an array of Message objects") {
+                    func test__096__Channel__publish__expect_either__an_array_of_Message_objects() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = ARTRealtime(options: options)
@@ -2874,7 +2899,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(result).toEventually(equal(messages.map{ $0.data as! JSONObject }), timeout: testTimeout)
                     }
 
-                    it("a name string and data payload") {
+                    func test__097__Channel__publish__expect_either__a_name_string_and_data_payload() {
                         let client = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
                         let channel = client.channels.get("test")
@@ -2891,7 +2916,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(result).toEventually(equal(expectedResult), timeout: testTimeout)
                     }
 
-                    it("allows name to be null") {
+                    func test__098__Channel__publish__expect_either__allows_name_to_be_null() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = ARTRealtime(options: options)
@@ -2929,7 +2954,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(resultMessage!.data as? String).to(equal(expectedObject["data"]))
                     }
 
-                    it("allows data to be null") {
+                    func test__099__Channel__publish__expect_either__allows_data_to_be_null() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = ARTRealtime(options: options)
@@ -2967,7 +2992,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(resultMessage!.data).to(beNil())
                     }
 
-                    it("allows name and data to be assigned") {
+                    func test__100__Channel__publish__expect_either__allows_name_and_data_to_be_assigned() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = ARTRealtime(options: options)
@@ -2996,16 +3021,14 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(resultObject).to(equal(expectedObject as NSDictionary))
                     }
 
-                }
-
                 // RTL6g
-                context("Identified clients with clientId") {
+                
 
                     // RTL6g1
-                    context("When publishing a Message with clientId set to null") {
+                    
 
                         // RTL6g1a & RTL6g1b
-                        it("should be unnecessary to set clientId of the Message before publishing and have clientId value set for the Message when received") {
+                        func test__105__Channel__publish__Identified_clients_with_clientId__When_publishing_a_Message_with_clientId_set_to_null__should_be_unnecessary_to_set_clientId_of_the_Message_before_publishing_and_have_clientId_value_set_for_the_Message_when_received() {
                             let options = AblyTests.commonAppSetup()
                             options.clientId = "client_string"
                             options.autoConnect = false
@@ -3035,10 +3058,8 @@ override class var defaultTestSuite : XCTestSuite {
                             expect(messageReceived.messages![0].clientId).to(equal(options.clientId))
                         }
 
-                    }
-
                     // RTL6g2
-                    it("when publishing a Message with the clientId attribute value set to the identified client’s clientId") {
+                    func test__101__Channel__publish__Identified_clients_with_clientId__when_publishing_a_Message_with_the_clientId_attribute_value_set_to_the_identified_client_s_clientId() {
                         let options = AblyTests.commonAppSetup()
                         options.clientId = "john"
                         let client = ARTRealtime(options: options)
@@ -3064,7 +3085,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTL6g3
-                    it("when publishing a Message with a different clientId attribute value from the identified client’s clientId, it should reject that publish operation immediately") {
+                    func test__102__Channel__publish__Identified_clients_with_clientId__when_publishing_a_Message_with_a_different_clientId_attribute_value_from_the_identified_client_s_clientId__it_should_reject_that_publish_operation_immediately() {
                         let options = AblyTests.commonAppSetup()
                         options.clientId = "john"
                         let client = ARTRealtime(options: options)
@@ -3087,7 +3108,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTL6g4
-                    it("message should be published following authentication and received back with the clientId intact") {
+                    func test__103__Channel__publish__Identified_clients_with_clientId__message_should_be_published_following_authentication_and_received_back_with_the_clientId_intact() {
                         let options = AblyTests.clientOptions()
                         options.authCallback = { tokenParams, completion in
                             getTestTokenDetails(clientId: "john", completion: completion)
@@ -3110,7 +3131,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTL6g4
-                    it("message should be rejected by the Ably service and the message error should contain the server error") {
+                    func test__104__Channel__publish__Identified_clients_with_clientId__message_should_be_rejected_by_the_Ably_service_and_the_message_error_should_contain_the_server_error() {
                         let options = AblyTests.clientOptions()
                         options.authCallback = { tokenParams, completion in
                             getTestTokenDetails(clientId: "john", completion: completion)
@@ -3127,10 +3148,8 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
                 // RTL6h
-                it("should provide an optional argument that allows the clientId value to be specified") {
+                func test__066__Channel__publish__should_provide_an_optional_argument_that_allows_the_clientId_value_to_be_specified() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -3150,14 +3169,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-
-            }
-
             // RTL7
-            context("subscribe") {
+            
 
                 // RTL7a
-                it("with no arguments subscribes a listener to all messages") {
+                func test__106__Channel__subscribe__with_no_arguments_subscribes_a_listener_to_all_messages() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -3181,7 +3197,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL7b
-                it("with a single name argument subscribes a listener to only messages whose name member matches the string name") {
+                func test__107__Channel__subscribe__with_a_single_name_argument_subscribes_a_listener_to_only_messages_whose_name_member_matches_the_string_name() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -3206,7 +3222,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(Test.counter).toEventually(equal(2), timeout: testTimeout)
                 }
 
-                it("with a attach callback should subscribe and call the callback when attached") {
+                func test__108__Channel__subscribe__with_a_attach_callback_should_subscribe_and_call_the_callback_when_attached() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -3232,7 +3248,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL7c
-                it("should implicitly attach the channel") {
+                func test__109__Channel__subscribe__should_implicitly_attach_the_channel() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -3244,7 +3260,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL7c
-                it("should result in an error if channel is in the FAILED state") {
+                func test__110__Channel__subscribe__should_result_in_an_error_if_channel_is_in_the_FAILED_state() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -3265,21 +3281,20 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL7d
-                context("should deliver the message even if there is an error while decoding") {
+                
                     
-                    it("using crypto-data-128") {
+                    func test__112__Channel__subscribe__should_deliver_the_message_even_if_there_is_an_error_while_decoding__using_crypto_data_128() {
                         testHandlesDecodingErrorInFixture("crypto-data-128")
                     }
                     
-                    it("using crypto-data-256") {
+                    func test__113__Channel__subscribe__should_deliver_the_message_even_if_there_is_an_error_while_decoding__using_crypto_data_256() {
                         testHandlesDecodingErrorInFixture("crypto-data-256")
                     }
-                }
 
-                context("message cannot be decoded or decrypted") {
+                
 
                     // RTL7e
-                    it("should deliver with encoding attribute set indicating the residual encoding and error should be emitted") {
+                    func test__114__Channel__subscribe__message_cannot_be_decoded_or_decrypted__should_deliver_with_encoding_attribute_set_indicating_the_residual_encoding_and_error_should_be_emitted() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         options.logHandler = ARTLog(capturingOutput: true)
@@ -3324,11 +3339,9 @@ override class var defaultTestSuite : XCTestSuite {
                             channel.publish(nil, data: expectedMessage)
                         }
                     }
-                    
-                }
 
                 // RTL7f
-                it("should exist ensuring published messages are not echoed back to the subscriber when echoMessages is false") {
+                func test__111__Channel__subscribe__should_exist_ensuring_published_messages_are_not_echoed_back_to_the_subscriber_when_echoMessages_is_false() {
                     let options = AblyTests.commonAppSetup()
                     let client1 = ARTRealtime(options: options)
                     defer { client1.close() }
@@ -3357,13 +3370,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTL8
-            context("unsubscribe") {
+            
 
                 // RTL8a
-                it("with no arguments unsubscribes the provided listener to all messages if subscribed") {
+                func test__115__Channel__unsubscribe__with_no_arguments_unsubscribes_the_provided_listener_to_all_messages_if_subscribed() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -3385,7 +3396,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL8b
-                it("with a single name argument unsubscribes the provided listener if previously subscribed with a name-specific subscription") {
+                func test__116__Channel__unsubscribe__with_a_single_name_argument_unsubscribes_the_provided_listener_if_previously_subscribed_with_a_name_specific_subscription() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -3406,12 +3417,10 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTL10
-            context("history") {
+            
                 // RTL10a 
-                it("should support all the same params as Rest") {
+                func test__117__Channel__history__should_support_all_the_same_params_as_Rest() {
                     let options = AblyTests.commonAppSetup()
 
                     let rest = ARTRest(options: options)
@@ -3463,14 +3472,14 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL10b
-                context("supports the param untilAttach") {
+                
 
-                    it("should be false as default") {
+                    func test__123__Channel__history__supports_the_param_untilAttach__should_be_false_as_default() {
                         let query = ARTRealtimeHistoryQuery()
                         expect(query.untilAttach).to(equal(false))
                     }
 
-                    it("should invoke an error when the untilAttach is specified and the channel is not attached") {
+                    func test__124__Channel__history__supports_the_param_untilAttach__should_invoke_an_error_when_the_untilAttach_is_specified_and_the_channel_is_not_attached() {
                         let client = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
                         let channel = client.channels.get("test")
@@ -3490,15 +3499,15 @@ override class var defaultTestSuite : XCTestSuite {
                         fail("Should raise an error")
                     }
                     
-                    it("where value is true, should pass the querystring param fromSerial with the serial number assigned to the channel") {
+                    func test__125__Channel__history__supports_the_param_untilAttach__where_value_is_true__should_pass_the_querystring_param_fromSerial_with_the_serial_number_assigned_to_the_channel() {
                         testWithUntilAttach(true)
                     }
                     
-                    it("where value is false, should pass the querystring param fromSerial with the serial number assigned to the channel") {
+                    func test__126__Channel__history__supports_the_param_untilAttach__where_value_is_false__should_pass_the_querystring_param_fromSerial_with_the_serial_number_assigned_to_the_channel() {
                         testWithUntilAttach(true)
                     }
 
-                    it("should retrieve messages prior to the moment that the channel was attached") {
+                    func test__127__Channel__history__supports_the_param_untilAttach__should_retrieve_messages_prior_to_the_moment_that_the_channel_was_attached() {
                         let options = AblyTests.commonAppSetup()
                         let client1 = ARTRealtime(options: options)
                         defer { client1.close() }
@@ -3564,10 +3573,8 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
                 // RTL10c
-                it("should return a PaginatedResult page") {
+                func test__118__Channel__history__should_return_a_PaginatedResult_page() {
                     let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { realtime.close() }
                     let channel = realtime.channels.get("test")
@@ -3596,7 +3603,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL10d
-                it("should retrieve all available messages") {
+                func test__119__Channel__history__should_retrieve_all_available_messages() {
                     let options = AblyTests.commonAppSetup()
                     let client1 = ARTRealtime(options: options)
                     defer { client1.close() }
@@ -3649,7 +3656,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL12
-                it("attached channel may receive an additional ATTACHED ProtocolMessage") {
+                func test__120__Channel__history__attached_channel_may_receive_an_additional_ATTACHED_ProtocolMessage() {
                     let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -3703,10 +3710,10 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL13
-                context("if the channel receives a server initiated DETACHED message when") {
+                
 
                     // RTL13a
-                    it("the channel is in the ATTACHED states, an attempt to reattach the channel should be made immediately by sending a new ATTACH message and the channel should transition to the ATTACHING state with the error emitted in the ChannelStateChange event") {
+                    func test__128__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__the_channel_is_in_the_ATTACHED_states__an_attempt_to_reattach_the_channel_should_be_made_immediately_by_sending_a_new_ATTACH_message_and_the_channel_should_transition_to_the_ATTACHING_state_with_the_error_emitted_in_the_ChannelStateChange_event() {
                         let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
                         let channel = client.channels.get("foo")
@@ -3745,7 +3752,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTL13a
-                    it("the channel is in the SUSPENDED state, an attempt to reattach the channel should be made immediately by sending a new ATTACH message and the channel should transition to the ATTACHING state with the error emitted in the ChannelStateChange event") {
+                    func test__129__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__the_channel_is_in_the_SUSPENDED_state__an_attempt_to_reattach_the_channel_should_be_made_immediately_by_sending_a_new_ATTACH_message_and_the_channel_should_transition_to_the_ATTACHING_state_with_the_error_emitted_in_the_ChannelStateChange_event() {
                         let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
 
@@ -3800,7 +3807,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTL13b
-                    it("if the attempt to re-attach fails the channel will transition to the SUSPENDED state and the error will be emitted in the ChannelStateChange event") {
+                    func test__130__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__if_the_attempt_to_re_attach_fails_the_channel_will_transition_to_the_SUSPENDED_state_and_the_error_will_be_emitted_in_the_ChannelStateChange_event() {
                         let options = AblyTests.commonAppSetup()
                         options.channelRetryTimeout = 1.0
                         let client = AblyTests.newRealtime(options)
@@ -3862,7 +3869,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTL13b
-                    it("if the channel was already in the ATTACHING state, the channel will transition to the SUSPENDED state and the error will be emitted in the ChannelStateChange event") {
+                    func test__131__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__if_the_channel_was_already_in_the_ATTACHING_state__the_channel_will_transition_to_the_SUSPENDED_state_and_the_error_will_be_emitted_in_the_ChannelStateChange_event() {
                         let options = AblyTests.commonAppSetup()
                         options.channelRetryTimeout = 1.0
                         let client = AblyTests.newRealtime(options)
@@ -3901,7 +3908,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTL13c
-                    it("if the connection is no longer CONNECTED, then the automatic attempts to re-attach the channel must be cancelled") {
+                    func test__132__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__if_the_connection_is_no_longer_CONNECTED__then_the_automatic_attempts_to_re_attach_the_channel_must_be_cancelled() {
                         let options = AblyTests.commonAppSetup()
                         options.channelRetryTimeout = 1.0
                         let client = AblyTests.newRealtime(options)
@@ -3958,10 +3965,8 @@ override class var defaultTestSuite : XCTestSuite {
                         })
                     }
 
-                }
-
                 // RTL14
-                it("If an ERROR ProtocolMessage is received for this channel then the channel should immediately transition to the FAILED state, the errorReason should be set and an error should be emitted on the channel") {
+                func test__121__Channel__history__If_an_ERROR_ProtocolMessage_is_received_for_this_channel_then_the_channel_should_immediately_transition_to_the_FAILED_state__the_errorReason_should_be_set_and_an_error_should_be_emitted_on_the_channel() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("foo")
@@ -3993,11 +3998,11 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTL16
-                context("Channel options") {
+                
 
                     // RTL16a
-                    context("setOptions") {
-                        it("should send an ATTACH message with params & modes if the channel is attached") {
+                    
+                        func test__133__Channel__history__Channel_options__setOptions__should_send_an_ATTACH_message_with_params___modes_if_the_channel_is_attached() {
                             let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                             defer { client.dispose(); client.close() }
                             let channel = client.channels.get("foo")
@@ -4048,7 +4053,7 @@ override class var defaultTestSuite : XCTestSuite {
                             expect(lastAttached.params).to(equal(channelOptions.params))
                         }
 
-                        it("should send an ATTACH message with params & modes if the channel is attaching") {
+                        func test__134__Channel__history__Channel_options__setOptions__should_send_an_ATTACH_message_with_params___modes_if_the_channel_is_attaching() {
                             let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                             defer { client.dispose(); client.close() }
 
@@ -4105,7 +4110,7 @@ override class var defaultTestSuite : XCTestSuite {
                             expect(lastAttached.params).to(equal(channelOptions.params))
                         }
 
-                        it("should success immediately if channel is not attaching or attached") {
+                        func test__135__Channel__history__Channel_options__setOptions__should_success_immediately_if_channel_is_not_attaching_or_attached() {
                             let options = AblyTests.commonAppSetup()
                             options.autoConnect = false
                             let client = AblyTests.newRealtime(options)
@@ -4127,7 +4132,7 @@ override class var defaultTestSuite : XCTestSuite {
                             expect(channel.options?.params).to(equal(channelOptions.params))
                         }
 
-                        it("should fail if the attach moves to FAILED") {
+                        func test__136__Channel__history__Channel_options__setOptions__should_fail_if_the_attach_moves_to_FAILED() {
                             let options = AblyTests.commonAppSetup()
                             options.token = getTestToken(capability: "{\"secret\":[\"subscribe\"]}") //access denied
                             let client = AblyTests.newRealtime(options)
@@ -4177,7 +4182,7 @@ override class var defaultTestSuite : XCTestSuite {
                             expect(attachedMessages).to(beEmpty())
                         }
 
-                        it("should fail if the attach moves to DETACHED") {
+                        func test__137__Channel__history__Channel_options__setOptions__should_fail_if_the_attach_moves_to_DETACHED() {
                             let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                             defer { client.dispose(); client.close() }
                             let channel = client.channels.get("foo")
@@ -4229,12 +4234,9 @@ override class var defaultTestSuite : XCTestSuite {
                             expect(lastAttach.flags & subscribeFlag).to(equal(subscribeFlag))
                             expect(lastAttach.params).to(equal(channelOptions.params))
                         }
-                    }
-
-                }
 
                 // RTL17
-                it("should not emit messages to subscribers if the channel is in any state other than ATTACHED") {
+                func test__122__Channel__history__should_not_emit_messages_to_subscribers_if_the_channel_is_in_any_state_other_than_ATTACHED() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.close(); client.dispose() }
@@ -4280,10 +4282,8 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(subscribeEmittedCount) == 1
                 }
 
-            }
-
-            context("crypto") {
-                it("if configured for encryption, channels encrypt and decrypt messages' data") {
+            
+                func test__138__Channel__crypto__if_configured_for_encryption__channels_encrypt_and_decrypt_messages__data() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
 
@@ -4366,10 +4366,9 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
             // https://github.com/ably/ably-cocoa/issues/614
-            it("should not crash when an ATTACH request is responded with a DETACHED") {
+            func test__002__Channel__should_not_crash_when_an_ATTACH_request_is_responded_with_a_DETACHED() {
                 let options = AblyTests.commonAppSetup()
                 let client = AblyTests.newRealtime(options)
                 defer { client.dispose(); client.close() }
@@ -4401,12 +4400,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
             }
-        }
         
-        describe("message attributes") {
+        
             
             // TM2a
-            it("if the message does not contain an id, it should be set to protocolMsgId:index") {
+            func test__139__message_attributes__if_the_message_does_not_contain_an_id__it_should_be_set_to_protocolMsgId_index() {
                 let client = ARTRealtime(options: AblyTests.commonAppSetup())
                 defer { client.dispose(); client.close() }
                 let p = ARTProtocolMessage()
@@ -4429,6 +4427,4 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
             }
-        }
-    }
 }

--- a/Spec/RealtimeClientChannels.swift
+++ b/Spec/RealtimeClientChannels.swift
@@ -9,12 +9,11 @@ extension ARTRealtimeChannels: Sequence {
     }
 }
 
-class RealtimeClientChannels: QuickSpec {
-    override func spec() {
-        describe("Channels") {
+class RealtimeClientChannels: XCTestCase {
+        
 
             // RTS2
-            it("should exist methods to check if a channel exists or iterate through the existing channels") {
+            func test__001__Channels__should_exist_methods_to_check_if_a_channel_exists_or_iterate_through_the_existing_channels() {
                 let client = ARTRealtime(options: AblyTests.commonAppSetup())
                 defer { client.dispose(); client.close() }
                 var disposable = [String]()
@@ -33,10 +32,10 @@ class RealtimeClientChannels: QuickSpec {
             }
 
             // RTS3
-            context("get") {
+            
 
                 // RTS3a
-                it("should create a new Channel if none exists or return the existing one") {
+                func test__002__Channels__get__should_create_a_new_Channel_if_none_exists_or_return_the_existing_one() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.dispose(); client.close() }
@@ -51,7 +50,7 @@ class RealtimeClientChannels: QuickSpec {
                 }
 
                 // RTS3b
-                it("should be possible to specify a ChannelOptions") {
+                func test__003__Channels__get__should_be_possible_to_specify_a_ChannelOptions() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let options = ARTRealtimeChannelOptions()
@@ -60,7 +59,7 @@ class RealtimeClientChannels: QuickSpec {
                 }
 
                 // RTS3c
-                it("accessing an existing Channel with options should update the options and then return the object") {
+                func test__004__Channels__get__accessing_an_existing_Channel_with_options_should_update_the_options_and_then_return_the_object() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     expect(client.channels.get("test").options).to(beNil())
@@ -69,11 +68,9 @@ class RealtimeClientChannels: QuickSpec {
                     expect(channel.options).to(beIdenticalTo(options))
                 }
 
-            }
-
             // RTS4
-            context("release") {
-                it("should release a channel") {
+            
+                func test__005__Channels__release__should_release_a_channel() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -102,8 +99,4 @@ class RealtimeClientChannels: QuickSpec {
                         sameChannel.publish("foo", data: nil)
                     }
                 }
-            }
-
-        }
-    }
 }

--- a/Spec/RealtimeClientChannels.swift
+++ b/Spec/RealtimeClientChannels.swift
@@ -1,102 +1,99 @@
 import Ably
-import Quick
 import Nimble
+import Quick
 
 // Swift isn't yet smart enough to do this automatically when bridging Objective-C APIs
 extension ARTRealtimeChannels: Sequence {
     public func makeIterator() -> NSFastEnumerationIterator {
-        return NSFastEnumerationIterator(self.iterate())
+        return NSFastEnumerationIterator(iterate())
     }
 }
 
 class RealtimeClientChannels: XCTestCase {
-        
+    // RTS2
+    func test__001__Channels__should_exist_methods_to_check_if_a_channel_exists_or_iterate_through_the_existing_channels() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        var disposable = [String]()
 
-            // RTS2
-            func test__001__Channels__should_exist_methods_to_check_if_a_channel_exists_or_iterate_through_the_existing_channels() {
-                let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                defer { client.dispose(); client.close() }
-                var disposable = [String]()
+        disposable.append(client.channels.get("test1").name)
+        disposable.append(client.channels.get("test2").name)
+        disposable.append(client.channels.get("test3").name)
 
-                disposable.append(client.channels.get("test1").name)
-                disposable.append(client.channels.get("test2").name)
-                disposable.append(client.channels.get("test3").name)
+        expect(client.channels.get("test2")).toNot(beNil())
+        expect(client.channels.exists("test2")).to(beTrue())
+        expect(client.channels.exists("testX")).to(beFalse())
 
-                expect(client.channels.get("test2")).toNot(beNil())
-                expect(client.channels.exists("test2")).to(beTrue())
-                expect(client.channels.exists("testX")).to(beFalse())
+        for channel in client.channels {
+            expect(disposable.contains((channel as! ARTRealtimeChannel).name)).to(beTrue())
+        }
+    }
 
-                for channel in client.channels {
-                    expect(disposable.contains((channel as! ARTRealtimeChannel).name)).to(beTrue())
+    // RTS3
+
+    // RTS3a
+    func test__002__Channels__get__should_create_a_new_Channel_if_none_exists_or_return_the_existing_one() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        expect(client.channels.internal.collection).to(haveCount(0))
+        let channel = client.channels.get("test")
+        expect(channel.name).to(equal("\(options.channelNamePrefix!)-test"))
+
+        expect(client.channels.internal.collection).to(haveCount(1))
+        expect(client.channels.get("test").internal).to(beIdenticalTo(channel.internal))
+        expect(client.channels.internal.collection).to(haveCount(1))
+    }
+
+    // RTS3b
+    func test__003__Channels__get__should_be_possible_to_specify_a_ChannelOptions() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let options = ARTRealtimeChannelOptions()
+        let channel = client.channels.get("test", options: options)
+        expect(channel.options).to(beIdenticalTo(options))
+    }
+
+    // RTS3c
+    func test__004__Channels__get__accessing_an_existing_Channel_with_options_should_update_the_options_and_then_return_the_object() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        expect(client.channels.get("test").options).to(beNil())
+        let options = ARTRealtimeChannelOptions()
+        let channel = client.channels.get("test", options: options)
+        expect(channel.options).to(beIdenticalTo(options))
+    }
+
+    // RTS4
+
+    func test__005__Channels__release__should_release_a_channel() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+        channel.subscribe { _ in
+            fail("shouldn't happen")
+        }
+        channel.presence.subscribe { _ in
+            fail("shouldn't happen")
+        }
+        waitUntil(timeout: testTimeout) { done in
+            client.channels.release("test") { errorInfo in
+                expect(errorInfo).to(beNil())
+                expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
+                done()
+            }
+        }
+
+        let sameChannel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            sameChannel.subscribe { _ in
+                sameChannel.presence.enterClient("foo", data: nil) { _ in
+                    delay(0.0) { done() } // Delay to make sure EventEmitter finish its cycle.
                 }
             }
-
-            // RTS3
-            
-
-                // RTS3a
-                func test__002__Channels__get__should_create_a_new_Channel_if_none_exists_or_return_the_existing_one() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-
-                    expect(client.channels.internal.collection).to(haveCount(0))
-                    let channel = client.channels.get("test")
-                    expect(channel.name).to(equal("\(options.channelNamePrefix!)-test"))
-
-                    expect(client.channels.internal.collection).to(haveCount(1))
-                    expect(client.channels.get("test").internal).to(beIdenticalTo(channel.internal))
-                    expect(client.channels.internal.collection).to(haveCount(1))
-                }
-
-                // RTS3b
-                func test__003__Channels__get__should_be_possible_to_specify_a_ChannelOptions() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let options = ARTRealtimeChannelOptions()
-                    let channel = client.channels.get("test", options: options)
-                    expect(channel.options).to(beIdenticalTo(options))
-                }
-
-                // RTS3c
-                func test__004__Channels__get__accessing_an_existing_Channel_with_options_should_update_the_options_and_then_return_the_object() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    expect(client.channels.get("test").options).to(beNil())
-                    let options = ARTRealtimeChannelOptions()
-                    let channel = client.channels.get("test", options: options)
-                    expect(channel.options).to(beIdenticalTo(options))
-                }
-
-            // RTS4
-            
-                func test__005__Channels__release__should_release_a_channel() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-
-                    let channel = client.channels.get("test")
-                    channel.subscribe { _ in
-                        fail("shouldn't happen")
-                    }
-                    channel.presence.subscribe { _ in
-                        fail("shouldn't happen")
-                    }
-                    waitUntil(timeout: testTimeout) { done in
-                        client.channels.release("test") { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
-                            done()
-                        }
-                    }
-
-                    let sameChannel = client.channels.get("test")
-                    waitUntil(timeout: testTimeout) { done in
-                        sameChannel.subscribe { _ in
-                            sameChannel.presence.enterClient("foo", data: nil) { _ in
-                                delay(0.0) { done() } // Delay to make sure EventEmitter finish its cycle.
-                            }
-                        }
-                        sameChannel.publish("foo", data: nil)
-                    }
-                }
+            sameChannel.publish("foo", data: nil)
+        }
+    }
 }

--- a/Spec/RealtimeClientChannels.swift
+++ b/Spec/RealtimeClientChannels.swift
@@ -1,6 +1,6 @@
 import Ably
 import Nimble
-import Quick
+import XCTest
 
 // Swift isn't yet smart enough to do this automatically when bridging Objective-C APIs
 extension ARTRealtimeChannels: Sequence {

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -1,8 +1,8 @@
 import Ably
-import Quick
-import Nimble
-import SwiftyJSON
 import Aspects
+import Nimble
+import Quick
+import SwiftyJSON
 
 func countChannels(_ channels: ARTRealtimeChannels) -> Int {
     var i = 0
@@ -12,4819 +12,4757 @@ func countChannels(_ channels: ARTRealtimeChannels) -> Int {
     return i
 }
 
-                    private var ttlAndIdleIntervalPassedTestsClient: ARTRealtime!
-                    private var ttlAndIdleIntervalPassedTestsConnectionId = ""
-                    private let customTtlInterval: TimeInterval = 0.1
-                    private let customIdleInterval: TimeInterval = 0.1
-                    private var ttlAndIdleIntervalNotPassedTestsClient: ARTRealtime!
-                    private var ttlAndIdleIntervalNotPassedTestsConnectionId = ""
-                private let expectedHostOrder = [3, 4, 0, 2, 1]
-                private let originalARTFallback_shuffleArray = ARTFallback_shuffleArray
-                    private func testUsesAlternativeHostOnResponse(_ caseTest: FakeNetworkResponse) {
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-                        client.channels.get("test")
+private var ttlAndIdleIntervalPassedTestsClient: ARTRealtime!
+private var ttlAndIdleIntervalPassedTestsConnectionId = ""
+private let customTtlInterval: TimeInterval = 0.1
+private let customIdleInterval: TimeInterval = 0.1
+private var ttlAndIdleIntervalNotPassedTestsClient: ARTRealtime!
+private var ttlAndIdleIntervalNotPassedTestsConnectionId = ""
+private let expectedHostOrder = [3, 4, 0, 2, 1]
+private let originalARTFallback_shuffleArray = ARTFallback_shuffleArray
+private func testUsesAlternativeHostOnResponse(_ caseTest: FakeNetworkResponse) {
+    let options = ARTClientOptions(key: "xxxx:xxxx")
+    options.autoConnect = false
+    let client = ARTRealtime(options: options)
+    defer { client.dispose(); client.close() }
+    client.channels.get("test")
 
-                        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                        ARTDefault.setRealtimeRequestTimeout(1.0)
+    let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+    defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+    ARTDefault.setRealtimeRequestTimeout(1.0)
 
-                        client.internal.setTransport(TestProxyTransport.self)
-                        TestProxyTransport.fakeNetworkResponse = caseTest
-                        defer { TestProxyTransport.fakeNetworkResponse = nil }
+    client.internal.setTransport(TestProxyTransport.self)
+    TestProxyTransport.fakeNetworkResponse = caseTest
+    defer { TestProxyTransport.fakeNetworkResponse = nil }
 
-                        var urlConnections = [URL]()
-                        TestProxyTransport.networkConnectEvent = { transport, url in
-                            if client.internal.transport !== transport {
-                                return
-                            }
-                            urlConnections.append(url)
-                            if urlConnections.count == 1 {
-                                TestProxyTransport.fakeNetworkResponse = nil
-                            }
-                        }
-                        defer { TestProxyTransport.networkConnectEvent = nil }
+    var urlConnections = [URL]()
+    TestProxyTransport.networkConnectEvent = { transport, url in
+        if client.internal.transport !== transport {
+            return
+        }
+        urlConnections.append(url)
+        if urlConnections.count == 1 {
+            TestProxyTransport.fakeNetworkResponse = nil
+        }
+    }
+    defer { TestProxyTransport.networkConnectEvent = nil }
 
-                        waitUntil(timeout: testTimeout) { done in
-                            // wss://[a-e].ably-realtime.com: when a timeout occurs
-                            client.connection.once(.disconnected) { error in
-                                done()
-                            }
-                            // wss://[a-e].ably-realtime.com: when a 401 occurs because of the `xxxx:xxxx` key
-                            client.connection.once(.failed) { error in
-                                done()
-                            }
-                            client.connect()
-                        }
+    waitUntil(timeout: testTimeout) { done in
+        // wss://[a-e].ably-realtime.com: when a timeout occurs
+        client.connection.once(.disconnected) { _ in
+            done()
+        }
+        // wss://[a-e].ably-realtime.com: when a 401 occurs because of the `xxxx:xxxx` key
+        client.connection.once(.failed) { _ in
+            done()
+        }
+        client.connect()
+    }
 
-                        expect(urlConnections).to(haveCount(2))
-                        expect(NSRegularExpression.match(urlConnections[0].absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
-                        expect(NSRegularExpression.match(urlConnections[1].absoluteString, pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                    }
-                    private func testMovesToDisconnectedWithNetworkingError(_ error: Error) {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = AblyTests.newRealtime(options)
-                        defer {
-                            client.dispose()
-                            client.close()
-                        }
-                        client.internal.setTransport(TestProxyTransport.self)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.connected) { _ in
-                                done()
-                            }
-                            client.connect()
-                        }
-
-                        var _transport: ARTWebSocketTransport?
-                        AblyTests.queue.sync {
-                            _transport = client.internal.transport as? ARTWebSocketTransport
-                        }
-
-                        guard let wsTransport = _transport else {
-                            fail("expected WS transport")
-                            return
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.disconnected) { _ in
-                                done()
-                            }
-                            wsTransport.webSocket(wsTransport.websocket!, didFailWithError:error)
-                        }
-                    }
-                    private var internetConnectionNotAvailableTestsClient: ARTRealtime!
-                private let fixtures = try! JSON(data: NSData(contentsOfFile: pathForTestResource(testResourcesPath + "messages-encoding.json"))! as Data, options: .mutableContainers)
-
-                private func expectDataToMatch(_ message: ARTMessage, _ fixtureMessage: JSON) {
-                    switch fixtureMessage["expectedType"].string! {
-                    case "string":
-                        expect(message.data as? NSString).to(equal(fixtureMessage["expectedValue"].string! as NSString?))
-                    case "jsonObject":
-                        if let data = message.data as? NSDictionary {
-                            expect(JSON(data)).to(equal(fixtureMessage["expectedValue"]))
-                        } else {
-                            fail("expected NSDictionary")
-                        }              
-                    case "jsonArray":
-                        if let data = message.data as? NSArray {
-                            expect(JSON(data)).to(equal(fixtureMessage["expectedValue"]))
-                        } else {
-                            fail("expected NSArray")
-                        }
-                    case "binary":
-                        expect(message.data as? NSData).to(equal(fixtureMessage["expectedHexValue"].string!.dataFromHexadecimalString()! as NSData?))
-                    default:
-                        fail("unhandled: \(fixtureMessage["expectedType"].string!)")
-                    }
-                }
-
-                private var jsonOptions: ARTClientOptions!
-                private var msgpackOptions: ARTClientOptions!
-
-                private func setupDependencies() {
-                    if (jsonOptions == nil) {
-                        jsonOptions = AblyTests.commonAppSetup()
-                        jsonOptions.useBinaryProtocol = false
-                        // Keep the same key and channel prefix
-                        msgpackOptions = (jsonOptions.copy() as! ARTClientOptions)
-                        msgpackOptions.useBinaryProtocol = true
-                    }
-                }
-
-class RealtimeClientConnection: XCTestCase {
-
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = ttlAndIdleIntervalPassedTestsClient
-    let _ = ttlAndIdleIntervalPassedTestsConnectionId
-    let _ = customTtlInterval
-    let _ = customIdleInterval
-    let _ = ttlAndIdleIntervalNotPassedTestsClient
-    let _ = ttlAndIdleIntervalNotPassedTestsConnectionId
-    let _ = expectedHostOrder
-    let _ = originalARTFallback_shuffleArray
-    let _ = internetConnectionNotAvailableTestsClient
-    let _ = fixtures
-    let _ = jsonOptions
-    let _ = msgpackOptions
-
-    return super.defaultTestSuite
+    expect(urlConnections).to(haveCount(2))
+    expect(NSRegularExpression.match(urlConnections[0].absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
+    expect(NSRegularExpression.match(urlConnections[1].absoluteString, pattern: "//[a-e].ably-realtime.com")).to(beTrue())
 }
 
+private func testMovesToDisconnectedWithNetworkingError(_ error: Error) {
+    let options = AblyTests.commonAppSetup()
+    options.autoConnect = false
+    let client = AblyTests.newRealtime(options)
+    defer {
+        client.dispose()
+        client.close()
+    }
+    client.internal.setTransport(TestProxyTransport.self)
 
-                    class TotalMessages {
-                        static var expected: Int32 = 0
-                        static var succeeded: Int32 = 0
-                        fileprivate init() {}
-                    }
-        
-            
-            // CD2c
-            
-                func test__016__Connection__ConnectionDetails__maxMessageSize_overrides_the_default_maxMessageSize() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    client.internal.setTransport(TestProxyTransport.self)
-                    let defaultMaxMessageSize = ARTDefault.maxMessageSize()
-                    expect(defaultMaxMessageSize).to(equal(65536))
-                    defer {
-                        ARTDefault.setMaxMessageSize(defaultMaxMessageSize)
-                        client.dispose()
-                        client.close()
-                    }
-                    ARTDefault.setMaxMessageSize(1)
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { _ in
-                            let transport = client.internal.transport as! TestProxyTransport
-                            let firstConnectionDetails = transport.protocolMessagesReceived.filter{ $0.action == .connected }[0].connectionDetails
-                            expect(firstConnectionDetails!.maxMessageSize).to(equal(16384)) // Sandbox apps have a 16384 limit
-                            done()
-                        }
-                        client.connect()
-                    }
-                }
-            
-            // RTN2
-            
-                func test__017__Connection__url__should_connect_to_the_default_host() {
-                    let options = ARTClientOptions(key: "keytest:secret")
-                    options.autoConnect = false
+    waitUntil(timeout: testTimeout) { done in
+        client.connection.once(.connected) { _ in
+            done()
+        }
+        client.connect()
+    }
 
-                    let client = ARTRealtime(options: options)
-                    client.internal.setTransport(TestProxyTransport.self)
-                    client.connect()
-                    defer { client.dispose(); client.close() }
+    var _transport: ARTWebSocketTransport?
+    AblyTests.queue.sync {
+        _transport = client.internal.transport as? ARTWebSocketTransport
+    }
 
-                    if let transport = client.internal.transport as? TestProxyTransport, let url = transport.lastUrl {
-                        expect(url.host).to(equal("realtime.ably.io"))
-                    }
-                    else {
+    guard let wsTransport = _transport else {
+        fail("expected WS transport")
+        return
+    }
+
+    waitUntil(timeout: testTimeout) { done in
+        client.connection.once(.disconnected) { _ in
+            done()
+        }
+        wsTransport.webSocket(wsTransport.websocket!, didFailWithError: error)
+    }
+}
+
+private var internetConnectionNotAvailableTestsClient: ARTRealtime!
+private let fixtures = try! JSON(data: NSData(contentsOfFile: pathForTestResource(testResourcesPath + "messages-encoding.json"))! as Data, options: .mutableContainers)
+
+private func expectDataToMatch(_ message: ARTMessage, _ fixtureMessage: JSON) {
+    switch fixtureMessage["expectedType"].string! {
+    case "string":
+        expect(message.data as? NSString).to(equal(fixtureMessage["expectedValue"].string! as NSString?))
+    case "jsonObject":
+        if let data = message.data as? NSDictionary {
+            expect(JSON(data)).to(equal(fixtureMessage["expectedValue"]))
+        } else {
+            fail("expected NSDictionary")
+        }
+    case "jsonArray":
+        if let data = message.data as? NSArray {
+            expect(JSON(data)).to(equal(fixtureMessage["expectedValue"]))
+        } else {
+            fail("expected NSArray")
+        }
+    case "binary":
+        expect(message.data as? NSData).to(equal(fixtureMessage["expectedHexValue"].string!.dataFromHexadecimalString()! as NSData?))
+    default:
+        fail("unhandled: \(fixtureMessage["expectedType"].string!)")
+    }
+}
+
+private var jsonOptions: ARTClientOptions!
+private var msgpackOptions: ARTClientOptions!
+
+private func setupDependencies() {
+    if jsonOptions == nil {
+        jsonOptions = AblyTests.commonAppSetup()
+        jsonOptions.useBinaryProtocol = false
+        // Keep the same key and channel prefix
+        msgpackOptions = (jsonOptions.copy() as! ARTClientOptions)
+        msgpackOptions.useBinaryProtocol = true
+    }
+}
+
+class RealtimeClientConnection: XCTestCase {
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = ttlAndIdleIntervalPassedTestsClient
+        _ = ttlAndIdleIntervalPassedTestsConnectionId
+        _ = customTtlInterval
+        _ = customIdleInterval
+        _ = ttlAndIdleIntervalNotPassedTestsClient
+        _ = ttlAndIdleIntervalNotPassedTestsConnectionId
+        _ = expectedHostOrder
+        _ = originalARTFallback_shuffleArray
+        _ = internetConnectionNotAvailableTestsClient
+        _ = fixtures
+        _ = jsonOptions
+        _ = msgpackOptions
+
+        return super.defaultTestSuite
+    }
+
+    class TotalMessages {
+        static var expected: Int32 = 0
+        static var succeeded: Int32 = 0
+        fileprivate init() {}
+    }
+
+    // CD2c
+
+    func test__016__Connection__ConnectionDetails__maxMessageSize_overrides_the_default_maxMessageSize() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        let defaultMaxMessageSize = ARTDefault.maxMessageSize()
+        expect(defaultMaxMessageSize).to(equal(65536))
+        defer {
+            ARTDefault.setMaxMessageSize(defaultMaxMessageSize)
+            client.dispose()
+            client.close()
+        }
+        ARTDefault.setMaxMessageSize(1)
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                let transport = client.internal.transport as! TestProxyTransport
+                let firstConnectionDetails = transport.protocolMessagesReceived.filter { $0.action == .connected }[0].connectionDetails
+                expect(firstConnectionDetails!.maxMessageSize).to(equal(16384)) // Sandbox apps have a 16384 limit
+                done()
+            }
+            client.connect()
+        }
+    }
+
+    // RTN2
+
+    func test__017__Connection__url__should_connect_to_the_default_host() {
+        let options = ARTClientOptions(key: "keytest:secret")
+        options.autoConnect = false
+
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        if let transport = client.internal.transport as? TestProxyTransport, let url = transport.lastUrl {
+            expect(url.host).to(equal("realtime.ably.io"))
+        } else {
+            XCTFail("MockTransport isn't working")
+        }
+    }
+
+    func test__018__Connection__url__should_connect_with_query_string_params() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let errorInfo = stateChange.reason
+                switch state {
+                case .failed:
+                    AblyTests.checkError(errorInfo, withAlternative: "Failed state")
+                    done()
+                case .connected:
+                    if let transport = client.internal.transport as? TestProxyTransport, let query = transport.lastUrl?.query {
+                        expect(query).to(haveParam("key", withValue: options.key ?? ""))
+                        expect(query).to(haveParam("echo", withValue: "true"))
+                        expect(query).to(haveParam("format", withValue: "msgpack"))
+                    } else {
                         XCTFail("MockTransport isn't working")
                     }
+                    done()
+                default:
+                    break
                 }
+            }
+        }
+    }
 
-                func test__018__Connection__url__should_connect_with_query_string_params() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
+    func test__019__Connection__url__should_connect_with_query_string_params_including_clientId() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "client_string"
+        options.useTokenAuth = true
+        options.autoConnect = false
+        options.echoMessages = false
 
-                    let client = ARTRealtime(options: options)
-                    client.internal.setTransport(TestProxyTransport.self)
-                    client.connect()
-                    defer { client.dispose(); client.close() }
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.on { stateChange in
-                            let state = stateChange.current
-                            let errorInfo = stateChange.reason
-                            switch state {
-                            case .failed:
-                                AblyTests.checkError(errorInfo, withAlternative: "Failed state")
-                                done()
-                            case .connected:
-                                if let transport = client.internal.transport as? TestProxyTransport, let query = transport.lastUrl?.query {
-                                    expect(query).to(haveParam("key", withValue: options.key ?? ""))
-                                    expect(query).to(haveParam("echo", withValue: "true"))
-                                    expect(query).to(haveParam("format", withValue: "msgpack"))
-                                }
-                                else {
-                                    XCTFail("MockTransport isn't working")
-                                }
-                                done()
-                                break
-                            default:
-                                break
-                            }
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let errorInfo = stateChange.reason
+                switch state {
+                case .failed:
+                    AblyTests.checkError(errorInfo, withAlternative: "Failed state")
+                    done()
+                case .connected:
+                    if let transport = client.internal.transport as? TestProxyTransport, let query = transport.lastUrl?.query {
+                        expect(query).to(haveParam("accessToken", withValue: client.auth.tokenDetails?.token ?? ""))
+                        expect(query).to(haveParam("echo", withValue: "false"))
+                        expect(query).to(haveParam("format", withValue: "msgpack"))
+                        expect(query).to(haveParam("clientId", withValue: "client_string"))
+                    } else {
+                        XCTFail("MockTransport isn't working")
+                    }
+                    done()
+                default:
+                    break
+                }
+            }
+        }
+    }
+
+    // RTN3
+    func test__001__Connection__should_connect_automatically() {
+        let options = AblyTests.commonAppSetup()
+        var connected = false
+
+        // Default
+        expect(options.autoConnect).to(beTrue(), description: "autoConnect should be true by default")
+
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        // The only way to control this functionality is with the options flag
+        client.connection.on { stateChange in
+            let state = stateChange.current
+            let error = stateChange.reason
+            expect(error).to(beNil())
+            switch state {
+            case .connected:
+                connected = true
+            default:
+                break
+            }
+        }
+        expect(connected).toEventually(beTrue(), timeout: DispatchTimeInterval.seconds(10), description: "Can't connect automatically")
+    }
+
+    func test__002__Connection__should_connect_manually() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        var waiting = true
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let error = stateChange.reason
+                expect(error).to(beNil())
+                switch state {
+                case .connected:
+                    if waiting {
+                        XCTFail("Expected to be disconnected")
+                    }
+                    done()
+                default:
+                    break
+                }
+            }
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + DispatchTimeInterval.seconds(2)) {
+                waiting = false
+                client.connect()
+            }
+        }
+    }
+
+    // RTN2f
+    func test__003__Connection__API_version_param_must_be_included_in_all_connections() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connecting) { _ in
+                guard let webSocketTransport = client.internal.transport as? ARTWebSocketTransport else {
+                    fail("Transport should be of type ARTWebSocketTransport"); done()
+                    return
+                }
+                expect(webSocketTransport.websocketURL).toNot(beNil())
+
+                // This test should not directly validate version against ARTDefault.version(), as
+                // ultimately the version header has been derived from that value.
+                expect(webSocketTransport.websocketURL?.query).to(haveParam("v", withValue: "1.2"))
+
+                done()
+            }
+            client.connect()
+        }
+    }
+
+    // RTN2g (Deprecated in favor of RCS7d)
+
+    // RSC7d
+    func test__004__Connection__Library_and_version_param__agent__should_include_the__Ably_Agent__header_value() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let errorInfo = stateChange.reason
+                switch state {
+                case .failed:
+                    AblyTests.checkError(errorInfo, withAlternative: "Failed state")
+                    done()
+                case .connected:
+                    if let transport = client.internal.transport as? TestProxyTransport, let query = transport.lastUrl?.query {
+                        expect(query).to(haveParam("agent", hasPrefix: "ably-cocoa/1.2.7"))
+                    } else {
+                        XCTFail("MockTransport isn't working")
+                    }
+                    done()
+                default:
+                    break
+                }
+            }
+        }
+        client.close()
+    }
+
+    // RTN4
+
+    // RTN4a
+    func test__020__Connection__event_emitter__should_emit_events_for_state_changes() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let connection = client.connection
+        var events: [ARTRealtimeConnectionState] = []
+
+        waitUntil(timeout: testTimeout) { done in
+            var alreadyDisconnected = false
+            var alreadyClosed = false
+
+            connection.on { stateChange in
+                let state = stateChange.current
+                let errorInfo = stateChange.reason
+                switch state {
+                case .connecting:
+                    if !alreadyDisconnected {
+                        events += [state]
+                    }
+                case .connected:
+                    if alreadyClosed {
+                        delay(0) {
+                            client.internal.onSuspended()
+                        }
+                    } else if alreadyDisconnected {
+                        client.close()
+                    } else {
+                        events += [state]
+                        delay(0) {
+                            client.internal.onDisconnected()
                         }
                     }
-                }
-
-                func test__019__Connection__url__should_connect_with_query_string_params_including_clientId() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "client_string"
-                    options.useTokenAuth = true
-                    options.autoConnect = false
-                    options.echoMessages = false
-
-                    let client = ARTRealtime(options: options)
-                    client.internal.setTransport(TestProxyTransport.self)
+                case .disconnected:
+                    events += [state]
+                    alreadyDisconnected = true
+                case .suspended:
+                    events += [state]
+                    client.internal.onError(AblyTests.newErrorProtocolMessage())
+                case .closing:
+                    events += [state]
+                case .closed:
+                    events += [state]
+                    alreadyClosed = true
                     client.connect()
-                    defer { client.dispose(); client.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.on { stateChange in
-                            let state = stateChange.current
-                            let errorInfo = stateChange.reason
-                            switch state {
-                            case .failed:
-                                AblyTests.checkError(errorInfo, withAlternative: "Failed state")
-                                done()
-                            case .connected:
-                                if let transport = client.internal.transport as? TestProxyTransport, let query = transport.lastUrl?.query {
-                                    expect(query).to(haveParam("accessToken", withValue: client.auth.tokenDetails?.token ?? ""))
-                                    expect(query).to(haveParam("echo", withValue: "false"))
-                                    expect(query).to(haveParam("format", withValue: "msgpack"))
-                                    expect(query).to(haveParam("clientId", withValue: "client_string"))
-                                }
-                                else {
-                                    XCTFail("MockTransport isn't working")
-                                }
-                                done()
-                                break
-                            default:
-                                break
-                            }
-                        }
-                    }
+                case .failed:
+                    events += [state]
+                    expect(errorInfo).toNot(beNil(), description: "Error is nil")
+                    connection.off()
+                    done()
+                default:
+                    break
                 }
+            }
+            events += [connection.state]
+            connection.connect()
+        }
 
-            // RTN3
-            func test__001__Connection__should_connect_automatically() {
-                let options = AblyTests.commonAppSetup()
-                var connected = false
+        if events.count != 8 {
+            fail("Missing some states, got \(events)")
+            return
+        }
 
-                // Default
-                expect(options.autoConnect).to(beTrue(), description: "autoConnect should be true by default")
+        expect(events[0].rawValue).to(equal(ARTRealtimeConnectionState.initialized.rawValue), description: "Should be INITIALIZED state")
+        expect(events[1].rawValue).to(equal(ARTRealtimeConnectionState.connecting.rawValue), description: "Should be CONNECTING state")
+        expect(events[2].rawValue).to(equal(ARTRealtimeConnectionState.connected.rawValue), description: "Should be CONNECTED state")
+        expect(events[3].rawValue).to(equal(ARTRealtimeConnectionState.disconnected.rawValue), description: "Should be DISCONNECTED state")
+        expect(events[4].rawValue).to(equal(ARTRealtimeConnectionState.closing.rawValue), description: "Should be CLOSING state")
+        expect(events[5].rawValue).to(equal(ARTRealtimeConnectionState.closed.rawValue), description: "Should be CLOSED state")
+        expect(events[6].rawValue).to(equal(ARTRealtimeConnectionState.suspended.rawValue), description: "Should be SUSPENDED state")
+        expect(events[7].rawValue).to(equal(ARTRealtimeConnectionState.failed.rawValue), description: "Should be FAILED state")
+    }
 
+    // RTN4h
+    func test__021__Connection__event_emitter__should_never_emit_a_ConnectionState_event_for_a_state_equal_to_the_previous_state() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+        }
+
+        client.connection.once(.connected) { _ in
+            fail("Should not emit a Connected state")
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.update) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+                expect(stateChange.current).to(equal(ARTRealtimeConnectionState.connected))
+                expect(stateChange.current).to(equal(stateChange.previous))
+                done()
+            }
+
+            let authMessage = ARTProtocolMessage()
+            authMessage.action = .auth
+            client.internal.transport?.receive(authMessage)
+        }
+    }
+
+    // RTN4b
+    func test__022__Connection__event_emitter__should_emit_states_on_a_new_connection() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let connection = client.connection
+        var events: [ARTRealtimeConnectionState] = []
+
+        waitUntil(timeout: testTimeout) { done in
+            connection.on { stateChange in
+                let state = stateChange.current
+                let error = stateChange.reason
+                expect(error).to(beNil())
+                switch state {
+                case .connecting:
+                    events += [state]
+                case .connected:
+                    events += [state]
+                    done()
+                default:
+                    break
+                }
+            }
+            connection.connect()
+        }
+
+        expect(events).to(haveCount(2), description: "Missing CONNECTING or CONNECTED state")
+
+        if events.count != 2 {
+            return
+        }
+
+        expect(events[0].rawValue).to(equal(ARTRealtimeConnectionState.connecting.rawValue), description: "Should be CONNECTING state")
+        expect(events[1].rawValue).to(equal(ARTRealtimeConnectionState.connected.rawValue), description: "Should be CONNECTED state")
+    }
+
+    // RTN4c
+    func test__023__Connection__event_emitter__should_emit_states_when_connection_is_closed() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        let connection = client.connection
+        defer { client.dispose(); client.close() }
+        var events: [ARTRealtimeConnectionState] = []
+
+        waitUntil(timeout: testTimeout) { done in
+            connection.on { stateChange in
+                let state = stateChange.current
+                let error = stateChange.reason
+                expect(error).to(beNil())
+                switch state {
+                case .connected:
+                    connection.close()
+                case .closing:
+                    events += [state]
+                case .closed:
+                    events += [state]
+                    done()
+                default:
+                    break
+                }
+            }
+        }
+
+        expect(events).to(haveCount(2), description: "Missing CLOSING or CLOSED state")
+
+        if events.count != 2 {
+            return
+        }
+
+        expect(events[0].rawValue).to(equal(ARTRealtimeConnectionState.closing.rawValue), description: "Should be CLOSING state")
+        expect(events[1].rawValue).to(equal(ARTRealtimeConnectionState.closed.rawValue), description: "Should be CLOSED state")
+    }
+
+    // RTN4d
+    func test__024__Connection__event_emitter__should_have_the_current_state() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let connection = client.connection
+        expect(connection.state.rawValue).to(equal(ARTRealtimeConnectionState.initialized.rawValue), description: "Missing INITIALIZED state")
+
+        waitUntil(timeout: testTimeout) { done in
+            connection.on { stateChange in
+                let state = stateChange.current
+                let error = stateChange.reason
+                expect(error).to(beNil())
+                switch state {
+                case .connecting:
+                    expect(connection.state.rawValue).to(equal(ARTRealtimeConnectionState.connecting.rawValue), description: "Missing CONNECTING state")
+                case .connected:
+                    expect(connection.state.rawValue).to(equal(ARTRealtimeConnectionState.connected.rawValue), description: "Missing CONNECTED state")
+                    done()
+                default:
+                    break
+                }
+            }
+            client.connect()
+        }
+    }
+
+    // RTN4e
+    func test__025__Connection__event_emitter__should_have_a_ConnectionStateChange_as_first_argument_for_every_connection_state_change() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(ARTRealtimeConnectionEvent.connected) { stateChange in
+                expect(stateChange).to(beAKindOf(ARTConnectionStateChange.self))
+                expect(stateChange.current).to(equal(ARTRealtimeConnectionState.connected))
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
+                done()
+            }
+            client.connect()
+        }
+    }
+
+    // RTN4f
+    func test__026__Connection__event_emitter__should_have_the_reason_which_contains_an_ErrorInfo() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let connection = client.connection
+
+        var errorInfo: ARTErrorInfo?
+        waitUntil(timeout: testTimeout) { done in
+            connection.on { stateChange in
+                let state = stateChange.current
+                let reason = stateChange.reason
+                switch state {
+                case .connected:
+                    expect(stateChange.event).to(equal(ARTRealtimeConnectionEvent.connected))
+                    client.internal.onError(AblyTests.newErrorProtocolMessage())
+                case .failed:
+                    expect(stateChange.event).to(equal(ARTRealtimeConnectionEvent.failed))
+                    errorInfo = reason
+                    done()
+                default:
+                    break
+                }
+            }
+        }
+
+        expect(errorInfo).toNot(beNil())
+    }
+
+    // RTN4f
+    func test__027__Connection__event_emitter__any_state_change_triggered_by_a_ProtocolMessage_that_contains_an_Error_member_should_populate_the_Reason_property() {
+        let options = AblyTests.commonAppSetup()
+        options.useTokenAuth = true
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+        }
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+        guard let originalConnectedMessage = transport.protocolMessagesReceived.filter({ $0.action == .connected }).first else {
+            fail("First CONNECTED message not received"); return
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.update) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Reason error is nil"); done(); return
+                }
+                expect(error.code) == 1234
+                expect(error.message) == "fabricated error"
+                expect(stateChange.event).to(equal(ARTRealtimeConnectionEvent.update))
+                done()
+            }
+
+            let connectedMessageWithError = originalConnectedMessage
+            connectedMessageWithError.error = ARTErrorInfo.create(withCode: 1234, message: "fabricated error")
+            client.internal.transport?.receive(connectedMessageWithError)
+        }
+    }
+
+    // RTN5
+    func test__005__Connection__basic_operations_should_work_simultaneously() {
+        let options = AblyTests.commonAppSetup()
+        options.echoMessages = false
+        var disposable = [ARTRealtime]()
+        let numClients = 50
+        let numMessages = 5
+        let channelName = "chat"
+        let testTimeout = DispatchTimeInterval.seconds(60)
+
+        defer {
+            for client in disposable {
+                client.dispose()
+                client.close()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(numClients, done: done)
+            for _ in 1 ... numClients {
                 let client = ARTRealtime(options: options)
-                defer { client.dispose(); client.close() }
-                // The only way to control this functionality is with the options flag
-                client.connection.on { stateChange in
+                disposable.append(client)
+                let channel = client.channels.get(channelName)
+                channel.attach { error in
+                    if let error = error {
+                        fail(error.message); done()
+                    }
+                    partialDone()
+                }
+            }
+        }
+
+        var messagesReceived = 0
+        waitUntil(timeout: testTimeout) { done in
+            // Sends numMessages messages from different clients to the same channel
+            // numMessages messages for numClients clients = numMessages*numClients total messages
+            // echo is off, so we need to subtract one message per publish
+            let messagesExpected = numMessages * numClients - 1 * numMessages
+            var messagesSent = 0
+            for client in disposable {
+                let channel = client.channels.get(channelName)
+                expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+
+                channel.subscribe { message in
+                    expect(message.data as? String).to(equal("message_string"))
+                    messagesReceived += 1
+                    if messagesReceived == messagesExpected {
+                        done()
+                    }
+                }
+
+                if messagesSent < numMessages {
+                    channel.publish(nil, data: "message_string", callback: nil)
+                    messagesSent += 1
+                }
+            }
+        }
+
+        expect(disposable.count).to(equal(numClients))
+        expect(countChannels(disposable.first!.channels)).to(equal(1))
+        expect(countChannels(disposable.last!.channels)).to(equal(1))
+    }
+
+    // RTN6
+    func test__006__Connection__should_have_an_opened_websocket_connection_and_received_a_CONNECTED_ProtocolMessage() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer {
+            client.dispose()
+            client.close()
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let error = stateChange.reason
+                expect(error).to(beNil())
+                if state == .connected, error == nil {
+                    done()
+                }
+            }
+        }
+
+        if let webSocketTransport = client.internal.transport as? ARTWebSocketTransport {
+            expect(webSocketTransport.state).to(equal(ARTRealtimeTransportState.opened))
+        } else {
+            XCTFail("WebSocket is not the default transport")
+        }
+
+        if let transport = client.internal.transport as? TestProxyTransport {
+            // CONNECTED ProtocolMessage
+            expect(transport.protocolMessagesReceived.map { $0.action }).to(contain(ARTProtocolMessageAction.connected))
+        } else {
+            XCTFail("MockTransport is not working")
+        }
+    }
+
+    // RTN7
+
+    // RTN7a
+
+    func test__028__Connection__ACK_and_NACK__should_expect_either_an_ACK_or_NACK_to_confirm__successful_receipt_and_acceptance_of_message() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.clientId = "client_string"
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            publishFirstTestMessage(client, completion: { error in
+                expect(error).to(beNil())
+                done()
+            })
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+
+        guard let publishedMessage = transport.protocolMessagesSent.filter({ $0.action == .message }).last else {
+            XCTFail("No MESSAGE action was sent"); return
+        }
+
+        guard let receivedAck = transport.protocolMessagesReceived.filter({ $0.action == .ack }).last else {
+            XCTFail("No ACK action was received"); return
+        }
+
+        expect(publishedMessage.msgSerial).to(equal(receivedAck.msgSerial))
+    }
+
+    func test__029__Connection__ACK_and_NACK__should_expect_either_an_ACK_or_NACK_to_confirm__successful_receipt_and_acceptance_of_presence() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.clientId = "client_string"
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let error = stateChange.reason
+                expect(error).to(beNil())
+                if state == .connected {
+                    let channel = client.channels.get("test")
+                    channel.attach { error in
+                        expect(error).to(beNil())
+                        channel.presence.enterClient("client_string", data: nil, callback: { errorInfo in
+                            expect(errorInfo).to(beNil())
+                            done()
+                        })
+                    }
+                }
+            }
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+
+        guard let publishedMessage = transport.protocolMessagesSent.filter({ $0.action == .presence }).last else {
+            XCTFail("No PRESENCE action was sent"); return
+        }
+
+        guard let receivedAck = transport.protocolMessagesReceived.filter({ $0.action == .ack }).last else {
+            XCTFail("No ACK action was received"); return
+        }
+
+        expect(publishedMessage.msgSerial).to(equal(receivedAck.msgSerial))
+    }
+
+    func test__030__Connection__ACK_and_NACK__should_expect_either_an_ACK_or_NACK_to_confirm__message_failure() {
+        let options = AblyTests.commonAppSetup()
+        options.token = getTestToken(key: options.key, capability: "{ \"\(options.channelNamePrefix!)-test\":[\"subscribe\"] }")
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            publishFirstTestMessage(client, completion: { error in
+                expect(error).toNot(beNil())
+                done()
+            })
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+
+        guard let publishedMessage = transport.protocolMessagesSent.filter({ $0.action == .message }).last else {
+            XCTFail("No MESSAGE action was sent"); return
+        }
+
+        guard let receivedNack = transport.protocolMessagesReceived.filter({ $0.action == .nack }).last else {
+            XCTFail("No NACK action was received"); return
+        }
+
+        expect(publishedMessage.msgSerial).to(equal(receivedNack.msgSerial))
+    }
+
+    func test__031__Connection__ACK_and_NACK__should_expect_either_an_ACK_or_NACK_to_confirm__presence_failure() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.clientId = "client_string"
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let error = stateChange.reason
+                expect(error).to(beNil())
+                if state == .connected {
+                    let channel = client.channels.get("test")
+                    channel.attach { error in
+                        expect(error).to(beNil())
+                        channel.presence.enterClient("invalid", data: nil, callback: { errorInfo in
+                            expect(errorInfo).toNot(beNil())
+                            done()
+                        })
+                    }
+                }
+            }
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+
+        guard let publishedMessage = transport.protocolMessagesSent.filter({ $0.action == .presence }).last else {
+            XCTFail("No PRESENCE action was sent"); return
+        }
+
+        guard let receivedNack = transport.protocolMessagesReceived.filter({ $0.action == .nack }).last else {
+            XCTFail("No NACK action was received"); return
+        }
+
+        expect(publishedMessage.msgSerial).to(equal(receivedNack.msgSerial))
+    }
+
+    // RTN7b
+
+    func test__032__Connection__ACK_and_NACK__ProtocolMessage__should_contain_unique_serially_incrementing_msgSerial_along_with_the_count() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.clientId = "client_string"
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("channel")
+        channel.attach()
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+
+        TotalMessages.expected = 5
+        for index in 1 ... TotalMessages.expected {
+            channel.publish(nil, data: "message\(index)") { errorInfo in
+                if errorInfo == nil {
+                    TotalMessages.succeeded += 1
+                }
+            }
+        }
+        expect(TotalMessages.succeeded).toEventually(equal(TotalMessages.expected), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enterClient("invalid", data: nil, callback: { errorInfo in
+                expect(errorInfo).toNot(beNil())
+                done()
+            })
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+        let acks = transport.protocolMessagesReceived.filter { $0.action == .ack }
+        let nacks = transport.protocolMessagesReceived.filter { $0.action == .nack }
+
+        if acks.count != 2 {
+            fail("Received invalid number of ACK responses: \(acks.count)")
+            return
+        }
+
+        expect(acks[0].msgSerial).to(equal(0))
+        expect(acks[0].count).to(equal(1))
+
+        // Messages covered in a single ACK response
+        expect(acks[1].msgSerial).to(equal(1))
+        expect(acks[1].count).to(equal(TotalMessages.expected))
+
+        if nacks.count != 1 {
+            fail("Received invalid number of NACK responses: \(nacks.count)")
+            return
+        }
+
+        expect(nacks[0].msgSerial).to(equal(6))
+        expect(nacks[0].count).to(equal(1))
+    }
+
+    func test__033__Connection__ACK_and_NACK__ProtocolMessage__should_continue_incrementing_msgSerial_serially_if_the_connection_resumes_successfully() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "tester"
+        options.tokenDetails = getTestTokenDetails(key: options.key!, clientId: options.clientId, ttl: 5.0)
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let initialConnectionId = client.connection.id else {
+            fail("Connection ID is empty"); return
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(4, done: done)
+            (1 ... 3).forEach { index in
+                channel.publish(nil, data: "message\(index)") { error in
+                    if error == nil {
+                        partialDone()
+                    }
+                }
+            }
+            channel.presence.enterClient("invalid", data: nil) { error in
+                expect(error).toNot(beNil())
+                partialDone()
+            }
+        }
+
+        expect(client.internal.msgSerial) == 5
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.disconnected) { stateChange in
+                expect(stateChange.reason).toNot(beNil())
+                // Token expired
+                done()
+            }
+        }
+
+        // Reconnected and resumed
+        expect(client.connection.id).to(equal(initialConnectionId))
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(4, done: done)
+            (1 ... 3).forEach { index in
+                channel.publish(nil, data: "message\(index)") { error in
+                    if error == nil {
+                        partialDone()
+                    }
+                }
+            }
+            channel.presence.enterClient("invalid", data: nil) { error in
+                expect(error).toNot(beNil())
+                partialDone()
+            }
+        }
+
+        guard let reconnectedTransport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+        let acks = reconnectedTransport.protocolMessagesReceived.filter { $0.action == .ack }
+        let nacks = reconnectedTransport.protocolMessagesReceived.filter { $0.action == .nack }
+
+        if acks.count != 1 {
+            fail("Received invalid number of ACK responses: \(acks.count)")
+            return
+        }
+        // Messages covered in a single ACK response
+        expect(acks[0].msgSerial) == 5 // [0] 1st publish + [1.2.4] publish + [4] enter with invalid client + [5] queued messages
+        expect(acks[0].count) == 1
+
+        if nacks.count != 1 {
+            fail("Received invalid number of NACK responses: \(nacks.count)")
+            return
+        }
+        expect(nacks[0].msgSerial) == 6
+        expect(nacks[0].count) == 1
+
+        expect(client.internal.msgSerial) == 7
+    }
+
+    func test__034__Connection__ACK_and_NACK__ProtocolMessage__should_reset_msgSerial_serially_if_the_connection_does_not_resume() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "tester"
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let initialConnectionId = client.connection.id else {
+            fail("Connection ID is empty"); return
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(4, done: done)
+            (1 ... 3).forEach { index in
+                channel.publish(nil, data: "message\(index)") { error in
+                    if error == nil {
+                        partialDone()
+                    }
+                }
+            }
+            channel.presence.enterClient("invalid", data: nil) { error in
+                expect(error?.code).to(equal(ARTErrorCode.invalidClientId.intValue))
+                partialDone()
+            }
+        }
+
+        expect(client.internal.msgSerial) == 5
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            client.connection.once(.disconnected) { _ in
+                partialDone()
+            }
+            client.connection.once(.connected) { _ in
+                partialDone()
+            }
+            client.simulateLostConnectionAndState()
+        }
+
+        // Reconnected but not resumed
+        expect(client.connection.id).toNot(equal(initialConnectionId))
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(4, done: done)
+            (1 ... 3).forEach { index in
+                channel.publish(nil, data: "message\(index)") { error in
+                    if error == nil {
+                        partialDone()
+                    }
+                }
+            }
+            channel.presence.enterClient("invalid", data: nil) { error in
+                expect(error?.code).to(equal(ARTErrorCode.invalidClientId.intValue))
+                partialDone()
+            }
+        }
+
+        guard let reconnectedTransport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+        let acks = reconnectedTransport.protocolMessagesReceived.filter { $0.action == .ack }
+        let nacks = reconnectedTransport.protocolMessagesReceived.filter { $0.action == .nack }
+
+        // The server is free to roll up multiple acks into one or not
+        if acks.count < 1 {
+            fail("Received invalid number of ACK responses: \(acks.count)")
+            return
+        }
+        expect(acks[0].msgSerial) == 0
+        expect(acks.reduce(0) { $0 + $1.count }) == 3
+
+        if nacks.count != 1 {
+            fail("Received invalid number of NACK responses: \(nacks.count)")
+            return
+        }
+        expect(nacks[0].msgSerial) == 3
+        expect(nacks[0].count) == 1
+
+        expect(client.internal.msgSerial) == 4
+    }
+
+    // RTN7c
+
+    func test__035__Connection__ACK_and_NACK__should_trigger_the_failure_callback_for_the_remaining_pending_messages_if__connection_is_closed() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.clientId = "client_string"
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("channel")
+        let transport = client.internal.transport as! TestProxyTransport
+        transport.actionsIgnored += [.ack, .nack]
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                channel.publish(nil, data: "message", callback: { error in
+                    guard let error = error else {
+                        fail("Error is nil"); done(); return
+                    }
+                    expect(error.message).to(contain("connection broken before receiving publishing acknowledgment"))
+                    done()
+                })
+                // Wait until the message is pushed to Ably first
+                delay(1.0) {
+                    client.close()
+                }
+            }
+        }
+
+        // This verifies that the pending message as been released and the publish callback is called only once!
+        waitUntil(timeout: testTimeout) { done in
+            delay(1.0) {
+                done()
+            }
+        }
+    }
+
+    func test__036__Connection__ACK_and_NACK__should_trigger_the_failure_callback_for_the_remaining_pending_messages_if__connection_state_enters_FAILED() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.clientId = "client_string"
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("channel")
+        let transport = client.internal.transport as! TestProxyTransport
+        transport.actionsIgnored += [.ack, .nack]
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                channel.publish(nil, data: "message", callback: { errorInfo in
+                    expect(errorInfo).toNot(beNil())
+                    done()
+                })
+                // Wait until the message is pushed to Ably first
+                delay(1.0) {
+                    transport.simulateIncomingError()
+                }
+            }
+        }
+    }
+
+    func test__037__Connection__ACK_and_NACK__should_trigger_the_failure_callback_for_the_remaining_pending_messages_if__lost_connection_state() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer {
+            client.dispose()
+            client.close()
+        }
+
+        let channel = client.channels.get("channel")
+
+        let transport = client.internal.transport as! TestProxyTransport
+        transport.actionsIgnored += [.ack, .nack]
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { _ in
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(3, done: done)
+
+            channel.publish(nil, data: "message") { error in
+                guard let error = error else {
+                    fail("Error is nil"); return
+                }
+                expect(error.code) == ARTErrorCode.unableToRecoverConnectionExpired.intValue
+                expect(error.message).to(contain("Unable to recover connection"))
+                partialDone()
+            }
+
+            let oldConnectionId = client.connection.id!
+
+            // Wait until the message is pushed to Ably first
+            delay(1.0) {
+                client.connection.once(.disconnected) { _ in
+                    partialDone()
+                }
+                client.connection.once(.connected) { _ in
+                    expect(client.connection.id).toNot(equal(oldConnectionId))
+                    partialDone()
+                }
+                client.simulateLostConnectionAndState()
+            }
+        }
+    }
+
+    // RTN8
+
+    // RTN8a
+    func test__038__Connection__connection_id__should_be_null_until_connected() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        let connection = client.connection
+        defer {
+            client.dispose()
+            client.close()
+        }
+
+        expect(connection.id).to(beNil())
+
+        waitUntil(timeout: testTimeout) { done in
+            connection.on { stateChange in
+                let state = stateChange.current
+                let errorInfo = stateChange.reason
+                expect(errorInfo).to(beNil())
+                if state == .connected {
+                    expect(connection.id).toNot(beNil())
+                    done()
+                } else if state == .connecting {
+                    expect(connection.id).to(beNil())
+                }
+            }
+        }
+    }
+
+    // RTN8b
+    func test__039__Connection__connection_id__should_have_unique_IDs() {
+        let options = AblyTests.commonAppSetup()
+        var disposable = [ARTRealtime]()
+        defer {
+            for client in disposable {
+                client.dispose()
+                client.close()
+            }
+        }
+        var ids = [String]()
+        let max = 25
+        let sync = NSLock()
+
+        waitUntil(timeout: testTimeout) { done in
+            for _ in 1 ... max {
+                disposable.append(ARTRealtime(options: options))
+                let currentConnection = disposable.last!.connection
+                currentConnection.on { stateChange in
                     let state = stateChange.current
                     let error = stateChange.reason
                     expect(error).to(beNil())
+                    if state == .connected {
+                        guard let connectionId = currentConnection.id else {
+                            fail("connectionId is nil on CONNECTED")
+                            done()
+                            return
+                        }
+                        expect(ids).toNot(contain(connectionId))
+
+                        sync.lock()
+                        ids.append(connectionId)
+                        if ids.count == max {
+                            done()
+                        }
+                        sync.unlock()
+
+                        currentConnection.off()
+                        currentConnection.close()
+                    }
+                }
+            }
+        }
+
+        expect(ids).to(haveCount(max))
+    }
+
+    // RTN9
+
+    // RTN9a
+    func test__040__Connection__connection_key__should_be_null_until_connected() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer {
+            client.dispose()
+            client.close()
+        }
+        let connection = client.connection
+
+        expect(connection.key).to(beNil())
+
+        waitUntil(timeout: testTimeout) { done in
+            connection.on { stateChange in
+                let state = stateChange.current
+                let errorInfo = stateChange.reason
+                expect(errorInfo).to(beNil())
+                if state == .connected {
+                    expect(connection.id).toNot(beNil())
+                    done()
+                } else if state == .connecting {
+                    expect(connection.key).to(beNil())
+                }
+            }
+        }
+    }
+
+    // RTN9b
+    func test__041__Connection__connection_key__should_have_unique_connection_keys() {
+        let options = AblyTests.commonAppSetup()
+        var disposable = [ARTRealtime]()
+        defer {
+            for client in disposable {
+                client.dispose()
+                client.close()
+            }
+        }
+        var keys = [String]()
+        let max = 25
+
+        waitUntil(timeout: testTimeout) { done in
+            for _ in 1 ... max {
+                disposable.append(ARTRealtime(options: options))
+                let currentConnection = disposable.last!.connection
+                currentConnection.on { stateChange in
+                    let state = stateChange.current
+                    let error = stateChange.reason
+                    expect(error).to(beNil())
+                    if state == .connected {
+                        guard let connectionKey = currentConnection.key else {
+                            fail("connectionKey is nil on CONNECTED")
+                            done()
+                            return
+                        }
+                        expect(keys).toNot(contain(connectionKey))
+                        keys.append(connectionKey)
+
+                        if keys.count == max {
+                            done()
+                        }
+
+                        currentConnection.off()
+                        currentConnection.close()
+                    }
+                }
+            }
+        }
+
+        expect(keys).to(haveCount(max))
+    }
+
+    // RTN10
+
+    // RTN10a
+    func test__042__Connection__serial__should_be_minus_1_once_connected() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer {
+            client.dispose()
+            client.close()
+        }
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let error = stateChange.reason
+                expect(error).to(beNil())
+                if state == .connected {
+                    expect(client.connection.serial).to(equal(-1))
+                    done()
+                }
+            }
+        }
+    }
+
+    // RTN10b
+    func test__043__Connection__serial__should_not_update_when_a_message_is_sent_but_increments_by_one_when_ACK_is_received() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer {
+            client.dispose()
+            client.close()
+        }
+        let channel = client.channels.get("test")
+
+        expect(client.connection.serial).to(equal(-1))
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        expect(client.connection.serial).to(equal(-1))
+
+        for index in 0 ... 3 {
+            waitUntil(timeout: testTimeout) { done in
+                let partialDone = AblyTests.splitDone(2, done: done)
+                channel.publish(nil, data: "message", callback: { errorInfo in
+                    expect(errorInfo).to(beNil())
+                    partialDone()
+                })
+                channel.subscribe { _ in
+                    // Updated
+                    expect(client.connection.serial).to(equal(Int64(index)))
+                    channel.unsubscribe()
+                    partialDone()
+                }
+                // Not updated
+                expect(client.connection.serial).to(equal(Int64(index - 1)))
+            }
+        }
+    }
+
+    func test__044__Connection__serial__should_have_last_known_connection_serial_from_restored_connection() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer {
+            client.dispose()
+            client.close()
+        }
+        let channel = client.channels.get("test")
+
+        // Attach first to avoid bundling publishes in the same ProtocolMessage.
+        channel.attach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        for _ in 1 ... 5 {
+            waitUntil(timeout: testTimeout) { done in
+                let partialDone = AblyTests.splitDone(2, done: done)
+                channel.publish(nil, data: "message", callback: { errorInfo in
+                    expect(errorInfo).to(beNil())
+                    partialDone()
+                })
+                channel.subscribe { _ in
+                    channel.unsubscribe()
+                    partialDone()
+                }
+            }
+        }
+        let lastSerial = client.connection.serial
+        expect(lastSerial).to(equal(4))
+
+        options.recover = client.connection.recoveryKey
+        client.internal.onError(AblyTests.newErrorProtocolMessage())
+
+        let recoveredClient = ARTRealtime(options: options)
+        defer { recoveredClient.close() }
+        expect(recoveredClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            expect(recoveredClient.connection.serial).to(equal(lastSerial))
+            let recoveredChannel = recoveredClient.channels.get("test")
+            recoveredChannel.publish(nil, data: "message", callback: { errorInfo in
+                expect(errorInfo).to(beNil())
+            })
+            recoveredChannel.subscribe { _ in
+                expect(recoveredClient.connection.serial).to(equal(lastSerial + 1))
+                recoveredChannel.unsubscribe()
+                done()
+            }
+        }
+    }
+
+    // RTN11b
+    func test__007__Connection__should_make_a_new_connection_with_a_new_transport_instance_if_the_state_is_CLOSING() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                done()
+            }
+        }
+
+        weak var oldTransport: ARTRealtimeTransport?
+        weak var newTransport: ARTRealtimeTransport?
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+
+            client.connection.once(.closing) { _ in
+                oldTransport = client.internal.transport
+                client.connect()
+                newTransport = client.internal.transport
+                expect(newTransport).toNot(beIdenticalTo(oldTransport))
+                partialDone()
+            }
+
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(client.connection.errorReason).to(beNil())
+                partialDone()
+            }
+
+            client.close()
+        }
+
+        expect(newTransport).toNot(beNil())
+    }
+
+    // RTN11b
+    func test__008__Connection__it_should_make_sure_that__when_the_CLOSED_ProtocolMessage_arrives_for_the_old_connection__it_doesn_t_affect_the_new_one() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                done()
+            }
+        }
+
+        var oldTransport: ARTRealtimeTransport? // retain
+        weak var newTransport: ARTRealtimeTransport?
+
+        autoreleasepool {
+            waitUntil(timeout: testTimeout) { done in
+                let partialDone = AblyTests.splitDone(3, done: done)
+
+                client.connection.once(.closing) { _ in
+                    client.internalSync { _internal in
+                        oldTransport = _internal.transport
+                    }
+                    // Old connection must complete the close request
+                    weak var oldTestProxyTransport = oldTransport as? TestProxyTransport
+                    oldTestProxyTransport?.setBeforeIncomingMessageModifier { protocolMessage in
+                        if protocolMessage.action == .closed {
+                            partialDone()
+                        }
+                        return protocolMessage
+                    }
+
+                    client.connect()
+
+                    client.internalSync { _internal in
+                        newTransport = _internal.transport
+                    }
+
+                    expect(newTransport).toNot(beIdenticalTo(oldTransport))
+                    expect(newTransport).toNot(beNil())
+                    expect(oldTransport).toNot(beNil())
+                    partialDone()
+                }
+
+                client.connection.once(.closed) { _ in
+                    fail("New connection should not receive the old connection event")
+                }
+
+                client.connection.once(.connected) { _ in
+                    partialDone()
+                }
+
+                client.close()
+            }
+
+            oldTransport = nil
+        }
+
+        expect(newTransport).toNot(beNil())
+        expect(oldTransport).to(beNil())
+    }
+
+    // RTN12
+
+    // RTN12f
+    func test__045__Connection__close__if_CONNECTING__do_the_operation_once_CONNECTED() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose() }
+
+        client.connect()
+        var lastStateChange: ARTConnectionStateChange?
+        client.connection.on { stateChange in
+            lastStateChange = stateChange
+        }
+
+        client.close()
+        expect(lastStateChange).to(beNil())
+
+        expect(lastStateChange).toEventuallyNot(beNil(), timeout: testTimeout)
+        expect(lastStateChange!.current).toEventually(equal(ARTRealtimeConnectionState.closed), timeout: testTimeout)
+    }
+
+    // RTN12a
+    func test__046__Connection__close__if_CONNECTED__should_send_a_CLOSE_action__change_state_to_CLOSING_and_receive_a_CLOSED_action() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer {
+            client.dispose()
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+        var states: [ARTRealtimeConnectionState] = []
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let error = stateChange.reason
+                expect(error).to(beNil())
+                switch state {
+                case .connected:
+                    client.close()
+                case .closing:
+                    expect(transport.protocolMessagesSent.filter { $0.action == .close }).to(haveCount(1))
+                    states += [state]
+                case .closed:
+                    expect(transport.protocolMessagesReceived.filter { $0.action == .closed }).to(haveCount(1))
+                    states += [state]
+                    done()
+                default:
+                    break
+                }
+            }
+        }
+
+        if states.count != 2 {
+            fail("Invalid number of connection states. Expected CLOSING and CLOSE states")
+            return
+        }
+        expect(states[0]).to(equal(ARTRealtimeConnectionState.closing))
+        expect(states[1]).to(equal(ARTRealtimeConnectionState.closed))
+    }
+
+    // RTN12b
+    func test__047__Connection__close__should_transition_to_CLOSED_action_when_the_close_process_timeouts() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer {
+            client.dispose()
+            client.close()
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+        transport.actionsIgnored += [.closed]
+
+        var states: [ARTRealtimeConnectionState] = []
+        var start: NSDate?
+        var end: NSDate?
+
+        client.connection.on { stateChange in
+            let state = stateChange.current
+            let error = stateChange.reason
+            expect(error).to(beNil())
+            switch state {
+            case .connected:
+                client.close()
+            case .closing:
+                start = NSDate()
+                states += [state]
+            case .closed:
+                end = NSDate()
+                states += [state]
+            case .disconnected:
+                states += [state]
+            default:
+                break
+            }
+        }
+
+        expect(start).toEventuallyNot(beNil(), timeout: testTimeout)
+        expect(end).toEventuallyNot(beNil(), timeout: DispatchTimeInterval.milliseconds(Int(1000.0 * ARTDefault.realtimeRequestTimeout())))
+
+        if states.count != 2 {
+            fail("Invalid number of connection states. Expected CLOSING and CLOSE states")
+            return
+        }
+
+        expect(states[0]).to(equal(ARTRealtimeConnectionState.closing))
+        expect(states[1]).to(equal(ARTRealtimeConnectionState.closed))
+    }
+
+    // RTN12c
+    func test__048__Connection__close__transitions_to_the_CLOSING_state_and_then_to_the_CLOSED_state_if_the_transport_is_abruptly_closed() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer {
+            client.dispose()
+            client.close()
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+        var states: [ARTRealtimeConnectionState] = []
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let error = stateChange.reason
+                expect(error).to(beNil())
+                switch state {
+                case .connected:
+                    states += [state]
+                    client.close()
+                case .closing:
+                    states += [state]
+                    transport.simulateIncomingAbruptlyClose()
+                case .closed:
+                    states += [state]
+                    done()
+                case .disconnected, .suspended, .failed:
+                    states += [state]
+                default:
+                    break
+                }
+            }
+        }
+
+        if states.count != 3 {
+            fail("Invalid number of connection states. Expected CONNECTED, CLOSING and CLOSE states (got \(states.map { $0.rawValue }))")
+            return
+        }
+
+        expect(states[0]).to(equal(ARTRealtimeConnectionState.connected))
+        expect(states[1]).to(equal(ARTRealtimeConnectionState.closing))
+        expect(states[2]).to(equal(ARTRealtimeConnectionState.closed))
+    }
+
+    // RTN12d
+    func test__049__Connection__close__if_DISCONNECTED__aborts_the_retry_and_moves_immediately_to_CLOSED() {
+        let options = AblyTests.commonAppSetup()
+        options.disconnectedRetryTimeout = 1.0
+        let client = ARTRealtime(options: options)
+        defer {
+            client.close()
+            client.dispose()
+        }
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+
+        client.internal.onDisconnected()
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.disconnected), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            client.connection.once { stateChange in
+                expect(stateChange.current).to(equal(ARTRealtimeConnectionState.closed))
+                partialDone()
+            }
+
+            client.close()
+
+            delay(options.disconnectedRetryTimeout + 0.5) {
+                // Make sure the retry doesn't happen.
+                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closed))
+                partialDone()
+            }
+        }
+    }
+
+    // RTN12e
+    func test__050__Connection__close__if_SUSPENDED__aborts_the_retry_and_moves_immediately_to_CLOSED() {
+        let options = AblyTests.commonAppSetup()
+        options.suspendedRetryTimeout = 1.0
+        let client = ARTRealtime(options: options)
+        defer {
+            client.close()
+            client.dispose()
+        }
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+
+        client.internal.onSuspended()
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.suspended), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            client.connection.once { stateChange in
+                expect(stateChange.current).to(equal(ARTRealtimeConnectionState.closed))
+                partialDone()
+            }
+
+            client.close()
+
+            delay(options.suspendedRetryTimeout + 0.5) {
+                // Make sure the retry doesn't happen.
+                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closed))
+                partialDone()
+            }
+        }
+    }
+
+    // RTN13
+
+    // RTN13b
+    func test__051__Connection__ping__fails_if_in_the_INITIALIZED__SUSPENDED__CLOSING__CLOSED_or_FAILED_state() {
+        let options = AblyTests.commonAppSetup()
+        options.suspendedRetryTimeout = 0.1
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer {
+            client.close()
+            client.dispose()
+        }
+
+        var error: ARTErrorInfo?
+        func ping() {
+            error = nil
+            waitUntil(timeout: testTimeout) { done in
+                client.ping { e in
+                    error = e
+                    done()
+                }
+            }
+        }
+
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.initialized))
+        ping()
+        expect(error).toNot(beNil())
+
+        client.connect()
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        client.internal.onSuspended()
+
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.suspended))
+        ping()
+        expect(error).toNot(beNil())
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        client.close()
+
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closing))
+        ping()
+        expect(error).toNot(beNil())
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.closed), timeout: testTimeout)
+        ping()
+        expect(error).toNot(beNil())
+
+        client.internal.onError(AblyTests.newErrorProtocolMessage())
+
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.failed))
+        ping()
+        expect(error).toNot(beNil())
+    }
+
+    // RTN13a
+    func test__052__Connection__ping__should_send_a_ProtocolMessage_with_action_HEARTBEAT_and_expects_a_HEARTBEAT_message_in_response() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        waitUntil(timeout: testTimeout) { done in
+            client.ping { error in
+                expect(error).to(beNil())
+                let transport = client.internal.transport as! TestProxyTransport
+                expect(transport.protocolMessagesSent.filter { $0.action == .heartbeat }).to(haveCount(1))
+                expect(transport.protocolMessagesReceived.filter { $0.action == .heartbeat }).to(haveCount(1))
+                done()
+            }
+        }
+    }
+
+    // RTN13c
+    func test__053__Connection__ping__should_fail_if_a_HEARTBEAT_ProtocolMessage_is_not_received_within_the_default_realtime_request_timeout() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                done()
+            }
+        }
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(3.0)
+
+        transport.actionsIgnored += [.heartbeat]
+
+        waitUntil(timeout: testTimeout) { done in
+            let start = NSDate()
+            transport.ignoreSends = true
+
+            client.ping { error in
+                guard let error = error else {
+                    fail("expected error"); done(); return
+                }
+                let end = NSDate()
+                expect(error.message).to(contain("timed out"))
+                expect(end.timeIntervalSince(start as Date)).to(beCloseTo(ARTDefault.realtimeRequestTimeout(), within: 1.5))
+                done()
+            }
+        }
+    }
+
+    // RTN14a
+    func test__009__Connection__should_enter_FAILED_state_when_API_key_is_invalid() {
+        let options = AblyTests.commonAppSetup()
+        options.key = String(options.key!.reversed())
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer {
+            client.dispose()
+            client.close()
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let errorInfo = stateChange.reason
+                switch state {
+                case .failed:
+                    expect(errorInfo).toNot(beNil())
+                    done()
+                default:
+                    break
+                }
+            }
+            client.connect()
+        }
+    }
+
+    // RTN14b
+
+    func test__054__Connection__connection_request_fails__on_DISCONNECTED_after_CONNECTED__should_not_emit_error_with_a_renewable_token() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.authCallback = { tokenParams, callback in
+            getTestTokenDetails(key: options.key, capability: tokenParams.capability, ttl: tokenParams.ttl as! TimeInterval?, completion: callback)
+        }
+        let tokenTtl = 3.0
+        options.token = getTestToken(key: options.key, ttl: tokenTtl)
+
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        defer {
+            client.dispose()
+            client.close()
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            // Let the token expire
+            client.connection.once(.disconnected) { stateChange in
+                guard let reason = stateChange.reason else {
+                    fail("Token error is missing"); done(); return
+                }
+                expect(reason.code) == ARTErrorCode.tokenExpired.intValue
+
+                client.connection.on { stateChange in
+                    let state = stateChange.current
+                    let errorInfo = stateChange.reason
                     switch state {
                     case .connected:
-                        connected = true
+                        expect(errorInfo).to(beNil())
+                        // New token
+                        expect(client.auth.tokenDetails!.token).toNot(equal(options.token))
+                        done()
+                    case .failed, .suspended:
+                        fail("Should not emit error (\(String(describing: errorInfo)))")
+                        done()
                     default:
                         break
                     }
                 }
-                expect(connected).toEventually(beTrue(), timeout: DispatchTimeInterval.seconds(10), description: "Can't connect automatically")
+            }
+            client.connect()
+        }
+    }
+
+    func test__055__Connection__connection_request_fails__on_token_error_while_CONNECTING__reissues_token_and_reconnects() {
+        var authCallbackCalled = 0
+
+        var tokenTTL = 1.0
+
+        let options = AblyTests.commonAppSetup()
+        options.authCallback = { _, callback in
+            authCallbackCalled += 1
+            getTestTokenDetails(ttl: tokenTTL) { token, err in
+                // Let the token expire
+                delay(2.0) {
+                    callback(token, err)
+                }
+                // Next time, tokenTTL will be longer so that it doesn't expire right away
+                tokenTTL = 60
+            }
+        }
+        options.autoConnect = false
+
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.close() }
+
+        var hookToken: AspectToken?
+        waitUntil(timeout: testTimeout.multiplied(by: 2)) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            realtime.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                partialDone()
+            }
+            hookToken = realtime.internal.testSuite_getArgument(from: NSSelectorFromString("onError:"), at: 0) { arg0 in
+                guard let message = arg0 as? ARTProtocolMessage, let error = message.error else {
+                    fail("Expecting a protocol message with Token error"); partialDone(); return
+                }
+                expect(error.code).to(equal(ARTErrorCode.tokenExpired.intValue))
+                partialDone()
+            }
+            realtime.connect()
+        }
+        hookToken?.remove()
+
+        // First token issue, and then reissue on token error.
+        expect(authCallbackCalled).to(equal(2))
+    }
+
+    func test__056__Connection__connection_request_fails__should_transition_to_disconnected_when_the_token_renewal_fails() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let tokenTtl = 3.0
+        let tokenDetails = getTestTokenDetails(key: options.key, capability: nil, ttl: tokenTtl)!
+        options.token = tokenDetails.token
+        options.authCallback = { _, callback in
+            delay(0) {
+                callback(tokenDetails, nil) // Return the same expired token again.
+            }
+        }
+
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        defer {
+            client.dispose()
+            client.close()
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                partialDone()
+            }
+            client.connection.once(.disconnected) { stateChange in
+                guard let reason = stateChange.reason else {
+                    fail("Reason is nil"); done(); return
+                }
+                expect(reason.code).to(equal(ARTErrorCode.tokenExpired.intValue))
+                expect(reason.statusCode).to(equal(401))
+                expect(reason.message).to(contain("Key/token status changed (expire)"))
+                partialDone()
+            }
+            client.connect()
+        }
+    }
+
+    func test__057__Connection__connection_request_fails__should_transition_to_Failed_state_because_the_token_is_invalid_and_not_renewable() {
+        let options = AblyTests.clientOptions()
+        options.autoConnect = false
+        let tokenTtl = 1.0
+        options.token = getTestToken(ttl: tokenTtl)
+
+        // Let the token expire
+        waitUntil(timeout: testTimeout) { done in
+            delay(tokenTtl) {
+                done()
+            }
+        }
+
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        defer {
+            client.dispose()
+            client.close()
+        }
+
+        var transport: TestProxyTransport!
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                let state = stateChange.current
+                let errorInfo = stateChange.reason
+                switch state {
+                case .connected:
+                    fail("Should not be connected")
+                    done()
+                case .failed, .disconnected, .suspended:
+                    guard let errorInfo = errorInfo else {
+                        fail("ErrorInfo is nil"); done(); return
+                    }
+                    expect(errorInfo.code).to(equal(ARTErrorCode.tokenExpired.intValue))
+                    done()
+                default:
+                    break
+                }
+            }
+            client.connect()
+            transport = (client.internal.transport as! TestProxyTransport)
+        }
+
+        let failures = transport.protocolMessagesReceived.filter { $0.action == .error }
+
+        if failures.count != 1 {
+            fail("Should have only one connection request fail")
+            return
+        }
+
+        expect(failures[0].error!.code).to(equal(ARTErrorCode.tokenExpired.intValue))
+    }
+
+    // RTN14c
+    func test__058__Connection__connection_request_fails__connection_attempt_should_fail_if_not_connected_within_the_default_realtime_request_timeout() {
+        let options = AblyTests.commonAppSetup()
+        options.realtimeHost = "10.255.255.1" // non-routable IP address
+        options.autoConnect = false
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(0.5)
+
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        var start, end: NSDate?
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on(.disconnected) { stateChange in
+                end = NSDate()
+                expect(stateChange.reason!.message).to(contain("timed out"))
+                expect(client.connection.errorReason!).to(beIdenticalTo(stateChange.reason))
+                done()
+            }
+            client.connect()
+            start = NSDate()
+        }
+        if let start = start, let end = end {
+            expect(end.timeIntervalSince(start as Date)).to(beCloseTo(ARTDefault.realtimeRequestTimeout(), within: 1.5))
+        } else {
+            fail("Start date or end date are empty")
+        }
+    }
+
+    // RTN14d
+    func test__059__Connection__connection_request_fails__connection_attempt_fails_for_any_recoverable_reason() {
+        let options = AblyTests.commonAppSetup()
+        options.realtimeHost = "10.255.255.1" // non-routable IP address
+        options.disconnectedRetryTimeout = 1.0
+        options.autoConnect = false
+        let expectedTime = 3.0
+
+        options.authCallback = { _, _ in
+            // Ignore `completion` closure to force a time out
+        }
+
+        let previousConnectionStateTtl = ARTDefault.connectionStateTtl()
+        defer { ARTDefault.setConnectionStateTtl(previousConnectionStateTtl) }
+        ARTDefault.setConnectionStateTtl(expectedTime)
+
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(0.1)
+
+        let client = ARTRealtime(options: options)
+        client.internal.shouldImmediatelyReconnect = false
+        defer {
+            client.connection.off()
+            client.close()
+        }
+
+        var totalRetry = 0
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            var start: NSDate?
+
+            client.connection.once(.disconnected) { stateChange in
+                expect(stateChange.reason!.message).to(contain("timed out"))
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
+                expect(stateChange.retryIn).to(beCloseTo(options.disconnectedRetryTimeout))
+                partialDone()
+                start = NSDate()
             }
 
-            func test__002__Connection__should_connect_manually() {
-                let options = AblyTests.commonAppSetup()
-                options.autoConnect = false
+            client.connection.on(.suspended) { _ in
+                let end = NSDate()
+                expect(end.timeIntervalSince(start! as Date)).to(beCloseTo(expectedTime, within: 0.9))
+                partialDone()
+            }
 
-                let client = ARTRealtime(options: options)
-                defer { client.dispose(); client.close() }
-                var waiting = true
+            client.connect()
 
-                waitUntil(timeout: testTimeout) { done in
-                    client.connection.on { stateChange in
-                        let state = stateChange.current
-                        let error = stateChange.reason
-                        expect(error).to(beNil())
-                        switch state {
-                        case .connected:
-                            if waiting {
-                                XCTFail("Expected to be disconnected")
-                            }
+            client.connection.on(.connecting) { stateChange in
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.disconnected))
+                totalRetry += 1
+            }
+        }
+
+        expect(totalRetry).to(equal(Int(expectedTime / options.disconnectedRetryTimeout)))
+    }
+
+    // RTN14e
+    func test__060__Connection__connection_request_fails__connection_state_has_been_in_the_DISCONNECTED_state_for_more_than_the_default_connectionStateTtl_should_change_the_state_to_SUSPENDED() {
+        let options = AblyTests.commonAppSetup()
+        options.disconnectedRetryTimeout = 0.1
+        options.suspendedRetryTimeout = 0.5
+        options.autoConnect = false
+
+        options.authCallback = { _, _ in
+            // Force a timeout
+        }
+
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(0.1)
+
+        let client = ARTRealtime(options: options)
+        client.internal.shouldImmediatelyReconnect = false
+        defer { client.dispose(); client.close() }
+
+        let ttlHookToken = client.overrideConnectionStateTTL(0.3)
+        defer { ttlHookToken.remove() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on(.suspended) { _ in
+                expect(client.connection.errorReason!.message).to(contain("timed out"))
+
+                let start = NSDate()
+                client.connection.once(.connecting) { _ in
+                    let end = NSDate()
+                    expect(end.timeIntervalSince(start as Date)).to(beCloseTo(options.suspendedRetryTimeout, within: 0.5))
+                    done()
+                }
+            }
+            client.connect()
+        }
+    }
+
+    // RTN14e - https://github.com/ably/ably-cocoa/issues/913
+    func test__061__Connection__connection_request_fails__should_change_the_state_to_SUSPENDED_when_the_connection_state_has_been_in_the_DISCONNECTED_state_for_more_than_the_connectionStateTtl() {
+        let options = AblyTests.commonAppSetup()
+        options.disconnectedRetryTimeout = 0.5
+        options.suspendedRetryTimeout = 2.0
+        options.autoConnect = false
+
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.internal.setReachabilityClass(TestReachability.self)
+        defer {
+            client.simulateRestoreInternetConnection()
+            client.dispose()
+            client.close()
+        }
+
+        let ttlHookToken = client.overrideConnectionStateTTL(3.0)
+        defer { ttlHookToken.remove() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+            client.connect()
+        }
+
+        var events: [ARTRealtimeConnectionState] = []
+        client.connection.on { stateChange in
+            events.append(stateChange.current)
+        }
+        client.simulateNoInternetConnection()
+
+        expect(events).toEventually(equal([
+            .disconnected,
+            .connecting, // 0.5 - 1
+            .disconnected,
+            .connecting, // 1.0 - 2
+            .disconnected,
+            .connecting, // 1.5 - 3
+            .disconnected,
+            .connecting, // 2.0 - 4
+            .disconnected,
+            .connecting, // 2.5 - 5
+            .disconnected,
+            .connecting, // 3.0 - 6
+            .suspended,
+            .connecting,
+            .suspended,
+        ]), timeout: testTimeout)
+
+        events.removeAll()
+        client.simulateRestoreInternetConnection(after: 7.0)
+
+        expect(events).toEventually(equal([
+            .connecting, // 2.0 - 1
+            .suspended,
+            .connecting, // 4.0 - 2
+            .suspended,
+            .connecting, // 6.0 - 3
+            .suspended,
+            .connecting,
+            .connected,
+        ]), timeout: testTimeout)
+
+        client.connection.off()
+
+        expect(client.connection.errorReason).to(beNil())
+        expect(client.connection.state).to(equal(.connected))
+    }
+
+    func test__062__Connection__connection_request_fails__on_CLOSE_the_connection_should_stop_connection_retries() {
+        let options = AblyTests.commonAppSetup()
+        // to avoid waiting for the default 15s before trying a reconnection
+        options.disconnectedRetryTimeout = 0.1
+        options.suspendedRetryTimeout = 0.5
+        options.autoConnect = false
+        let expectedTime: TimeInterval = 1.0
+
+        options.authCallback = { _, _ in
+            // Force a timeout
+        }
+
+        let previousConnectionStateTtl = ARTDefault.connectionStateTtl()
+        defer { ARTDefault.setConnectionStateTtl(previousConnectionStateTtl) }
+        ARTDefault.setConnectionStateTtl(expectedTime)
+
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(0.1)
+
+        let client = ARTRealtime(options: options)
+        client.internal.shouldImmediatelyReconnect = false
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on(.suspended) { _ in
+                expect(client.connection.errorReason!.message).to(contain("timed out"))
+
+                let start = NSDate()
+                client.connection.once(.connecting) { _ in
+                    let end = NSDate()
+                    expect(end.timeIntervalSince(start as Date)).to(beCloseTo(options.suspendedRetryTimeout, within: 0.5))
+                    done()
+                }
+            }
+            client.connect()
+        }
+
+        client.close()
+
+        // Check if the connection gets closed
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connecting) { _ in
+                fail("Should be closing the connection"); done()
+            }
+            delay(2.0) {
+                done()
+            }
+        }
+    }
+
+    // RTN15
+
+    // RTN15a
+    func test__063__Connection__connection_failures_once_CONNECTED__should_not_receive_published_messages_until_the_connection_reconnects_successfully() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+
+        let client1 = ARTRealtime(options: options)
+        defer { client1.close() }
+        let channel1 = client1.channels.get("test")
+
+        var states = [ARTRealtimeConnectionState]()
+        client1.connection.on { stateChange in
+            states = states + [stateChange.current]
+        }
+        client1.connect()
+
+        let client2 = ARTRealtime(options: options)
+        client2.connect()
+        defer { client2.close() }
+        let channel2 = client2.channels.get("test")
+
+        channel1.subscribe { _ in
+            fail("Shouldn't receive the messsage")
+        }
+
+        expect(channel1.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        let firstConnection: (id: String, key: String) = (client1.connection.id!, client1.connection.key!)
+
+        // Connection state cannot be resumed
+        client1.simulateLostConnectionAndState()
+
+        channel2.publish(nil, data: "message") { errorInfo in
+            expect(errorInfo).to(beNil())
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            client1.connection.once(.connecting) { _ in
+                expect(client1.internal.resuming).to(beTrue())
+                partialDone()
+            }
+            client1.connection.once(.connected) { _ in
+                expect(client1.internal.resuming).to(beFalse())
+                expect(client1.connection.id).toNot(equal(firstConnection.id))
+                expect(client1.connection.key).toNot(equal(firstConnection.key))
+                partialDone()
+            }
+        }
+
+        expect(states).toEventually(equal([.connecting, .connected, .disconnected, .connecting, .connected]), timeout: testTimeout)
+    }
+
+    // RTN15a
+    func test__064__Connection__connection_failures_once_CONNECTED__if_a_Connection_transport_is_disconnected_unexpectedly_or_if_a_token_expires__then_the_Connection_manager_will_immediately_attempt_to_reconnect() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.tokenDetails = getTestTokenDetails(ttl: 3.0)
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on(.disconnected) { _ in
+                let disconnectedTime = Date()
+                client.connection.on(.connected) { _ in
+                    let reconnectedTime = Date()
+                    // test that reconnection happens within 10 seconds,
+                    // so that we are sure it doesn't wait for the default 15s
+                    expect(reconnectedTime.timeIntervalSince(disconnectedTime)).to(beCloseTo(0, within: 10))
+                    done()
+                }
+            }
+            client.connect()
+        }
+    }
+
+    // RTN15b
+
+    // RTN15b1, RTN15b2
+    func test__067__Connection__connection_failures_once_CONNECTED__reconnects_to_the_websocket_endpoint_with_additional_querystring_params__resume_is_the_private_connection_key_and_connection_serial_is_the_most_recent_ProtocolMessage_connectionSerial_received() {
+        let options = AblyTests.commonAppSetup()
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        let expectedConnectionKey = client.connection.key!
+        let expectedConnectionSerial = client.connection.serial
+        client.internal.onDisconnected()
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                let transport = client.internal.transport as! TestProxyTransport
+                let query = transport.lastUrl!.query
+                expect(query).to(haveParam("resume", withValue: expectedConnectionKey))
+                expect(query).to(haveParam("connectionSerial", withValue: "\(expectedConnectionSerial)"))
+                done()
+            }
+        }
+    }
+
+    // RTN15c
+
+    // RTN15c1
+    func test__068__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__CONNECTED_ProtocolMessage_with_the_same_connectionId_as_the_current_client__and_no_error() {
+        let options = AblyTests.commonAppSetup()
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        let expectedConnectionId = client.connection.id
+        client.internal.onDisconnected()
+
+        channel.attach()
+        channel.publish(nil, data: "queued message")
+        expect(client.internal.queuedMessages).toEventually(haveCount(1), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                let transport = client.internal.transport as! TestProxyTransport
+                let connectedPM = transport.protocolMessagesReceived.filter { $0.action == .connected }[0]
+                expect(connectedPM.connectionId).to(equal(expectedConnectionId))
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+        }
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+        expect(client.internal.queuedMessages).toEventually(haveCount(0), timeout: testTimeout)
+    }
+
+    // RTN15c2
+    func test__069__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__CONNECTED_ProtocolMessage_with_the_same_connectionId_as_the_current_client_and_an_non_fatal_error() {
+        let options = AblyTests.commonAppSetup()
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+
+        let expectedConnectionId = client.connection.id
+        client.internalAsync { _internal in
+            _internal.onDisconnected()
+        }
+
+        channel.attach()
+        channel.publish(nil, data: "queued message")
+        expect(client.internal.queuedMessages).toEventually(haveCount(1), timeout: testTimeout)
+
+        client.connection.once(.connecting) { _ in
+            client.internalSync { _internal in
+                let transport = _internal.transport as! TestProxyTransport
+                transport.setBeforeIncomingMessageModifier { protocolMessage in
+                    if protocolMessage.action == .connected {
+                        protocolMessage.error = .create(withCode: 0, message: "Injected error")
+                    } else if protocolMessage.action == .attached {
+                        protocolMessage.error = .create(withCode: 0, message: "Channel injected error")
+                    }
+                    return protocolMessage
+                }
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason?.message).to(equal("Injected error"))
+                expect(client.connection.errorReason).to(beIdenticalTo(stateChange.reason))
+                let transport = client.internal.transport as! TestProxyTransport
+                let connectedPM = transport.protocolMessagesReceived.filter { $0.action == .connected }[0]
+                expect(connectedPM.connectionId).to(equal(expectedConnectionId))
+                expect(client.connection.id).to(equal(expectedConnectionId))
+                partialDone()
+            }
+            channel.once(.attached) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Reason error is nil"); done(); return
+                }
+                expect(error.message).to(equal("Channel injected error"))
+                expect(channel.errorReason).to(beIdenticalTo(error))
+                partialDone()
+            }
+        }
+
+        expect(client.internal.queuedMessages).toEventually(haveCount(0), timeout: testTimeout)
+    }
+
+    // RTN15c3
+    func test__070__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__CONNECTED_ProtocolMessage_with_a_new_connectionId_and_an_error() {
+        let options = AblyTests.commonAppSetup()
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        let oldConnectionId = client.connection.id
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+
+            channel.once(.attaching) { _ in
+                expect(channel.errorReason).to(beNil())
+                partialDone()
+            }
+
+            client.connection.once(.connected) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Connection resume failed and error should be propagated to the channel"); done(); return
+                }
+                expect(error.code).to(equal(ARTErrorCode.unableToRecoverConnectionExpired.intValue))
+                expect(error.message).to(contain("Unable to recover connection"))
+                expect(client.connection.errorReason).to(beIdenticalTo(stateChange.reason))
+                partialDone()
+            }
+
+            client.simulateLostConnectionAndState()
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+        let connectedPM = transport.protocolMessagesReceived.filter { $0.action == .connected }[0]
+        expect(connectedPM.connectionId).toNot(equal(oldConnectionId))
+        expect(client.connection.id).to(equal(connectedPM.connectionId))
+        expect(client.internal.msgSerial).to(equal(0))
+
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+    }
+
+    // RTN15c4
+    func test__071__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__ERROR_ProtocolMessage_indicating_a_fatal_error_in_the_connection() {
+        let options = AblyTests.commonAppSetup()
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+
+        client.internal.onDisconnected()
+
+        let protocolError = AblyTests.newErrorProtocolMessage()
+        client.connection.once(.connecting) { _ in
+            // Resuming
+            guard let transport = client.internal.transport as? TestProxyTransport else {
+                fail("TestProxyTransport is not set"); return
+            }
+            transport.actionsIgnored += [.connected]
+            client.internal.onError(protocolError)
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.failed) { stateChange in
+                expect(stateChange.reason).to(beIdenticalTo(protocolError.error))
+                expect(client.connection.errorReason).to(beIdenticalTo(protocolError.error))
+                done()
+            }
+        }
+        expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+        expect(channel.errorReason).to(beIdenticalTo(protocolError.error))
+    }
+
+    func skipped__test__072__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__should_resume_the_connection_after_an_auth_renewal() {
+        let options = AblyTests.commonAppSetup()
+        options.tokenDetails = getTestTokenDetails(ttl: 5.0)
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let restOptions = AblyTests.clientOptions(key: options.key!)
+        restOptions.channelNamePrefix = options.channelNamePrefix
+        let rest = ARTRest(options: restOptions)
+
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        let initialConnectionId = client.connection.id
+
+        guard let _ = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        channel.once(.detached) { _ in
+            fail("Should not detach channels")
+        }
+        defer { channel.off() }
+
+        waitUntil(timeout: testTimeout) { done in
+            // Wait for token to expire
+            client.connection.once(.disconnected) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error.code) == ARTErrorCode.tokenExpired.intValue
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            // Wait for connection resume
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+        }
+
+        guard let secondTransport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        let connectedMessages = secondTransport.protocolMessagesReceived.filter { $0.action == .connected }
+        expect(connectedMessages).to(haveCount(1)) // New transport connected
+        guard let receivedConnectionId = connectedMessages.first?.connectionId else {
+            fail("ConnectionID is nil"); return
+        }
+        expect(client.connection.id).to(equal(receivedConnectionId))
+        expect(client.connection.id).to(equal(initialConnectionId))
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            let expectedMessage = ARTMessage(name: "ios", data: "message1")
+
+            channel.subscribe { message in
+                expect(message.name).to(equal(expectedMessage.name))
+                expect(message.data as? String).to(equal(expectedMessage.data as? String))
+                partialDone()
+            }
+
+            rest.channels.get("test").publish([expectedMessage]) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
+    }
+
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    // RTN15d
+    func skipped__test__065__Connection__connection_failures_once_CONNECTED__should_recover_from_disconnection_and_messages_should_be_delivered_once_the_connection_is_resumed() {
+        let options = AblyTests.commonAppSetup()
+
+        let client1 = ARTRealtime(options: options)
+        defer { client1.close() }
+        let channel1 = client1.channels.get("test")
+
+        let client2 = ARTRealtime(options: options)
+        defer { client2.close() }
+        let channel2 = client2.channels.get("test")
+
+        let expectedMessages = ["message X", "message Y"]
+        var receivedMessages = [String]()
+
+        waitUntil(timeout: testTimeout) { done in
+            channel1.subscribe(attachCallback: { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }, callback: { message in
+                receivedMessages.append(message.data as! String)
+            })
+        }
+
+        client1.internal.onDisconnected()
+
+        channel2.publish(expectedMessages.map { ARTMessage(name: nil, data: $0) }) { errorInfo in
+            expect(errorInfo).to(beNil())
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            client1.connection.once(.connecting) { _ in
+                expect(receivedMessages).to(beEmpty())
+                done()
+            }
+        }
+
+        expect(client1.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        expect(receivedMessages).toEventually(equal(expectedMessages), timeout: testTimeout)
+    }
+
+    // RTN15e
+
+    func test__073__Connection__connection_failures_once_CONNECTED__when_a_connection_is_resumed__the_connection_key_may_change_and_will_be_provided_in_the_first_CONNECTED_ProtocolMessage_connectionDetails() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        channel.attach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        client.internal.onDisconnected()
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connecting) { _ in
+                client.connection.internal.setKey("key_to_be_replaced")
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                let transport = client.internal.transport as! TestProxyTransport
+                let firstConnectionDetails = transport.protocolMessagesReceived.filter { $0.action == .connected }[0].connectionDetails
+                expect(firstConnectionDetails!.connectionKey).toNot(beNil())
+                expect(client.connection.key).to(equal(firstConnectionDetails!.connectionKey))
+                done()
+            }
+        }
+    }
+
+    // RTN15f
+    func test__066__Connection__connection_failures_once_CONNECTED__ACK_and_NACK_responses_for_published_messages_can_only_ever_be_received_on_the_transport_connection_on_which_those_messages_were_sent() {
+        let options = AblyTests.commonAppSetup()
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        var resumed = false
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+
+            guard let transport1 = client.internal.transport as? TestProxyTransport else {
+                fail("TestProxyTransport not setup"); done(); return
+            }
+
+            var sentPendingMessage: ARTMessage?
+            channel.publish(nil, data: "message") { _ in
+                if resumed {
+                    guard let transport2 = client.internal.transport as? TestProxyTransport else {
+                        fail("TestProxyTransport not setup"); done(); return
+                    }
+                    expect(transport2.protocolMessagesReceived.filter { $0.action == .ack }).to(haveCount(1))
+
+                    guard let _ = transport1.protocolMessagesSent.filter({ $0.action == .message }).first?.messages?.first else {
+                        fail("Message that has been re-sent isn't available"); done(); return
+                    }
+                    guard let sentTransportMessage2 = transport2.protocolMessagesSent.filter({ $0.action == .message }).first?.messages?.first else {
+                        fail("Message that has been re-sent isn't available"); done(); return
+                    }
+
+                    expect(transport1).toNot(beIdenticalTo(transport2))
+                    expect(sentPendingMessage).to(beIdenticalTo(sentTransportMessage2))
+
+                    partialDone()
+                } else {
+                    fail("Shouldn't be called")
+                }
+            }
+            AblyTests.queue.async {
+                client.internal.onDisconnected()
+            }
+            client.connection.once(.connected) { _ in
+                resumed = true
+            }
+            client.internal.testSuite_injectIntoMethod(before: Selector(("resendPendingMessages"))) {
+                expect(client.internal.pendingMessages.count).to(equal(1))
+                let pm: ARTProtocolMessage? = (client.internal.pendingMessages.firstObject as? ARTPendingMessage)?.msg
+                sentPendingMessage = pm?.messages?[0]
+            }
+            client.internal.testSuite_injectIntoMethod(after: Selector(("resendPendingMessages"))) {
+                partialDone()
+            }
+        }
+    }
+
+    // RTN15g RTN15g1
+
+    func skipped__test__074__Connection__connection_failures_once_CONNECTED__when_connection__ttl_plus_idle_interval__period_has_passed_since_last_activity__uses_a_new_connection() {
+        let options = AblyTests.commonAppSetup()
+        // We want this to be > than the sum of customTtlInterval and customIdleInterval
+        options.disconnectedRetryTimeout = 5.0 + customTtlInterval + customIdleInterval
+        ttlAndIdleIntervalPassedTestsClient = AblyTests.newRealtime(options)
+        ttlAndIdleIntervalPassedTestsClient.internal.shouldImmediatelyReconnect = false
+        ttlAndIdleIntervalPassedTestsClient.connect()
+        defer { ttlAndIdleIntervalPassedTestsClient.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            ttlAndIdleIntervalPassedTestsClient.connection.once(.connected) { _ in
+                expect(ttlAndIdleIntervalPassedTestsClient.connection.id).toNot(beNil())
+                ttlAndIdleIntervalPassedTestsConnectionId = ttlAndIdleIntervalPassedTestsClient.connection.id!
+                ttlAndIdleIntervalPassedTestsClient.internal.connectionStateTtl = customTtlInterval
+                ttlAndIdleIntervalPassedTestsClient.internal.maxIdleInterval = customIdleInterval
+                ttlAndIdleIntervalPassedTestsClient.connection.once(.disconnected) { _ in
+                    let disconnectedAt = Date()
+                    expect(ttlAndIdleIntervalPassedTestsClient.internal.connectionStateTtl).to(equal(customTtlInterval))
+                    expect(ttlAndIdleIntervalPassedTestsClient.internal.maxIdleInterval).to(equal(customIdleInterval))
+                    ttlAndIdleIntervalPassedTestsClient.connection.once(.connecting) { _ in
+                        let reconnectionInterval = Date().timeIntervalSince(disconnectedAt)
+                        expect(reconnectionInterval).to(beGreaterThan(ttlAndIdleIntervalPassedTestsClient.internal.connectionStateTtl + ttlAndIdleIntervalPassedTestsClient.internal.maxIdleInterval))
+                        ttlAndIdleIntervalPassedTestsClient.connection.once(.connected) { _ in
+                            expect(ttlAndIdleIntervalPassedTestsClient.connection.id).toNot(equal(ttlAndIdleIntervalPassedTestsConnectionId))
                             done()
-                        default:
-                            break
                         }
                     }
-                    DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + DispatchTimeInterval.seconds(2)) {
-                        waiting = false
-                        client.connect()
+                }
+                ttlAndIdleIntervalPassedTestsClient.internal.onDisconnected()
+            }
+        }
+    }
+
+    // RTN15g3
+    func test__075__Connection__connection_failures_once_CONNECTED__when_connection__ttl_plus_idle_interval__period_has_passed_since_last_activity__reattaches_to_the_same_channels_after_a_new_connection_has_been_established() {
+        let options = AblyTests.commonAppSetup()
+        // We want this to be > than the sum of customTtlInterval and customIdleInterval
+        options.disconnectedRetryTimeout = 5.0
+        ttlAndIdleIntervalPassedTestsClient = AblyTests.newRealtime(options)
+        ttlAndIdleIntervalPassedTestsClient.internal.shouldImmediatelyReconnect = false
+        defer { ttlAndIdleIntervalPassedTestsClient.close() }
+        let channelName = "test-reattach-after-ttl"
+        let channel = ttlAndIdleIntervalPassedTestsClient.channels.get(channelName)
+
+        waitUntil(timeout: testTimeout) { done in
+            ttlAndIdleIntervalPassedTestsClient.connection.once(.connected) { _ in
+                ttlAndIdleIntervalPassedTestsConnectionId = ttlAndIdleIntervalPassedTestsClient.connection.id!
+                ttlAndIdleIntervalPassedTestsClient.internal.connectionStateTtl = customTtlInterval
+                ttlAndIdleIntervalPassedTestsClient.internal.maxIdleInterval = customIdleInterval
+                channel.attach { error in
+                    if let error = error {
+                        fail(error.message)
+                    }
+                    expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+                    ttlAndIdleIntervalPassedTestsClient.internal.onDisconnected()
+                }
+                ttlAndIdleIntervalPassedTestsClient.connection.once(.disconnected) { _ in
+                    ttlAndIdleIntervalPassedTestsClient.connection.once(.connecting) { _ in
+                        ttlAndIdleIntervalPassedTestsClient.connection.once(.connected) { _ in
+                            expect(ttlAndIdleIntervalPassedTestsClient.connection.id).toNot(equal(ttlAndIdleIntervalPassedTestsConnectionId))
+                            channel.once(.attached) { stateChange in
+                                expect(stateChange.resumed).to(beFalse())
+                                done()
+                            }
+                        }
                     }
                 }
             }
+            ttlAndIdleIntervalPassedTestsClient.connect()
+        }
+    }
 
-            // RTN2f
-            func test__003__Connection__API_version_param_must_be_included_in_all_connections() {
-                let options = AblyTests.commonAppSetup()
-                options.autoConnect = false
-                let client = ARTRealtime(options: options)
-                defer { client.dispose(); client.close() }
-                waitUntil(timeout: testTimeout) { done in
-                    client.connection.once(.connecting) { _ in
-                        guard let webSocketTransport = client.internal.transport as? ARTWebSocketTransport else {
-                            fail("Transport should be of type ARTWebSocketTransport"); done()
-                            return
+    // RTN15g2
+
+    func test__076__Connection__connection_failures_once_CONNECTED__when_connection__ttl_plus_idle_interval__period_has_NOT_passed_since_last_activity__uses_the_same_connection() {
+        let options = AblyTests.commonAppSetup()
+        ttlAndIdleIntervalNotPassedTestsClient = AblyTests.newRealtime(options)
+        ttlAndIdleIntervalNotPassedTestsClient.connect()
+        defer { ttlAndIdleIntervalNotPassedTestsClient.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            ttlAndIdleIntervalNotPassedTestsClient.connection.once(.connected) { _ in
+                expect(ttlAndIdleIntervalNotPassedTestsClient.connection.id).toNot(beNil())
+                ttlAndIdleIntervalNotPassedTestsConnectionId = ttlAndIdleIntervalNotPassedTestsClient.connection.id!
+                ttlAndIdleIntervalNotPassedTestsClient.connection.once(.disconnected) { _ in
+                    let disconnectedAt = Date()
+                    ttlAndIdleIntervalNotPassedTestsClient.connection.once(.connecting) { _ in
+                        let reconnectionInterval = Date().timeIntervalSince(disconnectedAt)
+                        expect(reconnectionInterval).to(beLessThan(ttlAndIdleIntervalNotPassedTestsClient.internal.connectionStateTtl + ttlAndIdleIntervalNotPassedTestsClient.internal.maxIdleInterval))
+                        ttlAndIdleIntervalNotPassedTestsClient.connection.once(.connected) { _ in
+                            expect(ttlAndIdleIntervalNotPassedTestsClient.connection.id).to(equal(ttlAndIdleIntervalNotPassedTestsConnectionId))
+                            done()
                         }
-                        expect(webSocketTransport.websocketURL).toNot(beNil())
-                        
-                        // This test should not directly validate version against ARTDefault.version(), as
-                        // ultimately the version header has been derived from that value.
-                        expect(webSocketTransport.websocketURL?.query).to(haveParam("v", withValue: "1.2"))
-                        
-                        done()
                     }
-                    client.connect()
+                }
+                ttlAndIdleIntervalNotPassedTestsClient.internal.onDisconnected()
+            }
+        }
+    }
+
+    // RTN15h
+
+    func skipped__test__077__Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__if_the_token_is_renewable_then_error_should_not_be_emitted() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.authCallback = { tokenParams, callback in
+            getTestTokenDetails(key: options.key, capability: tokenParams.capability, ttl: TimeInterval(60 * 60), completion: callback)
+        }
+        let tokenTtl = 2.0
+        options.token = getTestToken(key: options.key, ttl: tokenTtl)
+
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        defer {
+            client.dispose()
+            client.close()
+        }
+
+        client.connect()
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        let firstTransport = client.internal.transport as? TestProxyTransport
+
+        waitUntil(timeout: testTimeout) { done in
+            // Wait for token to expire
+            client.connection.once(.disconnected) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error.code) == ARTErrorCode.tokenExpired.intValue
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+        }
+        expect(client.connection.errorReason).to(beNil())
+
+        // New connection
+        expect(client.internal.transport).toNot(beNil())
+        expect(client.internal.transport).toNot(beIdenticalTo(firstTransport))
+
+        waitUntil(timeout: testTimeout) { done in
+            client.ping { error in
+                expect(error).to(beNil())
+                expect((client.internal.transport as! TestProxyTransport).protocolMessagesReceived.filter { $0.action == .connected }).to(haveCount(1))
+                done()
+            }
+        }
+    }
+
+    // RTN15h1
+    func test__078__Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__and_the_library_does_not_have_a_means_to_renew_the_token__the_connection_will_transition_to_the_FAILED_state() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let key = options.key
+        // set the key to nil so that the client can't sign further token requests
+        options.key = nil
+        let tokenTtl = 3.0
+        let tokenDetails = getTestTokenDetails(key: key, ttl: tokenTtl)!
+        options.token = tokenDetails.token
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.failed) { stateChange in
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connected))
+                expect(stateChange.reason?.code).to(equal(ARTErrorCode.tokenExpired.intValue))
+                done()
+            }
+            client.connect()
+        }
+    }
+
+    // RTN15h2
+    func skipped__test__079__Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__should_transition_to_disconnected_when_the_token_renewal_fails_and_the_error_should_be_emitted() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let tokenTtl = 3.0
+        let tokenDetails = getTestTokenDetails(key: options.key, capability: nil, ttl: tokenTtl)!
+        options.token = tokenDetails.token
+        options.authCallback = { _, callback in
+            delay(0.1) {
+                callback(tokenDetails, nil) // Return the same expired token again.
+            }
+        }
+
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        defer {
+            client.dispose()
+            client.close()
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            // Wait for token to expire
+            client.connection.once(.disconnected) { stateChange in
+                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connected))
+                guard let error = stateChange.reason else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error.code) == ARTErrorCode.tokenExpired.intValue
+
+                // Renewal will lead to another disconnection
+                client.connection.once(.disconnected) { stateChange in
+                    guard let error = stateChange.reason else {
+                        fail("Error is nil"); done(); return
+                    }
+                    expect(error.code) == ARTErrorCode.tokenExpired.intValue
+                    expect(client.connection.errorReason).to(beIdenticalTo(error))
+                    done()
                 }
             }
 
-            // RTN2g (Deprecated in favor of RCS7d)
+            client.connect()
+        }
+    }
 
-            // RSC7d
-            func test__004__Connection__Library_and_version_param__agent__should_include_the__Ably_Agent__header_value() {
-                let options = AblyTests.commonAppSetup()
-                options.autoConnect = false
-                
-                let client = ARTRealtime(options: options)
-                client.internal.setTransport(TestProxyTransport.self)
-                client.connect()
-                
-                waitUntil(timeout: testTimeout) { done in
-                    client.connection.on { stateChange in
-                        let state = stateChange.current
-                        let errorInfo = stateChange.reason
-                        switch state {
-                        case .failed:
-                            AblyTests.checkError(errorInfo, withAlternative: "Failed state")
-                            done()
-                        case .connected:
-                            if let transport = client.internal.transport as? TestProxyTransport, let query = transport.lastUrl?.query {
-                                expect(query).to(haveParam("agent", hasPrefix: "ably-cocoa/1.2.7"))
-                            }
-                            else {
-                                XCTFail("MockTransport isn't working")
-                            }
-                            done()
-                            break
-                        default:
-                            break
-                        }
-                    }
+    // RTN16
+
+    // RTN16a
+    func test__080__Connection__Connection_recovery__connection_state_should_recover_explicitly_with_a_recover_key() {
+        let options = AblyTests.commonAppSetup()
+
+        let clientSend = ARTRealtime(options: options)
+        defer { clientSend.close() }
+        let channelSend = clientSend.channels.get("test")
+
+        let clientReceive = ARTRealtime(options: options)
+        defer { clientReceive.close() }
+        let channelReceive = clientReceive.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channelReceive.subscribe(attachCallback: { error in
+                expect(error).to(beNil())
+                channelSend.publish(nil, data: "message") { error in
+                    expect(error).to(beNil())
+                }
+            }, callback: { message in
+                expect(message.data as? String).to(equal("message"))
+                done()
+            })
+        }
+
+        options.recover = clientReceive.connection.recoveryKey
+        clientReceive.internal.onError(AblyTests.newErrorProtocolMessage())
+
+        waitUntil(timeout: testTimeout) { done in
+            channelSend.publish(nil, data: "queue a message") { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        let clientRecover = ARTRealtime(options: options)
+        defer { clientRecover.close() }
+        let channelRecover = clientRecover.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channelRecover.subscribe { message in
+                expect(message.data as? String).to(equal("queue a message"))
+                done()
+            }
+        }
+    }
+
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    // RTN16b
+    func skipped__test__081__Connection__Connection_recovery__Connection_recoveryKey_should_be_composed_with_the_connection_key_and_latest_serial_received_and_msgSerial() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            client.connection.once(.connected) { _ in
+                expect(client.connection.serial).to(equal(-1))
+                expect(client.connection.recoveryKey).to(equal("\(client.connection.key!):\(client.connection.serial):\(client.internal.msgSerial)"))
+            }
+            channel.publish(nil, data: "message") { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+            channel.subscribe { message in
+                expect(message.data as? String).to(equal("message"))
+                expect(client.connection.serial).to(equal(0))
+                channel.unsubscribe()
+                partialDone()
+            }
+        }
+        expect(client.internal.msgSerial) == 1
+        expect(client.connection.recoveryKey).to(equal("\(client.connection.key!):\(client.connection.serial):\(client.internal.msgSerial)"))
+    }
+
+    // RTN16d
+    func test__082__Connection__Connection_recovery__when_a_connection_is_successfully_recovered__Connection_id_will_be_identical_to_the_id_of_the_connection_that_was_recovered_and_Connection_key_will_always_be_updated_to_the_ConnectionDetails_connectionKey_provided_in_the_first_CONNECTED_ProtocolMessage() {
+        let options = AblyTests.commonAppSetup()
+        let clientOriginal = ARTRealtime(options: options)
+        defer { clientOriginal.close() }
+
+        expect(clientOriginal.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+
+        let expectedConnectionId = clientOriginal.connection.id
+
+        options.recover = clientOriginal.connection.recoveryKey
+        clientOriginal.internal.onError(AblyTests.newErrorProtocolMessage())
+
+        let clientRecover = AblyTests.newRealtime(options)
+        defer { clientRecover.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            clientRecover.connection.once(.connected) { _ in
+                let transport = clientRecover.internal.transport as! TestProxyTransport
+                let firstConnectionDetails = transport.protocolMessagesReceived.filter { $0.action == .connected }.first!.connectionDetails
+                expect(firstConnectionDetails!.connectionKey).toNot(beNil())
+                expect(clientRecover.connection.id).to(equal(expectedConnectionId))
+                expect(clientRecover.connection.key).to(equal(firstConnectionDetails!.connectionKey))
+                done()
+            }
+        }
+    }
+
+    // RTN16c
+    func skipped__test__083__Connection__Connection_recovery__Connection_recoveryKey_should_become_becomes_null_when_a_connection_is_explicitly_CLOSED_or_CLOSED() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                client.connection.once(.closed) { _ in
+                    expect(client.connection.recoveryKey).to(beNil())
+                    expect(client.connection.key).to(beNil())
+                    expect(client.connection.id).to(beNil())
+                    done()
                 }
                 client.close()
             }
+        }
+    }
 
-            // RTN4
-            
-
-                // RTN4a
-                func test__020__Connection__event_emitter__should_emit_events_for_state_changes() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let connection = client.connection
-                    var events: [ARTRealtimeConnectionState] = []
-
-                    waitUntil(timeout: testTimeout) { done in
-                        var alreadyDisconnected = false
-                        var alreadyClosed = false
-
-                        connection.on { stateChange in
-                            let state = stateChange.current
-                            let errorInfo = stateChange.reason
-                            switch state {
-                            case .connecting:
-                                if !alreadyDisconnected {
-                                    events += [state]
-                                }
-                            case .connected:
-                                if alreadyClosed {
-                                    delay(0) {
-                                        client.internal.onSuspended()
-                                    }
-                                } else if alreadyDisconnected {
-                                    client.close()
-                                } else {
-                                    events += [state]
-                                    delay(0) {
-                                        client.internal.onDisconnected()
-                                    }
-                                }
-                            case .disconnected:
-                                events += [state]
-                                alreadyDisconnected = true
-                            case .suspended:
-                                events += [state]
-                                client.internal.onError(AblyTests.newErrorProtocolMessage())
-                            case .closing:
-                                events += [state]
-                            case .closed:
-                                events += [state]
-                                alreadyClosed = true
-                                client.connect()
-                            case .failed:
-                                events += [state]
-                                expect(errorInfo).toNot(beNil(), description: "Error is nil")
-                                connection.off()
-                                done()
-                            default:
-                                break
-                            }
-                        }
-                        events += [connection.state]
-                        connection.connect()
-                    }
-
-                    if events.count != 8 {
-                        fail("Missing some states, got \(events)")
-                        return
-                    }
-
-                    expect(events[0].rawValue).to(equal(ARTRealtimeConnectionState.initialized.rawValue), description: "Should be INITIALIZED state")
-                    expect(events[1].rawValue).to(equal(ARTRealtimeConnectionState.connecting.rawValue), description: "Should be CONNECTING state")
-                    expect(events[2].rawValue).to(equal(ARTRealtimeConnectionState.connected.rawValue), description: "Should be CONNECTED state")
-                    expect(events[3].rawValue).to(equal(ARTRealtimeConnectionState.disconnected.rawValue), description: "Should be DISCONNECTED state")
-                    expect(events[4].rawValue).to(equal(ARTRealtimeConnectionState.closing.rawValue), description: "Should be CLOSING state")
-                    expect(events[5].rawValue).to(equal(ARTRealtimeConnectionState.closed.rawValue), description: "Should be CLOSED state")
-                    expect(events[6].rawValue).to(equal(ARTRealtimeConnectionState.suspended.rawValue), description: "Should be SUSPENDED state")
-                    expect(events[7].rawValue).to(equal(ARTRealtimeConnectionState.failed.rawValue), description: "Should be FAILED state")
+    // RTN16e
+    func test__084__Connection__Connection_recovery__should_connect_anyway_if_the_recoverKey_is_no_longer_valid() {
+        let options = AblyTests.commonAppSetup()
+        options.recover = "99999!xxxxxx-xxxxxxxxx-xxxxxxxxx:-1"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                guard let reason = stateChange.reason else {
+                    fail("Reason is empty"); done(); return
                 }
-
-                // RTN4h
-                func test__021__Connection__event_emitter__should_never_emit_a_ConnectionState_event_for_a_state_equal_to_the_previous_state() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                    }
-
-                    client.connection.once(.connected) { stateChange in
-                        fail("Should not emit a Connected state")
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.update) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                            expect(stateChange.current).to(equal(ARTRealtimeConnectionState.connected))
-                            expect(stateChange.current).to(equal(stateChange.previous))
-                            done()
-                        }
-
-                        let authMessage = ARTProtocolMessage()
-                        authMessage.action = .auth
-                        client.internal.transport?.receive(authMessage)
-                    }
-                }
-
-                // RTN4b
-                func test__022__Connection__event_emitter__should_emit_states_on_a_new_connection() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let connection = client.connection
-                    var events: [ARTRealtimeConnectionState] = []
-
-                    waitUntil(timeout: testTimeout) { done in
-                        connection.on { stateChange in
-                            let state = stateChange.current
-                            let error = stateChange.reason
-                            expect(error).to(beNil())
-                            switch state {
-                            case .connecting:
-                                events += [state]
-                            case .connected:
-                                events += [state]
-                                done()
-                            default:
-                                break
-                            }
-                        }
-                        connection.connect()
-                    }
-
-                    expect(events).to(haveCount(2), description: "Missing CONNECTING or CONNECTED state")
-
-                    if events.count != 2 {
-                        return
-                    }
-
-                    expect(events[0].rawValue).to(equal(ARTRealtimeConnectionState.connecting.rawValue), description: "Should be CONNECTING state")
-                    expect(events[1].rawValue).to(equal(ARTRealtimeConnectionState.connected.rawValue), description: "Should be CONNECTED state")
-                }
-
-                // RTN4c
-                func test__023__Connection__event_emitter__should_emit_states_when_connection_is_closed() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    let connection = client.connection
-                    defer { client.dispose(); client.close() }
-                    var events: [ARTRealtimeConnectionState] = []
-
-                    waitUntil(timeout: testTimeout) { done in
-                        connection.on { stateChange in
-                            let state = stateChange.current
-                            let error = stateChange.reason
-                            expect(error).to(beNil())
-                            switch state {
-                            case .connected:
-                                connection.close()
-                            case .closing:
-                                events += [state]
-                            case .closed:
-                                events += [state]
-                                done()
-                            default:
-                                break
-                            }
-                        }
-                    }
-
-                    expect(events).to(haveCount(2), description: "Missing CLOSING or CLOSED state")
-
-                    if events.count != 2 {
-                        return
-                    }
-
-                    expect(events[0].rawValue).to(equal(ARTRealtimeConnectionState.closing.rawValue), description: "Should be CLOSING state")
-                    expect(events[1].rawValue).to(equal(ARTRealtimeConnectionState.closed.rawValue), description: "Should be CLOSED state")
-                }
-
-                // RTN4d
-                func test__024__Connection__event_emitter__should_have_the_current_state() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let connection = client.connection
-                    expect(connection.state.rawValue).to(equal(ARTRealtimeConnectionState.initialized.rawValue), description: "Missing INITIALIZED state")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        connection.on { stateChange in
-                            let state = stateChange.current
-                            let error = stateChange.reason
-                            expect(error).to(beNil())
-                            switch state {
-                            case .connecting:
-                                expect(connection.state.rawValue).to(equal(ARTRealtimeConnectionState.connecting.rawValue), description: "Missing CONNECTING state")
-                            case .connected:
-                                expect(connection.state.rawValue).to(equal(ARTRealtimeConnectionState.connected.rawValue), description: "Missing CONNECTED state")
-                                done()
-                            default:
-                                break
-                            }
-                        }
-                        client.connect()
-                    }
-                }
-
-                // RTN4e
-                func test__025__Connection__event_emitter__should_have_a_ConnectionStateChange_as_first_argument_for_every_connection_state_change() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(ARTRealtimeConnectionEvent.connected) { stateChange in
-                            expect(stateChange).to(beAKindOf(ARTConnectionStateChange.self))
-                            expect(stateChange.current).to(equal(ARTRealtimeConnectionState.connected))
-                            expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
-                            done()
-                        }
-                        client.connect()
-                    }
-                }
-
-                // RTN4f
-                func test__026__Connection__event_emitter__should_have_the_reason_which_contains_an_ErrorInfo() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let connection = client.connection
-
-                    var errorInfo: ARTErrorInfo?
-                    waitUntil(timeout: testTimeout) { done in
-                        connection.on { stateChange in
-                            let state = stateChange.current
-                            let reason = stateChange.reason
-                            switch state {
-                            case .connected:
-                                expect(stateChange.event).to(equal(ARTRealtimeConnectionEvent.connected))
-                                client.internal.onError(AblyTests.newErrorProtocolMessage())
-                            case .failed:
-                                expect(stateChange.event).to(equal(ARTRealtimeConnectionEvent.failed))
-                                errorInfo = reason
-                                done()
-                            default:
-                                break
-                            }
-                        }
-                    }
-
-                    expect(errorInfo).toNot(beNil())
-                }
-
-                // RTN4f
-                func test__027__Connection__event_emitter__any_state_change_triggered_by_a_ProtocolMessage_that_contains_an_Error_member_should_populate_the_Reason_property() {
-                    let options = AblyTests.commonAppSetup()
-                    options.useTokenAuth = true
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                    }
-
-                    guard let transport = client.internal.transport as? TestProxyTransport else {
-                        fail("TestProxyTransport is not set"); return
-                    }
-                    guard let originalConnectedMessage = transport.protocolMessagesReceived.filter({ $0.action == .connected }).first else {
-                        fail("First CONNECTED message not received"); return
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.update) { stateChange in
-                            guard let error = stateChange.reason else {
-                                fail("Reason error is nil"); done(); return
-                            }
-                            expect(error.code) == 1234
-                            expect(error.message) == "fabricated error"
-                            expect(stateChange.event).to(equal(ARTRealtimeConnectionEvent.update))
-                            done()
-                        }
-
-                        let connectedMessageWithError = originalConnectedMessage
-                        connectedMessageWithError.error = ARTErrorInfo.create(withCode: 1234, message: "fabricated error")
-                        client.internal.transport?.receive(connectedMessageWithError)
-                    }
-                }
-
-            // RTN5
-            func test__005__Connection__basic_operations_should_work_simultaneously() {
-                let options = AblyTests.commonAppSetup()
-                options.echoMessages = false
-                var disposable = [ARTRealtime]()
-                let numClients = 50
-                let numMessages = 5
-                let channelName = "chat"
-                let testTimeout = DispatchTimeInterval.seconds(60)
-
-                defer {
-                    for client in disposable {
-                        client.dispose()
-                        client.close()
-                    }
-                }
-
-                waitUntil(timeout: testTimeout) { done in
-                    let partialDone = AblyTests.splitDone(numClients, done: done)
-                    for _ in 1...numClients {
-                        let client = ARTRealtime(options: options)
-                        disposable.append(client)
-                        let channel = client.channels.get(channelName)
-                        channel.attach() { error in
-                            if let error = error {
-                                fail(error.message); done()
-                            }
-                            partialDone()
-                        }
-                    }
-                }
-
-                var messagesReceived = 0
-                waitUntil(timeout: testTimeout) { done in
-                    // Sends numMessages messages from different clients to the same channel
-                    // numMessages messages for numClients clients = numMessages*numClients total messages
-                    // echo is off, so we need to subtract one message per publish
-                    let messagesExpected = numMessages * numClients - 1 * numMessages
-                    var messagesSent = 0
-                    for client in disposable {
-                        let channel = client.channels.get(channelName)
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
-
-                        channel.subscribe { message in
-                            expect(message.data as? String).to(equal("message_string"))
-                            messagesReceived += 1
-                            if messagesReceived == messagesExpected {
-                                done()
-                            }
-                        }
-                        
-                        if messagesSent < numMessages {
-                            channel.publish(nil, data: "message_string", callback: nil)
-                            messagesSent += 1
-                        }
-                    }
-                }
-
-                expect(disposable.count).to(equal(numClients))
-                expect(countChannels(disposable.first!.channels)).to(equal(1))
-                expect(countChannels(disposable.last!.channels)).to(equal(1))
+                expect(reason.message).to(contain("Unable to recover connection"))
+                expect(client.connection.errorReason).to(beIdenticalTo(reason))
+                done()
             }
+        }
+    }
 
-            // RTN6
-            func test__006__Connection__should_have_an_opened_websocket_connection_and_received_a_CONNECTED_ProtocolMessage() {
-                let options = AblyTests.commonAppSetup()
-                options.autoConnect = false
-                let client = ARTRealtime(options: options)
-                client.internal.setTransport(TestProxyTransport.self)
-                client.connect()
-                defer {
-                    client.dispose()
-                    client.close()
-                }
+    // RTN16f
+    func test__085__Connection__Connection_recovery__should_use_msgSerial_from_recoveryKey_to_set_the_client_internal_msgSerial_but_is_not_sent_to_Ably() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.recover = "99999!xxxxxx-xxxxxxxxx-xxxxxxxxx:-1:7"
 
-                waitUntil(timeout: testTimeout) { done in
-                    client.connection.on { stateChange in
-                        let state = stateChange.current
-                        let error = stateChange.reason
-                        expect(error).to(beNil())
-                        if state == .connected && error == nil {
-                            done()
-                        }
-                    }
-                }
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
 
-                if let webSocketTransport = client.internal.transport as? ARTWebSocketTransport {
-                    expect(webSocketTransport.state).to(equal(ARTRealtimeTransportState.opened))
-                }
-                else {
-                    XCTFail("WebSocket is not the default transport")
-                }
-
-                if let transport = client.internal.transport as? TestProxyTransport {
-                    // CONNECTED ProtocolMessage
-                    expect(transport.protocolMessagesReceived.map{ $0.action }).to(contain(ARTProtocolMessageAction.connected))
-                }
-                else {
-                    XCTFail("MockTransport is not working")
-                }
+        var urlConnections = [URL]()
+        TestProxyTransport.networkConnectEvent = { transport, url in
+            if client.internal.transport !== transport {
+                return
             }
-
-            // RTN7
-            
-
-                // RTN7a
-                
-
-                    func test__028__Connection__ACK_and_NACK__should_expect_either_an_ACK_or_NACK_to_confirm__successful_receipt_and_acceptance_of_message() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        options.clientId = "client_string"
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            publishFirstTestMessage(client, completion: { error in
-                                expect(error).to(beNil())
-                                done()
-                            })
-                        }
-
-                        let transport = client.internal.transport as! TestProxyTransport
-
-                        guard let publishedMessage = transport.protocolMessagesSent.filter({ $0.action == .message }).last else {
-                            XCTFail("No MESSAGE action was sent"); return
-                        }
-
-                        guard let receivedAck = transport.protocolMessagesReceived.filter({ $0.action == .ack }).last else {
-                            XCTFail("No ACK action was received"); return
-                        }
-
-                        expect(publishedMessage.msgSerial).to(equal(receivedAck.msgSerial))
-                    }
-
-                    func test__029__Connection__ACK_and_NACK__should_expect_either_an_ACK_or_NACK_to_confirm__successful_receipt_and_acceptance_of_presence() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        options.clientId = "client_string"
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.on { stateChange in
-                                let state = stateChange.current
-                                let error = stateChange.reason
-                                expect(error).to(beNil())
-                                if state == .connected {
-                                    let channel = client.channels.get("test")
-                                    channel.attach() { error in
-                                        expect(error).to(beNil())
-                                        channel.presence.enterClient("client_string", data: nil, callback: { errorInfo in
-                                            expect(errorInfo).to(beNil())
-                                            done()
-                                        })
-                                    }
-                                }
-                            }
-                        }
-
-                        let transport = client.internal.transport as! TestProxyTransport
-
-                        guard let publishedMessage = transport.protocolMessagesSent.filter({ $0.action == .presence }).last else {
-                            XCTFail("No PRESENCE action was sent"); return
-                        }
-
-                        guard let receivedAck = transport.protocolMessagesReceived.filter({ $0.action == .ack }).last else {
-                            XCTFail("No ACK action was received"); return
-                        }
-
-                        expect(publishedMessage.msgSerial).to(equal(receivedAck.msgSerial))
-                    }
-
-                    func test__030__Connection__ACK_and_NACK__should_expect_either_an_ACK_or_NACK_to_confirm__message_failure() {
-                        let options = AblyTests.commonAppSetup()
-                        options.token = getTestToken(key: options.key, capability: "{ \"\(options.channelNamePrefix!)-test\":[\"subscribe\"] }")
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            publishFirstTestMessage(client, completion: { error in
-                                expect(error).toNot(beNil())
-                                done()
-                            })
-                        }
-
-                        let transport = client.internal.transport as! TestProxyTransport
-
-                        guard let publishedMessage = transport.protocolMessagesSent.filter({ $0.action == .message }).last else {
-                            XCTFail("No MESSAGE action was sent"); return
-                        }
-
-                        guard let receivedNack = transport.protocolMessagesReceived.filter({ $0.action == .nack }).last else {
-                            XCTFail("No NACK action was received"); return
-                        }
-
-                        expect(publishedMessage.msgSerial).to(equal(receivedNack.msgSerial))
-                    }
-
-                    func test__031__Connection__ACK_and_NACK__should_expect_either_an_ACK_or_NACK_to_confirm__presence_failure() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        options.clientId = "client_string"
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.on { stateChange in
-                                let state = stateChange.current
-                                let error = stateChange.reason
-                                expect(error).to(beNil())
-                                if state == .connected {
-                                    let channel = client.channels.get("test")
-                                    channel.attach() { error in
-                                        expect(error).to(beNil())
-                                        channel.presence.enterClient("invalid", data: nil, callback: { errorInfo in
-                                            expect(errorInfo).toNot(beNil())
-                                            done()
-                                        })
-                                    }
-                                }
-                            }
-                        }
-
-                        let transport = client.internal.transport as! TestProxyTransport
-
-                        guard let publishedMessage = transport.protocolMessagesSent.filter({ $0.action == .presence }).last else {
-                            XCTFail("No PRESENCE action was sent"); return
-                        }
-
-                        guard let receivedNack = transport.protocolMessagesReceived.filter({ $0.action == .nack }).last else {
-                            XCTFail("No NACK action was received"); return
-                        }
-
-                        expect(publishedMessage.msgSerial).to(equal(receivedNack.msgSerial))
-                    }
-
-                // RTN7b
-                
-
-                    func test__032__Connection__ACK_and_NACK__ProtocolMessage__should_contain_unique_serially_incrementing_msgSerial_along_with_the_count() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        options.clientId = "client_string"
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("channel")
-                        channel.attach()
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "message") { errorInfo in
-                                expect(errorInfo).to(beNil())
-                                done()
-                            }
-                        }
-
-                        TotalMessages.expected = 5
-                        for index in 1...TotalMessages.expected {
-                            channel.publish(nil, data: "message\(index)") { errorInfo in
-                                if errorInfo == nil {
-                                    TotalMessages.succeeded += 1
-                                }
-                            }
-                        }
-                        expect(TotalMessages.succeeded).toEventually(equal(TotalMessages.expected), timeout: testTimeout)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.presence.enterClient("invalid", data: nil, callback: { errorInfo in
-                                expect(errorInfo).toNot(beNil())
-                                done()
-                            })
-                        }
-
-                        let transport = client.internal.transport as! TestProxyTransport
-                        let acks = transport.protocolMessagesReceived.filter({ $0.action == .ack })
-                        let nacks = transport.protocolMessagesReceived.filter({ $0.action == .nack })
-
-                        if acks.count != 2 {
-                            fail("Received invalid number of ACK responses: \(acks.count)")
-                            return
-                        }
-
-                        expect(acks[0].msgSerial).to(equal(0))
-                        expect(acks[0].count).to(equal(1))
-
-                        // Messages covered in a single ACK response
-                        expect(acks[1].msgSerial).to(equal(1))
-                        expect(acks[1].count).to(equal(TotalMessages.expected))
-
-                        if nacks.count != 1 {
-                            fail("Received invalid number of NACK responses: \(nacks.count)")
-                            return
-                        }
-
-                        expect(nacks[0].msgSerial).to(equal(6))
-                        expect(nacks[0].count).to(equal(1))
-                    }
-
-                    func test__033__Connection__ACK_and_NACK__ProtocolMessage__should_continue_incrementing_msgSerial_serially_if_the_connection_resumes_successfully() {
-                        let options = AblyTests.commonAppSetup()
-                        options.clientId = "tester"
-                        options.tokenDetails = getTestTokenDetails(key: options.key!, clientId: options.clientId, ttl: 5.0)
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("foo")
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "message") { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        guard let initialConnectionId = client.connection.id else {
-                            fail("Connection ID is empty"); return
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(4, done: done)
-                            (1...3).forEach { index in
-                                channel.publish(nil, data: "message\(index)") { error in
-                                    if error == nil {
-                                        partialDone()
-                                    }
-                                }
-                            }
-                            channel.presence.enterClient("invalid", data: nil) { error in
-                                expect(error).toNot(beNil())
-                                partialDone()
-                            }
-                        }
-
-                        expect(client.internal.msgSerial) == 5
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.disconnected) { stateChange in
-                                expect(stateChange.reason).toNot(beNil())
-                                // Token expired
-                                done()
-                            }
-                        }
-
-                        // Reconnected and resumed
-                        expect(client.connection.id).to(equal(initialConnectionId))
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(4, done: done)
-                            (1...3).forEach { index in
-                                channel.publish(nil, data: "message\(index)") { error in
-                                    if error == nil {
-                                        partialDone()
-                                    }
-                                }
-                            }
-                            channel.presence.enterClient("invalid", data: nil) { error in
-                                expect(error).toNot(beNil())
-                                partialDone()
-                            }
-                        }
-
-                        guard let reconnectedTransport = client.internal.transport as? TestProxyTransport else {
-                            fail("TestProxyTransport is not set"); return
-                        }
-                        let acks = reconnectedTransport.protocolMessagesReceived.filter({ $0.action == .ack })
-                        let nacks = reconnectedTransport.protocolMessagesReceived.filter({ $0.action == .nack })
-
-                        if acks.count != 1 {
-                            fail("Received invalid number of ACK responses: \(acks.count)")
-                            return
-                        }
-                        // Messages covered in a single ACK response
-                        expect(acks[0].msgSerial) == 5 // [0] 1st publish + [1.2.4] publish + [4] enter with invalid client + [5] queued messages
-                        expect(acks[0].count) == 1
-
-                        if nacks.count != 1 {
-                            fail("Received invalid number of NACK responses: \(nacks.count)")
-                            return
-                        }
-                        expect(nacks[0].msgSerial) == 6
-                        expect(nacks[0].count) == 1
-
-                        expect(client.internal.msgSerial) == 7
-                    }
-
-                    func test__034__Connection__ACK_and_NACK__ProtocolMessage__should_reset_msgSerial_serially_if_the_connection_does_not_resume() {
-                        let options = AblyTests.commonAppSetup()
-                        options.clientId = "tester"
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("foo")
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "message") { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        guard let initialConnectionId = client.connection.id else {
-                            fail("Connection ID is empty"); return
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(4, done: done)
-                            (1...3).forEach { index in
-                                channel.publish(nil, data: "message\(index)") { error in
-                                    if error == nil {
-                                        partialDone()
-                                    }
-                                }
-                            }
-                            channel.presence.enterClient("invalid", data: nil) { error in
-                                expect(error?.code).to(equal(ARTErrorCode.invalidClientId.intValue))
-                                partialDone()
-                            }
-                        }
-
-                        expect(client.internal.msgSerial) == 5
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            client.connection.once(.disconnected) { _ in
-                                partialDone()
-                            }
-                            client.connection.once(.connected) { _ in
-                                partialDone()
-                            }
-                            client.simulateLostConnectionAndState()
-                        }
-
-                        // Reconnected but not resumed
-                        expect(client.connection.id).toNot(equal(initialConnectionId))
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(4, done: done)
-                            (1...3).forEach { index in
-                                channel.publish(nil, data: "message\(index)") { error in
-                                    if error == nil {
-                                        partialDone()
-                                    }
-                                }
-                            }
-                            channel.presence.enterClient("invalid", data: nil) { error in
-                                expect(error?.code).to(equal(ARTErrorCode.invalidClientId.intValue))
-                                partialDone()
-                            }
-                        }
-
-                        guard let reconnectedTransport = client.internal.transport as? TestProxyTransport else {
-                            fail("TestProxyTransport is not set"); return
-                        }
-                        let acks = reconnectedTransport.protocolMessagesReceived.filter({ $0.action == .ack })
-                        let nacks = reconnectedTransport.protocolMessagesReceived.filter({ $0.action == .nack })
-
-                        // The server is free to roll up multiple acks into one or not
-                        if acks.count < 1 {
-                            fail("Received invalid number of ACK responses: \(acks.count)")
-                            return
-                        }
-                        expect(acks[0].msgSerial) == 0
-                        expect(acks.reduce(0, { $0 + $1.count })) == 3
-
-                        if nacks.count != 1 {
-                            fail("Received invalid number of NACK responses: \(nacks.count)")
-                            return
-                        }
-                        expect(nacks[0].msgSerial) == 3
-                        expect(nacks[0].count) == 1
-                        
-                        expect(client.internal.msgSerial) == 4
-                    }
-
-                // RTN7c
-                
-
-                    func test__035__Connection__ACK_and_NACK__should_trigger_the_failure_callback_for_the_remaining_pending_messages_if__connection_is_closed() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        options.clientId = "client_string"
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("channel")
-                        let transport = client.internal.transport as! TestProxyTransport
-                        transport.actionsIgnored += [.ack, .nack]
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach() { error in
-                                expect(error).to(beNil())
-                                channel.publish(nil, data: "message", callback: { error in
-                                    guard let error = error else {
-                                        fail("Error is nil"); done(); return
-                                    }
-                                    expect(error.message).to(contain("connection broken before receiving publishing acknowledgment"))
-                                    done()
-                                })
-                                // Wait until the message is pushed to Ably first
-                                delay(1.0) {
-                                    client.close()
-                                }
-                            }
-                        }
-
-                        // This verifies that the pending message as been released and the publish callback is called only once!
-                        waitUntil(timeout: testTimeout) { done in
-                            delay(1.0) {
-                                done()
-                            }
-                        }
-                    }
-
-                    func test__036__Connection__ACK_and_NACK__should_trigger_the_failure_callback_for_the_remaining_pending_messages_if__connection_state_enters_FAILED() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        options.clientId = "client_string"
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("channel")
-                        let transport = client.internal.transport as! TestProxyTransport
-                        transport.actionsIgnored += [.ack, .nack]
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach() { error in
-                                expect(error).to(beNil())
-                                channel.publish(nil, data: "message", callback: { errorInfo in
-                                    expect(errorInfo).toNot(beNil())
-                                    done()
-                                })
-                                // Wait until the message is pushed to Ably first
-                                delay(1.0) {
-                                    transport.simulateIncomingError()
-                                }
-                            }
-                        }
-                    }
-
-                    func test__037__Connection__ACK_and_NACK__should_trigger_the_failure_callback_for_the_remaining_pending_messages_if__lost_connection_state() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer {
-                            client.dispose()
-                            client.close()
-                        }
-
-                        let channel = client.channels.get("channel")
-
-                        let transport = client.internal.transport as! TestProxyTransport
-                        transport.actionsIgnored += [.ack, .nack]
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach() { _ in
-                                done()
-                            }
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(3, done: done)
-
-                            channel.publish(nil, data: "message") { error in
-                                guard let error = error else {
-                                    fail("Error is nil"); return
-                                }
-                                expect(error.code) == ARTErrorCode.unableToRecoverConnectionExpired.intValue
-                                expect(error.message).to(contain("Unable to recover connection"))
-                                partialDone()
-                            }
-
-                            let oldConnectionId = client.connection.id!
-
-                            // Wait until the message is pushed to Ably first
-                            delay(1.0) {
-                                client.connection.once(.disconnected) { _ in
-                                    partialDone()
-                                }
-                                client.connection.once(.connected) { stateChange in
-                                    expect(client.connection.id).toNot(equal(oldConnectionId))
-                                    partialDone()
-                                }
-                                client.simulateLostConnectionAndState()
-                            }
-                        }
-                    }
-
-            // RTN8
-            
-
-                // RTN8a
-                func test__038__Connection__connection_id__should_be_null_until_connected() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    let connection = client.connection
-                    defer {
-                        client.dispose()
-                        client.close()
-                    }
-
-                    expect(connection.id).to(beNil())
-
-                    waitUntil(timeout: testTimeout) { done in
-                        connection.on { stateChange in
-                            let state = stateChange.current
-                            let errorInfo = stateChange.reason
-                            expect(errorInfo).to(beNil())
-                            if state == .connected {
-                                expect(connection.id).toNot(beNil())
-                                done()
-                            }
-                            else if state == .connecting {
-                                expect(connection.id).to(beNil())
-                            }
-                        }
-                    }
-                }
-
-                // RTN8b
-                func test__039__Connection__connection_id__should_have_unique_IDs() {
-                    let options = AblyTests.commonAppSetup()
-                    var disposable = [ARTRealtime]()
-                    defer {
-                        for client in disposable {
-                            client.dispose()
-                            client.close()
-                        }
-                    }
-                    var ids = [String]()
-                    let max = 25
-                    let sync = NSLock()
-
-                    waitUntil(timeout: testTimeout) { done in
-                        for _ in 1...max {
-                            disposable.append(ARTRealtime(options: options))
-                            let currentConnection = disposable.last!.connection
-                            currentConnection.on { stateChange in
-                                let state = stateChange.current
-                                let error = stateChange.reason
-                                expect(error).to(beNil())
-                                if state == .connected {
-                                    guard let connectionId = currentConnection.id else {
-                                        fail("connectionId is nil on CONNECTED")
-                                        done()
-                                        return
-                                    }
-                                    expect(ids).toNot(contain(connectionId))
-
-                                    sync.lock()
-                                    ids.append(connectionId)
-                                    if ids.count == max {
-                                        done()
-                                    }
-                                    sync.unlock()
-
-                                    currentConnection.off()
-                                    currentConnection.close()
-                                }
-                            }
-                        }
-                    }
-
-                    expect(ids).to(haveCount(max))
-                }
-
-            // RTN9
-            
-
-                // RTN9a
-                func test__040__Connection__connection_key__should_be_null_until_connected() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer {
-                        client.dispose()
-                        client.close()
-                    }
-                    let connection = client.connection
-
-                    expect(connection.key).to(beNil())
-
-                    waitUntil(timeout: testTimeout) { done in
-                        connection.on { stateChange in
-                            let state = stateChange.current
-                            let errorInfo = stateChange.reason
-                            expect(errorInfo).to(beNil())
-                            if state == .connected {
-                                expect(connection.id).toNot(beNil())
-                                done()
-                            }
-                            else if state == .connecting {
-                                expect(connection.key).to(beNil())
-                            }
-                        }
-                    }
-                }
-
-                // RTN9b
-                func test__041__Connection__connection_key__should_have_unique_connection_keys() {
-                    let options = AblyTests.commonAppSetup()
-                    var disposable = [ARTRealtime]()
-                    defer {
-                        for client in disposable {
-                            client.dispose()
-                            client.close()
-                        }
-                    }
-                    var keys = [String]()
-                    let max = 25
-
-                    waitUntil(timeout: testTimeout) { done in
-                        for _ in 1...max {
-                            disposable.append(ARTRealtime(options: options))
-                            let currentConnection = disposable.last!.connection
-                            currentConnection.on { stateChange in
-                                let state = stateChange.current
-                                let error = stateChange.reason
-                                expect(error).to(beNil())
-                                if state == .connected {
-                                    guard let connectionKey = currentConnection.key else {
-                                        fail("connectionKey is nil on CONNECTED")
-                                        done()
-                                        return
-                                    }
-                                    expect(keys).toNot(contain(connectionKey))
-                                    keys.append(connectionKey)
-
-                                    if keys.count == max {
-                                        done()
-                                    }
-
-                                    currentConnection.off()
-                                    currentConnection.close()
-                                }
-                            }
-                        }
-                    }
-
-                    expect(keys).to(haveCount(max))
-                }
-
-            // RTN10
-            
-
-                // RTN10a
-                func test__042__Connection__serial__should_be_minus_1_once_connected() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer {
-                        client.dispose()
-                        client.close()
-                    }
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.on { stateChange in
-                            let state = stateChange.current
-                            let error = stateChange.reason
-                            expect(error).to(beNil())
-                            if state == .connected {
-                                expect(client.connection.serial).to(equal(-1))
-                                done()
-                            }
-                        }
-                    }
-                }
-
-                // RTN10b
-                func test__043__Connection__serial__should_not_update_when_a_message_is_sent_but_increments_by_one_when_ACK_is_received() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer {
-                        client.dispose()
-                        client.close()
-                    }
-                    let channel = client.channels.get("test")
-
-                    expect(client.connection.serial).to(equal(-1))
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                    expect(client.connection.serial).to(equal(-1))
-
-                    for index in 0...3 {
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            channel.publish(nil, data: "message", callback: { errorInfo in
-                                expect(errorInfo).to(beNil())
-                                partialDone()
-                            })
-                            channel.subscribe() { _ in
-                                // Updated
-                                expect(client.connection.serial).to(equal(Int64(index)))
-                                channel.unsubscribe()
-                                partialDone()
-                            }
-                            // Not updated
-                            expect(client.connection.serial).to(equal(Int64(index - 1)))
-                        }
-                    }
-                }
-
-                func test__044__Connection__serial__should_have_last_known_connection_serial_from_restored_connection() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer {
-                        client.dispose()
-                        client.close()
-                    }
-                    let channel = client.channels.get("test")
-
-                    // Attach first to avoid bundling publishes in the same ProtocolMessage.
-                    channel.attach()
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                    for _ in 1...5 {
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            channel.publish(nil, data: "message", callback: { errorInfo in
-                                expect(errorInfo).to(beNil())
-                                partialDone()
-                            })
-                            channel.subscribe() { _ in
-                                channel.unsubscribe()
-                                partialDone()
-                            }
-                        }
-                    }
-                    let lastSerial = client.connection.serial
-                    expect(lastSerial).to(equal(4))
-
-                    options.recover = client.connection.recoveryKey
-                    client.internal.onError(AblyTests.newErrorProtocolMessage())
-
-                    let recoveredClient = ARTRealtime(options: options)
-                    defer { recoveredClient.close() }
-                    expect(recoveredClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        expect(recoveredClient.connection.serial).to(equal(lastSerial))
-                        let recoveredChannel = recoveredClient.channels.get("test")
-                        recoveredChannel.publish(nil, data: "message", callback: { errorInfo in
-                            expect(errorInfo).to(beNil())
-                        })
-                        recoveredChannel.subscribe() { _ in
-                            expect(recoveredClient.connection.serial).to(equal(lastSerial + 1))
-                            recoveredChannel.unsubscribe()
-                            done()
-                        }
-                    }
-                }
-
-            // RTN11b
-            func test__007__Connection__should_make_a_new_connection_with_a_new_transport_instance_if_the_state_is_CLOSING() {
-                let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                defer { client.dispose(); client.close() }
-
-                waitUntil(timeout: testTimeout) { done in
-                    client.connection.once(.connected) { _ in
-                        done()
-                    }
-                }
-
-                weak var oldTransport: ARTRealtimeTransport?
-                weak var newTransport: ARTRealtimeTransport?
-
-                waitUntil(timeout: testTimeout) { done in
-                    let partialDone = AblyTests.splitDone(2, done: done)
-
-                    client.connection.once(.closing) { _ in
-                        oldTransport = client.internal.transport
-                        client.connect()
-                        newTransport = client.internal.transport
-                        expect(newTransport).toNot(beIdenticalTo(oldTransport))
-                        partialDone()
-                    }
-
-                    client.connection.once(.connected) { stateChange in
-                        expect(stateChange.reason).to(beNil())
-                        expect(client.connection.errorReason).to(beNil())
-                        partialDone()
-                    }
-
-                    client.close()
-                }
-
-                expect(newTransport).toNot(beNil())
+            urlConnections.append(url)
+            if urlConnections.count == 1 {
+                TestProxyTransport.networkConnectEvent = nil
             }
+        }
+        defer { TestProxyTransport.networkConnectEvent = nil }
 
-            // RTN11b
-            func test__008__Connection__it_should_make_sure_that__when_the_CLOSED_ProtocolMessage_arrives_for_the_old_connection__it_doesn_t_affect_the_new_one() {
-                let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                defer { client.dispose(); client.close() }
-
-                waitUntil(timeout: testTimeout) { done in
-                    client.connection.once(.connected) { _ in
-                        done()
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                guard let reason = stateChange.reason else {
+                    fail("Reason is empty"); done(); return
                 }
 
-                var oldTransport: ARTRealtimeTransport? //retain
-                weak var newTransport: ARTRealtimeTransport?
-
-                autoreleasepool {
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(3, done: done)
-
-                        client.connection.once(.closing) { _ in
-                            client.internalSync { _internal in
-                                oldTransport = _internal.transport
-                            }
-                            // Old connection must complete the close request
-                            weak var oldTestProxyTransport = oldTransport as? TestProxyTransport
-                            oldTestProxyTransport?.setBeforeIncomingMessageModifier({ protocolMessage in
-                                if protocolMessage.action == .closed {
-                                    partialDone()
-                                }
-                                return protocolMessage
-                            })
-
-                            client.connect()
-
-                            client.internalSync { _internal in
-                                newTransport = _internal.transport
-                            }
-
-                            expect(newTransport).toNot(beIdenticalTo(oldTransport))
-                            expect(newTransport).toNot(beNil())
-                            expect(oldTransport).toNot(beNil())
-                            partialDone()
-                        }
-
-                        client.connection.once(.closed) { _ in
-                            fail("New connection should not receive the old connection event")
-                        }
-                        
-                        client.connection.once(.connected) { _ in
-                            partialDone()
-                        }
-
-                        client.close()
-                    }
-
-                    oldTransport = nil
+                expect(urlConnections.count) == 1
+                guard let urlConnectionQuery = urlConnections.first?.query else {
+                    fail("Missing URL Connection query"); done(); return
                 }
 
-                expect(newTransport).toNot(beNil())
-                expect(oldTransport).to(beNil())
+                expect(urlConnectionQuery).to(haveParam("recover", withValue: "99999!xxxxxx-xxxxxxxxx-xxxxxxxxx"))
+                expect(urlConnectionQuery).to(haveParam("connectionSerial", withValue: "-1"))
+                expect(urlConnectionQuery).toNot(haveParam("msgSerial"))
+
+                // recover fails, the counter should be reset to 0
+                expect(client.internal.msgSerial) == 0
+
+                expect(reason.message).to(contain("Unable to recover connection"))
+                expect(client.connection.errorReason).to(beIdenticalTo(reason))
+                done()
             }
+            client.connect()
+            expect(client.internal.msgSerial) == 7
+        }
+    }
 
-            // RTN12
-            
-                // RTN12f
-                func test__045__Connection__close__if_CONNECTING__do_the_operation_once_CONNECTED() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose() }
+    // RTN17
 
-                    client.connect()
-                    var lastStateChange: ARTConnectionStateChange?
-                    client.connection.on { stateChange in
-                        lastStateChange = stateChange
-                    }
-
-                    client.close()
-                    expect(lastStateChange).to(beNil())
-
-
-                    expect(lastStateChange).toEventuallyNot(beNil(), timeout: testTimeout)
-                    expect(lastStateChange!.current).toEventually(equal(ARTRealtimeConnectionState.closed), timeout: testTimeout)
-                }
-
-                // RTN12a
-                func test__046__Connection__close__if_CONNECTED__should_send_a_CLOSE_action__change_state_to_CLOSING_and_receive_a_CLOSED_action() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    client.internal.setTransport(TestProxyTransport.self)
-                    client.connect()
-                    defer {
-                        client.dispose()
-                    }
-
-                    let transport = client.internal.transport as! TestProxyTransport
-                    var states: [ARTRealtimeConnectionState] = []
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.on { stateChange in
-                            let state = stateChange.current
-                            let error = stateChange.reason
-                            expect(error).to(beNil())
-                            switch state {
-                            case .connected:
-                                client.close()
-                            case .closing:
-                                expect(transport.protocolMessagesSent.filter({ $0.action == .close })).to(haveCount(1))
-                                states += [state]
-                            case.closed:
-                                expect(transport.protocolMessagesReceived.filter({ $0.action == .closed })).to(haveCount(1))
-                                states += [state]
-                                done()
-                            default:
-                                break;
-                            }
-                        }
-                    }
-
-                    if states.count != 2 {
-                        fail("Invalid number of connection states. Expected CLOSING and CLOSE states")
-                        return
-                    }
-                    expect(states[0]).to(equal(ARTRealtimeConnectionState.closing))
-                    expect(states[1]).to(equal(ARTRealtimeConnectionState.closed))
-                }
-
-                // RTN12b
-                func test__047__Connection__close__should_transition_to_CLOSED_action_when_the_close_process_timeouts() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    client.internal.setTransport(TestProxyTransport.self)
-                    client.connect()
-                    defer {
-                        client.dispose()
-                        client.close()
-                    }
-
-                    let transport = client.internal.transport as! TestProxyTransport
-                    transport.actionsIgnored += [.closed]
-
-                    var states: [ARTRealtimeConnectionState] = []
-                    var start: NSDate?
-                    var end: NSDate?
-
-                    client.connection.on { stateChange in
-                        let state = stateChange.current
-                        let error = stateChange.reason
-                        expect(error).to(beNil())
-                        switch state {
-                        case .connected:
-                            client.close()
-                        case .closing:
-                            start = NSDate()
-                            states += [state]
-                        case .closed:
-                            end = NSDate()
-                            states += [state]
-                        case .disconnected:
-                            states += [state]
-                        default:
-                            break
-                        }
-                    }
-
-                    expect(start).toEventuallyNot(beNil(), timeout: testTimeout)
-                    expect(end).toEventuallyNot(beNil(), timeout: DispatchTimeInterval.milliseconds(Int(1000.0 * ARTDefault.realtimeRequestTimeout())))
-
-                    if states.count != 2 {
-                        fail("Invalid number of connection states. Expected CLOSING and CLOSE states")
-                        return
-                    }
-
-                    expect(states[0]).to(equal(ARTRealtimeConnectionState.closing))
-                    expect(states[1]).to(equal(ARTRealtimeConnectionState.closed))
-                }
-
-                // RTN12c
-                func test__048__Connection__close__transitions_to_the_CLOSING_state_and_then_to_the_CLOSED_state_if_the_transport_is_abruptly_closed() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    client.internal.setTransport(TestProxyTransport.self)
-                    client.connect()
-                    defer {
-                        client.dispose()
-                        client.close()
-                    }
-
-                    let transport = client.internal.transport as! TestProxyTransport
-                    var states: [ARTRealtimeConnectionState] = []
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.on { stateChange in
-                            let state = stateChange.current
-                            let error = stateChange.reason
-                            expect(error).to(beNil())
-                            switch state {
-                            case .connected:
-                                states += [state]
-                                client.close()
-                            case .closing:
-                                states += [state]
-                                transport.simulateIncomingAbruptlyClose()
-                            case .closed:
-                                states += [state]
-                                done()
-                            case .disconnected, .suspended, .failed:
-                                states += [state]
-                            default:
-                                break
-                            }
-                        }
-                    }
-
-                    if states.count != 3 {
-                        fail("Invalid number of connection states. Expected CONNECTED, CLOSING and CLOSE states (got \(states.map{ $0.rawValue }))")
-                        return
-                    }
-
-                    expect(states[0]).to(equal(ARTRealtimeConnectionState.connected))
-                    expect(states[1]).to(equal(ARTRealtimeConnectionState.closing))
-                    expect(states[2]).to(equal(ARTRealtimeConnectionState.closed))
-                }
-
-                // RTN12d
-                func test__049__Connection__close__if_DISCONNECTED__aborts_the_retry_and_moves_immediately_to_CLOSED() {
-                    let options = AblyTests.commonAppSetup()
-                    options.disconnectedRetryTimeout = 1.0
-                    let client = ARTRealtime(options: options)
-                    defer {
-                        client.close()
-                        client.dispose()
-                    }
-
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-
-                    client.internal.onDisconnected()
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.disconnected), timeout: testTimeout)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        client.connection.once { stateChange in
-                            expect(stateChange.current).to(equal(ARTRealtimeConnectionState.closed))
-                            partialDone()
-                        }
-
-                        client.close()
-
-                        delay(options.disconnectedRetryTimeout + 0.5) {
-                            // Make sure the retry doesn't happen.
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closed))
-                            partialDone()
-                        }
-                    }
-                }
-
-                // RTN12e
-                func test__050__Connection__close__if_SUSPENDED__aborts_the_retry_and_moves_immediately_to_CLOSED() {
-                    let options = AblyTests.commonAppSetup()
-                    options.suspendedRetryTimeout = 1.0
-                    let client = ARTRealtime(options: options)
-                    defer {
-                        client.close()
-                        client.dispose()
-                    }
-
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-
-                    client.internal.onSuspended()
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.suspended), timeout: testTimeout)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        client.connection.once { stateChange in
-                            expect(stateChange.current).to(equal(ARTRealtimeConnectionState.closed))
-                            partialDone()
-                        }
-
-                        client.close()
-
-                        delay(options.suspendedRetryTimeout + 0.5) {
-                            // Make sure the retry doesn't happen.
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closed))
-                            partialDone()
-                        }
-                    }
-                }
-
-            // RTN13
-            
-                // RTN13b
-                func test__051__Connection__ping__fails_if_in_the_INITIALIZED__SUSPENDED__CLOSING__CLOSED_or_FAILED_state() {
-                    let options = AblyTests.commonAppSetup()
-                    options.suspendedRetryTimeout = 0.1
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    defer {
-                        client.close()
-                        client.dispose()
-                    }
-
-                    var error: ARTErrorInfo?
-                    func ping() {
-                        error = nil
-                        waitUntil(timeout: testTimeout) { done in
-                            client.ping() { e in
-                                error = e
-                                done()
-                            }
-                        }
-                    }
-
-                    expect(client.connection.state).to(equal(ARTRealtimeConnectionState.initialized))
-                    ping()
-                    expect(error).toNot(beNil())
-
-                    client.connect()
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                    client.internal.onSuspended()
-
-                    expect(client.connection.state).to(equal(ARTRealtimeConnectionState.suspended))
-                    ping()
-                    expect(error).toNot(beNil())
-
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                    client.close()
-
-                    expect(client.connection.state).to(equal(ARTRealtimeConnectionState.closing))
-                    ping()
-                    expect(error).toNot(beNil())
-
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.closed), timeout: testTimeout)
-                    ping()
-                    expect(error).toNot(beNil())
-
-                    client.internal.onError(AblyTests.newErrorProtocolMessage())
-
-                    expect(client.connection.state).to(equal(ARTRealtimeConnectionState.failed))
-                    ping()
-                    expect(error).toNot(beNil())
-                }
-
-                // RTN13a
-                func test__052__Connection__ping__should_send_a_ProtocolMessage_with_action_HEARTBEAT_and_expects_a_HEARTBEAT_message_in_response() {
-                    let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    waitUntil(timeout: testTimeout) { done in
-                        client.ping() { error in
-                            expect(error).to(beNil())
-                            let transport = client.internal.transport as! TestProxyTransport
-                            expect(transport.protocolMessagesSent.filter{ $0.action == .heartbeat }).to(haveCount(1))
-                            expect(transport.protocolMessagesReceived.filter{ $0.action == .heartbeat }).to(haveCount(1))
-                            done()
-                        }
-                    }
-                }
-
-                // RTN13c
-                func test__053__Connection__ping__should_fail_if_a_HEARTBEAT_ProtocolMessage_is_not_received_within_the_default_realtime_request_timeout() {
-                    let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { _ in
-                            done()
-                        }
-                    }
-                    guard let transport = client.internal.transport as? TestProxyTransport else {
-                        fail("TestProxyTransport is not set"); return
-                    }
-
-                    let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                    defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                    ARTDefault.setRealtimeRequestTimeout(3.0)
-
-                    transport.actionsIgnored += [.heartbeat]
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let start = NSDate()
-                        transport.ignoreSends = true
-
-                        client.ping() { error in
-                            guard let error = error else {
-                                fail("expected error"); done(); return
-                            }
-                            let end = NSDate()
-                            expect(error.message).to(contain("timed out"))
-                            expect(end.timeIntervalSince(start as Date)).to(beCloseTo(ARTDefault.realtimeRequestTimeout(), within: 1.5))
-                            done()
-                        }
-                    }
-                }
-
-            // RTN14a
-            func test__009__Connection__should_enter_FAILED_state_when_API_key_is_invalid() {
-                let options = AblyTests.commonAppSetup()
-                options.key = String(options.key!.reversed())
-                options.autoConnect = false
-                let client = ARTRealtime(options: options)
-                defer {
-                    client.dispose()
-                    client.close()
-                }
-
-                waitUntil(timeout: testTimeout) { done in
-                    client.connection.on { stateChange in
-                        let state = stateChange.current
-                        let errorInfo = stateChange.reason
-                        switch state {
-                        case .failed:
-                            expect(errorInfo).toNot(beNil())
-                            done()
-                        default:
-                            break
-                        }
-                    }
-                    client.connect()
-                }
+    func beforeEach__Connection__Host_Fallback() {
+        ARTFallback_shuffleArray = { array in
+            let arranged = expectedHostOrder.reversed().map { array[$0] }
+            for (i, element) in arranged.enumerated() {
+                array[i] = element
             }
+        }
+    }
 
-            // RTN14b
-            
-                func test__054__Connection__connection_request_fails__on_DISCONNECTED_after_CONNECTED__should_not_emit_error_with_a_renewable_token() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    options.authCallback = { tokenParams, callback in
-                        getTestTokenDetails(key: options.key, capability: tokenParams.capability, ttl: tokenParams.ttl as! TimeInterval?, completion: callback)
-                    }
-                    let tokenTtl = 3.0
-                    options.token = getTestToken(key: options.key, ttl: tokenTtl)
+    func afterEach__Connection__Host_Fallback() {
+        ARTFallback_shuffleArray = originalARTFallback_shuffleArray
+    }
 
-                    let client = ARTRealtime(options: options)
-                    client.internal.setTransport(TestProxyTransport.self)
-                    defer {
-                        client.dispose()
-                        client.close()
-                    }
+    // RTN17b
+    func test__086__Connection__Host_Fallback__failing_connections_with_custom_endpoint_should_result_in_an_error_immediately() {
+        beforeEach__Connection__Host_Fallback()
 
-                    waitUntil(timeout: testTimeout) { done in
-                        // Let the token expire
-                        client.connection.once(.disconnected) { stateChange in
-                            guard let reason = stateChange.reason else {
-                                fail("Token error is missing"); done(); return
-                            }
-                            expect(reason.code) == ARTErrorCode.tokenExpired.intValue
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.environment = "test" // do not use the default endpoint
+        expect(options.fallbackHostsUseDefault).to(beFalse())
+        expect(options.fallbackHosts).to(beNil())
+        options.autoConnect = false
+        options.queueMessages = false
 
-                            client.connection.on { stateChange in
-                                let state = stateChange.current
-                                let errorInfo = stateChange.reason
-                                switch state {
-                                case .connected:
-                                    expect(errorInfo).to(beNil())
-                                    // New token
-                                    expect(client.auth.tokenDetails!.token).toNot(equal(options.token))
-                                    done()
-                                case .failed, .suspended:
-                                    fail("Should not emit error (\(String(describing: errorInfo)))")
-                                    done()
-                                default:
-                                    break
-                                }
-                            }
-                        }
-                        client.connect()
-                    }
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        TestProxyTransport.fakeNetworkResponse = .hostUnreachable
+        defer { TestProxyTransport.fakeNetworkResponse = nil }
+
+        var urlConnections = [URL]()
+        TestProxyTransport.networkConnectEvent = { transport, url in
+            if client.internal.transport !== transport {
+                return
+            }
+            urlConnections.append(url)
+        }
+        defer { TestProxyTransport.networkConnectEvent = nil }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.disconnected) { stateChange in
+                expect(stateChange.previous) == ARTRealtimeConnectionState.connecting
+                expect(stateChange.current) == ARTRealtimeConnectionState.disconnected
+                guard let reason = stateChange.reason else {
+                    fail("Reason is empty"); done(); return
                 }
-                
-                func test__055__Connection__connection_request_fails__on_token_error_while_CONNECTING__reissues_token_and_reconnects() {
-                    var authCallbackCalled = 0
-                    
-                    var tokenTTL = 1.0
+                expect(reason.message).to(contain("host unreachable"))
+                done()
+            }
+            client.connect()
+        }
 
-                    let options = AblyTests.commonAppSetup()
-                    options.authCallback = { _, callback in
-                        authCallbackCalled += 1
-                        getTestTokenDetails(ttl: tokenTTL) { token, err in
-                            // Let the token expire
-                            delay(2.0) {
-                                callback(token, err)
-                            }
-                            // Next time, tokenTTL will be longer so that it doesn't expire right away
-                            tokenTTL = 60
-                        }
-                    }
-                    options.autoConnect = false
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { error in
+                expect(error?.code).to(equal(2))
+                expect(error?.message).to(contain("host unreachable"))
+                expect(error?.reason).to(contain(".FakeNetworkResponse"))
+                done()
+            }
+        }
 
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.close() }
+        expect(urlConnections).to(haveCount(1))
 
-                    var hookToken: AspectToken?
-                    waitUntil(timeout: testTimeout.multiplied(by: 2)) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        realtime.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            partialDone()
-                        }
-                        hookToken = realtime.internal.testSuite_getArgument(from: NSSelectorFromString("onError:"), at: 0) { arg0 in
-                            guard let message = arg0 as? ARTProtocolMessage, let error = message.error else {
-                                fail("Expecting a protocol message with Token error"); partialDone(); return
-                            }
-                            expect(error.code).to(equal(ARTErrorCode.tokenExpired.intValue))
-                            partialDone()
-                        }
-                        realtime.connect()
-                    }
-                    hookToken?.remove()
+        afterEach__Connection__Host_Fallback()
+    }
 
-                    // First token issue, and then reissue on token error.
-                    expect(authCallbackCalled).to(equal(2))
+    // RTN17b
+    func test__087__Connection__Host_Fallback__failing_connections_with_custom_endpoint_should_result_in_time_outs() {
+        beforeEach__Connection__Host_Fallback()
+
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.environment = "test" // do not use the default endpoint
+        expect(options.fallbackHostsUseDefault).to(beFalse())
+        expect(options.fallbackHosts).to(beNil())
+        options.autoConnect = false
+
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(1.0)
+
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        client.channels.get("test")
+
+        TestProxyTransport.fakeNetworkResponse = .hostUnreachable
+        defer { TestProxyTransport.fakeNetworkResponse = nil }
+
+        var urlConnections = [URL]()
+        TestProxyTransport.networkConnectEvent = { transport, url in
+            if client.internal.transport !== transport {
+                return
+            }
+            urlConnections.append(url)
+        }
+        defer { TestProxyTransport.networkConnectEvent = nil }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on(.disconnected) { stateChange in
+                expect(stateChange.previous) == ARTRealtimeConnectionState.connecting
+                expect(stateChange.current) == ARTRealtimeConnectionState.disconnected
+                guard let reason = stateChange.reason else {
+                    fail("Reason is empty"); done(); return
                 }
+                expect(reason.message).to(contain("host unreachable"))
+                done()
+            }
+            client.connect()
+        }
 
+        expect(urlConnections).to(haveCount(1))
 
-                func test__056__Connection__connection_request_fails__should_transition_to_disconnected_when_the_token_renewal_fails() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let tokenTtl = 3.0
-                    let tokenDetails = getTestTokenDetails(key: options.key, capability: nil, ttl: tokenTtl)!
-                    options.token = tokenDetails.token
-                    options.authCallback = { tokenParams, callback in
-                        delay(0) {
-                            callback(tokenDetails, nil) // Return the same expired token again.
-                        }
-                    }
+        afterEach__Connection__Host_Fallback()
+    }
 
-                    let client = ARTRealtime(options: options)
-                    client.internal.setTransport(TestProxyTransport.self)
-                    defer {
-                        client.dispose()
-                        client.close()
-                    }
+    // RTN17b
+    func test__088__Connection__Host_Fallback__applies_when_the_default_realtime_ably_io_endpoint_is_being_used() {
+        beforeEach__Connection__Host_Fallback()
 
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            partialDone()
-                        }
-                        client.connection.once(.disconnected) { stateChange in
-                            guard let reason = stateChange.reason else {
-                                fail("Reason is nil"); done(); return;
-                            }
-                            expect(reason.code).to(equal(ARTErrorCode.tokenExpired.intValue))
-                            expect(reason.statusCode).to(equal(401))
-                            expect(reason.message).to(contain("Key/token status changed (expire)"))
-                            partialDone()
-                        }
-                        client.connect()
-                    }
-                }
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.channels.get("test")
 
-                func test__057__Connection__connection_request_fails__should_transition_to_Failed_state_because_the_token_is_invalid_and_not_renewable() {
-                    let options = AblyTests.clientOptions()
-                    options.autoConnect = false
-                    let tokenTtl = 1.0
-                    options.token = getTestToken(ttl: tokenTtl)
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(1.0)
 
-                    // Let the token expire
-                    waitUntil(timeout: testTimeout) { done in
-                        delay(tokenTtl) {
-                            done()
-                        }
-                    }
+        client.internal.setTransport(TestProxyTransport.self)
+        TestProxyTransport.fakeNetworkResponse = .hostUnreachable
+        defer { TestProxyTransport.fakeNetworkResponse = nil }
 
-                    let client = ARTRealtime(options: options)
-                    client.internal.setTransport(TestProxyTransport.self)
-                    defer {
-                        client.dispose()
-                        client.close()
-                    }
+        var urlConnections = [URL]()
+        TestProxyTransport.networkConnectEvent = { transport, url in
+            if client.internal.transport !== transport {
+                return
+            }
+            urlConnections.append(url)
+            if urlConnections.count == 1 {
+                TestProxyTransport.fakeNetworkResponse = nil
+            }
+        }
+        defer { TestProxyTransport.networkConnectEvent = nil }
 
-                    var transport: TestProxyTransport!
+        waitUntil(timeout: testTimeout) { done in
+            // wss://[a-e].ably-realtime.com: when a timeout occurs
+            client.connection.once(.disconnected) { _ in
+                done()
+            }
+            // wss://[a-e].ably-realtime.com: when a 401 occurs because of the `xxxx:xxxx` key
+            client.connection.once(.failed) { _ in
+                done()
+            }
+            client.connect()
+        }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.on { stateChange in
-                            let state = stateChange.current
-                            let errorInfo = stateChange.reason
-                            switch state {
-                            case .connected:
-                                fail("Should not be connected")
-                                done()
-                            case .failed, .disconnected, .suspended:
-                                guard let errorInfo = errorInfo else {
-                                    fail("ErrorInfo is nil"); done(); return
-                                }
-                                expect(errorInfo.code).to(equal(ARTErrorCode.tokenExpired.intValue))
-                                done()
-                            default:
-                                break
-                            }
-                        }
-                        client.connect()
-                        transport = (client.internal.transport as! TestProxyTransport)
-                    }
+        expect(urlConnections).to(haveCount(2))
+        if urlConnections.count != 2 {
+            return
+        }
+        expect(NSRegularExpression.match(urlConnections[0].absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
+        expect(NSRegularExpression.match(urlConnections[1].absoluteString, pattern: "//[a-e].ably-realtime.com")).to(beTrue())
 
-                    let failures = transport.protocolMessagesReceived.filter({ $0.action == .error })
+        afterEach__Connection__Host_Fallback()
+    }
 
-                    if failures.count != 1 {
-                        fail("Should have only one connection request fail")
-                        return
-                    }
+    func test__089__Connection__Host_Fallback__applies_when_an_array_of_ClientOptions_fallbackHosts_is_provided() {
+        beforeEach__Connection__Host_Fallback()
 
-                    expect(failures[0].error!.code).to(equal(ARTErrorCode.tokenExpired.intValue))
-                }
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.autoConnect = false
+        options.fallbackHosts = ["f.ably-realtime.com", "g.ably-realtime.com", "h.ably-realtime.com", "i.ably-realtime.com", "j.ably-realtime.com"]
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.channels.get("test")
 
-                // RTN14c
-                func test__058__Connection__connection_request_fails__connection_attempt_should_fail_if_not_connected_within_the_default_realtime_request_timeout() {
-                    let options = AblyTests.commonAppSetup()
-                    options.realtimeHost = "10.255.255.1" //non-routable IP address
-                    options.autoConnect = false
-                    let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                    defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                    ARTDefault.setRealtimeRequestTimeout(0.5)
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(1.0)
 
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    var start, end: NSDate?
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.on(.disconnected) { stateChange in
-                            end = NSDate()
-                            expect(stateChange.reason!.message).to(contain("timed out"))
-                            expect(client.connection.errorReason!).to(beIdenticalTo(stateChange.reason))
-                            done()
-                        }
-                        client.connect()
-                        start = NSDate()
-                    }
-                    if let start = start, let end = end {
-                        expect(end.timeIntervalSince(start as Date)).to(beCloseTo(ARTDefault.realtimeRequestTimeout(), within: 1.5))
-                    }
-                    else {
-                        fail("Start date or end date are empty")
-                    }
-                }
+        client.internal.setTransport(TestProxyTransport.self)
+        TestProxyTransport.fakeNetworkResponse = .hostUnreachable
+        defer { TestProxyTransport.fakeNetworkResponse = nil }
 
-                // RTN14d
-                func test__059__Connection__connection_request_fails__connection_attempt_fails_for_any_recoverable_reason() {
-                    let options = AblyTests.commonAppSetup()
-                    options.realtimeHost = "10.255.255.1" //non-routable IP address
-                    options.disconnectedRetryTimeout = 1.0
-                    options.autoConnect = false
-                    let expectedTime = 3.0
+        var urlConnections = [URL]()
+        TestProxyTransport.networkConnectEvent = { transport, url in
+            if client.internal.transport !== transport {
+                return
+            }
+            urlConnections.append(url)
+            if urlConnections.count == 1 {
+                TestProxyTransport.fakeNetworkResponse = nil
+            }
+        }
+        defer { TestProxyTransport.networkConnectEvent = nil }
 
-                    options.authCallback = { tokenParams, completion in
-                        // Ignore `completion` closure to force a time out
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            // wss://[a-e].ably-realtime.com: when a timeout occurs
+            client.connection.once(.disconnected) { _ in
+                done()
+            }
+            // wss://[a-e].ably-realtime.com: when a 401 occurs because of the `xxxx:xxxx` key
+            client.connection.once(.failed) { _ in
+                done()
+            }
+            client.connect()
+        }
 
-                    let previousConnectionStateTtl = ARTDefault.connectionStateTtl()
-                    defer { ARTDefault.setConnectionStateTtl(previousConnectionStateTtl) }
-                    ARTDefault.setConnectionStateTtl(expectedTime)
+        expect(urlConnections.count > 1 && urlConnections.count <= options.fallbackHosts!.count + 1).to(beTrue())
+        expect(NSRegularExpression.match(urlConnections[0].absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
+        for connection in urlConnections.dropFirst() {
+            expect(NSRegularExpression.match(connection.absoluteString, pattern: "//[f-j].ably-realtime.com")).to(beTrue())
+        }
 
-                    let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                    defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                    ARTDefault.setRealtimeRequestTimeout(0.1)
+        afterEach__Connection__Host_Fallback()
+    }
 
-                    let client = ARTRealtime(options: options)
-                    client.internal.shouldImmediatelyReconnect = false
-                    defer {
-                        client.connection.off()
-                        client.close()
-                    }
+    // RTN17d
 
-                    var totalRetry = 0
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        var start: NSDate?
+    func skipped__test__097__Connection__Host_Fallback__should_use_an_alternative_host_when___hostUnreachable() {
+        beforeEach__Connection__Host_Fallback()
 
-                        client.connection.once(.disconnected) { stateChange in
-                            expect(stateChange.reason!.message).to(contain("timed out"))
-                            expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connecting))
-                            expect(stateChange.retryIn).to(beCloseTo(options.disconnectedRetryTimeout))
-                            partialDone()
-                            start = NSDate()
-                        }
+        testUsesAlternativeHostOnResponse(.hostUnreachable)
 
-                        client.connection.on(.suspended) { stateChange in
-                            let end = NSDate()
-                            expect(end.timeIntervalSince(start! as Date)).to(beCloseTo(expectedTime, within: 0.9))
-                            partialDone()
-                        }
+        afterEach__Connection__Host_Fallback()
+    }
 
-                        client.connect()
+    func skipped__test__098__Connection__Host_Fallback__should_use_an_alternative_host_when___requestTimeout_timeout__0_1_() {
+        beforeEach__Connection__Host_Fallback()
 
-                        client.connection.on(.connecting) { stateChange in
-                            expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.disconnected))
-                            totalRetry += 1
-                        }
-                    }
+        testUsesAlternativeHostOnResponse(.requestTimeout(timeout: 0.1))
 
-                    expect(totalRetry).to(equal(Int(expectedTime / options.disconnectedRetryTimeout)))
-                }
+        afterEach__Connection__Host_Fallback()
+    }
 
-                // RTN14e
-                func test__060__Connection__connection_request_fails__connection_state_has_been_in_the_DISCONNECTED_state_for_more_than_the_default_connectionStateTtl_should_change_the_state_to_SUSPENDED() {
-                    let options = AblyTests.commonAppSetup()
-                    options.disconnectedRetryTimeout = 0.1
-                    options.suspendedRetryTimeout = 0.5
-                    options.autoConnect = false
+    func skipped__test__099__Connection__Host_Fallback__should_use_an_alternative_host_when___hostInternalError_code__501_() {
+        beforeEach__Connection__Host_Fallback()
 
-                    options.authCallback = { _ , _ in
-                        // Force a timeout
-                    }
+        testUsesAlternativeHostOnResponse(.hostInternalError(code: 501))
 
-                    let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                    defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                    ARTDefault.setRealtimeRequestTimeout(0.1)
+        afterEach__Connection__Host_Fallback()
+    }
 
-                    let client = ARTRealtime(options: options)
-                    client.internal.shouldImmediatelyReconnect = false
-                    defer { client.dispose(); client.close() }
+    func test__100__Connection__Host_Fallback__should_move_to_disconnected_when_there_s_no_internet__with_NSPOSIXErrorDomain_with_code_57() {
+        beforeEach__Connection__Host_Fallback()
 
-                    let ttlHookToken = client.overrideConnectionStateTTL(0.3)
-                    defer { ttlHookToken.remove() }
+        testMovesToDisconnectedWithNetworkingError(NSError(domain: "NSPOSIXErrorDomain", code: 57, userInfo: [NSLocalizedDescriptionKey: "shouldn't matter"]))
 
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.on(.suspended) { stateChange in
-                            expect(client.connection.errorReason!.message).to(contain("timed out"))
+        afterEach__Connection__Host_Fallback()
+    }
 
-                            let start = NSDate()
-                            client.connection.once(.connecting) { stateChange in
-                                let end = NSDate()
-                                expect(end.timeIntervalSince(start as Date)).to(beCloseTo(options.suspendedRetryTimeout, within: 0.5))
-                                done()
-                            }
-                        }
-                        client.connect()
-                    }
-                }
+    func test__101__Connection__Host_Fallback__should_move_to_disconnected_when_there_s_no_internet__with_NSPOSIXErrorDomain_with_code_50() {
+        beforeEach__Connection__Host_Fallback()
 
-                // RTN14e - https://github.com/ably/ably-cocoa/issues/913
-                func test__061__Connection__connection_request_fails__should_change_the_state_to_SUSPENDED_when_the_connection_state_has_been_in_the_DISCONNECTED_state_for_more_than_the_connectionStateTtl() {
-                    let options = AblyTests.commonAppSetup()
-                    options.disconnectedRetryTimeout = 0.5
-                    options.suspendedRetryTimeout = 2.0
-                    options.autoConnect = false
+        testMovesToDisconnectedWithNetworkingError(NSError(domain: "NSPOSIXErrorDomain", code: 50, userInfo: [NSLocalizedDescriptionKey: "shouldn't matter"]))
 
-                    let client = ARTRealtime(options: options)
-                    client.internal.setTransport(TestProxyTransport.self)
-                    client.internal.setReachabilityClass(TestReachability.self)
-                    defer {
-                        client.simulateRestoreInternetConnection()
-                        client.dispose()
-                        client.close()
-                    }
+        afterEach__Connection__Host_Fallback()
+    }
 
-                    let ttlHookToken = client.overrideConnectionStateTTL(3.0)
-                    defer { ttlHookToken.remove() }
+    func test__102__Connection__Host_Fallback__should_move_to_disconnected_when_there_s_no_internet__with_any_kCFErrorDomainCFNetwork() {
+        beforeEach__Connection__Host_Fallback()
 
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            done()
-                        }
-                        client.connect()
-                    }
+        testMovesToDisconnectedWithNetworkingError(NSError(domain: "kCFErrorDomainCFNetwork", code: 1337, userInfo: [NSLocalizedDescriptionKey: "shouldn't matter"]))
 
-                    var events: [ARTRealtimeConnectionState] = []
-                    client.connection.on { stateChange in
-                        events.append(stateChange.current)
-                    }
-                    client.simulateNoInternetConnection()
+        afterEach__Connection__Host_Fallback()
+    }
 
-                    expect(events).toEventually(equal([
-                        .disconnected,
-                        .connecting, //0.5 - 1
-                        .disconnected,
-                        .connecting, //1.0 - 2
-                        .disconnected,
-                        .connecting, //1.5 - 3
-                        .disconnected,
-                        .connecting, //2.0 - 4
-                        .disconnected,
-                        .connecting, //2.5 - 5
-                        .disconnected,
-                        .connecting, //3.0 - 6
-                        .suspended,
-                        .connecting,
-                        .suspended
-                    ]), timeout: testTimeout)
+    func test__090__Connection__Host_Fallback__should_not_use_an_alternative_host_when_the_client_receives_a_bad_request() {
+        beforeEach__Connection__Host_Fallback()
 
-                    events.removeAll()
-                    client.simulateRestoreInternetConnection(after: 7.0)
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        let channel = client.channels.get("test")
 
-                    expect(events).toEventually(equal([
-                        .connecting, //2.0 - 1
-                        .suspended,
-                        .connecting, //4.0 - 2
-                        .suspended,
-                        .connecting, //6.0 - 3
-                        .suspended,
-                        .connecting,
-                        .connected
-                    ]), timeout: testTimeout)
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(1.0)
 
+        client.internal.setTransport(TestProxyTransport.self)
+        TestProxyTransport.fakeNetworkResponse = .host400BadRequest
+        defer { TestProxyTransport.fakeNetworkResponse = nil }
+
+        var urlConnections = [URL]()
+        TestProxyTransport.networkConnectEvent = { transport, url in
+            if client.internal.transport !== transport {
+                return
+            }
+            urlConnections.append(url)
+        }
+        defer { TestProxyTransport.networkConnectEvent = nil }
+
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { _ in
+                done()
+            }
+        }
+
+        expect(urlConnections).to(haveCount(1))
+        expect(NSRegularExpression.match(urlConnections[0].absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
+
+        afterEach__Connection__Host_Fallback()
+    }
+
+    // RTN17a
+    func test__091__Connection__Host_Fallback__every_connection_is_first_attempted_to_the_primary_host_realtime_ably_io() {
+        beforeEach__Connection__Host_Fallback()
+
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.channels.get("test")
+
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(1.0)
+
+        client.internal.setTransport(TestProxyTransport.self)
+        TestProxyTransport.fakeNetworkResponse = .hostUnreachable
+        defer { TestProxyTransport.fakeNetworkResponse = nil }
+
+        var urlConnections = [URL]()
+        TestProxyTransport.networkConnectEvent = { transport, url in
+            if client.internal.transport !== transport {
+                return
+            }
+            urlConnections.append(url)
+            TestProxyTransport.fakeNetworkResponse = nil
+        }
+        defer { TestProxyTransport.networkConnectEvent = nil }
+
+        waitUntil(timeout: testTimeout) { done in
+            // Unreachable and try a fallback
+            client.connection.on { stateChange in
+                // Timeout or 401 occurs because of the `xxxx:xxxx` key
+                if stateChange.current == .disconnected || stateChange.current == .failed {
                     client.connection.off()
-
-                    expect(client.connection.errorReason).to(beNil())
-                    expect(client.connection.state).to(equal(.connected))
+                    done()
                 }
+            }
+            client.connect()
+        }
 
-                func test__062__Connection__connection_request_fails__on_CLOSE_the_connection_should_stop_connection_retries() {
-                    let options = AblyTests.commonAppSetup()
-                    // to avoid waiting for the default 15s before trying a reconnection
-                    options.disconnectedRetryTimeout = 0.1
-                    options.suspendedRetryTimeout = 0.5
-                    options.autoConnect = false
-                    let expectedTime: TimeInterval = 1.0
+        client.connect()
 
-                    options.authCallback = { _ , _ in
-                        // Force a timeout
-                    }
-
-                    let previousConnectionStateTtl = ARTDefault.connectionStateTtl()
-                    defer { ARTDefault.setConnectionStateTtl(previousConnectionStateTtl) }
-                    ARTDefault.setConnectionStateTtl(expectedTime)
-
-                    let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                    defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                    ARTDefault.setRealtimeRequestTimeout(0.1)
-
-                    let client = ARTRealtime(options: options)
-                    client.internal.shouldImmediatelyReconnect = false
-                    defer { client.dispose(); client.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.on(.suspended) { stateChange in
-                            expect(client.connection.errorReason!.message).to(contain("timed out"))
-
-                            let start = NSDate()
-                            client.connection.once(.connecting) { stateChange in
-                                let end = NSDate()
-                                expect(end.timeIntervalSince(start as Date)).to(beCloseTo(options.suspendedRetryTimeout, within: 0.5))
-                                done()
-                            }
-                        }
-                        client.connect()
-                    }
-
-                    client.close()
-
-                    // Check if the connection gets closed
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connecting) { stateChange in
-                            fail("Should be closing the connection"); done(); return
-                        }
-                        delay(2.0) {
-                            done()
-                        }
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            // 401 occurs because of the `xxxx:xxxx` key
+            client.connection.once(.failed) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Error is nil"); done(); return
                 }
+                expect(error.message).to(contain("Invalid key"))
+                done()
+            }
+        }
 
-            // RTN15
-            
+        expect(urlConnections).to(haveCount(3))
+        expect(NSRegularExpression.match(urlConnections.at(0)?.absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
+        expect(NSRegularExpression.match(urlConnections.at(1)?.absoluteString, pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+        expect(NSRegularExpression.match(urlConnections.at(2)?.absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
 
-                // RTN15a
-                func test__063__Connection__connection_failures_once_CONNECTED__should_not_receive_published_messages_until_the_connection_reconnects_successfully() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
+        afterEach__Connection__Host_Fallback()
+    }
 
-                    let client1 = ARTRealtime(options: options)
-                    defer { client1.close() }
-                    let channel1 = client1.channels.get("test")
+    // RTN17c
+    func test__092__Connection__Host_Fallback__should_retry_hosts_in_random_order_after_checkin_if_an_internet_connection_is_available() {
+        beforeEach__Connection__Host_Fallback()
 
-                    var states = [ARTRealtimeConnectionState]()
-                    client1.connection.on() { stateChange in
-                        states = states + [stateChange.current]
-                    }
-                    client1.connect()
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.channels.get("test")
 
-                    let client2 = ARTRealtime(options: options)
-                    client2.connect()
-                    defer { client2.close() }
-                    let channel2 = client2.channels.get("test")
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(1.0)
 
-                    channel1.subscribe { message in
-                        fail("Shouldn't receive the messsage")
-                    }
+        let testHttpExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.rest.httpExecutor = testHttpExecutor
 
-                    expect(channel1.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+        client.internal.setTransport(TestProxyTransport.self)
+        TestProxyTransport.fakeNetworkResponse = .hostUnreachable
+        defer { TestProxyTransport.fakeNetworkResponse = nil }
 
-                    let firstConnection: (id: String, key: String) = (client1.connection.id!, client1.connection.key!)
+        var urls = [URL]()
+        TestProxyTransport.networkConnectEvent = { transport, url in
+            if client.internal.transport !== transport {
+                return
+            }
+            DispatchQueue.main.async {
+                urls.append(url)
+            }
+        }
+        defer { TestProxyTransport.networkConnectEvent = nil }
+        testHttpExecutor.setListenerAfterRequest { request in
+            urls.append(request.url!)
+        }
 
-                    // Connection state cannot be resumed
-                    client1.simulateLostConnectionAndState()
+        waitUntil(timeout: testTimeout.multiplied(by: 1000)) { done in
+            // wss://[a-e].ably-realtime.com: when a timeout occurs
+            client.connection.once(.disconnected) { _ in
+                done()
+            }
+            // wss://[a-e].ably-realtime.com: when a 401 occurs because of the `xxxx:xxxx` key
+            client.connection.once(.failed) { _ in
+                done()
+            }
+            client.connect()
+        }
 
-                    channel2.publish(nil, data: "message") { errorInfo in
-                        expect(errorInfo).to(beNil())
-                    }
+        let extractHostname = { (url: URL) in
+            NSRegularExpression.extract(url.absoluteString, pattern: "[a-e].ably-realtime.com")
+        }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        client1.connection.once(.connecting) { _ in
-                            expect(client1.internal.resuming).to(beTrue())
-                            partialDone()
-                        }
-                        client1.connection.once(.connected) { _ in
-                            expect(client1.internal.resuming).to(beFalse())
-                            expect(client1.connection.id).toNot(equal(firstConnection.id))
-                            expect(client1.connection.key).toNot(equal(firstConnection.key))
-                            partialDone()
-                        }
-                    }
-
-                    expect(states).toEventually(equal([.connecting, .connected, .disconnected, .connecting, .connected]), timeout: testTimeout)
+        var resultFallbackHosts = [String]()
+        var gotInternetIsUpCheck = false
+        for url in urls {
+            if NSRegularExpression.match(url.absoluteString, pattern: "//internet-up.ably-realtime.com/is-the-internet-up.txt") {
+                gotInternetIsUpCheck = true
+            } else if let fallbackHost = extractHostname(url) {
+                if Optional(fallbackHost) == resultFallbackHosts.last {
+                    continue
                 }
-                
-                // RTN15a
-                func test__064__Connection__connection_failures_once_CONNECTED__if_a_Connection_transport_is_disconnected_unexpectedly_or_if_a_token_expires__then_the_Connection_manager_will_immediately_attempt_to_reconnect() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    options.tokenDetails = getTestTokenDetails(ttl: 3.0)
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.on(.disconnected) { _ in
-                            let disconnectedTime = Date()
-                            client.connection.on(.connected) { _ in
-                                let reconnectedTime = Date()
-                                // test that reconnection happens within 10 seconds,
-                                // so that we are sure it doesn't wait for the default 15s
-                                expect(reconnectedTime.timeIntervalSince(disconnectedTime)).to(beCloseTo(0, within: 10))
-                                done()
-                            }
-                        }
-                        client.connect()
-                    }
+                // Host changed; should've had an internet check before.
+                expect(gotInternetIsUpCheck).to(beTrue())
+                gotInternetIsUpCheck = false
+                resultFallbackHosts.append(fallbackHost)
+            }
+        }
+
+        let expectedFallbackHosts = Array(expectedHostOrder.map { ARTDefault.fallbackHosts()[$0] })
+
+        expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
+
+        afterEach__Connection__Host_Fallback()
+    }
+
+    // RTN17c
+    func test__093__Connection__Host_Fallback__doesn_t_try_fallback_host_if_Internet_connection_check_fails() {
+        beforeEach__Connection__Host_Fallback()
+
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.channels.get("test")
+
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(1.0)
+
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        let testHttpExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.rest.httpExecutor = testHttpExecutor
+
+        client.internal.setTransport(TestProxyTransport.self)
+        TestProxyTransport.fakeNetworkResponse = .hostUnreachable
+        defer { TestProxyTransport.fakeNetworkResponse = nil }
+
+        let extractHostname = { (url: URL) in
+            NSRegularExpression.extract(url.absoluteString, pattern: "[a-e].ably-realtime.com")
+        }
+
+        TestProxyTransport.networkConnectEvent = { transport, url in
+            if client.internal.transport !== transport {
+                return
+            }
+            if extractHostname(url) != nil {
+                fail("shouldn't try fallback host after failed connectivity check")
+            }
+        }
+        defer { TestProxyTransport.networkConnectEvent = nil }
+
+        mockHTTP.setNetworkState(network: .hostInternalError(code: 500), forHost: "internet-up.ably-realtime.com")
+
+        waitUntil(timeout: testTimeout) { done in
+            // wss://[a-e].ably-realtime.com: when a timeout occurs
+            client.connection.once(.disconnected) { _ in
+                done()
+            }
+            // wss://[a-e].ably-realtime.com: when a 401 occurs because of the `xxxx:xxxx` key
+            client.connection.once(.failed) { _ in
+                done()
+            }
+            client.connect()
+        }
+
+        afterEach__Connection__Host_Fallback()
+    }
+
+    func skipped__test__094__Connection__Host_Fallback__should_retry_custom_fallback_hosts_in_random_order_after_checkin_if_an_internet_connection_is_available() {
+        beforeEach__Connection__Host_Fallback()
+
+        let fbHosts = ["f.ably-realtime.com", "g.ably-realtime.com", "h.ably-realtime.com", "i.ably-realtime.com", "j.ably-realtime.com"]
+
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.autoConnect = false
+        options.fallbackHosts = fbHosts
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.channels.get("test")
+
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(1.0)
+
+        let testHttpExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.rest.httpExecutor = testHttpExecutor
+
+        client.internal.setTransport(TestProxyTransport.self)
+        TestProxyTransport.fakeNetworkResponse = .hostUnreachable
+        defer { TestProxyTransport.fakeNetworkResponse = nil }
+
+        var urls = [URL]()
+        TestProxyTransport.networkConnectEvent = { transport, url in
+            if client.internal.transport !== transport {
+                return
+            }
+            DispatchQueue.main.async {
+                urls.append(url)
+            }
+        }
+        defer { TestProxyTransport.networkConnectEvent = nil }
+
+        testHttpExecutor.setListenerAfterRequest { request in
+            urls.append(request.url!)
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            // wss://[a-e].ably-realtime.com: when a timeout occurs
+            client.connection.once(.disconnected) { _ in
+                done()
+            }
+            // wss://[a-e].ably-realtime.com: when a 401 occurs because of the `xxxx:xxxx` key
+            client.connection.once(.failed) { _ in
+                done()
+            }
+            client.connect()
+        }
+
+        let extractHostname = { (url: URL) in
+            NSRegularExpression.extract(url.absoluteString, pattern: "[f-j].ably-realtime.com")
+        }
+
+        var resultFallbackHosts = [String]()
+        var gotInternetIsUpCheck = false
+        for url in urls {
+            if NSRegularExpression.match(url.absoluteString, pattern: "//internet-up.ably-realtime.com/is-the-internet-up.txt") {
+                gotInternetIsUpCheck = true
+            } else if let fallbackHost = extractHostname(url) {
+                if Optional(fallbackHost) == resultFallbackHosts.last {
+                    continue
                 }
-
-                // RTN15b
-                
-
-                    // RTN15b1, RTN15b2
-                    func test__067__Connection__connection_failures_once_CONNECTED__reconnects_to_the_websocket_endpoint_with_additional_querystring_params__resume_is_the_private_connection_key_and_connection_serial_is_the_most_recent_ProtocolMessage_connectionSerial_received() {
-                        let options = AblyTests.commonAppSetup()
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-
-                        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                        let expectedConnectionKey = client.connection.key!
-                        let expectedConnectionSerial = client.connection.serial
-                        client.internal.onDisconnected()
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.connected) { _ in
-                                let transport = client.internal.transport as! TestProxyTransport
-                                let query = transport.lastUrl!.query
-                                expect(query).to(haveParam("resume", withValue: expectedConnectionKey))
-                                expect(query).to(haveParam("connectionSerial", withValue: "\(expectedConnectionSerial)"))
-                                done()
-                            }
-                        }
-                    }
-
-                // RTN15c
-                
-
-                    // RTN15c1
-                    func test__068__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__CONNECTED_ProtocolMessage_with_the_same_connectionId_as_the_current_client__and_no_error() {
-                        let options = AblyTests.commonAppSetup()
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-
-                        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                        let expectedConnectionId = client.connection.id
-                        client.internal.onDisconnected()
-
-                        channel.attach()
-                        channel.publish(nil, data: "queued message")
-                        expect(client.internal.queuedMessages).toEventually(haveCount(1), timeout: testTimeout)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.connected) { stateChange in
-                                let transport = client.internal.transport as! TestProxyTransport
-                                let connectedPM = transport.protocolMessagesReceived.filter{ $0.action == .connected }[0]
-                                expect(connectedPM.connectionId).to(equal(expectedConnectionId))
-                                expect(stateChange.reason).to(beNil())
-                                done()
-                            }
-                        }
-                        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-                        expect(client.internal.queuedMessages).toEventually(haveCount(0), timeout: testTimeout)
-                    }
-
-                    // RTN15c2
-                    func test__069__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__CONNECTED_ProtocolMessage_with_the_same_connectionId_as_the_current_client_and_an_non_fatal_error() {
-                        let options = AblyTests.commonAppSetup()
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-
-                        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-
-                        let expectedConnectionId = client.connection.id
-                        client.internalAsync { _internal in
-                            _internal.onDisconnected()
-                        }
-
-                        channel.attach()
-                        channel.publish(nil, data: "queued message")
-                        expect(client.internal.queuedMessages).toEventually(haveCount(1), timeout: testTimeout)
-
-                        client.connection.once(.connecting) { _ in
-                            client.internalSync { _internal in
-                                let transport = _internal.transport as! TestProxyTransport
-                                transport.setBeforeIncomingMessageModifier({ protocolMessage in
-                                    if protocolMessage.action == .connected {
-                                        protocolMessage.error = .create(withCode: 0, message: "Injected error")
-                                    }
-                                    else if protocolMessage.action == .attached {
-                                        protocolMessage.error = .create(withCode: 0, message: "Channel injected error")
-                                    }
-                                    return protocolMessage
-                                })
-                            }
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            client.connection.once(.connected) { stateChange in
-                                expect(stateChange.reason?.message).to(equal("Injected error"))
-                                expect(client.connection.errorReason).to(beIdenticalTo(stateChange.reason))
-                                let transport = client.internal.transport as! TestProxyTransport
-                                let connectedPM = transport.protocolMessagesReceived.filter{ $0.action == .connected }[0]
-                                expect(connectedPM.connectionId).to(equal(expectedConnectionId))
-                                expect(client.connection.id).to(equal(expectedConnectionId))
-                                partialDone()
-                            }
-                            channel.once(.attached) { stateChange in
-                                guard let error = stateChange.reason else {
-                                    fail("Reason error is nil"); done(); return
-                                }
-                                expect(error.message).to(equal("Channel injected error"))
-                                expect(channel.errorReason).to(beIdenticalTo(error))
-                                partialDone()
-                            }
-                        }
-
-                        expect(client.internal.queuedMessages).toEventually(haveCount(0), timeout: testTimeout)
-                    }
-
-                    // RTN15c3
-                    func test__070__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__CONNECTED_ProtocolMessage_with_a_new_connectionId_and_an_error() {
-                        let options = AblyTests.commonAppSetup()
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        let oldConnectionId = client.connection.id
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-
-                            channel.once(.attaching) { _ in
-                                expect(channel.errorReason).to(beNil())
-                                partialDone()
-                            }
-
-                            client.connection.once(.connected) { stateChange in
-                                guard let error = stateChange.reason else {
-                                    fail("Connection resume failed and error should be propagated to the channel"); done(); return
-                                }
-                                expect(error.code).to(equal(ARTErrorCode.unableToRecoverConnectionExpired.intValue))
-                                expect(error.message).to(contain("Unable to recover connection"))
-                                expect(client.connection.errorReason).to(beIdenticalTo(stateChange.reason))
-                                partialDone()
-                            }
-                            
-                            client.simulateLostConnectionAndState()
-                        }
-
-                        let transport = client.internal.transport as! TestProxyTransport
-                        let connectedPM = transport.protocolMessagesReceived.filter{ $0.action == .connected }[0]
-                        expect(connectedPM.connectionId).toNot(equal(oldConnectionId))
-                        expect(client.connection.id).to(equal(connectedPM.connectionId))
-                        expect(client.internal.msgSerial).to(equal(0))
-
-                        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-                    }
-
-                    // RTN15c4
-                    func test__071__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__ERROR_ProtocolMessage_indicating_a_fatal_error_in_the_connection() {
-                        let options = AblyTests.commonAppSetup()
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-
-                        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-
-                        client.internal.onDisconnected()
-
-                        let protocolError = AblyTests.newErrorProtocolMessage()
-                        client.connection.once(.connecting) { _ in
-                            // Resuming
-                            guard let transport = client.internal.transport as? TestProxyTransport else {
-                                fail("TestProxyTransport is not set"); return
-                            }
-                            transport.actionsIgnored += [.connected]
-                            client.internal.onError(protocolError)
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.failed) { stateChange in
-                                expect(stateChange.reason).to(beIdenticalTo(protocolError.error))
-                                expect(client.connection.errorReason).to(beIdenticalTo(protocolError.error))
-                                done()
-                            }
-                        }
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-                        expect(channel.errorReason).to(beIdenticalTo(protocolError.error))
-                    }
-
-                    func skipped__test__072__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__should_resume_the_connection_after_an_auth_renewal() {
-                        let options = AblyTests.commonAppSetup()
-                        options.tokenDetails = getTestTokenDetails(ttl: 5.0)
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-                        let restOptions = AblyTests.clientOptions(key: options.key!)
-                        restOptions.channelNamePrefix = options.channelNamePrefix
-                        let rest = ARTRest(options: restOptions)
-
-                        let channel = client.channels.get("test")
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach() { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        let initialConnectionId = client.connection.id
-
-                        guard let _ = client.internal.transport as? TestProxyTransport else {
-                            fail("TestProxyTransport is not set"); return
-                        }
-
-                        channel.once(.detached) { _ in
-                            fail("Should not detach channels")
-                        }
-                        defer { channel.off() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            // Wait for token to expire
-                            client.connection.once(.disconnected) { stateChange in
-                                guard let error = stateChange.reason else {
-                                    fail("Error is nil"); done(); return
-                                }
-                                expect(error.code) == ARTErrorCode.tokenExpired.intValue
-                                done()
-                            }
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            // Wait for connection resume
-                            client.connection.once(.connected) { stateChange in
-                                expect(stateChange.reason).to(beNil())
-                                done()
-                            }
-                        }
-
-                        guard let secondTransport = client.internal.transport as? TestProxyTransport else {
-                            fail("TestProxyTransport is not set"); return
-                        }
-
-                        let connectedMessages = secondTransport.protocolMessagesReceived.filter{ $0.action == .connected }
-                        expect(connectedMessages).to(haveCount(1)) //New transport connected
-                        guard let receivedConnectionId = connectedMessages.first?.connectionId else {
-                            fail("ConnectionID is nil"); return
-                        }
-                        expect(client.connection.id).to(equal(receivedConnectionId))
-                        expect(client.connection.id).to(equal(initialConnectionId))
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            let expectedMessage = ARTMessage(name: "ios", data: "message1")
-
-                            channel.subscribe() { message in
-                                expect(message.name).to(equal(expectedMessage.name))
-                                expect(message.data as? String).to(equal(expectedMessage.data as? String))
-                                partialDone()
-                            }
-
-                            rest.channels.get("test").publish([expectedMessage]) { error in
-                                expect(error).to(beNil())
-                                partialDone()
-                            }
-                        }
-                    }
-
-                // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                // RTN15d
-                func skipped__test__065__Connection__connection_failures_once_CONNECTED__should_recover_from_disconnection_and_messages_should_be_delivered_once_the_connection_is_resumed() {
-                    let options = AblyTests.commonAppSetup()
-
-                    let client1 = ARTRealtime(options: options)
-                    defer { client1.close() }
-                    let channel1 = client1.channels.get("test")
-
-                    let client2 = ARTRealtime(options: options)
-                    defer { client2.close() }
-                    let channel2 = client2.channels.get("test")
-
-                    let expectedMessages = ["message X", "message Y"]
-                    var receivedMessages = [String]()
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel1.subscribe(attachCallback: { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            done()
-                        }, callback: { message in
-                            receivedMessages.append(message.data as! String)
-                        })
-                    }
-
-                    client1.internal.onDisconnected()
-
-                    channel2.publish(expectedMessages.map{ ARTMessage(name: nil, data: $0) }) { errorInfo in
-                        expect(errorInfo).to(beNil())
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client1.connection.once(.connecting) { _ in
-                            expect(receivedMessages).to(beEmpty())
-                            done()
-                        }
-                    }
-
-                    expect(client1.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                    expect(receivedMessages).toEventually(equal(expectedMessages), timeout: testTimeout)
-                }
-
-                // RTN15e
-                
-
-                    func test__073__Connection__connection_failures_once_CONNECTED__when_a_connection_is_resumed__the_connection_key_may_change_and_will_be_provided_in_the_first_CONNECTED_ProtocolMessage_connectionDetails() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        client.connect()
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-
-                        channel.attach()
-                        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                        client.internal.onDisconnected()
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.connecting) { _ in
-                                client.connection.internal.setKey("key_to_be_replaced")
-                                done()
-                            }
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.connected) { _ in
-                                let transport = client.internal.transport as! TestProxyTransport
-                                let firstConnectionDetails = transport.protocolMessagesReceived.filter{ $0.action == .connected }[0].connectionDetails
-                                expect(firstConnectionDetails!.connectionKey).toNot(beNil())
-                                expect(client.connection.key).to(equal(firstConnectionDetails!.connectionKey))
-                                done()
-                            }
-                        }
-                    }
-
-                // RTN15f
-                func test__066__Connection__connection_failures_once_CONNECTED__ACK_and_NACK_responses_for_published_messages_can_only_ever_be_received_on_the_transport_connection_on_which_those_messages_were_sent() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    var resumed = false
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { _ in
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-
-                        guard let transport1 = client.internal.transport as? TestProxyTransport else {
-                            fail("TestProxyTransport not setup"); done(); return
-                        }
-
-                        var sentPendingMessage: ARTMessage?
-                        channel.publish(nil, data: "message") { _ in
-                            if resumed {
-                                guard let transport2 = client.internal.transport as? TestProxyTransport else {
-                                    fail("TestProxyTransport not setup"); done(); return
-                                }
-                                expect(transport2.protocolMessagesReceived.filter{ $0.action == .ack }).to(haveCount(1))
-
-                                guard let _ = transport1.protocolMessagesSent.filter({ $0.action == .message }).first?.messages?.first else {
-                                    fail("Message that has been re-sent isn't available"); done(); return
-                                }
-                                guard let sentTransportMessage2 = transport2.protocolMessagesSent.filter({ $0.action == .message }).first?.messages?.first else {
-                                    fail("Message that has been re-sent isn't available"); done(); return
-                                }
-
-                                expect(transport1).toNot(beIdenticalTo(transport2))
-                                expect(sentPendingMessage).to(beIdenticalTo(sentTransportMessage2))
-
-                                partialDone()
-                            }
-                            else {
-                                fail("Shouldn't be called")
-                            }
-                        }
-                        AblyTests.queue.async {
-                            client.internal.onDisconnected()
-                        }
-                        client.connection.once(.connected) { _ in
-                            resumed = true
-                        }
-                        client.internal.testSuite_injectIntoMethod(before: Selector(("resendPendingMessages"))) {
-                            expect(client.internal.pendingMessages.count).to(equal(1))
-                            let pm: ARTProtocolMessage? = (client.internal.pendingMessages.firstObject as? ARTPendingMessage)?.msg
-                            sentPendingMessage = pm?.messages?[0]
-                        }
-                        client.internal.testSuite_injectIntoMethod(after: Selector(("resendPendingMessages"))) {
-                            partialDone()
-                        }
-                    }
-                }
-                
-                // RTN15g RTN15g1
-                
-                    
-                    func skipped__test__074__Connection__connection_failures_once_CONNECTED__when_connection__ttl_plus_idle_interval__period_has_passed_since_last_activity__uses_a_new_connection() {
-                        let options = AblyTests.commonAppSetup()
-                        // We want this to be > than the sum of customTtlInterval and customIdleInterval
-                        options.disconnectedRetryTimeout = 5.0 + customTtlInterval + customIdleInterval
-                        ttlAndIdleIntervalPassedTestsClient = AblyTests.newRealtime(options)
-                        ttlAndIdleIntervalPassedTestsClient.internal.shouldImmediatelyReconnect = false
-                        ttlAndIdleIntervalPassedTestsClient.connect()
-                        defer { ttlAndIdleIntervalPassedTestsClient.close() }
-                        
-                        waitUntil(timeout: testTimeout) { done in
-                            ttlAndIdleIntervalPassedTestsClient.connection.once(.connected) { _ in
-                                expect(ttlAndIdleIntervalPassedTestsClient.connection.id).toNot(beNil())
-                                ttlAndIdleIntervalPassedTestsConnectionId = ttlAndIdleIntervalPassedTestsClient.connection.id!
-                                ttlAndIdleIntervalPassedTestsClient.internal.connectionStateTtl = customTtlInterval
-                                ttlAndIdleIntervalPassedTestsClient.internal.maxIdleInterval = customIdleInterval
-                                ttlAndIdleIntervalPassedTestsClient.connection.once(.disconnected) { _ in
-                                    let disconnectedAt = Date()
-                                    expect(ttlAndIdleIntervalPassedTestsClient.internal.connectionStateTtl).to(equal(customTtlInterval))
-                                    expect(ttlAndIdleIntervalPassedTestsClient.internal.maxIdleInterval).to(equal(customIdleInterval))
-                                    ttlAndIdleIntervalPassedTestsClient.connection.once(.connecting) { _ in
-                                        let reconnectionInterval = Date().timeIntervalSince(disconnectedAt)
-                                        expect(reconnectionInterval).to(beGreaterThan(ttlAndIdleIntervalPassedTestsClient.internal.connectionStateTtl + ttlAndIdleIntervalPassedTestsClient.internal.maxIdleInterval))
-                                        ttlAndIdleIntervalPassedTestsClient.connection.once(.connected) { _ in
-                                            expect(ttlAndIdleIntervalPassedTestsClient.connection.id).toNot(equal(ttlAndIdleIntervalPassedTestsConnectionId))
-                                            done()
-                                        }
-                                    }
-                                }
-                                ttlAndIdleIntervalPassedTestsClient.internal.onDisconnected()
-                            }
-                        }
-                    }
-                    // RTN15g3
-                    func test__075__Connection__connection_failures_once_CONNECTED__when_connection__ttl_plus_idle_interval__period_has_passed_since_last_activity__reattaches_to_the_same_channels_after_a_new_connection_has_been_established() {
-                        let options = AblyTests.commonAppSetup()
-                        // We want this to be > than the sum of customTtlInterval and customIdleInterval
-                        options.disconnectedRetryTimeout = 5.0
-                        ttlAndIdleIntervalPassedTestsClient = AblyTests.newRealtime(options)
-                        ttlAndIdleIntervalPassedTestsClient.internal.shouldImmediatelyReconnect = false
-                        defer { ttlAndIdleIntervalPassedTestsClient.close() }
-                        let channelName = "test-reattach-after-ttl"
-                        let channel = ttlAndIdleIntervalPassedTestsClient.channels.get(channelName)
-                        
-                        waitUntil(timeout: testTimeout) { done in
-                            ttlAndIdleIntervalPassedTestsClient.connection.once(.connected) { _ in
-                                ttlAndIdleIntervalPassedTestsConnectionId = ttlAndIdleIntervalPassedTestsClient.connection.id!
-                                ttlAndIdleIntervalPassedTestsClient.internal.connectionStateTtl = customTtlInterval
-                                ttlAndIdleIntervalPassedTestsClient.internal.maxIdleInterval = customIdleInterval
-                                channel.attach { error in
-                                    if let error = error {
-                                        fail(error.message)
-                                    }
-                                    expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
-                                    ttlAndIdleIntervalPassedTestsClient.internal.onDisconnected()
-                                }
-                                ttlAndIdleIntervalPassedTestsClient.connection.once(.disconnected) { _ in
-                                    ttlAndIdleIntervalPassedTestsClient.connection.once(.connecting) { _ in
-                                        ttlAndIdleIntervalPassedTestsClient.connection.once(.connected) { _ in
-                                            expect(ttlAndIdleIntervalPassedTestsClient.connection.id).toNot(equal(ttlAndIdleIntervalPassedTestsConnectionId))
-                                            channel.once(.attached) { stateChange in
-                                                expect(stateChange.resumed).to(beFalse())
-                                                done()
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            ttlAndIdleIntervalPassedTestsClient.connect()
-                        }
-                    }
-                
-                // RTN15g2
-                
-                    
-                    func test__076__Connection__connection_failures_once_CONNECTED__when_connection__ttl_plus_idle_interval__period_has_NOT_passed_since_last_activity__uses_the_same_connection() {
-                        let options = AblyTests.commonAppSetup()
-                        ttlAndIdleIntervalNotPassedTestsClient = AblyTests.newRealtime(options)
-                        ttlAndIdleIntervalNotPassedTestsClient.connect()
-                        defer { ttlAndIdleIntervalNotPassedTestsClient.close() }
-                        
-                        waitUntil(timeout: testTimeout) { done in
-                            ttlAndIdleIntervalNotPassedTestsClient.connection.once(.connected) { _ in
-                                expect(ttlAndIdleIntervalNotPassedTestsClient.connection.id).toNot(beNil())
-                                ttlAndIdleIntervalNotPassedTestsConnectionId = ttlAndIdleIntervalNotPassedTestsClient.connection.id!
-                                ttlAndIdleIntervalNotPassedTestsClient.connection.once(.disconnected) { _ in
-                                    let disconnectedAt = Date()
-                                    ttlAndIdleIntervalNotPassedTestsClient.connection.once(.connecting) { _ in
-                                        let reconnectionInterval = Date().timeIntervalSince(disconnectedAt)
-                                        expect(reconnectionInterval).to(beLessThan(ttlAndIdleIntervalNotPassedTestsClient.internal.connectionStateTtl + ttlAndIdleIntervalNotPassedTestsClient.internal.maxIdleInterval))
-                                        ttlAndIdleIntervalNotPassedTestsClient.connection.once(.connected) { _ in
-                                            expect(ttlAndIdleIntervalNotPassedTestsClient.connection.id).to(equal(ttlAndIdleIntervalNotPassedTestsConnectionId))
-                                            done()
-                                        }
-                                    }
-                                }
-                                ttlAndIdleIntervalNotPassedTestsClient.internal.onDisconnected()
-                            }
-                        }
-                    }
-
-                // RTN15h
-                
-
-                    func skipped__test__077__Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__if_the_token_is_renewable_then_error_should_not_be_emitted() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        options.authCallback = { tokenParams, callback in
-                            getTestTokenDetails(key: options.key, capability: tokenParams.capability, ttl: TimeInterval(60 * 60), completion: callback)
-                        }
-                        let tokenTtl = 2.0
-                        options.token = getTestToken(key: options.key, ttl: tokenTtl)
-
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        defer {
-                            client.dispose()
-                            client.close()
-                        }
-
-                        client.connect()
-                        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                        let firstTransport = client.internal.transport as? TestProxyTransport
-
-                        waitUntil(timeout: testTimeout) { done in
-                            // Wait for token to expire
-                            client.connection.once(.disconnected) { stateChange in
-                                guard let error = stateChange.reason else {
-                                    fail("Error is nil"); done(); return
-                                }
-                                expect(error.code) == ARTErrorCode.tokenExpired.intValue
-                                done()
-                            }
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.connected) { stateChange in
-                                expect(stateChange.reason).to(beNil())
-                                done()
-                            }
-                        }
-                        expect(client.connection.errorReason).to(beNil())
-
-                        // New connection
-                        expect(client.internal.transport).toNot(beNil())
-                        expect(client.internal.transport).toNot(beIdenticalTo(firstTransport))
-
-                        waitUntil(timeout: testTimeout) { done in 
-                            client.ping { error in
-                                expect(error).to(beNil())
-                                expect((client.internal.transport as! TestProxyTransport).protocolMessagesReceived.filter({ $0.action == .connected })).to(haveCount(1))
-                                done()
-                            }
-                        }                        
-                    }
-                    
-                    // RTN15h1
-                    func test__078__Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__and_the_library_does_not_have_a_means_to_renew_the_token__the_connection_will_transition_to_the_FAILED_state() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let key = options.key
-                        // set the key to nil so that the client can't sign further token requests
-                        options.key = nil
-                        let tokenTtl = 3.0
-                        let tokenDetails = getTestTokenDetails(key: key, ttl: tokenTtl)!
-                        options.token = tokenDetails.token
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-                        
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.failed) { stateChange in
-                                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connected))
-                                expect(stateChange.reason?.code).to(equal(ARTErrorCode.tokenExpired.intValue))
-                                done()
-                            }
-                            client.connect()
-                        }
-                    }
-
-                    // RTN15h2
-                    func skipped__test__079__Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__should_transition_to_disconnected_when_the_token_renewal_fails_and_the_error_should_be_emitted() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let tokenTtl = 3.0
-                        let tokenDetails = getTestTokenDetails(key: options.key, capability: nil, ttl: tokenTtl)!
-                        options.token = tokenDetails.token
-                        options.authCallback = { tokenParams, callback in
-                            delay(0.1) {
-                                callback(tokenDetails, nil) // Return the same expired token again.
-                            }
-                        }
-
-                        let client = ARTRealtime(options: options)
-                        client.internal.setTransport(TestProxyTransport.self)
-                        defer {
-                            client.dispose()
-                            client.close()
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            // Wait for token to expire
-                            client.connection.once(.disconnected) { stateChange in
-                                expect(stateChange.previous).to(equal(ARTRealtimeConnectionState.connected))
-                                guard let error = stateChange.reason else {
-                                    fail("Error is nil"); done(); return
-                                }
-                                expect(error.code) == ARTErrorCode.tokenExpired.intValue
-                            
-                                // Renewal will lead to another disconnection
-                                client.connection.once(.disconnected) { stateChange in
-                                    guard let error = stateChange.reason else {
-                                        fail("Error is nil"); done(); return
-                                    }
-                                    expect(error.code) == ARTErrorCode.tokenExpired.intValue
-                                    expect(client.connection.errorReason).to(beIdenticalTo(error))
-                                    done()
-                                }
-                            }
-                            
-                            client.connect()
-                        }
-                    }
-
-            // RTN16
-            
-
-                // RTN16a
-                func test__080__Connection__Connection_recovery__connection_state_should_recover_explicitly_with_a_recover_key() {
-                    let options = AblyTests.commonAppSetup()
-
-                    let clientSend = ARTRealtime(options: options)
-                    defer { clientSend.close() }
-                    let channelSend = clientSend.channels.get("test")
-
-                    let clientReceive = ARTRealtime(options: options)
-                    defer { clientReceive.close() }
-                    let channelReceive = clientReceive.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channelReceive.subscribe(attachCallback: { error in
-                            expect(error).to(beNil())
-                            channelSend.publish(nil, data: "message") { error in
-                                expect(error).to(beNil())
-                            }
-                        }, callback: { message in
-                            expect(message.data as? String).to(equal("message"))
-                            done()
-                        })
-                    }
-
-                    options.recover = clientReceive.connection.recoveryKey
-                    clientReceive.internal.onError(AblyTests.newErrorProtocolMessage())
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channelSend.publish(nil, data: "queue a message") { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    let clientRecover = ARTRealtime(options: options)
-                    defer { clientRecover.close() }
-                    let channelRecover = clientRecover.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channelRecover.subscribe { message in
-                            expect(message.data as? String).to(equal("queue a message"))
-                            done()
-                        }
-                    }
-                }
-
-                
-                // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                // RTN16b
-                func skipped__test__081__Connection__Connection_recovery__Connection_recoveryKey_should_be_composed_with_the_connection_key_and_latest_serial_received_and_msgSerial() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        client.connection.once(.connected) { _ in
-                            expect(client.connection.serial).to(equal(-1))
-                            expect(client.connection.recoveryKey).to(equal("\(client.connection.key!):\(client.connection.serial):\(client.internal.msgSerial)"))
-                        }
-                        channel.publish(nil, data: "message") { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                        channel.subscribe { message in
-                            expect(message.data as? String).to(equal("message"))
-                            expect(client.connection.serial).to(equal(0))
-                            channel.unsubscribe()
-                            partialDone()
-                        }
-                    }
-                    expect(client.internal.msgSerial) == 1
-                    expect(client.connection.recoveryKey).to(equal("\(client.connection.key!):\(client.connection.serial):\(client.internal.msgSerial)"))
-                }
-
-                // RTN16d
-                func test__082__Connection__Connection_recovery__when_a_connection_is_successfully_recovered__Connection_id_will_be_identical_to_the_id_of_the_connection_that_was_recovered_and_Connection_key_will_always_be_updated_to_the_ConnectionDetails_connectionKey_provided_in_the_first_CONNECTED_ProtocolMessage() {
-                    let options = AblyTests.commonAppSetup()
-                    let clientOriginal = ARTRealtime(options: options)
-                    defer { clientOriginal.close() }
-
-                    expect(clientOriginal.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-
-                    let expectedConnectionId = clientOriginal.connection.id
-
-                    options.recover = clientOriginal.connection.recoveryKey
-                    clientOriginal.internal.onError(AblyTests.newErrorProtocolMessage())
-
-                    let clientRecover = AblyTests.newRealtime(options)
-                    defer { clientRecover.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        clientRecover.connection.once(.connected) { _ in
-                            let transport = clientRecover.internal.transport as! TestProxyTransport
-                            let firstConnectionDetails = transport.protocolMessagesReceived.filter{ $0.action == .connected }.first!.connectionDetails
-                            expect(firstConnectionDetails!.connectionKey).toNot(beNil())
-                            expect(clientRecover.connection.id).to(equal(expectedConnectionId))
-                            expect(clientRecover.connection.key).to(equal(firstConnectionDetails!.connectionKey))
-                            done()
-                        }
-                    }
-                }
-
-                // RTN16c
-                func skipped__test__083__Connection__Connection_recovery__Connection_recoveryKey_should_become_becomes_null_when_a_connection_is_explicitly_CLOSED_or_CLOSED() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { _ in
-                            client.connection.once(.closed) { _ in
-                                expect(client.connection.recoveryKey).to(beNil())
-                                expect(client.connection.key).to(beNil())
-                                expect(client.connection.id).to(beNil())
-                                done()
-                            }
-                            client.close()
-                        }
-                    }
-                }
-
-                // RTN16e
-                func test__084__Connection__Connection_recovery__should_connect_anyway_if_the_recoverKey_is_no_longer_valid() {
-                    let options = AblyTests.commonAppSetup()
-                    options.recover = "99999!xxxxxx-xxxxxxxxx-xxxxxxxxx:-1"
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            guard let reason = stateChange.reason else {
-                                fail("Reason is empty"); done(); return
-                            }
-                            expect(reason.message).to(contain("Unable to recover connection"))
-                            expect(client.connection.errorReason).to(beIdenticalTo(reason))
-                            done()
-                        }
-                    }
-                }
-
-                // RTN16f
-                func test__085__Connection__Connection_recovery__should_use_msgSerial_from_recoveryKey_to_set_the_client_internal_msgSerial_but_is_not_sent_to_Ably() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    options.recover = "99999!xxxxxx-xxxxxxxxx-xxxxxxxxx:-1:7"
-
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-
-                    var urlConnections = [URL]()
-                    TestProxyTransport.networkConnectEvent = { transport, url in
-                        if client.internal.transport !== transport {
-                            return
-                        }
-                        urlConnections.append(url)
-                        if urlConnections.count == 1 {
-                            TestProxyTransport.networkConnectEvent = nil
-                        }
-                    }
-                    defer { TestProxyTransport.networkConnectEvent = nil }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            guard let reason = stateChange.reason else {
-                                fail("Reason is empty"); done(); return
-                            }
-
-                            expect(urlConnections.count) == 1
-                            guard let urlConnectionQuery = urlConnections.first?.query else {
-                                fail("Missing URL Connection query"); done(); return
-                            }
-
-                            expect(urlConnectionQuery).to(haveParam("recover", withValue: "99999!xxxxxx-xxxxxxxxx-xxxxxxxxx"))
-                            expect(urlConnectionQuery).to(haveParam("connectionSerial", withValue: "-1"))
-                            expect(urlConnectionQuery).toNot(haveParam("msgSerial"))
-
-                            // recover fails, the counter should be reset to 0
-                            expect(client.internal.msgSerial) == 0
-
-                            expect(reason.message).to(contain("Unable to recover connection"))
-                            expect(client.connection.errorReason).to(beIdenticalTo(reason))
-                            done()
-                        }
-                        client.connect()
-                        expect(client.internal.msgSerial) == 7
-                    }
-                }
-
-            // RTN17
-            
-
-                func beforeEach__Connection__Host_Fallback() {
-                    ARTFallback_shuffleArray = { array in
-                        let arranged = expectedHostOrder.reversed().map { array[$0] }
-                        for (i, element) in arranged.enumerated() {
-                            array[i] = element
-                        }
-                    }
-                }
-
-                func afterEach__Connection__Host_Fallback() {
-                    ARTFallback_shuffleArray = originalARTFallback_shuffleArray
-                }
-
-                // RTN17b
-                func test__086__Connection__Host_Fallback__failing_connections_with_custom_endpoint_should_result_in_an_error_immediately() {
-beforeEach__Connection__Host_Fallback()
-
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.environment = "test" //do not use the default endpoint
-                    expect(options.fallbackHostsUseDefault).to(beFalse())
-                    expect(options.fallbackHosts).to(beNil())
-                    options.autoConnect = false
-                    options.queueMessages = false
-
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    TestProxyTransport.fakeNetworkResponse = .hostUnreachable
-                    defer { TestProxyTransport.fakeNetworkResponse = nil }
-
-                    var urlConnections = [URL]()
-                    TestProxyTransport.networkConnectEvent = { transport, url in
-                        if client.internal.transport !== transport {
-                            return
-                        }
-                        urlConnections.append(url)
-                    }
-                    defer { TestProxyTransport.networkConnectEvent = nil }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.disconnected) { stateChange in
-                            expect(stateChange.previous) == ARTRealtimeConnectionState.connecting
-                            expect(stateChange.current) == ARTRealtimeConnectionState.disconnected
-                            guard let reason = stateChange.reason else {
-                                fail("Reason is empty"); done(); return
-                            }
-                            expect(reason.message).to(contain("host unreachable"))
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: "message") { error in
-                            expect(error?.code).to(equal(2))
-                            expect(error?.message).to(contain("host unreachable"))
-                            expect(error?.reason).to(contain(".FakeNetworkResponse"))
-                            done()
-                        }
-                    }
-
-                    expect(urlConnections).to(haveCount(1))
-
-afterEach__Connection__Host_Fallback()
-
-                }
-
-                // RTN17b
-                func test__087__Connection__Host_Fallback__failing_connections_with_custom_endpoint_should_result_in_time_outs() {
-beforeEach__Connection__Host_Fallback()
-
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.environment = "test" //do not use the default endpoint
-                    expect(options.fallbackHostsUseDefault).to(beFalse())
-                    expect(options.fallbackHosts).to(beNil())
-                    options.autoConnect = false
-
-                    let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                    defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                    ARTDefault.setRealtimeRequestTimeout(1.0)
-
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    client.channels.get("test")
-
-                    TestProxyTransport.fakeNetworkResponse = .hostUnreachable
-                    defer { TestProxyTransport.fakeNetworkResponse = nil }
-
-                    var urlConnections = [URL]()
-                    TestProxyTransport.networkConnectEvent = { transport, url in
-                        if client.internal.transport !== transport {
-                            return
-                        }
-                        urlConnections.append(url)
-                    }
-                    defer { TestProxyTransport.networkConnectEvent = nil }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.on(.disconnected) { stateChange in
-                            expect(stateChange.previous) == ARTRealtimeConnectionState.connecting
-                            expect(stateChange.current) == ARTRealtimeConnectionState.disconnected
-                            guard let reason = stateChange.reason else {
-                                fail("Reason is empty"); done(); return
-                            }
-                            expect(reason.message).to(contain("host unreachable"))
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    expect(urlConnections).to(haveCount(1))
-
-afterEach__Connection__Host_Fallback()
-
-                }
-
-                // RTN17b
-                func test__088__Connection__Host_Fallback__applies_when_the_default_realtime_ably_io_endpoint_is_being_used() {
-beforeEach__Connection__Host_Fallback()
-
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.channels.get("test")
-
-                    let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                    defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                    ARTDefault.setRealtimeRequestTimeout(1.0)
-
-                    client.internal.setTransport(TestProxyTransport.self)
-                    TestProxyTransport.fakeNetworkResponse = .hostUnreachable
-                    defer { TestProxyTransport.fakeNetworkResponse = nil }
-
-                    var urlConnections = [URL]()
-                    TestProxyTransport.networkConnectEvent = { transport, url in
-                        if client.internal.transport !== transport {
-                            return
-                        }
-                        urlConnections.append(url)
-                        if urlConnections.count == 1 {
-                            TestProxyTransport.fakeNetworkResponse = nil
-                        }
-                    }
-                    defer { TestProxyTransport.networkConnectEvent = nil }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        // wss://[a-e].ably-realtime.com: when a timeout occurs
-                        client.connection.once(.disconnected) { error in
-                            done()
-                        }
-                        // wss://[a-e].ably-realtime.com: when a 401 occurs because of the `xxxx:xxxx` key
-                        client.connection.once(.failed) { error in
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    expect(urlConnections).to(haveCount(2))
-                    if urlConnections.count != 2 {
-                        return
-                    }
-                    expect(NSRegularExpression.match(urlConnections[0].absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
-                    expect(NSRegularExpression.match(urlConnections[1].absoluteString, pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-
-afterEach__Connection__Host_Fallback()
-
-                }
-                
-                func test__089__Connection__Host_Fallback__applies_when_an_array_of_ClientOptions_fallbackHosts_is_provided() {
-beforeEach__Connection__Host_Fallback()
-
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.autoConnect = false
-                    options.fallbackHosts = ["f.ably-realtime.com", "g.ably-realtime.com", "h.ably-realtime.com", "i.ably-realtime.com", "j.ably-realtime.com"]                    
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.channels.get("test")
-
-                    let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                    defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                    ARTDefault.setRealtimeRequestTimeout(1.0)
-
-                    client.internal.setTransport(TestProxyTransport.self)
-                    TestProxyTransport.fakeNetworkResponse = .hostUnreachable
-                    defer { TestProxyTransport.fakeNetworkResponse = nil }
-                    
-                    var urlConnections = [URL]()
-                    TestProxyTransport.networkConnectEvent = { transport, url in
-                        if client.internal.transport !== transport {
-                            return
-                        }
-                        urlConnections.append(url)
-                        if urlConnections.count == 1 {
-                            TestProxyTransport.fakeNetworkResponse = nil
-                        }
-                    }
-                    defer { TestProxyTransport.networkConnectEvent = nil }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        // wss://[a-e].ably-realtime.com: when a timeout occurs
-                        client.connection.once(.disconnected) { error in
-                            done()
-                        }
-                        // wss://[a-e].ably-realtime.com: when a 401 occurs because of the `xxxx:xxxx` key
-                        client.connection.once(.failed) { error in
-                            done()
-                        }
-                        client.connect()
-                    }
-                    
-                    expect(urlConnections.count > 1 && urlConnections.count <= options.fallbackHosts!.count + 1).to(beTrue())
-                    expect(NSRegularExpression.match(urlConnections[0].absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
-                    for connection in urlConnections.dropFirst() {
-                        expect(NSRegularExpression.match(connection.absoluteString, pattern: "//[f-j].ably-realtime.com")).to(beTrue())
-                    }
-
-afterEach__Connection__Host_Fallback()
-
-                }
-
-                // RTN17d
-                
-                    
-                    func skipped__test__097__Connection__Host_Fallback__should_use_an_alternative_host_when___hostUnreachable() {
-beforeEach__Connection__Host_Fallback()
-
-                        testUsesAlternativeHostOnResponse(.hostUnreachable)
-
-afterEach__Connection__Host_Fallback()
-
-                    }
-                    
-                    func skipped__test__098__Connection__Host_Fallback__should_use_an_alternative_host_when___requestTimeout_timeout__0_1_() {
-beforeEach__Connection__Host_Fallback()
-
-                        testUsesAlternativeHostOnResponse(.requestTimeout(timeout: 0.1))
-
-afterEach__Connection__Host_Fallback()
-
-                    }
-                    
-                    func skipped__test__099__Connection__Host_Fallback__should_use_an_alternative_host_when___hostInternalError_code__501_() {
-beforeEach__Connection__Host_Fallback()
-
-                        testUsesAlternativeHostOnResponse(.hostInternalError(code: 501))
-
-afterEach__Connection__Host_Fallback()
-
-                    }
-
-                
-                    
-                    func test__100__Connection__Host_Fallback__should_move_to_disconnected_when_there_s_no_internet__with_NSPOSIXErrorDomain_with_code_57() {
-beforeEach__Connection__Host_Fallback()
-
-                        testMovesToDisconnectedWithNetworkingError(NSError(domain: "NSPOSIXErrorDomain", code: 57, userInfo: [NSLocalizedDescriptionKey: "shouldn't matter"]))
-
-afterEach__Connection__Host_Fallback()
-
-                    }
-                    
-                    func test__101__Connection__Host_Fallback__should_move_to_disconnected_when_there_s_no_internet__with_NSPOSIXErrorDomain_with_code_50() {
-beforeEach__Connection__Host_Fallback()
-
-                        testMovesToDisconnectedWithNetworkingError(NSError(domain: "NSPOSIXErrorDomain", code: 50, userInfo: [NSLocalizedDescriptionKey: "shouldn't matter"]))
-
-afterEach__Connection__Host_Fallback()
-
-                    }
-                    
-                    func test__102__Connection__Host_Fallback__should_move_to_disconnected_when_there_s_no_internet__with_any_kCFErrorDomainCFNetwork() {
-beforeEach__Connection__Host_Fallback()
-
-                        testMovesToDisconnectedWithNetworkingError(NSError(domain: "kCFErrorDomainCFNetwork", code: 1337, userInfo: [NSLocalizedDescriptionKey: "shouldn't matter"]))
-
-afterEach__Connection__Host_Fallback()
-
-                    }
-
-                func test__090__Connection__Host_Fallback__should_not_use_an_alternative_host_when_the_client_receives_a_bad_request() {
-beforeEach__Connection__Host_Fallback()
-
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    let channel = client.channels.get("test")
-
-                    let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                    defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                    ARTDefault.setRealtimeRequestTimeout(1.0)
-
-                    client.internal.setTransport(TestProxyTransport.self)
-                    TestProxyTransport.fakeNetworkResponse = .host400BadRequest
-                    defer { TestProxyTransport.fakeNetworkResponse = nil }
-
-                    var urlConnections = [URL]()
-                    TestProxyTransport.networkConnectEvent = { transport, url in
-                        if client.internal.transport !== transport {
-                            return
-                        }
-                        urlConnections.append(url)
-                    }
-                    defer { TestProxyTransport.networkConnectEvent = nil }
-
-                    client.connect()
-                    defer { client.dispose(); client.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: "message") { error in
-                            done()
-                        }
-                    }
-
-                    expect(urlConnections).to(haveCount(1))
-                    expect(NSRegularExpression.match(urlConnections[0].absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
-
-afterEach__Connection__Host_Fallback()
-
-                }
-
-                // RTN17a
-                func test__091__Connection__Host_Fallback__every_connection_is_first_attempted_to_the_primary_host_realtime_ably_io() {
-beforeEach__Connection__Host_Fallback()
-
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.channels.get("test")
-
-                    let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                    defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                    ARTDefault.setRealtimeRequestTimeout(1.0)
-
-                    client.internal.setTransport(TestProxyTransport.self)
-                    TestProxyTransport.fakeNetworkResponse = .hostUnreachable
-                    defer { TestProxyTransport.fakeNetworkResponse = nil }
-
-                    var urlConnections = [URL]()
-                    TestProxyTransport.networkConnectEvent = { transport, url in
-                        if client.internal.transport !== transport {
-                            return
-                        }
-                        urlConnections.append(url)
-                        TestProxyTransport.fakeNetworkResponse = nil
-                    }
-                    defer { TestProxyTransport.networkConnectEvent = nil }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        // Unreachable and try a fallback
-                        client.connection.on { stateChange in
-                            // Timeout or 401 occurs because of the `xxxx:xxxx` key
-                            if stateChange.current == .disconnected || stateChange.current == .failed {
-                                client.connection.off()
-                                done()
-                            }
-                        }
-                        client.connect()
-                    }
-
-                    client.connect()
-
-                    waitUntil(timeout: testTimeout) { done in
-                        // 401 occurs because of the `xxxx:xxxx` key
-                        client.connection.once(.failed) { stateChange in
-                            guard let error = stateChange.reason else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.message).to(contain("Invalid key"))
-                            done()
-                        }
-                    }
-
-                    expect(urlConnections).to(haveCount(3))
-                    expect(NSRegularExpression.match(urlConnections.at(0)?.absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
-                    expect(NSRegularExpression.match(urlConnections.at(1)?.absoluteString, pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                    expect(NSRegularExpression.match(urlConnections.at(2)?.absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
-
-afterEach__Connection__Host_Fallback()
-
-                }
-
-                // RTN17c
-                func test__092__Connection__Host_Fallback__should_retry_hosts_in_random_order_after_checkin_if_an_internet_connection_is_available() {
-beforeEach__Connection__Host_Fallback()
-
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.channels.get("test")
-
-                    let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                    defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                    ARTDefault.setRealtimeRequestTimeout(1.0)
-
-                    let testHttpExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    client.internal.rest.httpExecutor = testHttpExecutor
-
-                    client.internal.setTransport(TestProxyTransport.self)
-                    TestProxyTransport.fakeNetworkResponse = .hostUnreachable
-                    defer { TestProxyTransport.fakeNetworkResponse = nil }
-
-                    var urls = [URL]()
-                    TestProxyTransport.networkConnectEvent = { transport, url in
-                        if client.internal.transport !== transport {
-                            return
-                        }
-                        DispatchQueue.main.async {
-                            urls.append(url)
-                        }
-                    }
-                    defer { TestProxyTransport.networkConnectEvent = nil }
-                    testHttpExecutor.setListenerAfterRequest({ request in
-                        urls.append(request.url!)
-                    })
-                    
-                    waitUntil(timeout: testTimeout.multiplied(by: 1000)) { done in
-                        // wss://[a-e].ably-realtime.com: when a timeout occurs
-                        client.connection.once(.disconnected) { error in
-                            done()
-                        }
-                        // wss://[a-e].ably-realtime.com: when a 401 occurs because of the `xxxx:xxxx` key
-                        client.connection.once(.failed) { error in
-                            done()
-                        }
-                        client.connect()
-                    }
-                    
-                    let extractHostname = { (url: URL) in
-                        NSRegularExpression.extract(url.absoluteString, pattern: "[a-e].ably-realtime.com")
-                    }
-
-                    var resultFallbackHosts = [String]()
-                    var gotInternetIsUpCheck = false
-                    for url in urls {
-                        if NSRegularExpression.match(url.absoluteString, pattern: "//internet-up.ably-realtime.com/is-the-internet-up.txt") {
-                            gotInternetIsUpCheck = true
-                        } else if let fallbackHost = extractHostname(url) {
-                            if Optional(fallbackHost) == resultFallbackHosts.last {
-                                continue
-                            }
-                            // Host changed; should've had an internet check before.
-                            expect(gotInternetIsUpCheck).to(beTrue())
-                            gotInternetIsUpCheck = false
-                            resultFallbackHosts.append(fallbackHost)
-                        }
-                    }
-                    
-                    let expectedFallbackHosts = Array(expectedHostOrder.map({ ARTDefault.fallbackHosts()[$0] }))
-
-                    expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
-
-afterEach__Connection__Host_Fallback()
-
-                }
-                
-                // RTN17c
-                func test__093__Connection__Host_Fallback__doesn_t_try_fallback_host_if_Internet_connection_check_fails() {
-beforeEach__Connection__Host_Fallback()
-
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.channels.get("test")
-
-                    let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                    defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                    ARTDefault.setRealtimeRequestTimeout(1.0)
-
-                    let mockHTTP = MockHTTP(logger: options.logHandler)
-                    let testHttpExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                    client.internal.rest.httpExecutor = testHttpExecutor
-
-                    client.internal.setTransport(TestProxyTransport.self)
-                    TestProxyTransport.fakeNetworkResponse = .hostUnreachable
-                    defer { TestProxyTransport.fakeNetworkResponse = nil }
-
-                    let extractHostname = { (url: URL) in
-                        NSRegularExpression.extract(url.absoluteString, pattern: "[a-e].ably-realtime.com")
-                    }
-
-                    TestProxyTransport.networkConnectEvent = { transport, url in
-                        if client.internal.transport !== transport {
-                            return
-                        }
-                        if extractHostname(url) != nil {
-                            fail("shouldn't try fallback host after failed connectivity check")
-                        }
-                    }
-                    defer { TestProxyTransport.networkConnectEvent = nil }
-
-                    mockHTTP.setNetworkState(network: .hostInternalError(code: 500), forHost: "internet-up.ably-realtime.com")
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        // wss://[a-e].ably-realtime.com: when a timeout occurs
-                        client.connection.once(.disconnected) { error in
-                            done()
-                        }
-                        // wss://[a-e].ably-realtime.com: when a 401 occurs because of the `xxxx:xxxx` key
-                        client.connection.once(.failed) { error in
-                            done()
-                        }
-                        client.connect()
-                    }
-
-afterEach__Connection__Host_Fallback()
-
-                }
-
-                func skipped__test__094__Connection__Host_Fallback__should_retry_custom_fallback_hosts_in_random_order_after_checkin_if_an_internet_connection_is_available() {
-beforeEach__Connection__Host_Fallback()
-
-                    let fbHosts = ["f.ably-realtime.com", "g.ably-realtime.com", "h.ably-realtime.com", "i.ably-realtime.com", "j.ably-realtime.com"]
-                    
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.autoConnect = false
-                    options.fallbackHosts = fbHosts
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.channels.get("test")
-
-                    let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                    defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                    ARTDefault.setRealtimeRequestTimeout(1.0)
-
-                    let testHttpExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    client.internal.rest.httpExecutor = testHttpExecutor
-                    
-                    client.internal.setTransport(TestProxyTransport.self)
-                    TestProxyTransport.fakeNetworkResponse = .hostUnreachable
-                    defer { TestProxyTransport.fakeNetworkResponse = nil }
-                    
-                    var urls = [URL]()
-                    TestProxyTransport.networkConnectEvent = { transport, url in
-                        if client.internal.transport !== transport {
-                            return
-                        }
-                        DispatchQueue.main.async {
-                            urls.append(url)
-                        }
-                    }
-                    defer { TestProxyTransport.networkConnectEvent = nil }
-
-                    testHttpExecutor.setListenerAfterRequest({ request in
-                        urls.append(request.url!)
-                    })
-
-                    waitUntil(timeout: testTimeout) { done in
-                        // wss://[a-e].ably-realtime.com: when a timeout occurs
-                        client.connection.once(.disconnected) { error in
-                            done()
-                        }
-                        // wss://[a-e].ably-realtime.com: when a 401 occurs because of the `xxxx:xxxx` key
-                        client.connection.once(.failed) { error in
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    let extractHostname = { (url: URL) in
-                        NSRegularExpression.extract(url.absoluteString, pattern: "[f-j].ably-realtime.com")
-                    }
-
-                    var resultFallbackHosts = [String]()
-                    var gotInternetIsUpCheck = false
-                    for url in urls {
-                        if NSRegularExpression.match(url.absoluteString, pattern: "//internet-up.ably-realtime.com/is-the-internet-up.txt") {
-                            gotInternetIsUpCheck = true
-                        } else if let fallbackHost = extractHostname(url) {
-                            if Optional(fallbackHost) == resultFallbackHosts.last {
-                                continue
-                            }
-                            // Host changed; should've had an internet check before.
-                            expect(gotInternetIsUpCheck).to(beTrue())
-                            gotInternetIsUpCheck = false
-                            resultFallbackHosts.append(fallbackHost)
-                        }
-                    }
-
-                    let expectedFallbackHosts = Array(expectedHostOrder.map({ fbHosts[$0] }))
-                    
-                    expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
-
-afterEach__Connection__Host_Fallback()
-
-                }
-
-                func test__095__Connection__Host_Fallback__won_t_use_fallback_hosts_feature_if_an_empty_array_is_provided() {
-beforeEach__Connection__Host_Fallback()
-
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.autoConnect = false
-                    options.fallbackHosts = []
-                    let client = ARTRealtime(options: options)
-                    let channel = client.channels.get("test")
-                    
-                    let testHttpExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    client.internal.rest.httpExecutor = testHttpExecutor
-                    
-                    client.internal.setTransport(TestProxyTransport.self)
-                    TestProxyTransport.fakeNetworkResponse = .hostUnreachable
-                    defer { TestProxyTransport.fakeNetworkResponse = nil }
-                    
-                    var urlConnections = [URL]()
-                    TestProxyTransport.networkConnectEvent = { transport, url in
-                        if client.internal.transport !== transport {
-                            return
-                        }
-                        urlConnections.append(url)
-                    }
-                    defer { TestProxyTransport.networkConnectEvent = nil }
-                    
-                    client.connect()
-                    defer { client.dispose(); client.close() }
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: "message") { error in
-                            done()
-                        }
-                    }
-                    
-                    expect(urlConnections).to(haveCount(1))
-
-afterEach__Connection__Host_Fallback()
-
-                }
-
-                // RTN17e
-                func test__096__Connection__Host_Fallback__client_is_connected_to_a_fallback_host_endpoint_should_do_HTTP_requests_to_the_same_data_centre() {
-beforeEach__Connection__Host_Fallback()
-
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-
-                    let testHttpExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    client.internal.rest.httpExecutor = testHttpExecutor
-
-                    client.internal.setTransport(TestProxyTransport.self)
-                    TestProxyTransport.fakeNetworkResponse = .hostUnreachable
-                    defer { TestProxyTransport.fakeNetworkResponse = nil }
-
-                    var urlConnections = [URL]()
-                    TestProxyTransport.networkConnectEvent = { transport, url in
-                        if client.internal.transport !== transport {
-                            return
-                        }
-                        urlConnections.append(url)
-                        if urlConnections.count == 2 {
-                            TestProxyTransport.fakeNetworkResponse = nil
-                            (client.internal.transport as! TestProxyTransport).simulateTransportSuccess()
-                        }
-                    }
-                    defer { TestProxyTransport.networkConnectEvent = nil }
-
-                    client.connect()
-                    // Because we're faking the CONNECTED state, we can't client.close() or it
-                    // will actually try to use the connection believing it's ready and throw an
-                    // exception because it's really not.
-
-                    expect(urlConnections).toEventually(haveCount(2), timeout: testTimeout)
-
-                    expect(NSRegularExpression.match(urlConnections.at(1)?.absoluteString, pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-
-                    waitUntil(timeout: testTimeout) { done in
-                      client.time { _ , _  in
-                            done()
-                        }
-                    }
-
-                    let timeRequestUrl = testHttpExecutor.requests.last!.url!
-                    expect(timeRequestUrl.host).to(equal(urlConnections.at(1)?.host))
-
-afterEach__Connection__Host_Fallback()
-
-                }   
-
-            // RTN19
-            func test__010__Connection__attributes_within_ConnectionDetails_should_be_used_as_defaults() {
-                let options = AblyTests.commonAppSetup()
-                options.autoConnect = false
-                let realtime = AblyTests.newRealtime(options)
-                defer { realtime.close() }
-
-                waitUntil(timeout: testTimeout) { done in
-                    realtime.connection.once(.connecting) { stateChange in
-                        expect(stateChange.reason).to(beNil())
-
-                        let transport = realtime.internal.transport as! TestProxyTransport
-                        transport.setBeforeIncomingMessageModifier({ protocolMessage in
-                            if protocolMessage.action == .connected {
-                                protocolMessage.connectionDetails!.clientId = "john"
-                                protocolMessage.connectionDetails!.connectionKey = "123"
-                            }
-                            return protocolMessage
-                        })
-                    }
-                    realtime.connection.once(.connected) { stateChange in
-                        expect(stateChange.reason).to(beNil())
-
-                        let transport = realtime.internal.transport as! TestProxyTransport
-                        let connectedProtocolMessage = transport.protocolMessagesReceived.filter{ $0.action == .connected }[0]
-
-                        expect(realtime.auth.clientId).to(equal(connectedProtocolMessage.connectionDetails!.clientId))
-                        expect(realtime.connection.key).to(equal(connectedProtocolMessage.connectionDetails!.connectionKey))
-                        done()
-                    }
-                    realtime.connect()
-                }
+                // Host changed; should've had an internet check before.
+                expect(gotInternetIsUpCheck).to(beTrue())
+                gotInternetIsUpCheck = false
+                resultFallbackHosts.append(fallbackHost)
+            }
+        }
+
+        let expectedFallbackHosts = Array(expectedHostOrder.map { fbHosts[$0] })
+
+        expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
+
+        afterEach__Connection__Host_Fallback()
+    }
+
+    func test__095__Connection__Host_Fallback__won_t_use_fallback_hosts_feature_if_an_empty_array_is_provided() {
+        beforeEach__Connection__Host_Fallback()
+
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.autoConnect = false
+        options.fallbackHosts = []
+        let client = ARTRealtime(options: options)
+        let channel = client.channels.get("test")
+
+        let testHttpExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.rest.httpExecutor = testHttpExecutor
+
+        client.internal.setTransport(TestProxyTransport.self)
+        TestProxyTransport.fakeNetworkResponse = .hostUnreachable
+        defer { TestProxyTransport.fakeNetworkResponse = nil }
+
+        var urlConnections = [URL]()
+        TestProxyTransport.networkConnectEvent = { transport, url in
+            if client.internal.transport !== transport {
+                return
+            }
+            urlConnections.append(url)
+        }
+        defer { TestProxyTransport.networkConnectEvent = nil }
+
+        client.connect()
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { _ in
+                done()
+            }
+        }
+
+        expect(urlConnections).to(haveCount(1))
+
+        afterEach__Connection__Host_Fallback()
+    }
+
+    // RTN17e
+    func test__096__Connection__Host_Fallback__client_is_connected_to_a_fallback_host_endpoint_should_do_HTTP_requests_to_the_same_data_centre() {
+        beforeEach__Connection__Host_Fallback()
+
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+
+        let testHttpExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.rest.httpExecutor = testHttpExecutor
+
+        client.internal.setTransport(TestProxyTransport.self)
+        TestProxyTransport.fakeNetworkResponse = .hostUnreachable
+        defer { TestProxyTransport.fakeNetworkResponse = nil }
+
+        var urlConnections = [URL]()
+        TestProxyTransport.networkConnectEvent = { transport, url in
+            if client.internal.transport !== transport {
+                return
+            }
+            urlConnections.append(url)
+            if urlConnections.count == 2 {
+                TestProxyTransport.fakeNetworkResponse = nil
+                (client.internal.transport as! TestProxyTransport).simulateTransportSuccess()
+            }
+        }
+        defer { TestProxyTransport.networkConnectEvent = nil }
+
+        client.connect()
+        // Because we're faking the CONNECTED state, we can't client.close() or it
+        // will actually try to use the connection believing it's ready and throw an
+        // exception because it's really not.
+
+        expect(urlConnections).toEventually(haveCount(2), timeout: testTimeout)
+
+        expect(NSRegularExpression.match(urlConnections.at(1)?.absoluteString, pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+
+        waitUntil(timeout: testTimeout) { done in
+            client.time { _, _ in
+                done()
+            }
+        }
+
+        let timeRequestUrl = testHttpExecutor.requests.last!.url!
+        expect(timeRequestUrl.host).to(equal(urlConnections.at(1)?.host))
+
+        afterEach__Connection__Host_Fallback()
+    }
+
+    // RTN19
+    func test__010__Connection__attributes_within_ConnectionDetails_should_be_used_as_defaults() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let realtime = AblyTests.newRealtime(options)
+        defer { realtime.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            realtime.connection.once(.connecting) { stateChange in
+                expect(stateChange.reason).to(beNil())
 
                 let transport = realtime.internal.transport as! TestProxyTransport
-                let connectedProtocolMessage = transport.protocolMessagesReceived.filter{ $0.action == .connected }[0]
+                transport.setBeforeIncomingMessageModifier { protocolMessage in
+                    if protocolMessage.action == .connected {
+                        protocolMessage.connectionDetails!.clientId = "john"
+                        protocolMessage.connectionDetails!.connectionKey = "123"
+                    }
+                    return protocolMessage
+                }
+            }
+            realtime.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+
+                let transport = realtime.internal.transport as! TestProxyTransport
+                let connectedProtocolMessage = transport.protocolMessagesReceived.filter { $0.action == .connected }[0]
+
                 expect(realtime.auth.clientId).to(equal(connectedProtocolMessage.connectionDetails!.clientId))
                 expect(realtime.connection.key).to(equal(connectedProtocolMessage.connectionDetails!.connectionKey))
+                done()
             }
+            realtime.connect()
+        }
 
-            
+        let transport = realtime.internal.transport as! TestProxyTransport
+        let connectedProtocolMessage = transport.protocolMessagesReceived.filter { $0.action == .connected }[0]
+        expect(realtime.auth.clientId).to(equal(connectedProtocolMessage.connectionDetails!.clientId))
+        expect(realtime.connection.key).to(equal(connectedProtocolMessage.connectionDetails!.connectionKey))
+    }
 
-                // RTN19a
-                func skipped__test__103__Connection__Transport_disconnected_side_effects__should_resend_any_ProtocolMessage_that_is_awaiting_a_ACK_NACK() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-                    let transport = client.internal.transport as! TestProxyTransport
+    // RTN19a
+    func skipped__test__103__Connection__Transport_disconnected_side_effects__should_resend_any_ProtocolMessage_that_is_awaiting_a_ACK_NACK() {
+        let options = AblyTests.commonAppSetup()
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        let transport = client.internal.transport as! TestProxyTransport
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach { _ in done() }
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { _ in done() }
+        }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: "message") { error in
-                            expect(error).to(beNil())
-                            guard let newTransport = client.internal.transport as? TestProxyTransport else {
-                                fail("Transport is nil"); done(); return
-                            }
-                            expect(newTransport).toNot(beIdenticalTo(transport))
-                            expect(transport.protocolMessagesSent.filter{ $0.action == .message }).to(haveCount(1))
-                            expect(transport.protocolMessagesReceived.filter{ $0.action == .connected }).to(haveCount(1))
-                            expect(newTransport.protocolMessagesReceived.filter{ $0.action == .connected }).to(haveCount(1))
-                            expect(transport.protocolMessagesReceived.filter{ $0.action == .connected }).to(haveCount(1))
-                            expect(newTransport.protocolMessagesSent.filter{ $0.action == .message }).to(haveCount(1))
-                            done()
-                        }
-                        client.internal.onDisconnected()
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { error in
+                expect(error).to(beNil())
+                guard let newTransport = client.internal.transport as? TestProxyTransport else {
+                    fail("Transport is nil"); done(); return
                 }
-
-                // RTN19b
-                func skipped__test__104__Connection__Transport_disconnected_side_effects__should_resend_the_ATTACH_message_if_there_are_any_pending_channels() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-
-                    guard let transport = client.internal.transport as? TestProxyTransport else {
-                        fail("TestProxyTransport is not setup"); return
-                    }
-                    
-                    let channel = client.channels.get("test")
-                    waitUntil(timeout: testTimeout) { done in
-                        transport.ignoreSends = true
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            guard let newTransport = client.internal.transport as? TestProxyTransport else {
-                                fail("Transport is nil"); done(); return
-                            }
-                            expect(transport.protocolMessagesReceived.filter{ $0.action == .connected }).to(haveCount(1))
-                            expect(newTransport.protocolMessagesReceived.filter{ $0.action == .connected }).to(haveCount(1))
-                            expect(transport.protocolMessagesSent.filter{ $0.action == .attach }).to(haveCount(0))
-                            expect(transport.protocolMessagesSentIgnored.filter{ $0.action == .attach }).to(haveCount(1))
-                            expect(newTransport.protocolMessagesSent.filter{ $0.action == .attach }).to(haveCount(1))
-                            expect(transport).toNot(beIdenticalTo(newTransport))
-                            done()
-                        }
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-                        transport.ignoreSends = false
-                        AblyTests.queue.async {
-                            client.internal.onDisconnected()
-                        }
-                    }
-                }
-
-                // RTN19b
-                func skipped__test__105__Connection__Transport_disconnected_side_effects__should_resent_the_DETACH_message_if_there_are_any_pending_channels() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-                    let transport = client.internal.transport as! TestProxyTransport
-
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { _ in done() }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        transport.ignoreSends = true
-                        channel.detach() { error in
-                            expect(error).to(beNil())
-                            guard let newTransport = client.internal.transport as? TestProxyTransport else {
-                                fail("Transport is nil"); done(); return
-                            }
-                            expect(transport.protocolMessagesReceived.filter{ $0.action == .connected }).to(haveCount(1))
-                            expect(newTransport.protocolMessagesReceived.filter{ $0.action == .connected }).to(haveCount(1))
-                            expect(transport.protocolMessagesSent.filter{ $0.action == .detach }).to(haveCount(0))
-                            expect(transport.protocolMessagesSentIgnored.filter{ $0.action == .detach }).to(haveCount(1))
-                            expect(newTransport.protocolMessagesSent.filter{ $0.action == .detach }).to(haveCount(1))
-                            done()
-                        }
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.detaching))
-                        transport.ignoreSends = false
-                        client.internal.onDisconnected()
-                    }
-                }
-
-            // RTN20
-            
-
-                // RTN20a
-                
-
-                    func beforeEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available() {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        internetConnectionNotAvailableTestsClient = ARTRealtime(options: options)
-                        internetConnectionNotAvailableTestsClient.internal.setReachabilityClass(TestReachability.self)
-                    }
-
-                    func afterEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available() {
-                        internetConnectionNotAvailableTestsClient.dispose()
-                        internetConnectionNotAvailableTestsClient.close()
-                    }
-
-                    func test__109__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available__when_CONNECTING() {
-beforeEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available()
-
-                        waitUntil(timeout: testTimeout) { done in
-                            internetConnectionNotAvailableTestsClient.connection.on { stateChange in
-                                switch stateChange.current {
-                                case .connecting:
-                                    expect(stateChange.reason).to(beNil())
-                                    guard let reachability = internetConnectionNotAvailableTestsClient.internal.reachability as? TestReachability else {
-                                        fail("expected test reachability")
-                                        done(); return
-                                    }
-                                    expect(reachability.host).to(equal(internetConnectionNotAvailableTestsClient.internal.options.realtimeHost))
-                                    reachability.simulate(false)
-                                case .disconnected:
-                                    guard let reason = stateChange.reason else {
-                                        fail("expected error reason")
-                                        done(); return
-                                    }
-                                    expect(reason.code).to(equal(-1003))
-                                    done()
-                                default:
-                                    break
-                                }
-                            }
-                            internetConnectionNotAvailableTestsClient.connect()
-                        }
-
-afterEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available()
-
-                    }
-
-                    func test__110__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available__when_CONNECTED() {
-beforeEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available()
-
-                        waitUntil(timeout: testTimeout) { done in
-                            internetConnectionNotAvailableTestsClient.connection.on { stateChange in
-                                switch stateChange.current {
-                                case .connected:
-                                    expect(stateChange.reason).to(beNil())
-                                    guard let reachability = internetConnectionNotAvailableTestsClient.internal.reachability as? TestReachability else {
-                                        fail("expected test reachability")
-                                        done(); return
-                                    }
-                                    expect(reachability.host).to(equal(internetConnectionNotAvailableTestsClient.internal.options.realtimeHost))
-                                    reachability.simulate(false)
-                                case .disconnected:
-                                    guard let reason = stateChange.reason else {
-                                        fail("expected error reason")
-                                        done(); return
-                                    }
-                                    expect(reason.code).to(equal(-1003))
-                                    done()
-                                default:
-                                    break
-                                }
-                            }
-                            internetConnectionNotAvailableTestsClient.connect()
-                        }
-
-afterEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available()
-
-                    }
-
-                // RTN20b
-                func test__106__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_attempt_to_connect_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_now_available_when_DISCONNECTED_or_SUSPENDED() {
-                    var client: ARTRealtime!
-                    let options = AblyTests.commonAppSetup()
-                    // Ensure it won't reconnect because of timeouts.
-                    options.disconnectedRetryTimeout = testTimeout.incremented(by: 10).toTimeInterval()
-                    options.suspendedRetryTimeout = testTimeout.incremented(by: 10).toTimeInterval()
-                    options.autoConnect = false
-                    client = ARTRealtime(options: options)
-                    client.internal.setReachabilityClass(TestReachability.self)
-                    defer { client.dispose(); client.close() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.on { stateChange in
-                            switch stateChange.current {
-                            case .connecting:
-                                if stateChange.previous == .disconnected {
-                                    client.internal.onSuspended()
-                                } else if stateChange.previous == .suspended {
-                                    done()
-                                }
-                            case .connected:
-                                client.internal.onDisconnected()
-                            case .disconnected, .suspended:
-                                guard let reachability = client.internal.reachability as? TestReachability else {
-                                    fail("expected test reachability")
-                                    done(); return
-                                }
-                                expect(reachability.host).to(equal(client.internal.options.realtimeHost))
-                                reachability.simulate(true)
-                            default:
-                                break
-                            }
-                        }
-                        client.connect()
-                    }
-                }
-
-                // RTN22
-                func test__107__Connection__Operating_System_events_for_network_internet_connectivity_changes__Ably_can_request_that_a_connected_client_re_authenticates_by_sending_the_client_an_AUTH_ProtocolMessage() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    options.useTokenAuth = true
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    client.internal.setTransport(TestProxyTransport.self)
-                    let channel = client.channels.get("foo")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                        client.connect()
-                    }
-
-                    guard let initialConnectionId = client.connection.id else {
-                        fail("ConnectionId is nil"); return
-                    }
-
-                    guard let initialToken = client.auth.tokenDetails?.token else {
-                        fail("Initial token is nil"); return
-                    }
-
-                    guard let transport = client.internal.transport as? TestProxyTransport else {
-                        fail("TestProxyTransport is not set"); return
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.update) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            expect(initialToken).toNot(equal(client.auth.tokenDetails?.token))
-                            done()
-                        }
-
-                        let authMessage = ARTProtocolMessage()
-                        authMessage.action = .auth
-                        client.internal.transport?.receive(authMessage)
-                    }
-
-                    expect(client.connection.id).to(equal(initialConnectionId))
-                    expect(client.internal.transport).to(beIdenticalTo(transport))
-
-                    let authMessages = transport.protocolMessagesSent.filter({ $0.action == .auth })
-                    expect(authMessages).to(haveCount(1))
-
-                    guard let authMessage = authMessages.first else {
-                        fail("Missing AUTH protocol message"); return
-                    }
-
-                    expect(authMessage.auth).toNot(beNil())
-
-                    guard (authMessage.auth?.accessToken) != nil else {
-                        fail("Missing accessToken from AUTH ProtocolMessage auth attribute"); return
-                    }
-
-                    let restOptions = AblyTests.clientOptions(key: options.key!)
-                    restOptions.channelNamePrefix = options.channelNamePrefix
-                    let rest = ARTRest(options: restOptions)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        let expectedMessage = ARTMessage(name: "ios", data: "message1")
-                        
-                        channel.subscribe() { message in
-                            expect(message.name).to(equal(expectedMessage.name))
-                            expect(message.data as? String).to(equal(expectedMessage.data as? String))
-                            partialDone()
-                        }
-
-                        rest.channels.get("foo").publish([expectedMessage]) { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                    }
-                    
-                    channel.off()
-                }
-
-                // RTN22a
-                func test__108__Connection__Operating_System_events_for_network_internet_connectivity_changes__re_authenticate_and_resume_the_connection_when_the_client_is_forcibly_disconnected_following_a_DISCONNECTED_message_containing_an_error_code_greater_than_or_equal_to_40140_and_less_than_40150() {
-                    let options = AblyTests.commonAppSetup()
-                    options.token = getTestToken(key: options.key!, ttl: 5.0)
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("foo")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    guard let initialConnectionId = client.connection.id else {
-                        fail("ConnectionId is nil"); return
-                    }
-
-                    guard let initialToken = client.auth.tokenDetails?.token else {
-                        fail("Initial token is nil"); return
-                    }
-
-                    channel.once(.detached) { _ in
-                        fail("Should not detach channels")
-                    }
-
-                    var authorizeMethodCallCount = 0
-                    let hook = client.auth.internal.testSuite_injectIntoMethod(after: #selector(client.auth.internal._authorize(_:options:callback:))) {
-                        authorizeMethodCallCount += 1
-                    }
-                    defer { hook.remove() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.disconnected) { stateChange in
-                            guard let error = stateChange.reason else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.code) == ARTErrorCode.tokenExpired.intValue
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { stateChange in
-                            expect(stateChange.reason).to(beNil())
-                            expect(initialToken).toNot(equal(client.auth.tokenDetails?.token))
-                            done()
-                        }
-                    }
-
-                    expect(client.connection.id).to(equal(initialConnectionId))
-                    expect(authorizeMethodCallCount) == 1
-
-                    let restOptions = AblyTests.clientOptions(key: options.key!)
-                    restOptions.channelNamePrefix = options.channelNamePrefix
-                    let rest = ARTRest(options: restOptions)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        let expectedMessage = ARTMessage(name: "ios", data: "message1")
-
-                        channel.subscribe() { message in
-                            expect(message.name).to(equal(expectedMessage.name))
-                            expect(message.data as? String).to(equal(expectedMessage.data as? String))
-                            partialDone()
-                        }
-
-                        rest.channels.get("foo").publish([expectedMessage]) { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                    }
-
-                    channel.off()
-                }
-
-            // RTN23a
-            func test__011__Connection__should_disconnect_the_transport_when_no_activity_exist() {
-                let options = AblyTests.commonAppSetup()
-                let client = AblyTests.newRealtime(options)
-                defer { client.dispose(); client.close() }
-
-                let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                ARTDefault.setRealtimeRequestTimeout(0.5)
-
-                var expectedInactivityTimeout: TimeInterval?
-                waitUntil(timeout: testTimeout) { done in
-                    let partialDone = AblyTests.splitDone(2, done: done)
-
-                    guard let transport = client.internal.transport as? TestProxyTransport else {
-                        fail("TestProxyTransport is not set"); partialDone(); return
-                    }
-
-                    var noActivityHasStartedAt: Date?
-                    transport.setBeforeIncomingMessageModifier({ protocolMessage in
-                        if protocolMessage.action == .connected, let connectionDetails = protocolMessage.connectionDetails {
-                            connectionDetails.setMaxIdleInterval(3)
-                            expectedInactivityTimeout = connectionDetails.maxIdleInterval + ARTDefault.realtimeRequestTimeout()
-                            // Force no activity
-                            transport.ignoreWebSocket = true
-                            noActivityHasStartedAt = Date()
-                            transport.setBeforeIncomingMessageModifier(nil)
-                            partialDone()
-                        }
-                        return protocolMessage
-                    })
-
-                    client.connection.on(.disconnected) { stateChange in
-                        let now = Date()
-
-                        expect(stateChange.previous) == ARTRealtimeConnectionState.connected
-
-                        guard let noActivityHasStartedAt = noActivityHasStartedAt else {
-                            fail("No activity date is missing"); partialDone(); return
-                        }
-                        guard let expectedInactivityTimeout = expectedInactivityTimeout else {
-                            fail("Expected inactivity timeout is missing"); partialDone(); return
-                        }
-
-                        expect(now.timeIntervalSince(noActivityHasStartedAt)).to(beCloseTo(expectedInactivityTimeout, within: 1.0))
-
-                        guard let reason = stateChange.reason else {
-                            fail("ConnectionStateChange reason is missing"); partialDone(); return
-                        }
-                        guard let errorReason = client.connection.errorReason else {
-                            fail("Connection error is missing"); partialDone(); return
-                        }
-
-                        expect(reason.message).to(contain("Idle timer expired"))
-                        expect(errorReason.message).to(contain("Idle timer expired"))
-
-                        partialDone()
-                    }
-                }
-
-                expect(expectedInactivityTimeout) == 3.5
-                expect(client.internal.maxIdleInterval) == 3.0
+                expect(newTransport).toNot(beIdenticalTo(transport))
+                expect(transport.protocolMessagesSent.filter { $0.action == .message }).to(haveCount(1))
+                expect(transport.protocolMessagesReceived.filter { $0.action == .connected }).to(haveCount(1))
+                expect(newTransport.protocolMessagesReceived.filter { $0.action == .connected }).to(haveCount(1))
+                expect(transport.protocolMessagesReceived.filter { $0.action == .connected }).to(haveCount(1))
+                expect(newTransport.protocolMessagesSent.filter { $0.action == .message }).to(haveCount(1))
+                done()
             }
+            client.internal.onDisconnected()
+        }
+    }
 
-            // RTN24
-            func test__012__Connection__the_client_may_receive_a_CONNECTED_ProtocolMessage_from_Ably_at_any_point_and_should_emit_an_UPDATE_event() {
-                let options = AblyTests.commonAppSetup()
-                let client = ARTRealtime(options: options)
-                defer { client.dispose(); client.close() }
+    // RTN19b
+    func skipped__test__104__Connection__Transport_disconnected_side_effects__should_resend_the_ATTACH_message_if_there_are_any_pending_channels() {
+        let options = AblyTests.commonAppSetup()
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
 
-                waitUntil(timeout: testTimeout) { done in
-                    client.connection.once(.connected) { stateChange in
-                        expect(stateChange.reason).to(beNil())
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not setup"); return
+        }
+
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            transport.ignoreSends = true
+            channel.attach { error in
+                expect(error).to(beNil())
+                guard let newTransport = client.internal.transport as? TestProxyTransport else {
+                    fail("Transport is nil"); done(); return
+                }
+                expect(transport.protocolMessagesReceived.filter { $0.action == .connected }).to(haveCount(1))
+                expect(newTransport.protocolMessagesReceived.filter { $0.action == .connected }).to(haveCount(1))
+                expect(transport.protocolMessagesSent.filter { $0.action == .attach }).to(haveCount(0))
+                expect(transport.protocolMessagesSentIgnored.filter { $0.action == .attach }).to(haveCount(1))
+                expect(newTransport.protocolMessagesSent.filter { $0.action == .attach }).to(haveCount(1))
+                expect(transport).toNot(beIdenticalTo(newTransport))
+                done()
+            }
+            expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+            transport.ignoreSends = false
+            AblyTests.queue.async {
+                client.internal.onDisconnected()
+            }
+        }
+    }
+
+    // RTN19b
+    func skipped__test__105__Connection__Transport_disconnected_side_effects__should_resent_the_DETACH_message_if_there_are_any_pending_channels() {
+        let options = AblyTests.commonAppSetup()
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        let transport = client.internal.transport as! TestProxyTransport
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { _ in done() }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            transport.ignoreSends = true
+            channel.detach { error in
+                expect(error).to(beNil())
+                guard let newTransport = client.internal.transport as? TestProxyTransport else {
+                    fail("Transport is nil"); done(); return
+                }
+                expect(transport.protocolMessagesReceived.filter { $0.action == .connected }).to(haveCount(1))
+                expect(newTransport.protocolMessagesReceived.filter { $0.action == .connected }).to(haveCount(1))
+                expect(transport.protocolMessagesSent.filter { $0.action == .detach }).to(haveCount(0))
+                expect(transport.protocolMessagesSentIgnored.filter { $0.action == .detach }).to(haveCount(1))
+                expect(newTransport.protocolMessagesSent.filter { $0.action == .detach }).to(haveCount(1))
+                done()
+            }
+            expect(channel.state).to(equal(ARTRealtimeChannelState.detaching))
+            transport.ignoreSends = false
+            client.internal.onDisconnected()
+        }
+    }
+
+    // RTN20
+
+    // RTN20a
+
+    func beforeEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        internetConnectionNotAvailableTestsClient = ARTRealtime(options: options)
+        internetConnectionNotAvailableTestsClient.internal.setReachabilityClass(TestReachability.self)
+    }
+
+    func afterEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available() {
+        internetConnectionNotAvailableTestsClient.dispose()
+        internetConnectionNotAvailableTestsClient.close()
+    }
+
+    func test__109__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available__when_CONNECTING() {
+        beforeEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available()
+
+        waitUntil(timeout: testTimeout) { done in
+            internetConnectionNotAvailableTestsClient.connection.on { stateChange in
+                switch stateChange.current {
+                case .connecting:
+                    expect(stateChange.reason).to(beNil())
+                    guard let reachability = internetConnectionNotAvailableTestsClient.internal.reachability as? TestReachability else {
+                        fail("expected test reachability")
+                        done(); return
+                    }
+                    expect(reachability.host).to(equal(internetConnectionNotAvailableTestsClient.internal.options.realtimeHost))
+                    reachability.simulate(false)
+                case .disconnected:
+                    guard let reason = stateChange.reason else {
+                        fail("expected error reason")
+                        done(); return
+                    }
+                    expect(reason.code).to(equal(-1003))
+                    done()
+                default:
+                    break
+                }
+            }
+            internetConnectionNotAvailableTestsClient.connect()
+        }
+
+        afterEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available()
+    }
+
+    func test__110__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available__when_CONNECTED() {
+        beforeEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available()
+
+        waitUntil(timeout: testTimeout) { done in
+            internetConnectionNotAvailableTestsClient.connection.on { stateChange in
+                switch stateChange.current {
+                case .connected:
+                    expect(stateChange.reason).to(beNil())
+                    guard let reachability = internetConnectionNotAvailableTestsClient.internal.reachability as? TestReachability else {
+                        fail("expected test reachability")
+                        done(); return
+                    }
+                    expect(reachability.host).to(equal(internetConnectionNotAvailableTestsClient.internal.options.realtimeHost))
+                    reachability.simulate(false)
+                case .disconnected:
+                    guard let reason = stateChange.reason else {
+                        fail("expected error reason")
+                        done(); return
+                    }
+                    expect(reason.code).to(equal(-1003))
+                    done()
+                default:
+                    break
+                }
+            }
+            internetConnectionNotAvailableTestsClient.connect()
+        }
+
+        afterEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available()
+    }
+
+    // RTN20b
+    func test__106__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_attempt_to_connect_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_now_available_when_DISCONNECTED_or_SUSPENDED() {
+        var client: ARTRealtime!
+        let options = AblyTests.commonAppSetup()
+        // Ensure it won't reconnect because of timeouts.
+        options.disconnectedRetryTimeout = testTimeout.incremented(by: 10).toTimeInterval()
+        options.suspendedRetryTimeout = testTimeout.incremented(by: 10).toTimeInterval()
+        options.autoConnect = false
+        client = ARTRealtime(options: options)
+        client.internal.setReachabilityClass(TestReachability.self)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.on { stateChange in
+                switch stateChange.current {
+                case .connecting:
+                    if stateChange.previous == .disconnected {
+                        client.internal.onSuspended()
+                    } else if stateChange.previous == .suspended {
                         done()
                     }
+                case .connected:
+                    client.internal.onDisconnected()
+                case .disconnected, .suspended:
+                    guard let reachability = client.internal.reachability as? TestReachability else {
+                        fail("expected test reachability")
+                        done(); return
+                    }
+                    expect(reachability.host).to(equal(client.internal.options.realtimeHost))
+                    reachability.simulate(true)
+                default:
+                    break
+                }
+            }
+            client.connect()
+        }
+    }
+
+    // RTN22
+    func test__107__Connection__Operating_System_events_for_network_internet_connectivity_changes__Ably_can_request_that_a_connected_client_re_authenticates_by_sending_the_client_an_AUTH_ProtocolMessage() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.useTokenAuth = true
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        client.internal.setTransport(TestProxyTransport.self)
+        let channel = client.channels.get("foo")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+            client.connect()
+        }
+
+        guard let initialConnectionId = client.connection.id else {
+            fail("ConnectionId is nil"); return
+        }
+
+        guard let initialToken = client.auth.tokenDetails?.token else {
+            fail("Initial token is nil"); return
+        }
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.update) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(initialToken).toNot(equal(client.auth.tokenDetails?.token))
+                done()
+            }
+
+            let authMessage = ARTProtocolMessage()
+            authMessage.action = .auth
+            client.internal.transport?.receive(authMessage)
+        }
+
+        expect(client.connection.id).to(equal(initialConnectionId))
+        expect(client.internal.transport).to(beIdenticalTo(transport))
+
+        let authMessages = transport.protocolMessagesSent.filter { $0.action == .auth }
+        expect(authMessages).to(haveCount(1))
+
+        guard let authMessage = authMessages.first else {
+            fail("Missing AUTH protocol message"); return
+        }
+
+        expect(authMessage.auth).toNot(beNil())
+
+        guard (authMessage.auth?.accessToken) != nil else {
+            fail("Missing accessToken from AUTH ProtocolMessage auth attribute"); return
+        }
+
+        let restOptions = AblyTests.clientOptions(key: options.key!)
+        restOptions.channelNamePrefix = options.channelNamePrefix
+        let rest = ARTRest(options: restOptions)
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            let expectedMessage = ARTMessage(name: "ios", data: "message1")
+
+            channel.subscribe { message in
+                expect(message.name).to(equal(expectedMessage.name))
+                expect(message.data as? String).to(equal(expectedMessage.data as? String))
+                partialDone()
+            }
+
+            rest.channels.get("foo").publish([expectedMessage]) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
+
+        channel.off()
+    }
+
+    // RTN22a
+    func test__108__Connection__Operating_System_events_for_network_internet_connectivity_changes__re_authenticate_and_resume_the_connection_when_the_client_is_forcibly_disconnected_following_a_DISCONNECTED_message_containing_an_error_code_greater_than_or_equal_to_40140_and_less_than_40150() {
+        let options = AblyTests.commonAppSetup()
+        options.token = getTestToken(key: options.key!, ttl: 5.0)
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("foo")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let initialConnectionId = client.connection.id else {
+            fail("ConnectionId is nil"); return
+        }
+
+        guard let initialToken = client.auth.tokenDetails?.token else {
+            fail("Initial token is nil"); return
+        }
+
+        channel.once(.detached) { _ in
+            fail("Should not detach channels")
+        }
+
+        var authorizeMethodCallCount = 0
+        let hook = client.auth.internal.testSuite_injectIntoMethod(after: #selector(client.auth.internal._authorize(_:options:callback:))) {
+            authorizeMethodCallCount += 1
+        }
+        defer { hook.remove() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.disconnected) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error.code) == ARTErrorCode.tokenExpired.intValue
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(initialToken).toNot(equal(client.auth.tokenDetails?.token))
+                done()
+            }
+        }
+
+        expect(client.connection.id).to(equal(initialConnectionId))
+        expect(authorizeMethodCallCount) == 1
+
+        let restOptions = AblyTests.clientOptions(key: options.key!)
+        restOptions.channelNamePrefix = options.channelNamePrefix
+        let rest = ARTRest(options: restOptions)
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            let expectedMessage = ARTMessage(name: "ios", data: "message1")
+
+            channel.subscribe { message in
+                expect(message.name).to(equal(expectedMessage.name))
+                expect(message.data as? String).to(equal(expectedMessage.data as? String))
+                partialDone()
+            }
+
+            rest.channels.get("foo").publish([expectedMessage]) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
+
+        channel.off()
+    }
+
+    // RTN23a
+    func test__011__Connection__should_disconnect_the_transport_when_no_activity_exist() {
+        let options = AblyTests.commonAppSetup()
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+
+        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+        ARTDefault.setRealtimeRequestTimeout(0.5)
+
+        var expectedInactivityTimeout: TimeInterval?
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+
+            guard let transport = client.internal.transport as? TestProxyTransport else {
+                fail("TestProxyTransport is not set"); partialDone(); return
+            }
+
+            var noActivityHasStartedAt: Date?
+            transport.setBeforeIncomingMessageModifier { protocolMessage in
+                if protocolMessage.action == .connected, let connectionDetails = protocolMessage.connectionDetails {
+                    connectionDetails.setMaxIdleInterval(3)
+                    expectedInactivityTimeout = connectionDetails.maxIdleInterval + ARTDefault.realtimeRequestTimeout()
+                    // Force no activity
+                    transport.ignoreWebSocket = true
+                    noActivityHasStartedAt = Date()
+                    transport.setBeforeIncomingMessageModifier(nil)
+                    partialDone()
+                }
+                return protocolMessage
+            }
+
+            client.connection.on(.disconnected) { stateChange in
+                let now = Date()
+
+                expect(stateChange.previous) == ARTRealtimeConnectionState.connected
+
+                guard let noActivityHasStartedAt = noActivityHasStartedAt else {
+                    fail("No activity date is missing"); partialDone(); return
+                }
+                guard let expectedInactivityTimeout = expectedInactivityTimeout else {
+                    fail("Expected inactivity timeout is missing"); partialDone(); return
                 }
 
-                waitUntil(timeout: testTimeout) { done in
-                    let authMessage = ARTProtocolMessage()
-                    authMessage.action = ARTProtocolMessageAction.connected
-                    authMessage.error = ARTErrorInfo.create(withCode: 1234, message: "fabricated error")
+                expect(now.timeIntervalSince(noActivityHasStartedAt)).to(beCloseTo(expectedInactivityTimeout, within: 1.0))
 
-                    let listener = client.connection.once(.connected) { _ in 
-                        fail("shouldn't emit CONNECTED")
-                    }
-                    client.connection.once(.update) { stateChange in
-                        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                        expect(stateChange.current).to(equal(ARTRealtimeConnectionState.connected))
-                        expect(stateChange.current).to(equal(stateChange.previous))
-                        expect(stateChange.reason).to(beIdenticalTo(authMessage.error))
-                        delay(0.5) { // Give some time for the other listener to be triggered.
-                            client.connection.off(listener)
-                            done()
-                        }
-                    }
+                guard let reason = stateChange.reason else {
+                    fail("ConnectionStateChange reason is missing"); partialDone(); return
+                }
+                guard let errorReason = client.connection.errorReason else {
+                    fail("Connection error is missing"); partialDone(); return
+                }
 
-                    client.internal.transport?.receive(authMessage)
+                expect(reason.message).to(contain("Idle timer expired"))
+                expect(errorReason.message).to(contain("Idle timer expired"))
+
+                partialDone()
+            }
+        }
+
+        expect(expectedInactivityTimeout) == 3.5
+        expect(client.internal.maxIdleInterval) == 3.0
+    }
+
+    // RTN24
+    func test__012__Connection__the_client_may_receive_a_CONNECTED_ProtocolMessage_from_Ably_at_any_point_and_should_emit_an_UPDATE_event() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let authMessage = ARTProtocolMessage()
+            authMessage.action = ARTProtocolMessageAction.connected
+            authMessage.error = ARTErrorInfo.create(withCode: 1234, message: "fabricated error")
+
+            let listener = client.connection.once(.connected) { _ in
+                fail("shouldn't emit CONNECTED")
+            }
+            client.connection.once(.update) { stateChange in
+                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+                expect(stateChange.current).to(equal(ARTRealtimeConnectionState.connected))
+                expect(stateChange.current).to(equal(stateChange.previous))
+                expect(stateChange.reason).to(beIdenticalTo(authMessage.error))
+                delay(0.5) { // Give some time for the other listener to be triggered.
+                    client.connection.off(listener)
+                    done()
                 }
             }
 
-            // RTN24
-            func test__013__Connection__should_set_the_Connection_reason_attribute_based_on_the_Error_member_of_the_CONNECTED_ProtocolMessage() {
-                let options = AblyTests.commonAppSetup()
-                options.useTokenAuth = true
-                let client = AblyTests.newRealtime(options)
-                defer { client.dispose(); client.close() }
+            client.internal.transport?.receive(authMessage)
+        }
+    }
 
-                waitUntil(timeout: testTimeout) { done in
-                    client.connection.once(.connected) { stateChange in
-                        expect(stateChange.reason).to(beNil())
+    // RTN24
+    func test__013__Connection__should_set_the_Connection_reason_attribute_based_on_the_Error_member_of_the_CONNECTED_ProtocolMessage() {
+        let options = AblyTests.commonAppSetup()
+        options.useTokenAuth = true
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+        }
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+        guard let originalConnectedMessage = transport.protocolMessagesReceived.filter({ $0.action == .connected }).first else {
+            fail("First CONNECTED message not received"); return
+        }
+
+        client.connection.once(.connected) { _ in
+            fail("Should not emit a Connected state")
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.update) { stateChange in
+                guard let error = stateChange.reason else {
+                    fail("Reason error is nil"); done(); return
+                }
+                expect(error.code) == 1234
+                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+                expect(stateChange.current).to(equal(ARTRealtimeConnectionState.connected))
+                expect(stateChange.current).to(equal(stateChange.previous))
+                done()
+            }
+
+            let connectedMessageWithError = originalConnectedMessage
+            connectedMessageWithError.error = ARTErrorInfo.create(withCode: 1234, message: "fabricated error")
+            client.internal.transport?.receive(connectedMessageWithError)
+        }
+
+        expect(client.connection.errorReason).to(beNil())
+    }
+
+    // https://github.com/ably/ably-cocoa/issues/454
+    func test__014__Connection__should_not_move_to_FAILED_if_received_DISCONNECT_with_an_error() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer {
+            client.dispose()
+            client.close()
+        }
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+
+        let protoMsg = ARTProtocolMessage()
+        protoMsg.action = .disconnect
+        protoMsg.error = ARTErrorInfo.create(withCode: 123, message: "test error")
+        client.internal.transport?.receive(protoMsg)
+
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.disconnected))
+        expect(client.connection.errorReason).to(equal(protoMsg.error))
+    }
+
+    // https://github.com/ably/wiki/issues/22
+    func skipped__test__111__Connection__with_fixture_messages__should_encode_and_decode_fixture_messages_as_expected() {
+        let options = AblyTests.commonAppSetup()
+        options.useBinaryProtocol = false
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        channel.attach()
+
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+        if channel.state != .attached {
+            return
+        }
+
+        for (_, fixtureMessage) in fixtures["messages"] {
+            var receivedMessage: ARTMessage?
+
+            waitUntil(timeout: testTimeout) { done in
+                channel.subscribe { message in
+                    channel.unsubscribe()
+                    receivedMessage = message
+                    done()
+                }
+
+                let request = NSMutableURLRequest(url: URL(string: "/channels/\(channel.name)/messages")!)
+                request.httpMethod = "POST"
+                request.httpBody = try! fixtureMessage.rawData()
+                request.allHTTPHeaderFields = [
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                ]
+                client.internal.rest.execute(request, withAuthOption: .on, completion: { _, _, err in
+                    if let err = err {
+                        fail("\(err)")
+                    }
+                })
+            }
+
+            guard let message = receivedMessage else {
+                continue
+            }
+
+            expectDataToMatch(message, fixtureMessage)
+
+            waitUntil(timeout: testTimeout) { done in
+                channel.publish([message]) { err in
+                    if let err = err {
+                        fail("\(err)")
                         done()
-                    }
-                }
-
-                guard let transport = client.internal.transport as? TestProxyTransport else {
-                    fail("TestProxyTransport is not set"); return
-                }
-                guard let originalConnectedMessage = transport.protocolMessagesReceived.filter({ $0.action == .connected }).first else {
-                    fail("First CONNECTED message not received"); return
-                }
-
-                client.connection.once(.connected) { stateChange in
-                    fail("Should not emit a Connected state")
-                }
-
-                waitUntil(timeout: testTimeout) { done in
-                    client.connection.once(.update) { stateChange in
-                        guard let error = stateChange.reason else {
-                            fail("Reason error is nil"); done(); return
-                        }
-                        expect(error.code) == 1234
-                        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                        expect(stateChange.current).to(equal(ARTRealtimeConnectionState.connected))
-                        expect(stateChange.current).to(equal(stateChange.previous))
-                        done()
-                    }
-
-                    let connectedMessageWithError = originalConnectedMessage
-                    connectedMessageWithError.error = ARTErrorInfo.create(withCode: 1234, message: "fabricated error")
-                    client.internal.transport?.receive(connectedMessageWithError)
-                }
-
-                expect(client.connection.errorReason).to(beNil())
-            }
-
-            // https://github.com/ably/ably-cocoa/issues/454
-            func test__014__Connection__should_not_move_to_FAILED_if_received_DISCONNECT_with_an_error() {
-                let options = AblyTests.commonAppSetup()
-                let client = ARTRealtime(options: options)
-                defer {
-                    client.dispose()
-                    client.close()
-                }
-
-                expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-
-                let protoMsg = ARTProtocolMessage()
-                protoMsg.action = .disconnect
-                protoMsg.error = ARTErrorInfo.create(withCode: 123, message: "test error")
-                client.internal.transport?.receive(protoMsg)
-
-                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.disconnected))
-                expect(client.connection.errorReason).to(equal(protoMsg.error))
-            }
-
-            
-
-                // https://github.com/ably/wiki/issues/22
-                func skipped__test__111__Connection__with_fixture_messages__should_encode_and_decode_fixture_messages_as_expected() {
-                    let options = AblyTests.commonAppSetup()
-                    options.useBinaryProtocol = false
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-                    channel.attach()
-
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-                    if channel.state != .attached {
                         return
                     }
 
-                    for (_, fixtureMessage) in fixtures["messages"] {
-                        var receivedMessage: ARTMessage?
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.subscribe { message in
-                                channel.unsubscribe()
-                                receivedMessage = message
-                                done()
-                            }
-
-                            let request = NSMutableURLRequest(url: URL(string: "/channels/\(channel.name)/messages")!)
-                            request.httpMethod = "POST"
-                            request.httpBody = try! fixtureMessage.rawData()
-                            request.allHTTPHeaderFields = [
-                                "Accept" : "application/json",
-                                "Content-Type" : "application/json"
-                            ]
-                            client.internal.rest.execute(request, withAuthOption: .on, completion: { _, _, err in
-                                if let err = err {
-                                    fail("\(err)")
-                                }
-                            })
+                    let request = NSMutableURLRequest(url: URL(string: "/channels/\(channel.name)/messages?limit=1")!)
+                    request.httpMethod = "GET"
+                    request.allHTTPHeaderFields = ["Accept": "application/json"]
+                    client.internal.rest.execute(request, withAuthOption: .on, completion: { _, data, err in
+                        if let err = err {
+                            fail("\(err)")
+                            done()
+                            return
                         }
-
-                        guard let message = receivedMessage else {
-                            continue
-                        }
-
-                        expectDataToMatch(message, fixtureMessage)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish([message]) { err in
-                                if let err = err {
-                                    fail("\(err)")
-                                    done()
-                                    return
-                                }
-
-                                let request = NSMutableURLRequest(url: URL(string: "/channels/\(channel.name)/messages?limit=1")!)
-                                request.httpMethod = "GET"
-                                request.allHTTPHeaderFields = ["Accept" : "application/json"]
-                                client.internal.rest.execute(request, withAuthOption: .on, completion: { _, data, err in
-                                    if let err = err {
-                                        fail("\(err)")
-                                        done()
-                                        return
-                                    }
-                                    let persistedMessage = try! JSON(data: data!).array!.first!
-                                    expect(persistedMessage["data"]).to(equal(fixtureMessage["data"]))
-                                    expect(persistedMessage["encoding"]).to(equal(fixtureMessage["encoding"]))
-                                    done()
-                                })
-                            }
-                        }
-                    }
-                }
-
-                func skipped__test__112__Connection__with_fixture_messages__should_send_messages_through_raw_JSON_POST_and_retrieve_equal_messages_through_MsgPack_and_JSON() {
-                    setupDependencies()
-                    let restPublishClient = ARTRest(options: jsonOptions)
-                    let realtimeSubscribeClientMsgPack = AblyTests.newRealtime(msgpackOptions)
-                    let realtimeSubscribeClientJSON = AblyTests.newRealtime(jsonOptions)
-                    defer {
-                        realtimeSubscribeClientMsgPack.close()
-                        realtimeSubscribeClientJSON.close()
-                    }
-
-                    let realtimeSubscribeChannelMsgPack = realtimeSubscribeClientMsgPack.channels.get("test-subscribe")
-                    let realtimeSubscribeChannelJSON = realtimeSubscribeClientJSON.channels.get(realtimeSubscribeChannelMsgPack.name)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partlyDone = AblyTests.splitDone(2, done: done)
-                        realtimeSubscribeChannelMsgPack.attach { _ in partlyDone() }
-                        realtimeSubscribeChannelJSON.attach { _ in partlyDone() }
-                    }
-
-                    for (_, fixtureMessage) in fixtures["messages"] {
-                        waitUntil(timeout: testTimeout) { done in
-                            let partlyDone = AblyTests.splitDone(2, done: done)
-
-                            realtimeSubscribeChannelMsgPack.subscribe { message in
-                                realtimeSubscribeChannelMsgPack.unsubscribe()
-                                expectDataToMatch(message, fixtureMessage)
-                                partlyDone()
-                            }
-
-                            realtimeSubscribeChannelJSON.subscribe { message in
-                                realtimeSubscribeChannelJSON.unsubscribe()
-                                expectDataToMatch(message, fixtureMessage)
-                                partlyDone()
-                            }
-
-                            let request = NSMutableURLRequest(url: URL(string: "/channels/\(realtimeSubscribeChannelMsgPack.name)/messages")!)
-                            request.httpMethod = "POST"
-                            request.httpBody = try! fixtureMessage.rawData()
-                            request.allHTTPHeaderFields = [
-                                "Accept" : "application/json",
-                                "Content-Type" : "application/json"
-                            ]
-                            restPublishClient.internal.execute(request, withAuthOption: .on, completion: { _, _, err in
-                                if let err = err {
-                                    fail("\(err)")
-                                }
-                            })
-                        }
-                    }
-                }
-
-                func skipped__test__113__Connection__with_fixture_messages__should_send_messages_through_MsgPack_and_JSON_and_retrieve_equal_messages_through_raw_JSON_GET() {
-                    setupDependencies()
-                    let restPublishClientMsgPack = ARTRest(options: msgpackOptions)
-                    let restPublishClientJSON = ARTRest(options: jsonOptions)
-                    let restRetrieveClient = ARTRest(options: jsonOptions)
-
-                    let restPublishChannelMsgPack = restPublishClientMsgPack.channels.get("test-publish")
-                    let restPublishChannelJSON = restPublishClientJSON.channels.get(restPublishChannelMsgPack.name)
-
-                    for (_, fixtureMessage) in fixtures["messages"] {
-                        var data: AnyObject
-                        if fixtureMessage["expectedType"] == "binary" {
-                            data = fixtureMessage["expectedHexValue"].string!.dataFromHexadecimalString()! as AnyObject
-                        } else {
-                            data = fixtureMessage["expectedValue"].object as AnyObject
-                        }
-
-                        for restPublishChannel in [restPublishChannelMsgPack, restPublishChannelJSON] {
-                            waitUntil(timeout: testTimeout) { done in
-                                restPublishChannel.publish("event", data: data) { err in 
-                                    if let err = err {
-                                        fail("\(err)")
-                                        done()
-                                        return
-                                    }
-                                    done()
-                                }
-                            }
-
-                            waitUntil(timeout: testTimeout) { done in
-                                let request = NSMutableURLRequest(url: URL(string: "/channels/\(restPublishChannel.name)/messages?limit=1")!)
-                                request.httpMethod = "GET"
-                                request.allHTTPHeaderFields = ["Accept" : "application/json"]
-                                restRetrieveClient.internal.execute(request, withAuthOption: .on, completion: { _, data, err in
-                                    if let err = err {
-                                        fail("\(err)")
-                                        done()
-                                        return
-                                    }
-                                    let persistedMessage = try! JSON(data: data!).array!.first!
-                                    expect(persistedMessage["data"]).to(equal(persistedMessage["data"]))
-                                    expect(persistedMessage["encoding"]).to(equal(fixtureMessage["encoding"]))
-                                    done()
-                                })
-                            }
-                        }
-                    }
-                }
-
-            func test__015__Connection__should_abort_reconnection_with_new_token_if_the_server_has_requested_it_to_authorize_and_after_it_the_connection_has_been_closed() {
-                let options = AblyTests.commonAppSetup()
-                let client = ARTRealtime(options: options)
-                defer { client.dispose(); client.close() }
-
-                waitUntil(timeout: testTimeout) { done in
-                    client.connection.once(.connected) { stateChange in
-                        expect(stateChange.reason).to(beNil())
+                        let persistedMessage = try! JSON(data: data!).array!.first!
+                        expect(persistedMessage["data"]).to(equal(fixtureMessage["data"]))
+                        expect(persistedMessage["encoding"]).to(equal(fixtureMessage["encoding"]))
                         done()
-                    }
-                }
-
-                client.auth.internal.options.authCallback = { tokenParams, completion in
-                    getTestTokenDetails(ttl: 0.1) { tokenDetails, error in
-                        expect(error).to(beNil())
-                        guard let tokenDetails = tokenDetails else {
-                            fail("TokenDetails is nil"); return
-                        }
-                        // Let the token expire
-                        delay(0.1) {
-                            completion(tokenDetails.token as ARTTokenDetailsCompatible?, nil)
-                        }
-                    }
-                }
-
-                let authMessage = ARTProtocolMessage()
-                authMessage.action = .auth
-                client.internal.transport?.receive(authMessage)
-
-                client.close()
-
-                waitUntil(timeout: testTimeout) { done in
-                    client.connection.once(.failed) { _ in
-                        fail("Should not receive error 40142")
-                    }
-                    client.connection.once(.connected) { _ in
-                        fail("Should not connect")
-                    }
-                    client.connection.once(.closed) { _ in
-                        done()
-                    }
+                    })
                 }
             }
+        }
+    }
+
+    func skipped__test__112__Connection__with_fixture_messages__should_send_messages_through_raw_JSON_POST_and_retrieve_equal_messages_through_MsgPack_and_JSON() {
+        setupDependencies()
+        let restPublishClient = ARTRest(options: jsonOptions)
+        let realtimeSubscribeClientMsgPack = AblyTests.newRealtime(msgpackOptions)
+        let realtimeSubscribeClientJSON = AblyTests.newRealtime(jsonOptions)
+        defer {
+            realtimeSubscribeClientMsgPack.close()
+            realtimeSubscribeClientJSON.close()
+        }
+
+        let realtimeSubscribeChannelMsgPack = realtimeSubscribeClientMsgPack.channels.get("test-subscribe")
+        let realtimeSubscribeChannelJSON = realtimeSubscribeClientJSON.channels.get(realtimeSubscribeChannelMsgPack.name)
+
+        waitUntil(timeout: testTimeout) { done in
+            let partlyDone = AblyTests.splitDone(2, done: done)
+            realtimeSubscribeChannelMsgPack.attach { _ in partlyDone() }
+            realtimeSubscribeChannelJSON.attach { _ in partlyDone() }
+        }
+
+        for (_, fixtureMessage) in fixtures["messages"] {
+            waitUntil(timeout: testTimeout) { done in
+                let partlyDone = AblyTests.splitDone(2, done: done)
+
+                realtimeSubscribeChannelMsgPack.subscribe { message in
+                    realtimeSubscribeChannelMsgPack.unsubscribe()
+                    expectDataToMatch(message, fixtureMessage)
+                    partlyDone()
+                }
+
+                realtimeSubscribeChannelJSON.subscribe { message in
+                    realtimeSubscribeChannelJSON.unsubscribe()
+                    expectDataToMatch(message, fixtureMessage)
+                    partlyDone()
+                }
+
+                let request = NSMutableURLRequest(url: URL(string: "/channels/\(realtimeSubscribeChannelMsgPack.name)/messages")!)
+                request.httpMethod = "POST"
+                request.httpBody = try! fixtureMessage.rawData()
+                request.allHTTPHeaderFields = [
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                ]
+                restPublishClient.internal.execute(request, withAuthOption: .on, completion: { _, _, err in
+                    if let err = err {
+                        fail("\(err)")
+                    }
+                })
+            }
+        }
+    }
+
+    func skipped__test__113__Connection__with_fixture_messages__should_send_messages_through_MsgPack_and_JSON_and_retrieve_equal_messages_through_raw_JSON_GET() {
+        setupDependencies()
+        let restPublishClientMsgPack = ARTRest(options: msgpackOptions)
+        let restPublishClientJSON = ARTRest(options: jsonOptions)
+        let restRetrieveClient = ARTRest(options: jsonOptions)
+
+        let restPublishChannelMsgPack = restPublishClientMsgPack.channels.get("test-publish")
+        let restPublishChannelJSON = restPublishClientJSON.channels.get(restPublishChannelMsgPack.name)
+
+        for (_, fixtureMessage) in fixtures["messages"] {
+            var data: AnyObject
+            if fixtureMessage["expectedType"] == "binary" {
+                data = fixtureMessage["expectedHexValue"].string!.dataFromHexadecimalString()! as AnyObject
+            } else {
+                data = fixtureMessage["expectedValue"].object as AnyObject
+            }
+
+            for restPublishChannel in [restPublishChannelMsgPack, restPublishChannelJSON] {
+                waitUntil(timeout: testTimeout) { done in
+                    restPublishChannel.publish("event", data: data) { err in
+                        if let err = err {
+                            fail("\(err)")
+                            done()
+                            return
+                        }
+                        done()
+                    }
+                }
+
+                waitUntil(timeout: testTimeout) { done in
+                    let request = NSMutableURLRequest(url: URL(string: "/channels/\(restPublishChannel.name)/messages?limit=1")!)
+                    request.httpMethod = "GET"
+                    request.allHTTPHeaderFields = ["Accept": "application/json"]
+                    restRetrieveClient.internal.execute(request, withAuthOption: .on, completion: { _, data, err in
+                        if let err = err {
+                            fail("\(err)")
+                            done()
+                            return
+                        }
+                        let persistedMessage = try! JSON(data: data!).array!.first!
+                        expect(persistedMessage["data"]).to(equal(persistedMessage["data"]))
+                        expect(persistedMessage["encoding"]).to(equal(fixtureMessage["encoding"]))
+                        done()
+                    })
+                }
+            }
+        }
+    }
+
+    func test__015__Connection__should_abort_reconnection_with_new_token_if_the_server_has_requested_it_to_authorize_and_after_it_the_connection_has_been_closed() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                done()
+            }
+        }
+
+        client.auth.internal.options.authCallback = { _, completion in
+            getTestTokenDetails(ttl: 0.1) { tokenDetails, error in
+                expect(error).to(beNil())
+                guard let tokenDetails = tokenDetails else {
+                    fail("TokenDetails is nil"); return
+                }
+                // Let the token expire
+                delay(0.1) {
+                    completion(tokenDetails.token as ARTTokenDetailsCompatible?, nil)
+                }
+            }
+        }
+
+        let authMessage = ARTProtocolMessage()
+        authMessage.action = .auth
+        client.internal.transport?.receive(authMessage)
+
+        client.close()
+
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.failed) { _ in
+                fail("Should not receive error 40142")
+            }
+            client.connection.once(.connected) { _ in
+                fail("Should not connect")
+            }
+            client.connection.once(.closed) { _ in
+                done()
+            }
+        }
+    }
 }

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -1,7 +1,7 @@
 import Ably
 import Aspects
 import Nimble
-import Quick
+import XCTest
 import SwiftyJSON
 
 func countChannels(_ channels: ARTRealtimeChannels) -> Int {

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -12,7 +12,156 @@ func countChannels(_ channels: ARTRealtimeChannels) -> Int {
     return i
 }
 
+                    private var ttlAndIdleIntervalPassedTestsClient: ARTRealtime!
+                    private var ttlAndIdleIntervalPassedTestsConnectionId = ""
+                    private let customTtlInterval: TimeInterval = 0.1
+                    private let customIdleInterval: TimeInterval = 0.1
+                    private var ttlAndIdleIntervalNotPassedTestsClient: ARTRealtime!
+                    private var ttlAndIdleIntervalNotPassedTestsConnectionId = ""
+                private let expectedHostOrder = [3, 4, 0, 2, 1]
+                private let originalARTFallback_shuffleArray = ARTFallback_shuffleArray
+                    private func testUsesAlternativeHostOnResponse(_ caseTest: FakeNetworkResponse) {
+                        let options = ARTClientOptions(key: "xxxx:xxxx")
+                        options.autoConnect = false
+                        let client = ARTRealtime(options: options)
+                        defer { client.dispose(); client.close() }
+                        client.channels.get("test")
+
+                        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
+                        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
+                        ARTDefault.setRealtimeRequestTimeout(1.0)
+
+                        client.internal.setTransport(TestProxyTransport.self)
+                        TestProxyTransport.fakeNetworkResponse = caseTest
+                        defer { TestProxyTransport.fakeNetworkResponse = nil }
+
+                        var urlConnections = [URL]()
+                        TestProxyTransport.networkConnectEvent = { transport, url in
+                            if client.internal.transport !== transport {
+                                return
+                            }
+                            urlConnections.append(url)
+                            if urlConnections.count == 1 {
+                                TestProxyTransport.fakeNetworkResponse = nil
+                            }
+                        }
+                        defer { TestProxyTransport.networkConnectEvent = nil }
+
+                        waitUntil(timeout: testTimeout) { done in
+                            // wss://[a-e].ably-realtime.com: when a timeout occurs
+                            client.connection.once(.disconnected) { error in
+                                done()
+                            }
+                            // wss://[a-e].ably-realtime.com: when a 401 occurs because of the `xxxx:xxxx` key
+                            client.connection.once(.failed) { error in
+                                done()
+                            }
+                            client.connect()
+                        }
+
+                        expect(urlConnections).to(haveCount(2))
+                        expect(NSRegularExpression.match(urlConnections[0].absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
+                        expect(NSRegularExpression.match(urlConnections[1].absoluteString, pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+                    }
+                    private func testMovesToDisconnectedWithNetworkingError(_ error: Error) {
+                        let options = AblyTests.commonAppSetup()
+                        options.autoConnect = false
+                        let client = AblyTests.newRealtime(options)
+                        defer {
+                            client.dispose()
+                            client.close()
+                        }
+                        client.internal.setTransport(TestProxyTransport.self)
+
+                        waitUntil(timeout: testTimeout) { done in
+                            client.connection.once(.connected) { _ in
+                                done()
+                            }
+                            client.connect()
+                        }
+
+                        var _transport: ARTWebSocketTransport?
+                        AblyTests.queue.sync {
+                            _transport = client.internal.transport as? ARTWebSocketTransport
+                        }
+
+                        guard let wsTransport = _transport else {
+                            fail("expected WS transport")
+                            return
+                        }
+
+                        waitUntil(timeout: testTimeout) { done in
+                            client.connection.once(.disconnected) { _ in
+                                done()
+                            }
+                            wsTransport.webSocket(wsTransport.websocket!, didFailWithError:error)
+                        }
+                    }
+                    private var internetConnectionNotAvailableTestsClient: ARTRealtime!
+                private let fixtures = try! JSON(data: NSData(contentsOfFile: pathForTestResource(testResourcesPath + "messages-encoding.json"))! as Data, options: .mutableContainers)
+
+                private func expectDataToMatch(_ message: ARTMessage, _ fixtureMessage: JSON) {
+                    switch fixtureMessage["expectedType"].string! {
+                    case "string":
+                        expect(message.data as? NSString).to(equal(fixtureMessage["expectedValue"].string! as NSString?))
+                    case "jsonObject":
+                        if let data = message.data as? NSDictionary {
+                            expect(JSON(data)).to(equal(fixtureMessage["expectedValue"]))
+                        } else {
+                            fail("expected NSDictionary")
+                        }              
+                    case "jsonArray":
+                        if let data = message.data as? NSArray {
+                            expect(JSON(data)).to(equal(fixtureMessage["expectedValue"]))
+                        } else {
+                            fail("expected NSArray")
+                        }
+                    case "binary":
+                        expect(message.data as? NSData).to(equal(fixtureMessage["expectedHexValue"].string!.dataFromHexadecimalString()! as NSData?))
+                    default:
+                        fail("unhandled: \(fixtureMessage["expectedType"].string!)")
+                    }
+                }
+
+                private var jsonOptions: ARTClientOptions!
+                private var msgpackOptions: ARTClientOptions!
+
+                private func setupDependencies() {
+                    if (jsonOptions == nil) {
+                        jsonOptions = AblyTests.commonAppSetup()
+                        jsonOptions.useBinaryProtocol = false
+                        // Keep the same key and channel prefix
+                        msgpackOptions = (jsonOptions.copy() as! ARTClientOptions)
+                        msgpackOptions.useBinaryProtocol = true
+                    }
+                }
+
 class RealtimeClientConnection: QuickSpec {
+
+// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+override class var defaultTestSuite : XCTestSuite {
+    let _ = ttlAndIdleIntervalPassedTestsClient
+    let _ = ttlAndIdleIntervalPassedTestsConnectionId
+    let _ = customTtlInterval
+    let _ = customIdleInterval
+    let _ = ttlAndIdleIntervalNotPassedTestsClient
+    let _ = ttlAndIdleIntervalNotPassedTestsConnectionId
+    let _ = expectedHostOrder
+    let _ = originalARTFallback_shuffleArray
+    let _ = internetConnectionNotAvailableTestsClient
+    let _ = fixtures
+    let _ = jsonOptions
+    let _ = msgpackOptions
+
+    return super.defaultTestSuite
+}
+
+
+                    class TotalMessages {
+                        static var expected: Int32 = 0
+                        static var succeeded: Int32 = 0
+                        fileprivate init() {}
+                    }
 
     override func spec() {
         describe("Connection") {
@@ -802,12 +951,6 @@ class RealtimeClientConnection: QuickSpec {
 
                 // RTN7b
                 context("ProtocolMessage") {
-
-                    class TotalMessages {
-                        static var expected: Int32 = 0
-                        static var succeeded: Int32 = 0
-                        fileprivate init() {}
-                    }
 
                     it("should contain unique serially incrementing msgSerial along with the count") {
                         let options = AblyTests.commonAppSetup()
@@ -2815,10 +2958,6 @@ class RealtimeClientConnection: QuickSpec {
                 
                 // RTN15g RTN15g1
                 context("when connection (ttl plus idle interval) period has passed since last activity") {
-                    var ttlAndIdleIntervalPassedTestsClient: ARTRealtime!
-                    var ttlAndIdleIntervalPassedTestsConnectionId = ""
-                    let customTtlInterval: TimeInterval = 0.1
-                    let customIdleInterval: TimeInterval = 0.1
                     
                     xit("uses a new connection") {
                         let options = AblyTests.commonAppSetup()
@@ -2894,8 +3033,6 @@ class RealtimeClientConnection: QuickSpec {
                 
                 // RTN15g2
                 context("when connection (ttl plus idle interval) period has NOT passed since last activity") {
-                    var ttlAndIdleIntervalNotPassedTestsClient: ARTRealtime!
-                    var ttlAndIdleIntervalNotPassedTestsConnectionId = ""
                     
                     it("uses the same connection") {
                         let options = AblyTests.commonAppSetup()
@@ -3244,8 +3381,6 @@ class RealtimeClientConnection: QuickSpec {
 
             // RTN17
             context("Host Fallback") {
-                let expectedHostOrder = [3, 4, 0, 2, 1]
-                let originalARTFallback_shuffleArray = ARTFallback_shuffleArray
 
                 beforeEach {
                     ARTFallback_shuffleArray = { array in
@@ -3451,49 +3586,6 @@ class RealtimeClientConnection: QuickSpec {
 
                 // RTN17d
                 xcontext("should use an alternative host when") {
-                    func testUsesAlternativeHostOnResponse(_ caseTest: FakeNetworkResponse) {
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.autoConnect = false
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-                        client.channels.get("test")
-
-                        let previousRealtimeRequestTimeout = ARTDefault.realtimeRequestTimeout()
-                        defer { ARTDefault.setRealtimeRequestTimeout(previousRealtimeRequestTimeout) }
-                        ARTDefault.setRealtimeRequestTimeout(1.0)
-
-                        client.internal.setTransport(TestProxyTransport.self)
-                        TestProxyTransport.fakeNetworkResponse = caseTest
-                        defer { TestProxyTransport.fakeNetworkResponse = nil }
-
-                        var urlConnections = [URL]()
-                        TestProxyTransport.networkConnectEvent = { transport, url in
-                            if client.internal.transport !== transport {
-                                return
-                            }
-                            urlConnections.append(url)
-                            if urlConnections.count == 1 {
-                                TestProxyTransport.fakeNetworkResponse = nil
-                            }
-                        }
-                        defer { TestProxyTransport.networkConnectEvent = nil }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            // wss://[a-e].ably-realtime.com: when a timeout occurs
-                            client.connection.once(.disconnected) { error in
-                                done()
-                            }
-                            // wss://[a-e].ably-realtime.com: when a 401 occurs because of the `xxxx:xxxx` key
-                            client.connection.once(.failed) { error in
-                                done()
-                            }
-                            client.connect()
-                        }
-
-                        expect(urlConnections).to(haveCount(2))
-                        expect(NSRegularExpression.match(urlConnections[0].absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
-                        expect(NSRegularExpression.match(urlConnections[1].absoluteString, pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                    }
                     
                     it(".hostUnreachable") {
                         testUsesAlternativeHostOnResponse(.hostUnreachable)
@@ -3509,40 +3601,6 @@ class RealtimeClientConnection: QuickSpec {
                 }
 
                 context("should move to disconnected when there's no internet") {
-                    func testMovesToDisconnectedWithNetworkingError(_ error: Error) {
-                        let options = AblyTests.commonAppSetup()
-                        options.autoConnect = false
-                        let client = AblyTests.newRealtime(options)
-                        defer {
-                            client.dispose()
-                            client.close()
-                        }
-                        client.internal.setTransport(TestProxyTransport.self)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.connected) { _ in
-                                done()
-                            }
-                            client.connect()
-                        }
-
-                        var _transport: ARTWebSocketTransport?
-                        AblyTests.queue.sync {
-                            _transport = client.internal.transport as? ARTWebSocketTransport
-                        }
-
-                        guard let wsTransport = _transport else {
-                            fail("expected WS transport")
-                            return
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.disconnected) { _ in
-                                done()
-                            }
-                            wsTransport.webSocket(wsTransport.websocket!, didFailWithError:error)
-                        }
-                    }
                     
                     it("with NSPOSIXErrorDomain with code 57") {
                         testMovesToDisconnectedWithNetworkingError(NSError(domain: "NSPOSIXErrorDomain", code: 57, userInfo: [NSLocalizedDescriptionKey: "shouldn't matter"]))
@@ -4072,7 +4130,6 @@ class RealtimeClientConnection: QuickSpec {
 
                 // RTN20a
                 context("should immediately change the state to DISCONNECTED if the operating system indicates that the underlying internet connection is no longer available") {
-                    var internetConnectionNotAvailableTestsClient: ARTRealtime!
 
                     beforeEach {
                         let options = AblyTests.commonAppSetup()
@@ -4505,30 +4562,6 @@ class RealtimeClientConnection: QuickSpec {
             }
 
             context("with fixture messages") {
-                let fixtures = try! JSON(data: NSData(contentsOfFile: pathForTestResource(testResourcesPath + "messages-encoding.json"))! as Data, options: .mutableContainers)
-
-                func expectDataToMatch(_ message: ARTMessage, _ fixtureMessage: JSON) {
-                    switch fixtureMessage["expectedType"].string! {
-                    case "string":
-                        expect(message.data as? NSString).to(equal(fixtureMessage["expectedValue"].string! as NSString?))
-                    case "jsonObject":
-                        if let data = message.data as? NSDictionary {
-                            expect(JSON(data)).to(equal(fixtureMessage["expectedValue"]))
-                        } else {
-                            fail("expected NSDictionary")
-                        }              
-                    case "jsonArray":
-                        if let data = message.data as? NSArray {
-                            expect(JSON(data)).to(equal(fixtureMessage["expectedValue"]))
-                        } else {
-                            fail("expected NSArray")
-                        }
-                    case "binary":
-                        expect(message.data as? NSData).to(equal(fixtureMessage["expectedHexValue"].string!.dataFromHexadecimalString()! as NSData?))
-                    default:
-                        fail("unhandled: \(fixtureMessage["expectedType"].string!)")
-                    }
-                }
 
                 // https://github.com/ably/wiki/issues/22
                 xit("should encode and decode fixture messages as expected") {
@@ -4598,19 +4631,6 @@ class RealtimeClientConnection: QuickSpec {
                                 })
                             }
                         }
-                    }
-                }
-
-                var jsonOptions: ARTClientOptions!
-                var msgpackOptions: ARTClientOptions!
-
-                func setupDependencies() {
-                    if (jsonOptions == nil) {
-                        jsonOptions = AblyTests.commonAppSetup()
-                        jsonOptions.useBinaryProtocol = false
-                        // Keep the same key and channel prefix
-                        msgpackOptions = (jsonOptions.copy() as! ARTClientOptions)
-                        msgpackOptions.useBinaryProtocol = true
                     }
                 }
 

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -136,7 +136,7 @@ func countChannels(_ channels: ARTRealtimeChannels) -> Int {
                     }
                 }
 
-class RealtimeClientConnection: QuickSpec {
+class RealtimeClientConnection: XCTestCase {
 
 // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
 override class var defaultTestSuite : XCTestSuite {
@@ -162,13 +162,11 @@ override class var defaultTestSuite : XCTestSuite {
                         static var succeeded: Int32 = 0
                         fileprivate init() {}
                     }
-
-    override func spec() {
-        describe("Connection") {
+        
             
             // CD2c
-            context("ConnectionDetails") {
-                it("maxMessageSize overrides the default maxMessageSize") {
+            
+                func test__016__Connection__ConnectionDetails__maxMessageSize_overrides_the_default_maxMessageSize() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -192,11 +190,10 @@ override class var defaultTestSuite : XCTestSuite {
                         client.connect()
                     }
                 }
-            }
             
             // RTN2
-            context("url") {
-                it("should connect to the default host") {
+            
+                func test__017__Connection__url__should_connect_to_the_default_host() {
                     let options = ARTClientOptions(key: "keytest:secret")
                     options.autoConnect = false
 
@@ -213,7 +210,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should connect with query string params") {
+                func test__018__Connection__url__should_connect_with_query_string_params() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
 
@@ -248,7 +245,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should connect with query string params including clientId") {
+                func test__019__Connection__url__should_connect_with_query_string_params_including_clientId() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "client_string"
                     options.useTokenAuth = true
@@ -286,10 +283,9 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
             // RTN3
-            it("should connect automatically") {
+            func test__001__Connection__should_connect_automatically() {
                 let options = AblyTests.commonAppSetup()
                 var connected = false
 
@@ -313,7 +309,7 @@ override class var defaultTestSuite : XCTestSuite {
                 expect(connected).toEventually(beTrue(), timeout: DispatchTimeInterval.seconds(10), description: "Can't connect automatically")
             }
 
-            it("should connect manually") {
+            func test__002__Connection__should_connect_manually() {
                 let options = AblyTests.commonAppSetup()
                 options.autoConnect = false
 
@@ -344,7 +340,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTN2f
-            it("API version param must be included in all connections") {
+            func test__003__Connection__API_version_param_must_be_included_in_all_connections() {
                 let options = AblyTests.commonAppSetup()
                 options.autoConnect = false
                 let client = ARTRealtime(options: options)
@@ -370,7 +366,7 @@ override class var defaultTestSuite : XCTestSuite {
             // RTN2g (Deprecated in favor of RCS7d)
 
             // RSC7d
-            it("Library and version param `agent` should include the `Ably-Agent` header value") {
+            func test__004__Connection__Library_and_version_param__agent__should_include_the__Ably_Agent__header_value() {
                 let options = AblyTests.commonAppSetup()
                 options.autoConnect = false
                 
@@ -404,10 +400,10 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTN4
-            context("event emitter") {
+            
 
                 // RTN4a
-                it("should emit events for state changes") {
+                func test__020__Connection__event_emitter__should_emit_events_for_state_changes() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
 
@@ -482,7 +478,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN4h
-                it("should never emit a ConnectionState event for a state equal to the previous state") {
+                func test__021__Connection__event_emitter__should_never_emit_a_ConnectionState_event_for_a_state_equal_to_the_previous_state() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.dispose(); client.close() }
@@ -514,7 +510,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN4b
-                it("should emit states on a new connection") {
+                func test__022__Connection__event_emitter__should_emit_states_on_a_new_connection() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
 
@@ -552,7 +548,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN4c
-                it("should emit states when connection is closed") {
+                func test__023__Connection__event_emitter__should_emit_states_when_connection_is_closed() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     let connection = client.connection
                     defer { client.dispose(); client.close() }
@@ -588,7 +584,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN4d
-                it("should have the current state") {
+                func test__024__Connection__event_emitter__should_have_the_current_state() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -616,7 +612,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN4e
-                it("should have a ConnectionStateChange as first argument for every connection state change") {
+                func test__025__Connection__event_emitter__should_have_a_ConnectionStateChange_as_first_argument_for_every_connection_state_change() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -634,7 +630,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN4f
-                it("should have the reason which contains an ErrorInfo") {
+                func test__026__Connection__event_emitter__should_have_the_reason_which_contains_an_ErrorInfo() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.dispose(); client.close() }
@@ -663,7 +659,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN4f
-                it("any state change triggered by a ProtocolMessage that contains an Error member should populate the Reason property") {
+                func test__027__Connection__event_emitter__any_state_change_triggered_by_a_ProtocolMessage_that_contains_an_Error_member_should_populate_the_Reason_property() {
                     let options = AblyTests.commonAppSetup()
                     options.useTokenAuth = true
                     let client = AblyTests.newRealtime(options)
@@ -699,10 +695,9 @@ override class var defaultTestSuite : XCTestSuite {
                         client.internal.transport?.receive(connectedMessageWithError)
                     }
                 }
-            }
 
             // RTN5
-            it("basic operations should work simultaneously") {
+            func test__005__Connection__basic_operations_should_work_simultaneously() {
                 let options = AblyTests.commonAppSetup()
                 options.echoMessages = false
                 var disposable = [ARTRealtime]()
@@ -765,7 +760,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTN6
-            it("should have an opened websocket connection and received a CONNECTED ProtocolMessage") {
+            func test__006__Connection__should_have_an_opened_websocket_connection_and_received_a_CONNECTED_ProtocolMessage() {
                 let options = AblyTests.commonAppSetup()
                 options.autoConnect = false
                 let client = ARTRealtime(options: options)
@@ -804,12 +799,12 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTN7
-            context("ACK and NACK") {
+            
 
                 // RTN7a
-                context("should expect either an ACK or NACK to confirm") {
+                
 
-                    it("successful receipt and acceptance of message") {
+                    func test__028__Connection__ACK_and_NACK__should_expect_either_an_ACK_or_NACK_to_confirm__successful_receipt_and_acceptance_of_message() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         options.clientId = "client_string"
@@ -838,7 +833,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(publishedMessage.msgSerial).to(equal(receivedAck.msgSerial))
                     }
 
-                    it("successful receipt and acceptance of presence") {
+                    func test__029__Connection__ACK_and_NACK__should_expect_either_an_ACK_or_NACK_to_confirm__successful_receipt_and_acceptance_of_presence() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         options.clientId = "client_string"
@@ -878,7 +873,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(publishedMessage.msgSerial).to(equal(receivedAck.msgSerial))
                     }
 
-                    it("message failure") {
+                    func test__030__Connection__ACK_and_NACK__should_expect_either_an_ACK_or_NACK_to_confirm__message_failure() {
                         let options = AblyTests.commonAppSetup()
                         options.token = getTestToken(key: options.key, capability: "{ \"\(options.channelNamePrefix!)-test\":[\"subscribe\"] }")
                         options.autoConnect = false
@@ -907,7 +902,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(publishedMessage.msgSerial).to(equal(receivedNack.msgSerial))
                     }
 
-                    it("presence failure") {
+                    func test__031__Connection__ACK_and_NACK__should_expect_either_an_ACK_or_NACK_to_confirm__presence_failure() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         options.clientId = "client_string"
@@ -947,12 +942,10 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(publishedMessage.msgSerial).to(equal(receivedNack.msgSerial))
                     }
 
-                }
-
                 // RTN7b
-                context("ProtocolMessage") {
+                
 
-                    it("should contain unique serially incrementing msgSerial along with the count") {
+                    func test__032__Connection__ACK_and_NACK__ProtocolMessage__should_contain_unique_serially_incrementing_msgSerial_along_with_the_count() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         options.clientId = "client_string"
@@ -1013,7 +1006,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(nacks[0].count).to(equal(1))
                     }
 
-                    it("should continue incrementing msgSerial serially if the connection resumes successfully") {
+                    func test__033__Connection__ACK_and_NACK__ProtocolMessage__should_continue_incrementing_msgSerial_serially_if_the_connection_resumes_successfully() {
                         let options = AblyTests.commonAppSetup()
                         options.clientId = "tester"
                         options.tokenDetails = getTestTokenDetails(key: options.key!, clientId: options.clientId, ttl: 5.0)
@@ -1098,7 +1091,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(client.internal.msgSerial) == 7
                     }
 
-                    it("should reset msgSerial serially if the connection does not resume") {
+                    func test__034__Connection__ACK_and_NACK__ProtocolMessage__should_reset_msgSerial_serially_if_the_connection_does_not_resume() {
                         let options = AblyTests.commonAppSetup()
                         options.clientId = "tester"
                         let client = AblyTests.newRealtime(options)
@@ -1184,12 +1177,11 @@ override class var defaultTestSuite : XCTestSuite {
                         
                         expect(client.internal.msgSerial) == 4
                     }
-                }
 
                 // RTN7c
-                context("should trigger the failure callback for the remaining pending messages if") {
+                
 
-                    it("connection is closed") {
+                    func test__035__Connection__ACK_and_NACK__should_trigger_the_failure_callback_for_the_remaining_pending_messages_if__connection_is_closed() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         options.clientId = "client_string"
@@ -1227,7 +1219,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("connection state enters FAILED") {
+                    func test__036__Connection__ACK_and_NACK__should_trigger_the_failure_callback_for_the_remaining_pending_messages_if__connection_state_enters_FAILED() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         options.clientId = "client_string"
@@ -1255,7 +1247,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("lost connection state") {
+                    func test__037__Connection__ACK_and_NACK__should_trigger_the_failure_callback_for_the_remaining_pending_messages_if__lost_connection_state() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let client = ARTRealtime(options: options)
@@ -1305,15 +1297,11 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
-            }
-
             // RTN8
-            context("connection#id") {
+            
 
                 // RTN8a
-                it("should be null until connected") {
+                func test__038__Connection__connection_id__should_be_null_until_connected() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     let connection = client.connection
@@ -1341,7 +1329,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN8b
-                it("should have unique IDs") {
+                func test__039__Connection__connection_id__should_have_unique_IDs() {
                     let options = AblyTests.commonAppSetup()
                     var disposable = [ARTRealtime]()
                     defer {
@@ -1386,13 +1374,12 @@ override class var defaultTestSuite : XCTestSuite {
 
                     expect(ids).to(haveCount(max))
                 }
-            }
 
             // RTN9
-            context("connection#key") {
+            
 
                 // RTN9a
-                it("should be null until connected") {
+                func test__040__Connection__connection_key__should_be_null_until_connected() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer {
@@ -1420,7 +1407,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN9b
-                it("should have unique connection keys") {
+                func test__041__Connection__connection_key__should_have_unique_connection_keys() {
                     let options = AblyTests.commonAppSetup()
                     var disposable = [ARTRealtime]()
                     defer {
@@ -1463,13 +1450,11 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(keys).to(haveCount(max))
                 }
 
-            }
-
             // RTN10
-            context("serial") {
+            
 
                 // RTN10a
-                it("should be minus 1 once connected") {
+                func test__042__Connection__serial__should_be_minus_1_once_connected() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer {
                         client.dispose()
@@ -1489,7 +1474,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN10b
-                it("should not update when a message is sent but increments by one when ACK is received") {
+                func test__043__Connection__serial__should_not_update_when_a_message_is_sent_but_increments_by_one_when_ACK_is_received() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer {
                         client.dispose()
@@ -1520,7 +1505,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should have last known connection serial from restored connection") {
+                func test__044__Connection__serial__should_have_last_known_connection_serial_from_restored_connection() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer {
@@ -1570,10 +1555,8 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTN11b
-            it("should make a new connection with a new transport instance if the state is CLOSING") {
+            func test__007__Connection__should_make_a_new_connection_with_a_new_transport_instance_if_the_state_is_CLOSING() {
                 let client = ARTRealtime(options: AblyTests.commonAppSetup())
                 defer { client.dispose(); client.close() }
 
@@ -1610,7 +1593,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTN11b
-            it("it should make sure that, when the CLOSED ProtocolMessage arrives for the old connection, it doesn’t affect the new one") {
+            func test__008__Connection__it_should_make_sure_that__when_the_CLOSED_ProtocolMessage_arrives_for_the_old_connection__it_doesn_t_affect_the_new_one() {
                 let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                 defer { client.dispose(); client.close() }
 
@@ -1671,9 +1654,9 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTN12
-            context("close") {
+            
                 // RTN12f
-                it("if CONNECTING, do the operation once CONNECTED") {
+                func test__045__Connection__close__if_CONNECTING__do_the_operation_once_CONNECTED() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -1694,7 +1677,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN12a
-                it("if CONNECTED, should send a CLOSE action, change state to CLOSING and receive a CLOSED action") {
+                func test__046__Connection__close__if_CONNECTED__should_send_a_CLOSE_action__change_state_to_CLOSING_and_receive_a_CLOSED_action() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -1737,7 +1720,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN12b
-                it("should transition to CLOSED action when the close process timeouts") {
+                func test__047__Connection__close__should_transition_to_CLOSED_action_when_the_close_process_timeouts() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -1788,7 +1771,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN12c
-                it("transitions to the CLOSING state and then to the CLOSED state if the transport is abruptly closed") {
+                func test__048__Connection__close__transitions_to_the_CLOSING_state_and_then_to_the_CLOSED_state_if_the_transport_is_abruptly_closed() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -1836,7 +1819,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN12d
-                it("if DISCONNECTED, aborts the retry and moves immediately to CLOSED") {
+                func test__049__Connection__close__if_DISCONNECTED__aborts_the_retry_and_moves_immediately_to_CLOSED() {
                     let options = AblyTests.commonAppSetup()
                     options.disconnectedRetryTimeout = 1.0
                     let client = ARTRealtime(options: options)
@@ -1868,7 +1851,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN12e
-                it("if SUSPENDED, aborts the retry and moves immediately to CLOSED") {
+                func test__050__Connection__close__if_SUSPENDED__aborts_the_retry_and_moves_immediately_to_CLOSED() {
                     let options = AblyTests.commonAppSetup()
                     options.suspendedRetryTimeout = 1.0
                     let client = ARTRealtime(options: options)
@@ -1898,12 +1881,11 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
             // RTN13
-            context("ping") {
+            
                 // RTN13b
-                it("fails if in the INITIALIZED, SUSPENDED, CLOSING, CLOSED or FAILED state") {
+                func test__051__Connection__ping__fails_if_in_the_INITIALIZED__SUSPENDED__CLOSING__CLOSED_or_FAILED_state() {
                     let options = AblyTests.commonAppSetup()
                     options.suspendedRetryTimeout = 0.1
                     options.autoConnect = false
@@ -1955,7 +1937,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN13a
-                it("should send a ProtocolMessage with action HEARTBEAT and expects a HEARTBEAT message in response") {
+                func test__052__Connection__ping__should_send_a_ProtocolMessage_with_action_HEARTBEAT_and_expects_a_HEARTBEAT_message_in_response() {
                     let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     waitUntil(timeout: testTimeout) { done in
@@ -1970,7 +1952,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN13c
-                it("should fail if a HEARTBEAT ProtocolMessage is not received within the default realtime request timeout") {
+                func test__053__Connection__ping__should_fail_if_a_HEARTBEAT_ProtocolMessage_is_not_received_within_the_default_realtime_request_timeout() {
                     let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     waitUntil(timeout: testTimeout) { done in
@@ -2004,10 +1986,8 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTN14a
-            it("should enter FAILED state when API key is invalid") {
+            func test__009__Connection__should_enter_FAILED_state_when_API_key_is_invalid() {
                 let options = AblyTests.commonAppSetup()
                 options.key = String(options.key!.reversed())
                 options.autoConnect = false
@@ -2034,8 +2014,8 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTN14b
-            context("connection request fails") {
-                it("on DISCONNECTED after CONNECTED, should not emit error with a renewable token") {
+            
+                func test__054__Connection__connection_request_fails__on_DISCONNECTED_after_CONNECTED__should_not_emit_error_with_a_renewable_token() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     options.authCallback = { tokenParams, callback in
@@ -2080,7 +2060,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
                 
-                it("on token error while CONNECTING, reissues token and reconnects") {
+                func test__055__Connection__connection_request_fails__on_token_error_while_CONNECTING__reissues_token_and_reconnects() {
                     var authCallbackCalled = 0
                     
                     var tokenTTL = 1.0
@@ -2125,7 +2105,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
 
-                it("should transition to disconnected when the token renewal fails") {
+                func test__056__Connection__connection_request_fails__should_transition_to_disconnected_when_the_token_renewal_fails() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let tokenTtl = 3.0
@@ -2163,7 +2143,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should transition to Failed state because the token is invalid and not renewable") {
+                func test__057__Connection__connection_request_fails__should_transition_to_Failed_state_because_the_token_is_invalid_and_not_renewable() {
                     let options = AblyTests.clientOptions()
                     options.autoConnect = false
                     let tokenTtl = 1.0
@@ -2218,7 +2198,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN14c
-                it("connection attempt should fail if not connected within the default realtime request timeout") {
+                func test__058__Connection__connection_request_fails__connection_attempt_should_fail_if_not_connected_within_the_default_realtime_request_timeout() {
                     let options = AblyTests.commonAppSetup()
                     options.realtimeHost = "10.255.255.1" //non-routable IP address
                     options.autoConnect = false
@@ -2248,7 +2228,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN14d
-                it("connection attempt fails for any recoverable reason") {
+                func test__059__Connection__connection_request_fails__connection_attempt_fails_for_any_recoverable_reason() {
                     let options = AblyTests.commonAppSetup()
                     options.realtimeHost = "10.255.255.1" //non-routable IP address
                     options.disconnectedRetryTimeout = 1.0
@@ -2305,7 +2285,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN14e
-                it("connection state has been in the DISCONNECTED state for more than the default connectionStateTtl should change the state to SUSPENDED") {
+                func test__060__Connection__connection_request_fails__connection_state_has_been_in_the_DISCONNECTED_state_for_more_than_the_default_connectionStateTtl_should_change_the_state_to_SUSPENDED() {
                     let options = AblyTests.commonAppSetup()
                     options.disconnectedRetryTimeout = 0.1
                     options.suspendedRetryTimeout = 0.5
@@ -2342,7 +2322,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN14e - https://github.com/ably/ably-cocoa/issues/913
-                it("should change the state to SUSPENDED when the connection state has been in the DISCONNECTED state for more than the connectionStateTtl") {
+                func test__061__Connection__connection_request_fails__should_change_the_state_to_SUSPENDED_when_the_connection_state_has_been_in_the_DISCONNECTED_state_for_more_than_the_connectionStateTtl() {
                     let options = AblyTests.commonAppSetup()
                     options.disconnectedRetryTimeout = 0.5
                     options.suspendedRetryTimeout = 2.0
@@ -2412,7 +2392,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(client.connection.state).to(equal(.connected))
                 }
 
-                it("on CLOSE the connection should stop connection retries") {
+                func test__062__Connection__connection_request_fails__on_CLOSE_the_connection_should_stop_connection_retries() {
                     let options = AblyTests.commonAppSetup()
                     // to avoid waiting for the default 15s before trying a reconnection
                     options.disconnectedRetryTimeout = 0.1
@@ -2463,13 +2443,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTN15
-            context("connection failures once CONNECTED") {
+            
 
                 // RTN15a
-                it("should not receive published messages until the connection reconnects successfully") {
+                func test__063__Connection__connection_failures_once_CONNECTED__should_not_receive_published_messages_until_the_connection_reconnects_successfully() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
 
@@ -2521,7 +2499,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 
                 // RTN15a
-                it ("if a Connection transport is disconnected unexpectedly or if a token expires, then the Connection manager will immediately attempt to reconnect") {
+                func test__064__Connection__connection_failures_once_CONNECTED__if_a_Connection_transport_is_disconnected_unexpectedly_or_if_a_token_expires__then_the_Connection_manager_will_immediately_attempt_to_reconnect() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     options.tokenDetails = getTestTokenDetails(ttl: 3.0)
@@ -2544,10 +2522,10 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN15b
-                context("reconnects to the websocket endpoint with additional querystring params") {
+                
 
                     // RTN15b1, RTN15b2
-                    it("resume is the private connection key and connection_serial is the most recent ProtocolMessage#connectionSerial received") {
+                    func test__067__Connection__connection_failures_once_CONNECTED__reconnects_to_the_websocket_endpoint_with_additional_querystring_params__resume_is_the_private_connection_key_and_connection_serial_is_the_most_recent_ProtocolMessage_connectionSerial_received() {
                         let options = AblyTests.commonAppSetup()
                         let client = AblyTests.newRealtime(options)
                         defer { client.dispose(); client.close() }
@@ -2568,13 +2546,11 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
                 // RTN15c
-                context("System's response to a resume request") {
+                
 
                     // RTN15c1
-                    it("CONNECTED ProtocolMessage with the same connectionId as the current client, and no error") {
+                    func test__068__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__CONNECTED_ProtocolMessage_with_the_same_connectionId_as_the_current_client__and_no_error() {
                         let options = AblyTests.commonAppSetup()
                         let client = AblyTests.newRealtime(options)
                         defer { client.dispose(); client.close() }
@@ -2602,7 +2578,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTN15c2
-                    it("CONNECTED ProtocolMessage with the same connectionId as the current client and an non-fatal error") {
+                    func test__069__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__CONNECTED_ProtocolMessage_with_the_same_connectionId_as_the_current_client_and_an_non_fatal_error() {
                         let options = AblyTests.commonAppSetup()
                         let client = AblyTests.newRealtime(options)
                         defer { client.dispose(); client.close() }
@@ -2659,7 +2635,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTN15c3
-                    it("CONNECTED ProtocolMessage with a new connectionId and an error") {
+                    func test__070__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__CONNECTED_ProtocolMessage_with_a_new_connectionId_and_an_error() {
                         let options = AblyTests.commonAppSetup()
                         let client = AblyTests.newRealtime(options)
                         defer { client.dispose(); client.close() }
@@ -2705,7 +2681,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTN15c4
-                    it("ERROR ProtocolMessage indicating a fatal error in the connection") {
+                    func test__071__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__ERROR_ProtocolMessage_indicating_a_fatal_error_in_the_connection() {
                         let options = AblyTests.commonAppSetup()
                         let client = AblyTests.newRealtime(options)
                         defer { client.dispose(); client.close() }
@@ -2736,7 +2712,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(channel.errorReason).to(beIdenticalTo(protocolError.error))
                     }
 
-                    xit("should resume the connection after an auth renewal") {
+                    func skipped__test__072__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__should_resume_the_connection_after_an_auth_renewal() {
                         let options = AblyTests.commonAppSetup()
                         options.tokenDetails = getTestTokenDetails(ttl: 5.0)
                         let client = AblyTests.newRealtime(options)
@@ -2812,11 +2788,9 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
                 // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
                 // RTN15d
-                xit("should recover from disconnection and messages should be delivered once the connection is resumed") {
+                func skipped__test__065__Connection__connection_failures_once_CONNECTED__should_recover_from_disconnection_and_messages_should_be_delivered_once_the_connection_is_resumed() {
                     let options = AblyTests.commonAppSetup()
 
                     let client1 = ARTRealtime(options: options)
@@ -2857,9 +2831,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN15e
-                context("when a connection is resumed") {
+                
 
-                    it("the connection#key may change and will be provided in the first CONNECTED ProtocolMessage#connectionDetails") {
+                    func test__073__Connection__connection_failures_once_CONNECTED__when_a_connection_is_resumed__the_connection_key_may_change_and_will_be_provided_in_the_first_CONNECTED_ProtocolMessage_connectionDetails() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
 
@@ -2892,10 +2866,8 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
                 // RTN15f
-                it("ACK and NACK responses for published messages can only ever be received on the transport connection on which those messages were sent") {
+                func test__066__Connection__connection_failures_once_CONNECTED__ACK_and_NACK_responses_for_published_messages_can_only_ever_be_received_on_the_transport_connection_on_which_those_messages_were_sent() {
                     let options = AblyTests.commonAppSetup()
                     let client = AblyTests.newRealtime(options)
                     defer { client.dispose(); client.close() }
@@ -2957,9 +2929,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 
                 // RTN15g RTN15g1
-                context("when connection (ttl plus idle interval) period has passed since last activity") {
+                
                     
-                    xit("uses a new connection") {
+                    func skipped__test__074__Connection__connection_failures_once_CONNECTED__when_connection__ttl_plus_idle_interval__period_has_passed_since_last_activity__uses_a_new_connection() {
                         let options = AblyTests.commonAppSetup()
                         // We want this to be > than the sum of customTtlInterval and customIdleInterval
                         options.disconnectedRetryTimeout = 5.0 + customTtlInterval + customIdleInterval
@@ -2992,7 +2964,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                     // RTN15g3
-                    it("reattaches to the same channels after a new connection has been established") {
+                    func test__075__Connection__connection_failures_once_CONNECTED__when_connection__ttl_plus_idle_interval__period_has_passed_since_last_activity__reattaches_to_the_same_channels_after_a_new_connection_has_been_established() {
                         let options = AblyTests.commonAppSetup()
                         // We want this to be > than the sum of customTtlInterval and customIdleInterval
                         options.disconnectedRetryTimeout = 5.0
@@ -3029,12 +3001,11 @@ override class var defaultTestSuite : XCTestSuite {
                             ttlAndIdleIntervalPassedTestsClient.connect()
                         }
                     }
-                }
                 
                 // RTN15g2
-                context("when connection (ttl plus idle interval) period has NOT passed since last activity") {
+                
                     
-                    it("uses the same connection") {
+                    func test__076__Connection__connection_failures_once_CONNECTED__when_connection__ttl_plus_idle_interval__period_has_NOT_passed_since_last_activity__uses_the_same_connection() {
                         let options = AblyTests.commonAppSetup()
                         ttlAndIdleIntervalNotPassedTestsClient = AblyTests.newRealtime(options)
                         ttlAndIdleIntervalNotPassedTestsClient.connect()
@@ -3059,12 +3030,11 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                         }
                     }
-                }
 
                 // RTN15h
-                context("DISCONNECTED message contains a token error") {
+                
 
-                    xit("if the token is renewable then error should not be emitted") {
+                    func skipped__test__077__Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__if_the_token_is_renewable_then_error_should_not_be_emitted() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         options.authCallback = { tokenParams, callback in
@@ -3117,7 +3087,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                     
                     // RTN15h1
-                    it("and the library does not have a means to renew the token, the connection will transition to the FAILED state") {
+                    func test__078__Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__and_the_library_does_not_have_a_means_to_renew_the_token__the_connection_will_transition_to_the_FAILED_state() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let key = options.key
@@ -3140,7 +3110,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTN15h2
-                    xit("should transition to disconnected when the token renewal fails and the error should be emitted") {
+                    func skipped__test__079__Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__should_transition_to_disconnected_when_the_token_renewal_fails_and_the_error_should_be_emitted() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         let tokenTtl = 3.0
@@ -3183,15 +3153,11 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
-            }
-
             // RTN16
-            context("Connection recovery") {
+            
 
                 // RTN16a
-                it("connection state should recover explicitly with a recover key") {
+                func test__080__Connection__Connection_recovery__connection_state_should_recover_explicitly_with_a_recover_key() {
                     let options = AblyTests.commonAppSetup()
 
                     let clientSend = ARTRealtime(options: options)
@@ -3239,7 +3205,7 @@ override class var defaultTestSuite : XCTestSuite {
                 
                 // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
                 // RTN16b
-                xit("Connection#recoveryKey should be composed with the connection key and latest serial received and msgSerial") {
+                func skipped__test__081__Connection__Connection_recovery__Connection_recoveryKey_should_be_composed_with_the_connection_key_and_latest_serial_received_and_msgSerial() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.dispose(); client.close() }
@@ -3266,7 +3232,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN16d
-                it("when a connection is successfully recovered, Connection#id will be identical to the id of the connection that was recovered and Connection#key will always be updated to the ConnectionDetails#connectionKey provided in the first CONNECTED ProtocolMessage") {
+                func test__082__Connection__Connection_recovery__when_a_connection_is_successfully_recovered__Connection_id_will_be_identical_to_the_id_of_the_connection_that_was_recovered_and_Connection_key_will_always_be_updated_to_the_ConnectionDetails_connectionKey_provided_in_the_first_CONNECTED_ProtocolMessage() {
                     let options = AblyTests.commonAppSetup()
                     let clientOriginal = ARTRealtime(options: options)
                     defer { clientOriginal.close() }
@@ -3294,7 +3260,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN16c
-                xit("Connection#recoveryKey should become becomes null when a connection is explicitly CLOSED or CLOSED") {
+                func skipped__test__083__Connection__Connection_recovery__Connection_recoveryKey_should_become_becomes_null_when_a_connection_is_explicitly_CLOSED_or_CLOSED() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.dispose(); client.close() }
@@ -3312,7 +3278,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN16e
-                it("should connect anyway if the recoverKey is no longer valid") {
+                func test__084__Connection__Connection_recovery__should_connect_anyway_if_the_recoverKey_is_no_longer_valid() {
                     let options = AblyTests.commonAppSetup()
                     options.recover = "99999!xxxxxx-xxxxxxxxx-xxxxxxxxx:-1"
                     let client = ARTRealtime(options: options)
@@ -3330,7 +3296,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN16f
-                it("should use msgSerial from recoveryKey to set the client internal msgSerial but is not sent to Ably") {
+                func test__085__Connection__Connection_recovery__should_use_msgSerial_from_recoveryKey_to_set_the_client_internal_msgSerial_but_is_not_sent_to_Ably() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     options.recover = "99999!xxxxxx-xxxxxxxxx-xxxxxxxxx:-1:7"
@@ -3377,12 +3343,10 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTN17
-            context("Host Fallback") {
+            
 
-                beforeEach {
+                func beforeEach__Connection__Host_Fallback() {
                     ARTFallback_shuffleArray = { array in
                         let arranged = expectedHostOrder.reversed().map { array[$0] }
                         for (i, element) in arranged.enumerated() {
@@ -3391,12 +3355,14 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                afterEach {
+                func afterEach__Connection__Host_Fallback() {
                     ARTFallback_shuffleArray = originalARTFallback_shuffleArray
                 }
 
                 // RTN17b
-                it("failing connections with custom endpoint should result in an error immediately") {
+                func test__086__Connection__Host_Fallback__failing_connections_with_custom_endpoint_should_result_in_an_error_immediately() {
+beforeEach__Connection__Host_Fallback()
+
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.environment = "test" //do not use the default endpoint
                     expect(options.fallbackHostsUseDefault).to(beFalse())
@@ -3443,10 +3409,15 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     expect(urlConnections).to(haveCount(1))
+
+afterEach__Connection__Host_Fallback()
+
                 }
 
                 // RTN17b
-                it("failing connections with custom endpoint should result in time outs") {
+                func test__087__Connection__Host_Fallback__failing_connections_with_custom_endpoint_should_result_in_time_outs() {
+beforeEach__Connection__Host_Fallback()
+
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.environment = "test" //do not use the default endpoint
                     expect(options.fallbackHostsUseDefault).to(beFalse())
@@ -3487,10 +3458,15 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     expect(urlConnections).to(haveCount(1))
+
+afterEach__Connection__Host_Fallback()
+
                 }
 
                 // RTN17b
-                it("applies when the default realtime.ably.io endpoint is being used") {
+                func test__088__Connection__Host_Fallback__applies_when_the_default_realtime_ably_io_endpoint_is_being_used() {
+beforeEach__Connection__Host_Fallback()
+
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -3535,9 +3511,14 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                     expect(NSRegularExpression.match(urlConnections[0].absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
                     expect(NSRegularExpression.match(urlConnections[1].absoluteString, pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+
+afterEach__Connection__Host_Fallback()
+
                 }
                 
-                it("applies when an array of ClientOptions#fallbackHosts is provided") {
+                func test__089__Connection__Host_Fallback__applies_when_an_array_of_ClientOptions_fallbackHosts_is_provided() {
+beforeEach__Connection__Host_Fallback()
+
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.autoConnect = false
                     options.fallbackHosts = ["f.ably-realtime.com", "g.ably-realtime.com", "h.ably-realtime.com", "i.ably-realtime.com", "j.ably-realtime.com"]                    
@@ -3582,40 +3563,73 @@ override class var defaultTestSuite : XCTestSuite {
                     for connection in urlConnections.dropFirst() {
                         expect(NSRegularExpression.match(connection.absoluteString, pattern: "//[f-j].ably-realtime.com")).to(beTrue())
                     }
+
+afterEach__Connection__Host_Fallback()
+
                 }
 
                 // RTN17d
-                xcontext("should use an alternative host when") {
+                
                     
-                    it(".hostUnreachable") {
+                    func skipped__test__097__Connection__Host_Fallback__should_use_an_alternative_host_when___hostUnreachable() {
+beforeEach__Connection__Host_Fallback()
+
                         testUsesAlternativeHostOnResponse(.hostUnreachable)
+
+afterEach__Connection__Host_Fallback()
+
                     }
                     
-                    it(".requestTimeout(timeout: 0.1)") {
+                    func skipped__test__098__Connection__Host_Fallback__should_use_an_alternative_host_when___requestTimeout_timeout__0_1_() {
+beforeEach__Connection__Host_Fallback()
+
                         testUsesAlternativeHostOnResponse(.requestTimeout(timeout: 0.1))
+
+afterEach__Connection__Host_Fallback()
+
                     }
                     
-                    it(".hostInternalError(code: 501)") {
+                    func skipped__test__099__Connection__Host_Fallback__should_use_an_alternative_host_when___hostInternalError_code__501_() {
+beforeEach__Connection__Host_Fallback()
+
                         testUsesAlternativeHostOnResponse(.hostInternalError(code: 501))
-                    }
-                }
 
-                context("should move to disconnected when there's no internet") {
+afterEach__Connection__Host_Fallback()
+
+                    }
+
+                
                     
-                    it("with NSPOSIXErrorDomain with code 57") {
+                    func test__100__Connection__Host_Fallback__should_move_to_disconnected_when_there_s_no_internet__with_NSPOSIXErrorDomain_with_code_57() {
+beforeEach__Connection__Host_Fallback()
+
                         testMovesToDisconnectedWithNetworkingError(NSError(domain: "NSPOSIXErrorDomain", code: 57, userInfo: [NSLocalizedDescriptionKey: "shouldn't matter"]))
-                    }
-                    
-                    it("with NSPOSIXErrorDomain with code 50") {
-                        testMovesToDisconnectedWithNetworkingError(NSError(domain: "NSPOSIXErrorDomain", code: 50, userInfo: [NSLocalizedDescriptionKey: "shouldn't matter"]))
-                    }
-                    
-                    it("with any kCFErrorDomainCFNetwork") {
-                        testMovesToDisconnectedWithNetworkingError(NSError(domain: "kCFErrorDomainCFNetwork", code: 1337, userInfo: [NSLocalizedDescriptionKey: "shouldn't matter"]))
-                    }
-                }
 
-                it("should not use an alternative host when the client receives a bad request") {
+afterEach__Connection__Host_Fallback()
+
+                    }
+                    
+                    func test__101__Connection__Host_Fallback__should_move_to_disconnected_when_there_s_no_internet__with_NSPOSIXErrorDomain_with_code_50() {
+beforeEach__Connection__Host_Fallback()
+
+                        testMovesToDisconnectedWithNetworkingError(NSError(domain: "NSPOSIXErrorDomain", code: 50, userInfo: [NSLocalizedDescriptionKey: "shouldn't matter"]))
+
+afterEach__Connection__Host_Fallback()
+
+                    }
+                    
+                    func test__102__Connection__Host_Fallback__should_move_to_disconnected_when_there_s_no_internet__with_any_kCFErrorDomainCFNetwork() {
+beforeEach__Connection__Host_Fallback()
+
+                        testMovesToDisconnectedWithNetworkingError(NSError(domain: "kCFErrorDomainCFNetwork", code: 1337, userInfo: [NSLocalizedDescriptionKey: "shouldn't matter"]))
+
+afterEach__Connection__Host_Fallback()
+
+                    }
+
+                func test__090__Connection__Host_Fallback__should_not_use_an_alternative_host_when_the_client_receives_a_bad_request() {
+beforeEach__Connection__Host_Fallback()
+
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -3649,10 +3663,15 @@ override class var defaultTestSuite : XCTestSuite {
 
                     expect(urlConnections).to(haveCount(1))
                     expect(NSRegularExpression.match(urlConnections[0].absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
+
+afterEach__Connection__Host_Fallback()
+
                 }
 
                 // RTN17a
-                it("every connection is first attempted to the primary host realtime.ably.io") {
+                func test__091__Connection__Host_Fallback__every_connection_is_first_attempted_to_the_primary_host_realtime_ably_io() {
+beforeEach__Connection__Host_Fallback()
+
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -3706,10 +3725,15 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(NSRegularExpression.match(urlConnections.at(0)?.absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
                     expect(NSRegularExpression.match(urlConnections.at(1)?.absoluteString, pattern: "//[a-e].ably-realtime.com")).to(beTrue())
                     expect(NSRegularExpression.match(urlConnections.at(2)?.absoluteString, pattern: "//realtime.ably.io")).to(beTrue())
+
+afterEach__Connection__Host_Fallback()
+
                 }
 
                 // RTN17c
-                it("should retry hosts in random order after checkin if an internet connection is available") {
+                func test__092__Connection__Host_Fallback__should_retry_hosts_in_random_order_after_checkin_if_an_internet_connection_is_available() {
+beforeEach__Connection__Host_Fallback()
+
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -3776,10 +3800,15 @@ override class var defaultTestSuite : XCTestSuite {
                     let expectedFallbackHosts = Array(expectedHostOrder.map({ ARTDefault.fallbackHosts()[$0] }))
 
                     expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
+
+afterEach__Connection__Host_Fallback()
+
                 }
                 
                 // RTN17c
-                it("doesn't try fallback host if Internet connection check fails") {
+                func test__093__Connection__Host_Fallback__doesn_t_try_fallback_host_if_Internet_connection_check_fails() {
+beforeEach__Connection__Host_Fallback()
+
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -3825,9 +3854,14 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                         client.connect()
                     }
+
+afterEach__Connection__Host_Fallback()
+
                 }
 
-                xit("should retry custom fallback hosts in random order after checkin if an internet connection is available") {
+                func skipped__test__094__Connection__Host_Fallback__should_retry_custom_fallback_hosts_in_random_order_after_checkin_if_an_internet_connection_is_available() {
+beforeEach__Connection__Host_Fallback()
+
                     let fbHosts = ["f.ably-realtime.com", "g.ably-realtime.com", "h.ably-realtime.com", "i.ably-realtime.com", "j.ably-realtime.com"]
                     
                     let options = ARTClientOptions(key: "xxxx:xxxx")
@@ -3898,9 +3932,14 @@ override class var defaultTestSuite : XCTestSuite {
                     let expectedFallbackHosts = Array(expectedHostOrder.map({ fbHosts[$0] }))
                     
                     expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
+
+afterEach__Connection__Host_Fallback()
+
                 }
 
-                it("won't use fallback hosts feature if an empty array is provided") {
+                func test__095__Connection__Host_Fallback__won_t_use_fallback_hosts_feature_if_an_empty_array_is_provided() {
+beforeEach__Connection__Host_Fallback()
+
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.autoConnect = false
                     options.fallbackHosts = []
@@ -3933,10 +3972,15 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                     
                     expect(urlConnections).to(haveCount(1))
+
+afterEach__Connection__Host_Fallback()
+
                 }
 
                 // RTN17e
-                it("client is connected to a fallback host endpoint should do HTTP requests to the same data centre") {
+                func test__096__Connection__Host_Fallback__client_is_connected_to_a_fallback_host_endpoint_should_do_HTTP_requests_to_the_same_data_centre() {
+beforeEach__Connection__Host_Fallback()
+
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -3978,12 +4022,13 @@ override class var defaultTestSuite : XCTestSuite {
 
                     let timeRequestUrl = testHttpExecutor.requests.last!.url!
                     expect(timeRequestUrl.host).to(equal(urlConnections.at(1)?.host))
+
+afterEach__Connection__Host_Fallback()
+
                 }   
 
-            }
-
             // RTN19
-            it("attributes within ConnectionDetails should be used as defaults") {
+            func test__010__Connection__attributes_within_ConnectionDetails_should_be_used_as_defaults() {
                 let options = AblyTests.commonAppSetup()
                 options.autoConnect = false
                 let realtime = AblyTests.newRealtime(options)
@@ -4021,10 +4066,10 @@ override class var defaultTestSuite : XCTestSuite {
                 expect(realtime.connection.key).to(equal(connectedProtocolMessage.connectionDetails!.connectionKey))
             }
 
-            xcontext("Transport disconnected side effects") {
+            
 
                 // RTN19a
-                it("should resend any ProtocolMessage that is awaiting a ACK/NACK") {
+                func skipped__test__103__Connection__Transport_disconnected_side_effects__should_resend_any_ProtocolMessage_that_is_awaiting_a_ACK_NACK() {
                     let options = AblyTests.commonAppSetup()
                     let client = AblyTests.newRealtime(options)
                     defer { client.dispose(); client.close() }
@@ -4054,7 +4099,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN19b
-                it("should resend the ATTACH message if there are any pending channels") {
+                func skipped__test__104__Connection__Transport_disconnected_side_effects__should_resend_the_ATTACH_message_if_there_are_any_pending_channels() {
                     let options = AblyTests.commonAppSetup()
                     let client = AblyTests.newRealtime(options)
                     defer { client.dispose(); client.close() }
@@ -4090,7 +4135,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN19b
-                it("should resent the DETACH message if there are any pending channels") {
+                func skipped__test__105__Connection__Transport_disconnected_side_effects__should_resent_the_DETACH_message_if_there_are_any_pending_channels() {
                     let options = AblyTests.commonAppSetup()
                     let client = AblyTests.newRealtime(options)
                     defer { client.dispose(); client.close() }
@@ -4123,27 +4168,27 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTN20
-            context("Operating System events for network/internet connectivity changes") {
+            
 
                 // RTN20a
-                context("should immediately change the state to DISCONNECTED if the operating system indicates that the underlying internet connection is no longer available") {
+                
 
-                    beforeEach {
+                    func beforeEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available() {
                         let options = AblyTests.commonAppSetup()
                         options.autoConnect = false
                         internetConnectionNotAvailableTestsClient = ARTRealtime(options: options)
                         internetConnectionNotAvailableTestsClient.internal.setReachabilityClass(TestReachability.self)
                     }
 
-                    afterEach {
+                    func afterEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available() {
                         internetConnectionNotAvailableTestsClient.dispose()
                         internetConnectionNotAvailableTestsClient.close()
                     }
 
-                    it("when CONNECTING") {
+                    func test__109__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available__when_CONNECTING() {
+beforeEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available()
+
                         waitUntil(timeout: testTimeout) { done in
                             internetConnectionNotAvailableTestsClient.connection.on { stateChange in
                                 switch stateChange.current {
@@ -4168,9 +4213,14 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                             internetConnectionNotAvailableTestsClient.connect()
                         }
+
+afterEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available()
+
                     }
 
-                    it("when CONNECTED") {
+                    func test__110__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available__when_CONNECTED() {
+beforeEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available()
+
                         waitUntil(timeout: testTimeout) { done in
                             internetConnectionNotAvailableTestsClient.connection.on { stateChange in
                                 switch stateChange.current {
@@ -4195,11 +4245,13 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                             internetConnectionNotAvailableTestsClient.connect()
                         }
+
+afterEach__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_change_the_state_to_DISCONNECTED_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_no_longer_available()
+
                     }
-                }
 
                 // RTN20b
-                it("should immediately attempt to connect if the operating system indicates that the underlying internet connection is now available when DISCONNECTED or SUSPENDED") {
+                func test__106__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_immediately_attempt_to_connect_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_now_available_when_DISCONNECTED_or_SUSPENDED() {
                     var client: ARTRealtime!
                     let options = AblyTests.commonAppSetup()
                     // Ensure it won't reconnect because of timeouts.
@@ -4237,7 +4289,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN22
-                it("Ably can request that a connected client re-authenticates by sending the client an AUTH ProtocolMessage") {
+                func test__107__Connection__Operating_System_events_for_network_internet_connectivity_changes__Ably_can_request_that_a_connected_client_re_authenticates_by_sending_the_client_an_AUTH_ProtocolMessage() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     options.useTokenAuth = true
@@ -4318,7 +4370,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTN22a
-                it("re-authenticate and resume the connection when the client is forcibly disconnected following a DISCONNECTED message containing an error code greater than or equal to 40140 and less than 40150") {
+                func test__108__Connection__Operating_System_events_for_network_internet_connectivity_changes__re_authenticate_and_resume_the_connection_when_the_client_is_forcibly_disconnected_following_a_DISCONNECTED_message_containing_an_error_code_greater_than_or_equal_to_40140_and_less_than_40150() {
                     let options = AblyTests.commonAppSetup()
                     options.token = getTestToken(key: options.key!, ttl: 5.0)
                     let client = ARTRealtime(options: options)
@@ -4394,10 +4446,8 @@ override class var defaultTestSuite : XCTestSuite {
                     channel.off()
                 }
 
-            }
-
             // RTN23a
-            it("should disconnect the transport when no activity exist") {
+            func test__011__Connection__should_disconnect_the_transport_when_no_activity_exist() {
                 let options = AblyTests.commonAppSetup()
                 let client = AblyTests.newRealtime(options)
                 defer { client.dispose(); client.close() }
@@ -4461,7 +4511,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTN24
-            it("the client may receive a CONNECTED ProtocolMessage from Ably at any point and should emit an UPDATE event") {
+            func test__012__Connection__the_client_may_receive_a_CONNECTED_ProtocolMessage_from_Ably_at_any_point_and_should_emit_an_UPDATE_event() {
                 let options = AblyTests.commonAppSetup()
                 let client = ARTRealtime(options: options)
                 defer { client.dispose(); client.close() }
@@ -4497,7 +4547,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTN24
-            it("should set the Connection reason attribute based on the Error member of the CONNECTED ProtocolMessage") {
+            func test__013__Connection__should_set_the_Connection_reason_attribute_based_on_the_Error_member_of_the_CONNECTED_ProtocolMessage() {
                 let options = AblyTests.commonAppSetup()
                 options.useTokenAuth = true
                 let client = AblyTests.newRealtime(options)
@@ -4542,7 +4592,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // https://github.com/ably/ably-cocoa/issues/454
-            it("should not move to FAILED if received DISCONNECT with an error") {
+            func test__014__Connection__should_not_move_to_FAILED_if_received_DISCONNECT_with_an_error() {
                 let options = AblyTests.commonAppSetup()
                 let client = ARTRealtime(options: options)
                 defer {
@@ -4561,10 +4611,10 @@ override class var defaultTestSuite : XCTestSuite {
                 expect(client.connection.errorReason).to(equal(protoMsg.error))
             }
 
-            context("with fixture messages") {
+            
 
                 // https://github.com/ably/wiki/issues/22
-                xit("should encode and decode fixture messages as expected") {
+                func skipped__test__111__Connection__with_fixture_messages__should_encode_and_decode_fixture_messages_as_expected() {
                     let options = AblyTests.commonAppSetup()
                     options.useBinaryProtocol = false
                     let client = AblyTests.newRealtime(options)
@@ -4634,7 +4684,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                xit("should send messages through raw JSON POST and retrieve equal messages through MsgPack and JSON") {
+                func skipped__test__112__Connection__with_fixture_messages__should_send_messages_through_raw_JSON_POST_and_retrieve_equal_messages_through_MsgPack_and_JSON() {
                     setupDependencies()
                     let restPublishClient = ARTRest(options: jsonOptions)
                     let realtimeSubscribeClientMsgPack = AblyTests.newRealtime(msgpackOptions)
@@ -4685,7 +4735,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                xit("should send messages through MsgPack and JSON and retrieve equal messages through raw JSON GET") {
+                func skipped__test__113__Connection__with_fixture_messages__should_send_messages_through_MsgPack_and_JSON_and_retrieve_equal_messages_through_raw_JSON_GET() {
                     setupDependencies()
                     let restPublishClientMsgPack = ARTRest(options: msgpackOptions)
                     let restPublishClientJSON = ARTRest(options: jsonOptions)
@@ -4733,9 +4783,8 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
-            it("should abort reconnection with new token if the server has requested it to authorize and after it the connection has been closed") {
+            func test__015__Connection__should_abort_reconnection_with_new_token_if_the_server_has_requested_it_to_authorize_and_after_it_the_connection_has_been_closed() {
                 let options = AblyTests.commonAppSetup()
                 let client = ARTRealtime(options: options)
                 defer { client.dispose(); client.close() }
@@ -4778,7 +4827,4 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
             }
-
-        }
-    }
 }

--- a/Spec/RealtimeClientPresence.swift
+++ b/Spec/RealtimeClientPresence.swift
@@ -66,7 +66,7 @@ import Aspects
                             return getParams
                         }()
 
-class RealtimeClientPresence: QuickSpec {
+class RealtimeClientPresence: XCTestCase {
 
     override func setUp() {
         super.setUp()
@@ -80,16 +80,13 @@ override class var defaultTestSuite : XCTestSuite {
 
     return super.defaultTestSuite
 }
-
-
-    override func spec() {
-        describe("Presence") {
+        
 
             // RTP1
-            context("ProtocolMessage bit flag") {
+            
 
                 // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                xit("when no members are present") {
+                func skipped__test__009__Presence__ProtocolMessage_bit_flag__when_no_members_are_present() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -110,7 +107,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(channel.internal.presenceMap.syncComplete).to(beFalse())
                 }
 
-                xit("when members are present") {
+                func skipped__test__010__Presence__ProtocolMessage_bit_flag__when_members_are_present() {
                     let options = AblyTests.commonAppSetup()
 
                     var disposable = [ARTRealtime]()
@@ -146,11 +143,9 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(transport.protocolMessagesReceived.filter({ $0.action == .sync })).to(haveCount(3))
                 }
 
-            }
-
             // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
             // RTP3
-            xit("should complete the SYNC operation when the connection is disconnected unexpectedly") {
+            func skipped__test__001__Presence__should_complete_the_SYNC_operation_when_the_connection_is_disconnected_unexpectedly() {
                 let membersCount = 110
 
                 let options = AblyTests.commonAppSetup()
@@ -214,11 +209,11 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTP18
-            context("realtime system reserves the right to initiate a sync of the presence members at any point once a channel is attached") {
+            
 
                 // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
                 // RTP18a, RTP18b
-                xit("should do a new sync whenever a SYNC ProtocolMessage is received with a channel attribute and a new sync sequence identifier in the channelSerial attribute") {
+                func skipped__test__011__Presence__realtime_system_reserves_the_right_to_initiate_a_sync_of_the_presence_members_at_any_point_once_a_channel_is_attached__should_do_a_new_sync_whenever_a_SYNC_ProtocolMessage_is_received_with_a_channel_attribute_and_a_new_sync_sequence_identifier_in_the_channelSerial_attribute() {
                     let options = AblyTests.commonAppSetup()
                     let client = AblyTests.newRealtime(options)
                     defer { client.dispose(); client.close() }
@@ -301,7 +296,7 @@ override class var defaultTestSuite : XCTestSuite {
 
                 // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
                 // RTP18c, RTP18b
-                xit("when a SYNC is sent with no channelSerial attribute then the sync data is entirely contained within that ProtocolMessage") {
+                func skipped__test__012__Presence__realtime_system_reserves_the_right_to_initiate_a_sync_of_the_presence_members_at_any_point_once_a_channel_is_attached__when_a_SYNC_is_sent_with_no_channelSerial_attribute_then_the_sync_data_is_entirely_contained_within_that_ProtocolMessage() {
                     let options = AblyTests.commonAppSetup()
                     let client = AblyTests.newRealtime(options)
                     defer { client.dispose(); client.close() }
@@ -362,12 +357,10 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTP19
-            context("PresenceMap has existing members when a SYNC is started") {
+            
 
-                xit("should ensure that members no longer present on the channel are removed from the local PresenceMap once the sync is complete") {
+                func skipped__test__013__Presence__PresenceMap_has_existing_members_when_a_SYNC_is_started__should_ensure_that_members_no_longer_present_on_the_channel_are_removed_from_the_local_PresenceMap_once_the_sync_is_complete() {
                     let options = AblyTests.commonAppSetup()
                     let channelName = NSUUID().uuidString
                     var clientMembers: ARTRealtime?
@@ -433,7 +426,7 @@ override class var defaultTestSuite : XCTestSuite {
 
                 // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
                 // RTP19a
-                xit("should emit a LEAVE event for each existing member if the PresenceMap has existing members when an ATTACHED message is received without a HAS_PRESENCE flag") {
+                func skipped__test__014__Presence__PresenceMap_has_existing_members_when_a_SYNC_is_started__should_emit_a_LEAVE_event_for_each_existing_member_if_the_PresenceMap_has_existing_members_when_an_ATTACHED_message_is_received_without_a_HAS_PRESENCE_flag() {
                     let options = AblyTests.commonAppSetup()
                     let client = AblyTests.newRealtime(options)
                     defer { client.dispose(); client.close() }
@@ -478,10 +471,8 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTP4
-            xit("should receive all 250 members") {
+            func skipped__test__002__Presence__should_receive_all_250_members() {
                 let options = AblyTests.commonAppSetup()
                 var clientSource: ARTRealtime!
                 defer { clientSource.dispose(); clientSource.close() }
@@ -512,10 +503,10 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTP6
-            context("subscribe") {
+            
 
                 // RTP6a
-                it("with no arguments should subscribe a listener to all presence messages") {
+                func test__015__Presence__subscribe__with_no_arguments_should_subscribe_a_listener_to_all_presence_messages() {
                     let options = AblyTests.commonAppSetup()
 
                     let client1 = ARTRealtime(options: options)
@@ -559,13 +550,11 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(receivedMembers[2].clientId).to(equal("john"))
                 }
 
-            }
-
             // RTP7
-            context("unsubscribe") {
+            
 
                 // RTP7a
-                it("with no arguments unsubscribes the listener if previously subscribed with an action-specific subscription") {
+                func test__016__Presence__unsubscribe__with_no_arguments_unsubscribes_the_listener_if_previously_subscribed_with_an_action_specific_subscription() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -576,15 +565,13 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(channel.internal.presenceEventEmitter.anyListeners).to(haveCount(0))
                 }
 
-            }
-
             // RTP5
-            context("Channel state change side effects") {
+            
 
                 // RTP5a
-                context("if the channel enters the FAILED state") {
+                
 
-                    it("all queued presence messages should fail immediately") {
+                    func test__018__Presence__Channel_state_change_side_effects__if_the_channel_enters_the_FAILED_state__all_queued_presence_messages_should_fail_immediately() {
                         let client = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
                         let channel = client.channels.get("test")
@@ -603,7 +590,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    xit("should clear the PresenceMap including local members and does not emit any presence events") {
+                    func skipped__test__019__Presence__Channel_state_change_side_effects__if_the_channel_enters_the_FAILED_state__should_clear_the_PresenceMap_including_local_members_and_does_not_emit_any_presence_events() {
                         let client = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
                         let channel = client.channels.get("test")
@@ -640,12 +627,10 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
                 // RTP5a
-                context("if the channel enters the DETACHED state") {
+                
 
-                    it("all queued presence messages should fail immediately") {
+                    func test__020__Presence__Channel_state_change_side_effects__if_the_channel_enters_the_DETACHED_state__all_queued_presence_messages_should_fail_immediately() {
                         let client = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
                         let channel = client.channels.get("test")
@@ -662,7 +647,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("should clear the PresenceMap including local members and does not emit any presence events") {
+                    func test__021__Presence__Channel_state_change_side_effects__if_the_channel_enters_the_DETACHED_state__should_clear_the_PresenceMap_including_local_members_and_does_not_emit_any_presence_events() {
                         let client = ARTRealtime(options: AblyTests.commonAppSetup())
                         defer { client.dispose(); client.close() }
                         let channel = client.channels.get("test")
@@ -697,11 +682,9 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
                 // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
                 // RTP5b
-                xit("if a channel enters the ATTACHED state then all queued presence messages will be sent immediately and a presence SYNC may be initiated") {
+                func skipped__test__017__Presence__Channel_state_change_side_effects__if_a_channel_enters_the_ATTACHED_state_then_all_queued_presence_messages_will_be_sent_immediately_and_a_presence_SYNC_may_be_initiated() {
                     let options = AblyTests.commonAppSetup()
                     let client1 = AblyTests.newRealtime(options)
                     defer { client1.dispose(); client1.close() }
@@ -753,9 +736,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP5f
-                context("channel enters the SUSPENDED state") {
+                
 
-                    it("all queued presence messages should fail immediately") {
+                    func test__022__Presence__Channel_state_change_side_effects__channel_enters_the_SUSPENDED_state__all_queued_presence_messages_should_fail_immediately() {
                         let options = AblyTests.commonAppSetup()
                         let client = AblyTests.newRealtime(options)
                         defer { client.dispose(); client.close() }
@@ -788,7 +771,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("should maintain the PresenceMap and any members present before and after the sync should not emit presence events") {
+                    func test__023__Presence__Channel_state_change_side_effects__channel_enters_the_SUSPENDED_state__should_maintain_the_PresenceMap_and_any_members_present_before_and_after_the_sync_should_not_emit_presence_events() {
                         let options = AblyTests.commonAppSetup()
                         let channelName = NSUUID().uuidString
 
@@ -866,15 +849,11 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
-            }
-
             // RTP8
-            xcontext("enter") {
+            
 
                 // RTP8a
-                it("should enter the current client, optionally with the data provided") {
+                func skipped__test__024__Presence__enter__should_enter_the_current_client__optionally_with_the_data_provided() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
 
@@ -899,13 +878,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTP7
-            context("unsubscribe") {
+            
 
                 // RTP7b
-                it("with a single action argument unsubscribes the provided listener to all presence messages for that action") {
+                func test__025__Presence__unsubscribe__with_a_single_action_argument_unsubscribes_the_provided_listener_to_all_presence_messages_for_that_action() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -916,13 +893,11 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(channel.internal.presenceEventEmitter.listeners).to(haveCount(0))
                 }
 
-            }
-
             // RTP6
-            context("subscribe") {
+            
 
                 // RTP6c
-                it("should implicitly attach the channel") {
+                func test__026__Presence__subscribe__should_implicitly_attach_the_channel() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -941,7 +916,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP6c
-                it("should result in an error if the channel is in the FAILED state") {
+                func test__027__Presence__subscribe__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
 
@@ -962,7 +937,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP6c
-                it("should result in an error if the channel moves to the FAILED state") {
+                func test__028__Presence__subscribe__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -983,13 +958,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTP6
-            context("subscribe") {
+            
 
                 // RTP6b
-                it("with a single action argument") {
+                func test__029__Presence__subscribe__with_a_single_action_argument() {
                     let options = AblyTests.commonAppSetup()
 
                     let client1 = ARTRealtime(options: options)
@@ -1024,14 +997,12 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(count).toEventually(equal(1), timeout: testTimeout)
                 }
 
-            }
-
             // RTP8
-            context("enter") {
+            
 
                 // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
                 // RTP8b
-                xit("optionally a callback can be provided that is called for success") {
+                func skipped__test__030__Presence__enter__optionally_a_callback_can_be_provided_that_is_called_for_success() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
 
@@ -1057,7 +1028,7 @@ override class var defaultTestSuite : XCTestSuite {
 
                 // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
                 // RTP8b
-                xit("optionally a callback can be provided that is called for failure") {
+                func skipped__test__031__Presence__enter__optionally_a_callback_can_be_provided_that_is_called_for_failure() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
 
@@ -1085,7 +1056,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP8c
-                it("entering without an explicit PresenceMessage#clientId should implicitly use the clientId of the current connection") {
+                func test__032__Presence__enter__entering_without_an_explicit_PresenceMessage_clientId_should_implicitly_use_the_clientId_of_the_current_connection() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = AblyTests.newRealtime(options)
@@ -1115,13 +1086,11 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(received.clientId).to(equal("john"))
                 }
 
-            }
-
             // RTP8
-            context("enter") {
+            
 
                 // RTP8f
-                it("should result in an error immediately if the client is anonymous") {
+                func test__033__Presence__enter__should_result_in_an_error_immediately_if_the_client_is_anonymous() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -1134,13 +1103,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTP8
-            context("enter") {
+            
 
                 // RTP8g
-                it("should result in an error immediately if the channel is DETACHED") {
+                func test__034__Presence__enter__should_result_in_an_error_immediately_if_the_channel_is_DETACHED() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = ARTRealtime(options: options)
@@ -1164,7 +1131,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP8g
-                it("should result in an error immediately if the channel is FAILED") {
+                func test__035__Presence__enter__should_result_in_an_error_immediately_if_the_channel_is_FAILED() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = ARTRealtime(options: options)
@@ -1189,13 +1156,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTP8
-            context("enter") {
+            
 
                 // RTP8i
-                it("should result in an error if Ably service determines that the client is unidentified") {
+                func test__036__Presence__enter__should_result_in_an_error_if_Ably_service_determines_that_the_client_is_unidentified() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -1208,13 +1173,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTP9
-            context("update") {
+            
 
                 // RTP9a
-                it("should update the data for the present member with a value") {
+                func test__037__Presence__update__should_update_the_data_for_the_present_member_with_a_value() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = ARTRealtime(options: options)
@@ -1239,7 +1202,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP9a
-                xit("should update the data for the present member with null") {
+                func skipped__test__038__Presence__update__should_update_the_data_for_the_present_member_with_null() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = ARTRealtime(options: options)
@@ -1263,14 +1226,12 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTP9
-            context("update") {
+            
 
                 // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
                 // RTP9b
-                xit("should enter current client into the channel if the client was not already entered") {
+                func skipped__test__039__Presence__update__should_enter_current_client_into_the_channel_if_the_client_was_not_already_entered() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = ARTRealtime(options: options)
@@ -1288,13 +1249,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTP9
-            context("update") {
+            
 
                 // RTP9c
-                it("optionally a callback can be provided that is called for success") {
+                func test__040__Presence__update__optionally_a_callback_can_be_provided_that_is_called_for_success() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = ARTRealtime(options: options)
@@ -1310,7 +1269,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP9c
-                it("optionally a callback can be provided that is called for failure") {
+                func test__041__Presence__update__optionally_a_callback_can_be_provided_that_is_called_for_failure() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = AblyTests.newRealtime(options)
@@ -1333,7 +1292,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP9d
-                it("update without an explicit PresenceMessage#clientId should implicitly use the clientId of the current connection") {
+                func test__042__Presence__update__update_without_an_explicit_PresenceMessage_clientId_should_implicitly_use_the_clientId_of_the_current_connection() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = AblyTests.newRealtime(options)
@@ -1361,13 +1320,11 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(received.clientId).to(equal("john"))
                 }
 
-            }
-
             // RTP10
-            context("leave") {
+            
 
                 // RTP10a
-                xit("should leave the current client from the channel and the data will be updated with the value provided") {
+                func skipped__test__043__Presence__leave__should_leave_the_current_client_from_the_channel_and_the_data_will_be_updated_with_the_value_provided() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = ARTRealtime(options: options)
@@ -1396,7 +1353,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP10a
-                xit("should leave the current client with no data") {
+                func skipped__test__044__Presence__leave__should_leave_the_current_client_with_no_data() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = ARTRealtime(options: options)
@@ -1420,10 +1377,8 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTP2
-            xit("should be used a PresenceMap to maintain a list of members") {
+            func skipped__test__003__Presence__should_be_used_a_PresenceMap_to_maintain_a_list_of_members() {
                 let options = AblyTests.commonAppSetup()
                 var clientSecondary: ARTRealtime!
                 defer { clientSecondary.dispose(); clientSecondary.close() }
@@ -1455,10 +1410,10 @@ override class var defaultTestSuite : XCTestSuite {
 
             // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
             // RTP2
-            context("PresenceMap") {
+            
 
                 // RTP2a
-                xit("all incoming presence messages must be compared for newness with the matching member already in the PresenceMap") {
+                func skipped__test__045__Presence__PresenceMap__all_incoming_presence_messages_must_be_compared_for_newness_with_the_matching_member_already_in_the_PresenceMap() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.dispose(); client.close() }
@@ -1510,11 +1465,11 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP2b
-                context("compare for newness") {
+                
 
-                    context("presence message has a connectionId which is not an initial substring of its id") {
+                    
                         // RTP2b1
-                        it("compares them by timestamp numerically") {
+                        func test__053__Presence__PresenceMap__compare_for_newness__presence_message_has_a_connectionId_which_is_not_an_initial_substring_of_its_id__compares_them_by_timestamp_numerically() {
                             let options = AblyTests.commonAppSetup()
                             let now = NSDate()
                             let channelName = NSUUID().uuidString
@@ -1591,10 +1546,9 @@ override class var defaultTestSuite : XCTestSuite {
                                 }
                             }
                         }
-                    }
 
                     // RTP2b2
-                    it("split the id of both presence messages") {
+                    func test__052__Presence__PresenceMap__compare_for_newness__split_the_id_of_both_presence_messages() {
                         let options = AblyTests.commonAppSetup()
                         let now = NSDate()
                         let channelName = NSUUID().uuidString
@@ -1672,13 +1626,11 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
                 // RTP2c
-                context("all presence messages from a SYNC must also be compared for newness in the same way as they would from a PRESENCE") {
+                
 
                     // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                    xit("discard members where messages have arrived before the SYNC") {
+                    func skipped__test__054__Presence__PresenceMap__all_presence_messages_from_a_SYNC_must_also_be_compared_for_newness_in_the_same_way_as_they_would_from_a_PRESENCE__discard_members_where_messages_have_arrived_before_the_SYNC() {
                         let options = AblyTests.commonAppSetup()
                         let timeBeforeSync = NSDate()
                         let channelName = NSUUID().uuidString
@@ -1732,7 +1684,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                    xit("accept members where message have arrived after the SYNC") {
+                    func skipped__test__055__Presence__PresenceMap__all_presence_messages_from_a_SYNC_must_also_be_compared_for_newness_in_the_same_way_as_they_would_from_a_PRESENCE__accept_members_where_message_have_arrived_after_the_SYNC() {
                         let options = AblyTests.commonAppSetup()
                         let channelName = NSUUID().uuidString
                         var clientMembers: ARTRealtime?
@@ -1783,10 +1735,8 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
                 // RTP2d
-                xit("if action of ENTER arrives, it should be added to the presence map with the action set to PRESENT") {
+                func skipped__test__046__Presence__PresenceMap__if_action_of_ENTER_arrives__it_should_be_added_to_the_presence_map_with_the_action_set_to_PRESENT() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.dispose(); client.close() }
@@ -1810,7 +1760,7 @@ override class var defaultTestSuite : XCTestSuite {
 
                 // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
                 // RTP2d
-                xit("if action of UPDATE arrives, it should be added to the presence map with the action set to PRESENT") {
+                func skipped__test__047__Presence__PresenceMap__if_action_of_UPDATE_arrives__it_should_be_added_to_the_presence_map_with_the_action_set_to_PRESENT() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.dispose(); client.close() }
@@ -1838,7 +1788,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP2d
-                it("if action of PRESENT arrives, it should be added to the presence map with the action set to PRESENT") {
+                func test__048__Presence__PresenceMap__if_action_of_PRESENT_arrives__it_should_be_added_to_the_presence_map_with_the_action_set_to_PRESENT() {
                     let options = AblyTests.commonAppSetup()
                     let channelName = NSUUID().uuidString
                     var clientMembers: ARTRealtime!
@@ -1865,7 +1815,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP2e
-                xit("if a SYNC is not in progress, then when a presence message with an action of LEAVE arrives, that memberKey should be deleted from the presence map, if present") {
+                func skipped__test__049__Presence__PresenceMap__if_a_SYNC_is_not_in_progress__then_when_a_presence_message_with_an_action_of_LEAVE_arrives__that_memberKey_should_be_deleted_from_the_presence_map__if_present() {
                     let options = AblyTests.commonAppSetup()
 
                     var clientMembers: ARTRealtime?
@@ -1910,7 +1860,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP2f
-                xit("if a SYNC is in progress, then when a presence message with an action of LEAVE arrives, it should be stored in the presence map with the action set to ABSENT") {
+                func skipped__test__050__Presence__PresenceMap__if_a_SYNC_is_in_progress__then_when_a_presence_message_with_an_action_of_LEAVE_arrives__it_should_be_stored_in_the_presence_map_with_the_action_set_to_ABSENT() {
                     let options = AblyTests.commonAppSetup()
                     let channelName = NSUUID().uuidString
 
@@ -1973,7 +1923,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP2g
-                xit("any incoming presence message that passes the newness check should be emitted on the Presence object, with an event name set to its original action") {
+                func skipped__test__051__Presence__PresenceMap__any_incoming_presence_message_that_passes_the_newness_check_should_be_emitted_on_the_Presence_object__with_an_event_name_set_to_its_original_action() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.dispose(); client.close() }
@@ -1997,12 +1947,10 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTP8
-            context("enter") {
+            
                 // RTP8h
-                it("should result in an error if the client does not have required presence permission") {
+                func test__056__Presence__enter__should_result_in_an_error_if_the_client_does_not_have_required_presence_permission() {
                     let options = AblyTests.commonAppSetup()
                     options.token = getTestToken(clientId: "john", capability: "{ \"cannotpresence:john\":[\"publish\"] }")
                     options.clientId = "john"
@@ -2020,14 +1968,13 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
 
             // RTP9
-            context("update") {
+            
 
                 // RTP9e
-                it("should result in an error immediately if the client is anonymous") {
+                func test__057__Presence__update__should_result_in_an_error_immediately_if_the_client_is_anonymous() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -2041,7 +1988,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP9e
-                it("should result in an error immediately if the channel is DETACHED") {
+                func test__058__Presence__update__should_result_in_an_error_immediately_if_the_channel_is_DETACHED() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = ARTRealtime(options: options)
@@ -2061,7 +2008,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP9e
-                it("should result in an error immediately if the channel is FAILED") {
+                func test__059__Presence__update__should_result_in_an_error_immediately_if_the_channel_is_FAILED() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = ARTRealtime(options: options)
@@ -2081,7 +2028,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP9e
-                it("should result in an error if the client does not have required presence permission") {
+                func test__060__Presence__update__should_result_in_an_error_if_the_client_does_not_have_required_presence_permission() {
                     let options = AblyTests.clientOptions()
                     options.token = getTestToken(clientId: "john", capability: "{ \"cannotpresence:john\":[\"publish\"] }")
                     options.clientId = "john"
@@ -2101,7 +2048,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP9e
-                it("should result in an error if Ably service determines that the client is unidentified") {
+                func test__061__Presence__update__should_result_in_an_error_if_Ably_service_determines_that_the_client_is_unidentified() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -2116,13 +2063,12 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
             // RTP10
-            context("leave") {
+            
 
                 // RTP10b
-                it("optionally a callback can be provided that is called for success") {
+                func test__062__Presence__leave__optionally_a_callback_can_be_provided_that_is_called_for_success() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = ARTRealtime(options: options)
@@ -2145,7 +2091,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP10b
-                it("optionally a callback can be provided that is called for failure") {
+                func test__063__Presence__leave__optionally_a_callback_can_be_provided_that_is_called_for_failure() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = AblyTests.newRealtime(options)
@@ -2171,7 +2117,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should raise an error if client is not present") {
+                func test__064__Presence__leave__should_raise_an_error_if_client_is_not_present() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.dispose(); client.close() }
@@ -2189,7 +2135,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP10c
-                it("entering without an explicit PresenceMessage#clientId should implicitly use the clientId of the current connection") {
+                func test__065__Presence__leave__entering_without_an_explicit_PresenceMessage_clientId_should_implicitly_use_the_clientId_of_the_current_connection() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = AblyTests.newRealtime(options)
@@ -2219,7 +2165,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP10d
-                it("if the client is not currently ENTERED, Ably will respond with an ACK and the request will succeed") {
+                func test__066__Presence__leave__if_the_client_is_not_currently_ENTERED__Ably_will_respond_with_an_ACK_and_the_request_will_succeed() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
 
@@ -2249,13 +2195,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTP8
-            context("enter") {
+            
 
                 // RTP8d
-                it("implicitly attaches the Channel") {
+                func test__067__Presence__enter__implicitly_attaches_the_Channel() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
 
@@ -2275,7 +2219,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP8d
-                it("should result in an error if the channel is in the FAILED state") {
+                func test__068__Presence__enter__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
 
@@ -2297,7 +2241,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP8d
-                it("should result in an error if the channel is in the DETACHED state") {
+                func test__069__Presence__enter__should_result_in_an_error_if_the_channel_is_in_the_DETACHED_state() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
 
@@ -2326,13 +2270,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTP10
-            context("leave") {
+            
 
                 // RTP10e
-                it("should result in an error immediately if the client is anonymous") {
+                func test__070__Presence__leave__should_result_in_an_error_immediately_if_the_client_is_anonymous() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -2346,7 +2288,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP10e
-                it("should result in an error immediately if the channel is DETACHED") {
+                func test__071__Presence__leave__should_result_in_an_error_immediately_if_the_channel_is_DETACHED() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = ARTRealtime(options: options)
@@ -2371,7 +2313,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP10e
-                it("should result in an error immediately if the channel is FAILED") {
+                func test__072__Presence__leave__should_result_in_an_error_immediately_if_the_channel_is_FAILED() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john"
                     let client = ARTRealtime(options: options)
@@ -2398,7 +2340,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP10e
-                it("should result in an error if the client does not have required presence permission") {
+                func test__073__Presence__leave__should_result_in_an_error_if_the_client_does_not_have_required_presence_permission() {
                     let options = AblyTests.clientOptions()
                     options.token = getTestToken(clientId: "john", capability: "{ \"cannotpresence:other\":[\"publish\"] }")
                     options.clientId = "john"
@@ -2415,7 +2357,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP10e
-                it("should result in an error if Ably service determines that the client is unidentified") {
+                func test__074__Presence__leave__should_result_in_an_error_if_Ably_service_determines_that_the_client_is_unidentified() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -2428,13 +2370,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTP6
-            context("subscribe") {
+            
 
                 // RTP6c
-                it("should implicitly attach the channel") {
+                func test__075__Presence__subscribe__should_implicitly_attach_the_channel() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -2453,7 +2393,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP6c
-                it("should result in an error if the channel is in the FAILED state") {
+                func test__076__Presence__subscribe__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -2475,7 +2415,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP6c
-                it("should result in an error if the channel moves to the FAILED state") {
+                func test__077__Presence__subscribe__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -2495,13 +2435,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTP8
-            context("enter") {
+            
 
                 // RTP8e
-                it("optional data can be included when entering a channel") {
+                func test__078__Presence__enter__optional_data_can_be_included_when_entering_a_channel() {
                     let options = AblyTests.commonAppSetup()
 
                     options.clientId = "john"
@@ -2533,7 +2471,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP8e
-                it("should emit the data attribute in the LEAVE event when data is provided when entering but no data is provided when leaving") {
+                func test__079__Presence__enter__should_emit_the_data_attribute_in_the_LEAVE_event_when_data_is_provided_when_entering_but_no_data_is_provided_when_leaving() {
                     let options = AblyTests.commonAppSetup()
 
                     options.clientId = "john"
@@ -2571,13 +2509,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
             // RTP17
-            xcontext("private and internal PresenceMap containing only members that match the current connectionId") {
+            
 
-                it("any ENTER, PRESENT, UPDATE or LEAVE event that matches the current connectionId should be applied to this object") {
+                func skipped__test__080__Presence__private_and_internal_PresenceMap_containing_only_members_that_match_the_current_connectionId__any_ENTER__PRESENT__UPDATE_or_LEAVE_event_that_matches_the_current_connectionId_should_be_applied_to_this_object() {
                     let options = AblyTests.commonAppSetup()
                     let channelName = NSUUID().uuidString
 
@@ -2708,7 +2644,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP17a
-                it("all members belonging to the current connection are published as a PresenceMessage on the Channel by the server irrespective of whether the client has permission to subscribe or the Channel is configured to publish presence events") {
+                func skipped__test__081__Presence__private_and_internal_PresenceMap_containing_only_members_that_match_the_current_connectionId__all_members_belonging_to_the_current_connection_are_published_as_a_PresenceMessage_on_the_Channel_by_the_server_irrespective_of_whether_the_client_has_permission_to_subscribe_or_the_Channel_is_configured_to_publish_presence_events() {
                     let options = AblyTests.commonAppSetup()
                     let channelName = NSUUID().uuidString
                     let clientId = NSUUID().uuidString
@@ -2741,9 +2677,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP17b
-                context("events applied to presence map") {
+                
 
-                    it("should be applied to ENTER, PRESENT or UPDATE events with a connectionId that matches the current client’s connectionId") {
+                    func skipped__test__082__Presence__private_and_internal_PresenceMap_containing_only_members_that_match_the_current_connectionId__events_applied_to_presence_map__should_be_applied_to_ENTER__PRESENT_or_UPDATE_events_with_a_connectionId_that_matches_the_current_client_s_connectionId() {
                         let options = AblyTests.commonAppSetup()
                         let client = ARTRealtime(options: options)
                         defer { client.dispose(); client.close() }
@@ -2841,7 +2777,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("should be applied to any LEAVE event with a connectionId that matches the current client’s connectionId and is not a synthesized") {
+                    func skipped__test__083__Presence__private_and_internal_PresenceMap_containing_only_members_that_match_the_current_connectionId__events_applied_to_presence_map__should_be_applied_to_any_LEAVE_event_with_a_connectionId_that_matches_the_current_client_s_connectionId_and_is_not_a_synthesized() {
                         let options = AblyTests.commonAppSetup()
                         let client = ARTRealtime(options: options)
                         client.internal.shouldImmediatelyReconnect = false
@@ -2893,12 +2829,8 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
-            }
-
             // RTP15d
-            it("callback can be provided that will be called upon success") {
+            func test__004__Presence__callback_can_be_provided_that_will_be_called_upon_success() {
                 let options = AblyTests.commonAppSetup()
                 let client = ARTRealtime(options: options)
                 defer { client.dispose(); client.close() }
@@ -2913,7 +2845,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTP15d
-            it("callback can be provided that will be called upon failure") {
+            func test__005__Presence__callback_can_be_provided_that_will_be_called_upon_failure() {
                 let options = AblyTests.clientOptions()
                 options.token = getTestToken(capability: "{ \"room\":[\"subscribe\"] }")
                 let client = ARTRealtime(options: options)
@@ -2933,7 +2865,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTP15c
-            it("should also ensure that using updateClient has no side effects on a client that has entered normally using Presence#enter") {
+            func test__006__Presence__should_also_ensure_that_using_updateClient_has_no_side_effects_on_a_client_that_has_entered_normally_using_Presence_enter() {
                 let options = AblyTests.commonAppSetup()
                 options.clientId = "john"
                 let client = ARTRealtime(options: options)
@@ -2957,10 +2889,18 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
             }
+enum TestCase_ReusableTestsTestPresencePerformMethod {
+case should_implicitly_attach_the_Channel
+case should_result_in_an_error_if_the_channel_is_in_the_FAILED_state
+case should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state
+}
+
 
             // RTP15e
-            func reusableTestsTestPresencePerformMethod(_ performMethod: @escaping (ARTRealtimePresence, Optional<(ARTErrorInfo?)->Void>)->()) {
-                it("should implicitly attach the Channel") {
+            func reusableTestsTestPresencePerformMethod(testCase: TestCase_ReusableTestsTestPresencePerformMethod, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil, _ performMethod: @escaping (ARTRealtimePresence, Optional<(ARTErrorInfo?)->Void>)->()) {
+                func test__should_implicitly_attach_the_Channel() {
+contextBeforeEach?()
+
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -2975,9 +2915,14 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
                     }
                     expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+
+contextAfterEach?()
+
                 }
                 
-                it("should result in an error if the channel is in the FAILED state") {
+                func test__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
+contextBeforeEach?()
+
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -2999,9 +2944,14 @@ override class var defaultTestSuite : XCTestSuite {
                             done()
                         }
                     }
+
+contextAfterEach?()
+
                 }
                 
-                it("should result in an error if the channel moves to the FAILED state") {
+                func test__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
+contextBeforeEach?()
+
                     let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -3020,23 +2970,72 @@ override class var defaultTestSuite : XCTestSuite {
                             done()
                         }
                     }
+
+contextAfterEach?()
+
                 }
+
+switch testCase  {
+case .should_implicitly_attach_the_Channel:
+    test__should_implicitly_attach_the_Channel()
+case .should_result_in_an_error_if_the_channel_is_in_the_FAILED_state:
+    test__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state()
+case .should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state:
+    test__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state()
+}
+
             }
             
-            context("enterClient") {
-                reusableTestsTestPresencePerformMethod { $0.enterClient("john", data: nil, callback: $1) }
-            }
             
-            context("updateClient") {
-                reusableTestsTestPresencePerformMethod { $0.updateClient("john", data: nil, callback: $1) }
-            }
+                func reusableTestsWrapper__Presence__enterClient__reusableTestsTestPresencePerformMethod(testCase: TestCase_ReusableTestsTestPresencePerformMethod) {
+                reusableTestsTestPresencePerformMethod (testCase: testCase){ $0.enterClient("john", data: nil, callback: $1) }}
+func test__084__Presence__enterClient__should_implicitly_attach_the_Channel() {
+reusableTestsWrapper__Presence__enterClient__reusableTestsTestPresencePerformMethod(testCase: .should_implicitly_attach_the_Channel)
+}
+
+func test__085__Presence__enterClient__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
+reusableTestsWrapper__Presence__enterClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_is_in_the_FAILED_state)
+}
+
+func test__086__Presence__enterClient__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
+reusableTestsWrapper__Presence__enterClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state)
+}
+
             
-            context("leaveClient") {
-                reusableTestsTestPresencePerformMethod { $0.leaveClient("john", data: nil, callback: $1) }
-            }
+            
+                func reusableTestsWrapper__Presence__updateClient__reusableTestsTestPresencePerformMethod(testCase: TestCase_ReusableTestsTestPresencePerformMethod) {
+                reusableTestsTestPresencePerformMethod (testCase: testCase){ $0.updateClient("john", data: nil, callback: $1) }}
+func test__087__Presence__updateClient__should_implicitly_attach_the_Channel() {
+reusableTestsWrapper__Presence__updateClient__reusableTestsTestPresencePerformMethod(testCase: .should_implicitly_attach_the_Channel)
+}
+
+func test__088__Presence__updateClient__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
+reusableTestsWrapper__Presence__updateClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_is_in_the_FAILED_state)
+}
+
+func test__089__Presence__updateClient__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
+reusableTestsWrapper__Presence__updateClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state)
+}
+
+            
+            
+                func reusableTestsWrapper__Presence__leaveClient__reusableTestsTestPresencePerformMethod(testCase: TestCase_ReusableTestsTestPresencePerformMethod) {
+                reusableTestsTestPresencePerformMethod (testCase: testCase){ $0.leaveClient("john", data: nil, callback: $1) }}
+func test__090__Presence__leaveClient__should_implicitly_attach_the_Channel() {
+reusableTestsWrapper__Presence__leaveClient__reusableTestsTestPresencePerformMethod(testCase: .should_implicitly_attach_the_Channel)
+}
+
+func test__091__Presence__leaveClient__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
+reusableTestsWrapper__Presence__leaveClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_is_in_the_FAILED_state)
+}
+
+func test__092__Presence__leaveClient__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
+reusableTestsWrapper__Presence__leaveClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state)
+}
+
 
             // RTP15f
-            it("should indicate an error if the client is identified and has a valid clientId and the clientId argument does not match the client’s clientId") {
+            func test__007__Presence__should_indicate_an_error_if_the_client_is_identified_and_has_a_valid_clientId_and_the_clientId_argument_does_not_match_the_client_s_clientId() {
                 let options = AblyTests.commonAppSetup()
                 options.clientId = "john"
                 let client = ARTRealtime(options: options)
@@ -3062,10 +3061,10 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTP16
-            context("Connection state conditions") {
+            
 
                 // RTP16a
-                it("all presence messages are published immediately if the connection is CONNECTED") {
+                func test__093__Presence__Connection_state_conditions__all_presence_messages_are_published_immediately_if_the_connection_is_CONNECTED() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -3083,7 +3082,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP16b
-                it("all presence messages will be queued and delivered as soon as the connection state returns to CONNECTED") {
+                func test__094__Presence__Connection_state_conditions__all_presence_messages_will_be_queued_and_delivered_as_soon_as_the_connection_state_returns_to_CONNECTED() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.dispose(); client.close() }
@@ -3110,7 +3109,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP16b
-                it("all presence messages will be lost if queueMessages has been explicitly set to false") {
+                func test__095__Presence__Connection_state_conditions__all_presence_messages_will_be_lost_if_queueMessages_has_been_explicitly_set_to_false() {
                     let options = AblyTests.commonAppSetup()
                     options.queueMessages = false
                     let client = ARTRealtime(options: options)
@@ -3137,7 +3136,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP16c
-                it("should result in an error if the connection state is INITIALIZED and queueMessages has been explicitly set to false") {
+                func test__096__Presence__Connection_state_conditions__should_result_in_an_error_if_the_connection_state_is_INITIALIZED_and_queueMessages_has_been_explicitly_set_to_false() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     options.queueMessages = false
@@ -3157,7 +3156,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should result in an error if the connection state is .suspended") {
+                func test__097__Presence__Connection_state_conditions__should_result_in_an_error_if_the_connection_state_is__suspended() {
                     testResultsInErrorWithConnectionState(.suspended) { client in
                         AblyTests.queue.async {
                             client.internal.onSuspended()
@@ -3165,33 +3164,31 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
                 
-                it("should result in an error if the connection state is .closed") {
+                func test__098__Presence__Connection_state_conditions__should_result_in_an_error_if_the_connection_state_is__closed() {
                     testResultsInErrorWithConnectionState(.closed) { client in
                         client.close()
                     }
                 }
                 
-                it("should result in an error if the connection state is .failed") {
+                func test__099__Presence__Connection_state_conditions__should_result_in_an_error_if_the_connection_state_is__failed() {
                     testResultsInErrorWithConnectionState(.failed) { client in
                         AblyTests.queue.async {
                             client.internal.onError(AblyTests.newErrorProtocolMessage())
                         }
                     }
                 }
-            }
 
             // RTP11
-            context("get") {
+            
 
-                context("query") {
-                    it("waitForSync should be true by default") {
+                
+                    func test__106__Presence__get__query__waitForSync_should_be_true_by_default() {
                         expect(ARTRealtimePresenceQuery().waitForSync).to(beTrue())
                     }
-                }
                 
                 // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
                 // RTP11a
-                xit("should return a list of current members on the channel") {
+                func skipped__test__100__Presence__get__should_return_a_list_of_current_members_on_the_channel() {
                     let options = AblyTests.commonAppSetup()
 
                     var disposable = [ARTRealtime]()
@@ -3230,7 +3227,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP11b
-                it("should implicitly attach the channel") {
+                func test__101__Presence__get__should_implicitly_attach_the_channel() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -3248,7 +3245,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP11b
-                it("should result in an error if the channel is in the FAILED state") {
+                func test__102__Presence__get__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -3279,7 +3276,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP11b
-                it("should result in an error if the channel moves to the FAILED state") {
+                func test__103__Presence__get__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
                     let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -3309,7 +3306,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP11b
-                it("should result in an error if the channel is in the DETACHED state") {
+                func test__104__Presence__get__should_result_in_an_error_if_the_channel_is_in_the_DETACHED_state() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -3333,7 +3330,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP11b
-                it("should result in an error if the channel moves to the DETACHED state") {
+                func test__105__Presence__get__should_result_in_an_error_if_the_channel_moves_to_the_DETACHED_state() {
                     let options = AblyTests.commonAppSetup()
 
                     let client = ARTRealtime(options: options)
@@ -3364,29 +3361,27 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 
                 // RTP11d
-                context("If the Channel is in the SUSPENDED state then") {
+                
                     
-                    context("by default") {
-                        it("results in an error") {
+                    
+                        func test__107__Presence__get__If_the_Channel_is_in_the_SUSPENDED_state_then__by_default__results_in_an_error() {
                             testSuspendedStateResultsInError { channel, callback in
                                 channel.presence.get(callback)
                             }
                         }
-                    }
                     
-                    context("if waitForSync is true") {
-                        it("results in an error") {
+                    
+                        func test__108__Presence__get__If_the_Channel_is_in_the_SUSPENDED_state_then__if_waitForSync_is_true__results_in_an_error() {
                             testSuspendedStateResultsInError { channel, callback in
                                 let params = ARTRealtimePresenceQuery()
                                 params.waitForSync = true
                                 channel.presence.get(params, callback: callback)
                             }
                         }
-                    }
                     
-                    context("if waitForSync is false") {
+                    
                         
-                        it("returns the members in the current PresenceMap") {
+                        func test__109__Presence__get__If_the_Channel_is_in_the_SUSPENDED_state_then__if_waitForSync_is_false__returns_the_members_in_the_current_PresenceMap() {
                             let (channel, client) = getSuspendedChannel()
                             defer { client.dispose(); client.close() }
                             
@@ -3410,14 +3405,12 @@ override class var defaultTestSuite : XCTestSuite {
                                 expect(resultByClient).to(equal(msgs))
                             }
                         }
-                    }
-                }
 
                 // RTP11c
-                context("Query (set of params)") {
+                
 
                     // RTP11c1
-                    xit("waitForSync is true, should wait until SYNC is complete before returning a list of members") {
+                    func skipped__test__110__Presence__get__Query__set_of_params___waitForSync_is_true__should_wait_until_SYNC_is_complete_before_returning_a_list_of_members() {
                         let options = AblyTests.commonAppSetup()
                         var clientSecondary: ARTRealtime!
                         defer { clientSecondary.dispose(); clientSecondary.close() }
@@ -3450,7 +3443,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTP11c1
-                    it("waitForSync is false, should return immediately the known set of presence members") {
+                    func test__111__Presence__get__Query__set_of_params___waitForSync_is_false__should_return_immediately_the_known_set_of_presence_members() {
                         let options = AblyTests.commonAppSetup()
                         var clientSecondary: ARTRealtime!
                         defer { clientSecondary.dispose(); clientSecondary.close() }
@@ -3487,7 +3480,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTP11c2
-                    it("should return members filtered by clientId") {
+                    func test__112__Presence__get__Query__set_of_params___should_return_members_filtered_by_clientId() {
                         let options = AblyTests.commonAppSetup()
                         let now = NSDate()
 
@@ -3546,7 +3539,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RTP11c3
-                    it("should return members filtered by connectionId") {
+                    func test__113__Presence__get__Query__set_of_params___should_return_members_filtered_by_connectionId() {
                         let options = AblyTests.commonAppSetup()
                         let now = NSDate()
                         let channelName = NSUUID().uuidString
@@ -3625,15 +3618,11 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
-            }
-
             // RTP12
-            context("history") {
+            
 
                 // RTP12a
-                it("should support all the same params as Rest") {
+                func test__114__Presence__history__should_support_all_the_same_params_as_Rest() {
                     let options = AblyTests.commonAppSetup()
 
                     let rest = ARTRest(options: options)
@@ -3684,13 +3673,11 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(restPresenceHistoryMethodWasCalled).to(beTrue())
                 }
 
-            }
-
             // RTP12
-            context("history") {
+            
 
                 // RTP12c, RTP12d
-                it("should return a PaginatedResult page") {
+                func test__115__Presence__history__should_return_a_PaginatedResult_page() {
                     let options = AblyTests.commonAppSetup()
 
                     var clientSecondary: ARTRealtime!
@@ -3744,10 +3731,8 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RTP13
-            xit("Presence#syncComplete returns true if the initial SYNC operation has completed") {
+            func skipped__test__008__Presence__Presence_syncComplete_returns_true_if_the_initial_SYNC_operation_has_completed() {
                 let options = AblyTests.commonAppSetup()
 
                 var disposable = [ARTRealtime]()
@@ -3780,10 +3765,10 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RTP14
-            context("enterClient") {
+            
 
                 // RTP14a, RTP14b, RTP14c, RTP14d
-                xit("enters into presence on a channel on behalf of another clientId") {
+                func skipped__test__116__Presence__enterClient__enters_into_presence_on_a_channel_on_behalf_of_another_clientId() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test")
@@ -3833,7 +3818,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RTP14d
-                it("should be present all the registered members on a presence channel") {
+                func test__117__Presence__enterClient__should_be_present_all_the_registered_members_on_a_presence_channel() {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.dispose(); client.close() }
                     let channelName = NSUUID().uuidString
@@ -3872,12 +3857,11 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
             
-            context("presence message attributes") {
+            
                 
                 // TP3a
-                it("if the presence message does not contain an id, it should be set to protocolMsgId:index") {
+                func test__118__Presence__presence_message_attributes__if_the_presence_message_does_not_contain_an_id__it_should_be_set_to_protocolMsgId_index() {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)
@@ -3904,8 +3888,4 @@ override class var defaultTestSuite : XCTestSuite {
                         client.connect()
                     }
                 }
-            }
-
-        }
-    }
 }

--- a/Spec/RealtimeClientPresence.swift
+++ b/Spec/RealtimeClientPresence.swift
@@ -1,3891 +1,3835 @@
 import Ably
-import Quick
-import Nimble
-import Foundation
 import Aspects
+import Foundation
+import Nimble
+import Quick
 
-                private let channelName = NSUUID().uuidString
+private let channelName = NSUUID().uuidString
 
-                // RTP16c
-                private func testResultsInErrorWithConnectionState(_ connectionState: ARTRealtimeConnectionState, performMethod: @escaping (ARTRealtime) -> ()) {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-                    expect(client.internal.options.queueMessages).to(beTrue())
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { _ in
-                            performMethod(client)
-                            done()
-                        }
-                    }
-                    
-                    expect(client.connection.state).toEventually(equal(connectionState), timeout: testTimeout)
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enterClient("user", data: nil) { error in
-                            expect(error).toNot(beNil())
-                            expect(client.internal.queuedMessages).to(haveCount(0))
-                            done()
-                        }
-                        expect(client.internal.queuedMessages).to(haveCount(0))
-                    }
-                }
-                    private func getSuspendedChannel() -> (ARTRealtimeChannel, ARTRealtime) {
-                        let options = AblyTests.commonAppSetup()
-                        
-                        let client = ARTRealtime(options: options)
-                        let channel = client.channels.get("test")
-                        
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.once(.suspended) { _ in
-                                done()
-                            }
-                            client.internal.onSuspended()
-                        }
-                        
-                        return (channel, client)
-                    }
-                    
-                    private func testSuspendedStateResultsInError(_ getPresence: (ARTRealtimeChannel, @escaping ([ARTPresenceMessage]?, ARTErrorInfo?) -> Void) -> Void) {
-                        let (channel, client) = getSuspendedChannel()
-                        defer { client.dispose(); client.close() }
-                        
-                        getPresence(channel) { result, err in
-                            expect(result).to(beNil())
-                            expect(err).toNot(beNil())
-                            guard let err = err else {
-                                return
-                            }
-                            expect(err.code).to(equal(ARTErrorCode.presenceStateIsOutOfSync.intValue))
-                        }
-                    }
-                        private let getParams: ARTRealtimePresenceQuery = {
-                            let getParams = ARTRealtimePresenceQuery()
-                            getParams.waitForSync = false
-                            return getParams
-                        }()
+// RTP16c
+private func testResultsInErrorWithConnectionState(_ connectionState: ARTRealtimeConnectionState, performMethod: @escaping (ARTRealtime) -> Void) {
+    let client = ARTRealtime(options: AblyTests.commonAppSetup())
+    defer { client.dispose(); client.close() }
+    let channel = client.channels.get("test")
+    expect(client.internal.options.queueMessages).to(beTrue())
+
+    waitUntil(timeout: testTimeout) { done in
+        channel.attach { _ in
+            performMethod(client)
+            done()
+        }
+    }
+
+    expect(client.connection.state).toEventually(equal(connectionState), timeout: testTimeout)
+
+    waitUntil(timeout: testTimeout) { done in
+        channel.presence.enterClient("user", data: nil) { error in
+            expect(error).toNot(beNil())
+            expect(client.internal.queuedMessages).to(haveCount(0))
+            done()
+        }
+        expect(client.internal.queuedMessages).to(haveCount(0))
+    }
+}
+
+private func getSuspendedChannel() -> (ARTRealtimeChannel, ARTRealtime) {
+    let options = AblyTests.commonAppSetup()
+
+    let client = ARTRealtime(options: options)
+    let channel = client.channels.get("test")
+
+    waitUntil(timeout: testTimeout) { done in
+        channel.once(.suspended) { _ in
+            done()
+        }
+        client.internal.onSuspended()
+    }
+
+    return (channel, client)
+}
+
+private func testSuspendedStateResultsInError(_ getPresence: (ARTRealtimeChannel, @escaping ([ARTPresenceMessage]?, ARTErrorInfo?) -> Void) -> Void) {
+    let (channel, client) = getSuspendedChannel()
+    defer { client.dispose(); client.close() }
+
+    getPresence(channel) { result, err in
+        expect(result).to(beNil())
+        expect(err).toNot(beNil())
+        guard let err = err else {
+            return
+        }
+        expect(err.code).to(equal(ARTErrorCode.presenceStateIsOutOfSync.intValue))
+    }
+}
+
+private let getParams: ARTRealtimePresenceQuery = {
+    let getParams = ARTRealtimePresenceQuery()
+    getParams.waitForSync = false
+    return getParams
+}()
 
 class RealtimeClientPresence: XCTestCase {
-
     override func setUp() {
         super.setUp()
         AsyncDefaults.timeout = testTimeout
     }
 
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = channelName
-    let _ = getParams
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = channelName
+        _ = getParams
 
-    return super.defaultTestSuite
-}
-        
+        return super.defaultTestSuite
+    }
 
-            // RTP1
-            
+    // RTP1
 
-                // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                func skipped__test__009__Presence__ProtocolMessage_bit_flag__when_no_members_are_present() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    client.internal.setTransport(TestProxyTransport.self)
-                    client.connect()
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get(channelName)
-                    channel.attach()
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    func skipped__test__009__Presence__ProtocolMessage_bit_flag__when_no_members_are_present() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get(channelName)
+        channel.attach()
 
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
 
-                    let transport = client.internal.transport as! TestProxyTransport
-                    let attached = transport.protocolMessagesReceived.filter({ $0.action == .attached })[0]
+        let transport = client.internal.transport as! TestProxyTransport
+        let attached = transport.protocolMessagesReceived.filter { $0.action == .attached }[0]
 
-                    expect(attached.flags & 0x1).to(equal(0))
-                    expect(attached.hasPresence).to(beFalse())
-                    expect(channel.presence.syncComplete).to(beFalse())
-                    expect(channel.internal.presenceMap.syncComplete).to(beFalse())
-                }
+        expect(attached.flags & 0x1).to(equal(0))
+        expect(attached.hasPresence).to(beFalse())
+        expect(channel.presence.syncComplete).to(beFalse())
+        expect(channel.internal.presenceMap.syncComplete).to(beFalse())
+    }
 
-                func skipped__test__010__Presence__ProtocolMessage_bit_flag__when_members_are_present() {
-                    let options = AblyTests.commonAppSetup()
+    func skipped__test__010__Presence__ProtocolMessage_bit_flag__when_members_are_present() {
+        let options = AblyTests.commonAppSetup()
 
-                    var disposable = [ARTRealtime]()
-                    defer {
-                        for clientItem in disposable {
-                            clientItem.dispose()
-                            clientItem.close()
-                        }
-                    }
-
-                    disposable += [AblyTests.addMembersSequentiallyToChannel(channelName, members: 250, options: options)]
-
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    client.internal.setTransport(TestProxyTransport.self)
-                    client.connect()
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get(channelName)
-                    channel.attach()
-
-                    expect(channel.presence.syncComplete).to(beFalse())
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                    let transport = client.internal.transport as! TestProxyTransport
-                    let attached = transport.protocolMessagesReceived.filter({ $0.action == .attached })[0]
-
-                    // There are members present on the channel
-                    expect(attached.flags & 0x1).to(equal(1))
-                    expect(attached.hasPresence).to(beTrue())
-                    
-                    expect(channel.presence.syncComplete).toEventually(beTrue(), timeout: testTimeout)
-
-                    expect(transport.protocolMessagesReceived.filter({ $0.action == .sync })).to(haveCount(3))
-                }
-
-            // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-            // RTP3
-            func skipped__test__001__Presence__should_complete_the_SYNC_operation_when_the_connection_is_disconnected_unexpectedly() {
-                let membersCount = 110
-
-                let options = AblyTests.commonAppSetup()
-                var clientSecondary: ARTRealtime!
-                defer { clientSecondary.dispose(); clientSecondary.close() }
-
-                clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: membersCount, options: options)
-
-                let client = AblyTests.newRealtime(options)
-                defer { client.dispose(); client.close() }
-                let channel = client.channels.get("test")
-
-                var lastSyncSerial: String?
-                waitUntil(timeout: testTimeout) { done in
-                    let partialDone = AblyTests.splitDone(2, done: done)
-                    guard let transport = client.internal.transport as? TestProxyTransport else {
-                        fail("TestProxyTransport is not set"); return
-                    }
-                    transport.setBeforeIncomingMessageModifier({ protocolMessage in
-                        if protocolMessage.action == .sync {
-                            lastSyncSerial = protocolMessage.channelSerial
-                            expect(lastSyncSerial).toNot(beNil())
-                            client.internal.onDisconnected()
-                            partialDone()
-                            transport.setBeforeIncomingMessageModifier(nil)
-                        }
-                        return protocolMessage
-                    })
-                    channel.attach() { _ in
-                        partialDone()
-                    }
-                }
-
-                expect(channel.internal.presenceMap.members).toNot(haveCount(membersCount))
-                expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connecting), timeout: DispatchTimeInterval.milliseconds(Int(1000.0 * (options.disconnectedRetryTimeout + 1.0))))
-                expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-
-                // Client library requests a SYNC resume by sending a SYNC ProtocolMessage with the last received sync serial number
-                guard let transport = client.internal.transport as? TestProxyTransport else {
-                    fail("TestProxyTransport is not set"); return
-                }
-
-                let syncSentProtocolMessages = transport.protocolMessagesSent.filter({ $0.action == .sync })
-                guard let syncSentMessage = syncSentProtocolMessages.last, syncSentProtocolMessages.count == 1 else {
-                    fail("Should send one SYNC protocol message"); return
-                }
-                expect(syncSentMessage.channelSerial).to(equal(lastSyncSerial))
-
-                expect(transport.protocolMessagesReceived.filter{ $0.action == .sync }).toEventually(haveCount(2), timeout: testTimeout)
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.presence.get { members, error in
-                        expect(error).to(beNil())
-                        guard let members = members else {
-                            fail("No present members"); done(); return
-                        }
-                        expect(members).to(haveCount(membersCount))
-                        done()
-                    }
-                }
+        var disposable = [ARTRealtime]()
+        defer {
+            for clientItem in disposable {
+                clientItem.dispose()
+                clientItem.close()
             }
+        }
 
-            // RTP18
-            
+        disposable += [AblyTests.addMembersSequentiallyToChannel(channelName, members: 250, options: options)]
 
-                // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                // RTP18a, RTP18b
-                func skipped__test__011__Presence__realtime_system_reserves_the_right_to_initiate_a_sync_of_the_presence_members_at_any_point_once_a_channel_is_attached__should_do_a_new_sync_whenever_a_SYNC_ProtocolMessage_is_received_with_a_channel_attribute_and_a_new_sync_sequence_identifier_in_the_channelSerial_attribute() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    let channelName = NSUUID().uuidString
-                    let channel = client.channels.get(channelName)
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        client.internal.setTransport(TestProxyTransport.self)
+        client.connect()
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get(channelName)
+        channel.attach()
 
-                    guard let transport = client.internal.transport as? TestProxyTransport else {
-                        fail("TestProxyTransport is not set"); return
-                    }
+        expect(channel.presence.syncComplete).to(beFalse())
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
 
-                    expect(channel.internal.presenceMap.syncInProgress).to(beFalse())
-                    expect(channel.internal.presenceMap.members).to(beEmpty())
+        let transport = client.internal.transport as! TestProxyTransport
+        let attached = transport.protocolMessagesReceived.filter { $0.action == .attached }[0]
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.subscribe(.present) { msg in
-                            if msg.clientId != "a" {
-                                return
-                            }
-                            expect(channel.presence.syncComplete).to(beFalse())
-                            var aClientHasLeft = false;
-                            channel.presence.subscribe(.leave) { _ in
-                                if (aClientHasLeft) {
-                                    return
-                                }
-                                aClientHasLeft = true;
-                                done()
-                            }
-                        }
+        // There are members present on the channel
+        expect(attached.flags & 0x1).to(equal(1))
+        expect(attached.hasPresence).to(beTrue())
 
-                        guard let lastConnectionSerial = transport.protocolMessagesReceived.last?.connectionSerial else {
-                            fail("No protocol message has been received yet"); done(); return
-                        }
+        expect(channel.presence.syncComplete).toEventually(beTrue(), timeout: testTimeout)
 
-                        // Inject a SYNC Presence message (first page)
-                        let sync1Message = ARTProtocolMessage()
-                        sync1Message.action = .sync
-                        sync1Message.channel = channel.name
-                        sync1Message.channelSerial = "sequenceid:cursor"
-                        sync1Message.connectionSerial = lastConnectionSerial + 1
-                        sync1Message.timestamp = Date()
-                        sync1Message.presence = [
-                            ARTPresenceMessage(clientId: "a", action: .present, connectionId: "another", id: "another:0:0"),
-                            ARTPresenceMessage(clientId: "b", action: .present, connectionId: "another", id: "another:0:1"),
-                        ]
-                        transport.receive(sync1Message)
+        expect(transport.protocolMessagesReceived.filter { $0.action == .sync }).to(haveCount(3))
+    }
 
-                        // Inject a SYNC Presence message (last page)
-                        let sync2Message = ARTProtocolMessage()
-                        sync2Message.action = .sync
-                        sync2Message.channel = channel.name
-                        sync2Message.channelSerial = "sequenceid:" //indicates SYNC is complete
-                        sync2Message.connectionSerial = lastConnectionSerial + 2
-                        sync2Message.timestamp = Date()
-                        sync2Message.presence = [
-                            ARTPresenceMessage(clientId: "a", action: .leave, connectionId: "another", id: "another:1:0"),
-                        ]
-                        delay(0.5) {
-                            transport.receive(sync2Message)
-                        }
-                    }
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    // RTP3
+    func skipped__test__001__Presence__should_complete_the_SYNC_operation_when_the_connection_is_disconnected_unexpectedly() {
+        let membersCount = 110
 
-                    expect(channel.presence.syncComplete).to(beTrue())
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.get { members, error in
-                            expect(error).to(beNil())
-                            guard let members = members, members.count == 1 else {
-                                fail("Should at least have 1 member"); done(); return
-                            }
-                            expect(members[0].clientId).to(equal("b"))
-                            done()
-                        }
-                    }
-                }
+        let options = AblyTests.commonAppSetup()
+        var clientSecondary: ARTRealtime!
+        defer { clientSecondary.dispose(); clientSecondary.close() }
 
-                // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                // RTP18c, RTP18b
-                func skipped__test__012__Presence__realtime_system_reserves_the_right_to_initiate_a_sync_of_the_presence_members_at_any_point_once_a_channel_is_attached__when_a_SYNC_is_sent_with_no_channelSerial_attribute_then_the_sync_data_is_entirely_contained_within_that_ProtocolMessage() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    let channelName = NSUUID().uuidString
-                    let channel = client.channels.get(channelName)
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
+        clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: membersCount, options: options)
 
-                    guard let transport = client.internal.transport as? TestProxyTransport else {
-                        fail("TestProxyTransport is not set"); return
-                    }
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
 
-                    expect(channel.internal.presenceMap.syncInProgress).to(beFalse())
-                    expect(channel.internal.presenceMap.members).to(beEmpty())
-
-                    waitUntil(timeout: testTimeout) { done in
-                        var aClientHasLeft = false;
-                        channel.presence.subscribe(.leave) { error in
-                            if (aClientHasLeft) {
-                                return
-                            }
-                            aClientHasLeft = true;
-                            done()
-                        }
-
-                        guard let lastConnectionSerial = transport.protocolMessagesReceived.last?.connectionSerial else {
-                            fail("No protocol message has been received yet"); done(); return
-                        }
-
-                        // Inject a SYNC Presence message (entirely contained)
-                        let syncMessage = ARTProtocolMessage()
-                        syncMessage.action = .sync
-                        syncMessage.channel = channel.name
-                        syncMessage.connectionSerial = lastConnectionSerial + 1
-                        syncMessage.timestamp = Date()
-                        syncMessage.presence = [
-                            ARTPresenceMessage(clientId: "a", action: .present, connectionId: "another", id: "another:0:0"),
-                            ARTPresenceMessage(clientId: "b", action: .present, connectionId: "another", id: "another:0:1"),
-                            ARTPresenceMessage(clientId: "a", action: .leave, connectionId: "another", id: "another:1:0"),
-                        ]
-                        transport.receive(syncMessage)
-                    }
-
-                    expect(channel.presence.syncComplete).to(beTrue())
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.get { members, error in
-                            expect(error).to(beNil())
-                            guard let members = members, members.count == 1 else {
-                                fail("Should at least have 1 member"); done(); return
-                            }
-                            expect(members[0].clientId).to(equal("b"))
-                            done()
-                        }
-                    }
-                }
-
-            // RTP19
-            
-
-                func skipped__test__013__Presence__PresenceMap_has_existing_members_when_a_SYNC_is_started__should_ensure_that_members_no_longer_present_on_the_channel_are_removed_from_the_local_PresenceMap_once_the_sync_is_complete() {
-                    let options = AblyTests.commonAppSetup()
-                    let channelName = NSUUID().uuidString
-                    var clientMembers: ARTRealtime?
-                    defer { clientMembers?.dispose(); clientMembers?.close() }
-                    clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 2, options: options)
-
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get(channelName)
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.get { members, error in
-                            expect(error).to(beNil())
-                            expect(members).to(haveCount(2)) //synced
-                            done()
-                        }
-                    }
-
-                    expect(channel.internal.presenceMap.members).to(haveCount(2))
-                    // Inject a local member
-                    let localMember = ARTPresenceMessage(clientId: NSUUID().uuidString, action: .enter, connectionId: "another", id: "another:0:0")
-                    channel.internal.presenceMap.add(localMember)
-                    expect(channel.internal.presenceMap.members).to(haveCount(3))
-                    expect(channel.internal.presenceMap.members.filter{ memberKey, _ in memberKey.contains(localMember.clientId!) }).to(haveCount(1))
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.get { members, error in
-                            expect(error).to(beNil())
-                            guard let members = members, members.count == 3 else {
-                                fail("Should at least have 3 members"); done(); return
-                            }
-                            expect(members.filter{ $0.clientId == localMember.clientId }).to(haveCount(1))
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.subscribe(.leave) { leave in
-                            expect(leave.clientId).to(equal(localMember.clientId))
-                            done()
-                        }
-
-                        // Request a sync   
-                        let syncMessage = ARTProtocolMessage()
-                        syncMessage.action = .sync
-                        syncMessage.channel = channel.name
-                        guard let transport = client.internal.transport as? TestProxyTransport else {
-                            fail("TestProxyTransport is not set"); done(); return
-                        }
-                        transport.send(syncMessage)
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.get { members, error in
-                            expect(error).to(beNil())
-                            guard let members = members, members.count == 2 else {
-                                fail("Should at least have 2 members"); done(); return
-                            }
-                            expect(members.filter{ $0.clientId == localMember.clientId }).to(beEmpty())
-                            done()
-                        }
-                    }
-                }
-
-                // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                // RTP19a
-                func skipped__test__014__Presence__PresenceMap_has_existing_members_when_a_SYNC_is_started__should_emit_a_LEAVE_event_for_each_existing_member_if_the_PresenceMap_has_existing_members_when_an_ATTACHED_message_is_received_without_a_HAS_PRESENCE_flag() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    let channelName = NSUUID().uuidString
-                    let channel = client.channels.get(channelName)
-
-                    // Inject local members
-                    channel.internal.presenceMap.add(ARTPresenceMessage(clientId: "tester1", action: .enter, connectionId: "another", id: "another:0:0"))
-                    channel.internal.presenceMap.add(ARTPresenceMessage(clientId: "tester2", action: .enter, connectionId: "another", id: "another:0:1"))
-
-                    guard let transport = client.internal.transport as? TestProxyTransport else {
-                        fail("TestProxyTransport is not set"); return
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(4, done: done)
-                        transport.setListenerAfterProcessingIncomingMessage({ protocolMessage in
-                            if protocolMessage.action == .attached {
-                                expect(protocolMessage.hasPresence).to(beFalse())
-                                partialDone()
-                            }
-                        })
-                        channel.presence.subscribe(.leave) { leave in
-                            expect(leave.clientId?.hasPrefix("tester")).to(beTrue())
-                            expect(leave.action).to(equal(ARTPresenceAction.leave))
-                            expect(leave.timestamp).to(beCloseTo(Date(), within: 0.5))
-                            expect(leave.id).to(beNil())
-                            partialDone() //2 times
-                        }
-                        channel.attach { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.get { members, error in
-                            expect(error).to(beNil())
-                            expect(members).to(beEmpty())
-                            done()
-                        }
-                    }
-                }
-
-            // RTP4
-            func skipped__test__002__Presence__should_receive_all_250_members() {
-                let options = AblyTests.commonAppSetup()
-                var clientSource: ARTRealtime!
-                defer { clientSource.dispose(); clientSource.close() }
-                clientSource = AblyTests.addMembersSequentiallyToChannel("test", members: 250, options: options)
-
-                let clientTarget = ARTRealtime(options: options)
-                defer { clientTarget.close() }
-                let channel = clientTarget.channels.get("test")
-
-                waitUntil(timeout: testTimeout) { done in
-                    var pending = 250
-                    channel.presence.subscribe { member in
-                        expect(member.action).to(equal(ARTPresenceAction.present))
-                        pending -= 1
-                        if pending == 0 {
-                            done()
-                        }
-                    }
-                }
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.presence.get() { members, error in
-                        expect(error).to(beNil())
-                        expect(members).to(haveCount(250))
-                        done()
-                    }
-                }
+        var lastSyncSerial: String?
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            guard let transport = client.internal.transport as? TestProxyTransport else {
+                fail("TestProxyTransport is not set"); return
             }
+            transport.setBeforeIncomingMessageModifier { protocolMessage in
+                if protocolMessage.action == .sync {
+                    lastSyncSerial = protocolMessage.channelSerial
+                    expect(lastSyncSerial).toNot(beNil())
+                    client.internal.onDisconnected()
+                    partialDone()
+                    transport.setBeforeIncomingMessageModifier(nil)
+                }
+                return protocolMessage
+            }
+            channel.attach { _ in
+                partialDone()
+            }
+        }
 
-            // RTP6
-            
+        expect(channel.internal.presenceMap.members).toNot(haveCount(membersCount))
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connecting), timeout: DispatchTimeInterval.milliseconds(Int(1000.0 * (options.disconnectedRetryTimeout + 1.0))))
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
 
-                // RTP6a
-                func test__015__Presence__subscribe__with_no_arguments_should_subscribe_a_listener_to_all_presence_messages() {
-                    let options = AblyTests.commonAppSetup()
+        // Client library requests a SYNC resume by sending a SYNC ProtocolMessage with the last received sync serial number
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
 
-                    let client1 = ARTRealtime(options: options)
-                    defer { client1.close() }
-                    let channel1 = client1.channels.get("test")
+        let syncSentProtocolMessages = transport.protocolMessagesSent.filter { $0.action == .sync }
+        guard let syncSentMessage = syncSentProtocolMessages.last, syncSentProtocolMessages.count == 1 else {
+            fail("Should send one SYNC protocol message"); return
+        }
+        expect(syncSentMessage.channelSerial).to(equal(lastSyncSerial))
 
-                    let client2 = ARTRealtime(options: options)
-                    defer { client2.close() }
-                    let channel2 = client2.channels.get("test")
+        expect(transport.protocolMessagesReceived.filter { $0.action == .sync }).toEventually(haveCount(2), timeout: testTimeout)
 
-                    var receivedMembers = [ARTPresenceMessage]()
-                    channel1.presence.subscribe { member in
-                        receivedMembers.append(member)
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, error in
+                expect(error).to(beNil())
+                guard let members = members else {
+                    fail("No present members"); done(); return
+                }
+                expect(members).to(haveCount(membersCount))
+                done()
+            }
+        }
+    }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel2.presence.enterClient("john", data: "online") { err in
-                            channel2.presence.updateClient("john", data: "away") { err in
-                                channel2.presence.leaveClient("john", data: nil) { err in
-                                    done()
-                                }
-                            }
-                        }
-                    }
+    // RTP18
 
-                    expect(receivedMembers).toEventually(haveCount(3), timeout: testTimeout)
-                    if receivedMembers.count != 3 {
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    // RTP18a, RTP18b
+    func skipped__test__011__Presence__realtime_system_reserves_the_right_to_initiate_a_sync_of_the_presence_members_at_any_point_once_a_channel_is_attached__should_do_a_new_sync_whenever_a_SYNC_ProtocolMessage_is_received_with_a_channel_attribute_and_a_new_sync_sequence_identifier_in_the_channelSerial_attribute() {
+        let options = AblyTests.commonAppSetup()
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channelName = NSUUID().uuidString
+        let channel = client.channels.get(channelName)
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        expect(channel.internal.presenceMap.syncInProgress).to(beFalse())
+        expect(channel.internal.presenceMap.members).to(beEmpty())
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.subscribe(.present) { msg in
+                if msg.clientId != "a" {
+                    return
+                }
+                expect(channel.presence.syncComplete).to(beFalse())
+                var aClientHasLeft = false
+                channel.presence.subscribe(.leave) { _ in
+                    if aClientHasLeft {
                         return
                     }
-
-                    expect(receivedMembers[0].action).to(equal(ARTPresenceAction.enter))
-                    expect(receivedMembers[0].data as? NSObject).to(equal("online" as NSObject?))
-                    expect(receivedMembers[0].clientId).to(equal("john"))
-
-                    expect(receivedMembers[1].action).to(equal(ARTPresenceAction.update))
-                    expect(receivedMembers[1].data as? NSObject).to(equal("away" as NSObject?))
-                    expect(receivedMembers[1].clientId).to(equal("john"))
-
-                    expect(receivedMembers[2].action).to(equal(ARTPresenceAction.leave))
-                    expect(receivedMembers[2].data as? NSObject).to(equal("away" as NSObject?))
-                    expect(receivedMembers[2].clientId).to(equal("john"))
+                    aClientHasLeft = true
+                    done()
                 }
+            }
 
-            // RTP7
-            
+            guard let lastConnectionSerial = transport.protocolMessagesReceived.last?.connectionSerial else {
+                fail("No protocol message has been received yet"); done(); return
+            }
 
-                // RTP7a
-                func test__016__Presence__unsubscribe__with_no_arguments_unsubscribes_the_listener_if_previously_subscribed_with_an_action_specific_subscription() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
+            // Inject a SYNC Presence message (first page)
+            let sync1Message = ARTProtocolMessage()
+            sync1Message.action = .sync
+            sync1Message.channel = channel.name
+            sync1Message.channelSerial = "sequenceid:cursor"
+            sync1Message.connectionSerial = lastConnectionSerial + 1
+            sync1Message.timestamp = Date()
+            sync1Message.presence = [
+                ARTPresenceMessage(clientId: "a", action: .present, connectionId: "another", id: "another:0:0"),
+                ARTPresenceMessage(clientId: "b", action: .present, connectionId: "another", id: "another:0:1"),
+            ]
+            transport.receive(sync1Message)
 
-                    let listener = channel.presence.subscribe { _ in }!
-                    expect(channel.internal.presenceEventEmitter.anyListeners).to(haveCount(1))
-                    channel.presence.unsubscribe(listener)
-                    expect(channel.internal.presenceEventEmitter.anyListeners).to(haveCount(0))
+            // Inject a SYNC Presence message (last page)
+            let sync2Message = ARTProtocolMessage()
+            sync2Message.action = .sync
+            sync2Message.channel = channel.name
+            sync2Message.channelSerial = "sequenceid:" // indicates SYNC is complete
+            sync2Message.connectionSerial = lastConnectionSerial + 2
+            sync2Message.timestamp = Date()
+            sync2Message.presence = [
+                ARTPresenceMessage(clientId: "a", action: .leave, connectionId: "another", id: "another:1:0"),
+            ]
+            delay(0.5) {
+                transport.receive(sync2Message)
+            }
+        }
+
+        expect(channel.presence.syncComplete).to(beTrue())
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, error in
+                expect(error).to(beNil())
+                guard let members = members, members.count == 1 else {
+                    fail("Should at least have 1 member"); done(); return
                 }
+                expect(members[0].clientId).to(equal("b"))
+                done()
+            }
+        }
+    }
 
-            // RTP5
-            
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    // RTP18c, RTP18b
+    func skipped__test__012__Presence__realtime_system_reserves_the_right_to_initiate_a_sync_of_the_presence_members_at_any_point_once_a_channel_is_attached__when_a_SYNC_is_sent_with_no_channelSerial_attribute_then_the_sync_data_is_entirely_contained_within_that_ProtocolMessage() {
+        let options = AblyTests.commonAppSetup()
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channelName = NSUUID().uuidString
+        let channel = client.channels.get(channelName)
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
 
-                // RTP5a
-                
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
 
-                    func test__018__Presence__Channel_state_change_side_effects__if_the_channel_enters_the_FAILED_state__all_queued_presence_messages_should_fail_immediately() {
-                        let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
+        expect(channel.internal.presenceMap.syncInProgress).to(beFalse())
+        expect(channel.internal.presenceMap.members).to(beEmpty())
 
-                        waitUntil(timeout: testTimeout) { done in
-                            let protocolError = AblyTests.newErrorProtocolMessage()
-                            channel.presence.enterClient("user", data: nil) { error in
-                                expect(error).to(beIdenticalTo(protocolError.error))
-                                expect(channel.presence.internal.pendingPresence).to(haveCount(0))
-                                done()
-                            }
-                            expect(channel.presence.internal.pendingPresence).to(haveCount(1))
-                            client.internal.rest.queue.async {
-                                channel.internal.onError(protocolError)
-                            }
-                        }
-                    }
-
-                    func skipped__test__019__Presence__Channel_state_change_side_effects__if_the_channel_enters_the_FAILED_state__should_clear_the_PresenceMap_including_local_members_and_does_not_emit_any_presence_events() {
-                        let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            channel.presence.enterClient("user", data: nil) { error in
-                                expect(error).to(beNil())
-                                partialDone()
-                            }
-                            channel.presence.subscribe { message in
-                                expect(message.clientId).to(equal("user"))
-                                channel.presence.unsubscribe()
-                                partialDone()
-                            }
-                        }
-
-                        expect(channel.internal.presenceMap.members).to(haveCount(1))
-                        expect(channel.internal.presenceMap.localMembers).to(haveCount(1))
-
-                        channel.subscribe() { _ in
-                            fail("Shouldn't receive any presence event")
-                        }
-                        defer { channel.off() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.once(.failed) { _ in
-                                expect(channel.internal.presenceMap.members).to(beEmpty())
-                                expect(channel.internal.presenceMap.localMembers).to(beEmpty())
-                                done()
-                            }
-                            AblyTests.queue.async {
-                                channel.internal.onError(AblyTests.newErrorProtocolMessage())
-                            }
-                        }
-                    }
-
-                // RTP5a
-                
-
-                    func test__020__Presence__Channel_state_change_side_effects__if_the_channel_enters_the_DETACHED_state__all_queued_presence_messages_should_fail_immediately() {
-                        let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.once(.attaching) { _ in
-                                channel.detach()
-                            }
-                            channel.presence.enterClient("user", data: nil) { error in
-                                expect(error).toNot(beNil())
-                                expect(client.internal.queuedMessages).to(haveCount(0))
-                                done()
-                            }
-                        }
-                    }
-
-                    func test__021__Presence__Channel_state_change_side_effects__if_the_channel_enters_the_DETACHED_state__should_clear_the_PresenceMap_including_local_members_and_does_not_emit_any_presence_events() {
-                        let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            channel.presence.enterClient("user", data: nil) { error in
-                                expect(error).to(beNil())
-                                partialDone()
-                            }
-                            channel.presence.subscribe { message in
-                                expect(message.clientId).to(equal("user"))
-                                channel.presence.unsubscribe()
-                                partialDone()
-                            }
-                        }
-
-                        expect(channel.internal.presenceMap.members).to(haveCount(1))
-                        expect(channel.internal.presenceMap.localMembers).to(haveCount(1))
-
-                        channel.subscribe() { _ in
-                            fail("Shouldn't receive any presence event")
-                        }
-                        defer { channel.off() }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.once(.detached) { _ in
-                                expect(channel.internal.presenceMap.members).to(beEmpty())
-                                expect(channel.internal.presenceMap.localMembers).to(beEmpty())
-                                done()
-                            }
-                            channel.detach()
-                        }
-                    }
-
-                // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                // RTP5b
-                func skipped__test__017__Presence__Channel_state_change_side_effects__if_a_channel_enters_the_ATTACHED_state_then_all_queued_presence_messages_will_be_sent_immediately_and_a_presence_SYNC_may_be_initiated() {
-                    let options = AblyTests.commonAppSetup()
-                    let client1 = AblyTests.newRealtime(options)
-                    defer { client1.dispose(); client1.close() }
-                    let channel1 = client1.channels.get(NSUUID().uuidString)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel1.presence.enterClient("Client 1", data: nil) { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            done()
-                        }
-                    }
-
-                    let client2 = AblyTests.newRealtime(options)
-                    defer { client2.dispose(); client2.close() }
-                    let channel2 = client2.channels.get(channel1.name)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channel2.presence.enterClient("Client 2", data: nil) { error in
-                            expect(error).to(beNil())
-                            expect(client2.internal.queuedMessages).to(haveCount(0))
-                            expect(channel2.state).to(equal(ARTRealtimeChannelState.attached))
-                            partialDone()
-                        }
-                        channel2.presence.subscribe(.enter) { _ in
-                            if channel2.presence.syncComplete {
-                                expect(channel2.internal.presenceMap.members).to(haveCount(2))
-                            }
-                            else {
-                                expect(channel2.internal.presenceMap.members).to(haveCount(1))
-                            }
-                            channel2.presence.unsubscribe()
-                            partialDone()
-                        }
-
-                        expect(client2.internal.queuedMessages).to(haveCount(1))
-                        expect(channel2.presence.syncComplete).to(beFalse())
-                        expect(channel2.internal.presenceMap.members).to(haveCount(0))
-                    }
-
-                    guard let transport = client2.internal.transport as? TestProxyTransport else {
-                        fail("Transport should be a test proxy"); return
-                    }
-
-                    expect(transport.protocolMessagesReceived.filter{ $0.action == .sync }).to(haveCount(1))
-
-                    expect(channel2.presence.syncComplete).toEventually(beTrue(), timeout: testTimeout)
-                    expect(channel2.internal.presenceMap.members).to(haveCount(2))
+        waitUntil(timeout: testTimeout) { done in
+            var aClientHasLeft = false
+            channel.presence.subscribe(.leave) { _ in
+                if aClientHasLeft {
+                    return
                 }
+                aClientHasLeft = true
+                done()
+            }
 
-                // RTP5f
-                
+            guard let lastConnectionSerial = transport.protocolMessagesReceived.last?.connectionSerial else {
+                fail("No protocol message has been received yet"); done(); return
+            }
 
-                    func test__022__Presence__Channel_state_change_side_effects__channel_enters_the_SUSPENDED_state__all_queued_presence_messages_should_fail_immediately() {
-                        let options = AblyTests.commonAppSetup()
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-                        let channelName = NSUUID().uuidString
-                        let channel = client.channels.get(channelName)
+            // Inject a SYNC Presence message (entirely contained)
+            let syncMessage = ARTProtocolMessage()
+            syncMessage.action = .sync
+            syncMessage.channel = channel.name
+            syncMessage.connectionSerial = lastConnectionSerial + 1
+            syncMessage.timestamp = Date()
+            syncMessage.presence = [
+                ARTPresenceMessage(clientId: "a", action: .present, connectionId: "another", id: "another:0:0"),
+                ARTPresenceMessage(clientId: "b", action: .present, connectionId: "another", id: "another:0:1"),
+                ARTPresenceMessage(clientId: "a", action: .leave, connectionId: "another", id: "another:1:0"),
+            ]
+            transport.receive(syncMessage)
+        }
 
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(3, done: done)
-                            channel.once(.attaching) { stateChange in
-                                expect(stateChange.reason).to(beNil())
-                                expect(channel.presence.internal.pendingPresence.count) == 1
-                                channel.internalAsync { _internal in
-                                    _internal.setSuspended(ARTStatus.state(.error, info: ARTErrorInfo.create(withCode: 1234, message: "unknown error")))
-                                }
-                                partialDone()
-                            }
-                            channel.once(.suspended) { stateChange in
-                                // All queued presence messages will fail immediately
-                                expect(channel.presence.internal.pendingPresence.count) == 0
-                                partialDone()
-                            }
-                            channel.presence.enterClient("tester", data: nil) { error in
-                                guard let error = error else {
-                                    fail("Error is nil"); partialDone(); return
-                                }
-                                expect((error ).code) == 1234
-                                expect(error.message).to(contain("unknown error"))
-                                partialDone()
-                            }
-                        }
-                    }
-
-                    func test__023__Presence__Channel_state_change_side_effects__channel_enters_the_SUSPENDED_state__should_maintain_the_PresenceMap_and_any_members_present_before_and_after_the_sync_should_not_emit_presence_events() {
-                        let options = AblyTests.commonAppSetup()
-                        let channelName = NSUUID().uuidString
-
-                        var clientMembers: ARTRealtime?
-                        clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 3, options: options)
-                        defer { clientMembers?.dispose(); clientMembers?.close() }
-
-                        options.clientId = "tester"
-                        options.tokenDetails = getTestTokenDetails(key: options.key!, clientId: options.clientId, ttl: 5.0)
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get(channelName)
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(3, done: done)
-                            channel.presence.enter(nil) { error in
-                                expect(error).to(beNil())
-                                partialDone()
-                            }
-                            channel.presence.get { members, error in
-                                expect(error).to(beNil())
-                                expect(members).to(haveCount(3))
-                                partialDone()
-                            }
-                            channel.presence.subscribe(.enter) { message in
-                                if message.clientId == "tester" {
-                                    channel.presence.unsubscribe()
-                                    partialDone()
-                                }
-                            }
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(4, done: done)
-                            channel.presence.subscribe { presence in
-                                expect(presence.action).to(equal(ARTPresenceAction.leave))
-                                expect(presence.clientId).to(equal("tester"))
-                                partialDone()
-                            }
-                            channel.once(.suspended) { stateChange in
-                                channel.internalSync { _internal in
-                                    expect(_internal.presenceMap.members).to(haveCount(4))
-                                    expect(_internal.presenceMap.localMembers).to(haveCount(1))
-                                }
-                                partialDone()
-                            }
-                            channel.once(.attached) { stateChange in
-                                expect(stateChange.reason).to(beNil())
-                                channel.presence.leave(nil) { error in
-                                    expect(error).to(beNil())
-                                    partialDone()
-                                }
-                                partialDone()
-                            }
-                            channel.internalAsync { _internal in
-                                _internal.setSuspended(ARTStatus.state(.ok))
-                            }
-                        }
-
-                        channel.presence.unsubscribe()
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.presence.get { members, error in
-                                expect(error).to(beNil())
-                                guard let members = members else {
-                                    fail("Members is nil"); done(); return
-                                }
-                                expect(members).to(haveCount(3))
-                                expect(members).to(allPass({ (member: ARTPresenceMessage?) in member!.action != .absent }))
-                                done()
-                            }
-                        }
-
-                        channel.internalSync { _internal in
-                            expect(_internal.presenceMap.members).to(haveCount(3))
-                            expect(_internal.presenceMap.localMembers).to(beEmpty())
-                        }
-                    }
-
-            // RTP8
-            
-
-                // RTP8a
-                func skipped__test__024__Presence__enter__should_enter_the_current_client__optionally_with_the_data_provided() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-
-                    let client1 = ARTRealtime(options: options)
-                    defer { client1.close() }
-                    let channel1 = client1.channels.get("test")
-
-                    let client2 = ARTRealtime(options: options)
-                    defer { client2.close() }
-                    let channel2 = client2.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel1.attach { err in 
-                            expect(err).to(beNil())
-                            channel1.presence.subscribe(.enter) { member in
-                                expect(member.clientId).to(equal(options.clientId))
-                                expect(member.data as? NSObject).to(equal("online" as NSObject?))
-                                done()
-                            }
-                            channel2.presence.enter("online")
-                        }
-                    }
+        expect(channel.presence.syncComplete).to(beTrue())
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, error in
+                expect(error).to(beNil())
+                guard let members = members, members.count == 1 else {
+                    fail("Should at least have 1 member"); done(); return
                 }
+                expect(members[0].clientId).to(equal("b"))
+                done()
+            }
+        }
+    }
 
-            // RTP7
-            
+    // RTP19
 
-                // RTP7b
-                func test__025__Presence__unsubscribe__with_a_single_action_argument_unsubscribes_the_provided_listener_to_all_presence_messages_for_that_action() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
+    func skipped__test__013__Presence__PresenceMap_has_existing_members_when_a_SYNC_is_started__should_ensure_that_members_no_longer_present_on_the_channel_are_removed_from_the_local_PresenceMap_once_the_sync_is_complete() {
+        let options = AblyTests.commonAppSetup()
+        let channelName = NSUUID().uuidString
+        var clientMembers: ARTRealtime?
+        defer { clientMembers?.dispose(); clientMembers?.close() }
+        clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 2, options: options)
 
-                    let listener = channel.presence.subscribe(.present) { _ in }!
-                    expect(channel.internal.presenceEventEmitter.listeners).to(haveCount(1))
-                    channel.presence.unsubscribe(.present, listener: listener)
-                    expect(channel.internal.presenceEventEmitter.listeners).to(haveCount(0))
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get(channelName)
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, error in
+                expect(error).to(beNil())
+                expect(members).to(haveCount(2)) // synced
+                done()
+            }
+        }
+
+        expect(channel.internal.presenceMap.members).to(haveCount(2))
+        // Inject a local member
+        let localMember = ARTPresenceMessage(clientId: NSUUID().uuidString, action: .enter, connectionId: "another", id: "another:0:0")
+        channel.internal.presenceMap.add(localMember)
+        expect(channel.internal.presenceMap.members).to(haveCount(3))
+        expect(channel.internal.presenceMap.members.filter { memberKey, _ in memberKey.contains(localMember.clientId!) }).to(haveCount(1))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, error in
+                expect(error).to(beNil())
+                guard let members = members, members.count == 3 else {
+                    fail("Should at least have 3 members"); done(); return
                 }
+                expect(members.filter { $0.clientId == localMember.clientId }).to(haveCount(1))
+                done()
+            }
+        }
 
-            // RTP6
-            
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.subscribe(.leave) { leave in
+                expect(leave.clientId).to(equal(localMember.clientId))
+                done()
+            }
 
-                // RTP6c
-                func test__026__Presence__subscribe__should_implicitly_attach_the_channel() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
+            // Request a sync
+            let syncMessage = ARTProtocolMessage()
+            syncMessage.action = .sync
+            syncMessage.channel = channel.name
+            guard let transport = client.internal.transport as? TestProxyTransport else {
+                fail("TestProxyTransport is not set"); done(); return
+            }
+            transport.send(syncMessage)
+        }
 
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
-                    channel.presence.subscribe { _ in }
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                    channel.detach()
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
-
-                    channel.presence.subscribe(.present) { _ in }
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, error in
+                expect(error).to(beNil())
+                guard let members = members, members.count == 2 else {
+                    fail("Should at least have 2 members"); done(); return
                 }
+                expect(members.filter { $0.clientId == localMember.clientId }).to(beEmpty())
+                done()
+            }
+        }
+    }
 
-                // RTP6c
-                func test__027__Presence__subscribe__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    // RTP19a
+    func skipped__test__014__Presence__PresenceMap_has_existing_members_when_a_SYNC_is_started__should_emit_a_LEAVE_event_for_each_existing_member_if_the_PresenceMap_has_existing_members_when_an_ATTACHED_message_is_received_without_a_HAS_PRESENCE_flag() {
+        let options = AblyTests.commonAppSetup()
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channelName = NSUUID().uuidString
+        let channel = client.channels.get(channelName)
 
-                    let channel = client.channels.get("test")
-                    channel.internal.onError(AblyTests.newErrorProtocolMessage())
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+        // Inject local members
+        channel.internal.presenceMap.add(ARTPresenceMessage(clientId: "tester1", action: .enter, connectionId: "another", id: "another:0:0"))
+        channel.internal.presenceMap.add(ARTPresenceMessage(clientId: "tester2", action: .enter, connectionId: "another", id: "another:0:1"))
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.subscribe(attachCallback: { errorInfo in
-                            expect(errorInfo).toNot(beNil())
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
 
-                            channel.presence.subscribe(.enter, onAttach: { errorInfo in
-                                expect(errorInfo).toNot(beNil())
-                                done()
-                            }) { _ in }
-                        }) { _ in }
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(4, done: done)
+            transport.setListenerAfterProcessingIncomingMessage { protocolMessage in
+                if protocolMessage.action == .attached {
+                    expect(protocolMessage.hasPresence).to(beFalse())
+                    partialDone()
                 }
+            }
+            channel.presence.subscribe(.leave) { leave in
+                expect(leave.clientId?.hasPrefix("tester")).to(beTrue())
+                expect(leave.action).to(equal(ARTPresenceAction.leave))
+                expect(leave.timestamp).to(beCloseTo(Date(), within: 0.5))
+                expect(leave.id).to(beNil())
+                partialDone() // 2 times
+            }
+            channel.attach { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
 
-                // RTP6c
-                func test__028__Presence__subscribe__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, error in
+                expect(error).to(beNil())
+                expect(members).to(beEmpty())
+                done()
+            }
+        }
+    }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        let error = AblyTests.newErrorProtocolMessage()
-                        channel.presence.subscribe(attachCallback: { errorInfo in
-                            expect(errorInfo).toNot(beNil())
+    // RTP4
+    func skipped__test__002__Presence__should_receive_all_250_members() {
+        let options = AblyTests.commonAppSetup()
+        var clientSource: ARTRealtime!
+        defer { clientSource.dispose(); clientSource.close() }
+        clientSource = AblyTests.addMembersSequentiallyToChannel("test", members: 250, options: options)
 
-                            channel.presence.subscribe(.enter, onAttach: { errorInfo in
-                                expect(errorInfo).toNot(beNil())
-                                done()
-                            }) { _ in }
-                        }) {_ in }
-                        AblyTests.queue.async {
-                            channel.internal.onError(error)
-                        }
-                    }
+        let clientTarget = ARTRealtime(options: options)
+        defer { clientTarget.close() }
+        let channel = clientTarget.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            var pending = 250
+            channel.presence.subscribe { member in
+                expect(member.action).to(equal(ARTPresenceAction.present))
+                pending -= 1
+                if pending == 0 {
+                    done()
                 }
-
-            // RTP6
-            
-
-                // RTP6b
-                func test__029__Presence__subscribe__with_a_single_action_argument() {
-                    let options = AblyTests.commonAppSetup()
-
-                    let client1 = ARTRealtime(options: options)
-                    defer { client1.close() }
-                    let channel1 = client1.channels.get("test")
-
-                    let client2 = ARTRealtime(options: options)
-                    defer { client2.close() }
-                    let channel2 = client2.channels.get("test")
-
-                    var count = 0
-                    channel1.presence.subscribe(.update) { member in
-                        expect(member.action).to(equal(ARTPresenceAction.update))
-                        expect(member.clientId).to(equal("john"))
-                        expect(member.data as? NSObject).to(equal("away" as NSObject?))
-                        count += 1
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel2.presence.enterClient("john", data: "online") { error in
-                            expect(error).to(beNil())
-                            channel2.presence.updateClient("john", data: "away") { error in
-                                expect(error).to(beNil())
-                                channel2.presence.leaveClient("john", data: nil) { error in
-                                    expect(error).to(beNil())
-                                    done()
-                                }
-                            }
-                        }
-                    }
-
-                    expect(count).toEventually(equal(1), timeout: testTimeout)
-                }
-
-            // RTP8
-            
-
-                // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                // RTP8b
-                func skipped__test__030__Presence__enter__optionally_a_callback_can_be_provided_that_is_called_for_success() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-
-                    let client1 = ARTRealtime(options: options)
-                    defer { client1.close() }
-                    let channel1 = client1.channels.get("test")
-
-                    let client2 = ARTRealtime(options: options)
-                    defer { client2.close() }
-                    let channel2 = client2.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel1.presence.subscribe(.enter) { member in
-                            expect(member.clientId).to(equal(options.clientId))
-                            expect(member.data as? NSObject).to(equal("online" as NSObject?))
-                            done()
-                        }
-                        channel2.presence.enter("online") { error in
-                            expect(error).to(beNil())
-                        }
-                    }
-                }
-
-                // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                // RTP8b
-                func skipped__test__031__Presence__enter__optionally_a_callback_can_be_provided_that_is_called_for_failure() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-
-                    let client1 = ARTRealtime(options: options)
-                    defer { client1.close() }
-                    let channel1 = client1.channels.get("test")
-
-                    let client2 = ARTRealtime(options: options)
-                    defer { client2.close() }
-                    let channel2 = client2.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel1.presence.subscribe(.enter) { member in
-                            fail("shouldn't be called")
-                        }
-                        let protocolError = AblyTests.newErrorProtocolMessage()
-                        channel2.presence.enter("online") { error in
-                            expect(error).to(beIdenticalTo(protocolError.error))
-                            done()
-                        }
-                        delay(0.1) {
-                            channel2.internal.onError(protocolError)
-                        }
-                    }
-                }
-
-                // RTP8c
-                func test__032__Presence__enter__entering_without_an_explicit_PresenceMessage_clientId_should_implicitly_use_the_clientId_of_the_current_connection() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channel.presence.enter("online") { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                        channel.presence.subscribe { message in
-                            expect(message.clientId).to(equal("john"))
-                            channel.presence.unsubscribe()
-                            partialDone()
-                        }
-                    }
-
-                    let transport = client.internal.transport as! TestProxyTransport
-                    let sent = transport.protocolMessagesSent.filter({ $0.action == .presence })[0].presence![0]
-                    expect(sent.action).to(equal(ARTPresenceAction.enter))
-                    expect(sent.clientId).to(beNil())
-
-                    let received = transport.protocolMessagesReceived.filter({ $0.action == .presence })[0].presence![0]
-                    expect(received.action).to(equal(ARTPresenceAction.enter))
-                    expect(received.clientId).to(equal("john"))
-                }
-
-            // RTP8
-            
-
-                // RTP8f
-                func test__033__Presence__enter__should_result_in_an_error_immediately_if_the_client_is_anonymous() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enter(nil) { error in
-                            expect(error!.message).to(contain("attempted to publish presence message without clientId"))
-                            done()
-                        }
-                    }
-                }
-
-            // RTP8
-            
-
-                // RTP8g
-                func test__034__Presence__enter__should_result_in_an_error_immediately_if_the_channel_is_DETACHED() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { _ in
-                            channel.detach() { _ in done() }
-                        }
-                    }
-                    
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enter(nil) { error in
-                            expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
-                            done()
-                        }
-                    }
-                }
-
-                // RTP8g
-                func test__035__Presence__enter__should_result_in_an_error_immediately_if_the_channel_is_FAILED() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        AblyTests.queue.async {
-                            channel.internal.onError(AblyTests.newErrorProtocolMessage())
-                            done()
-                        }
-                    }
-
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-                        
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enter(nil) { error in
-                            expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
-                            done()
-                        }
-                    }
-                }
-
-            // RTP8
-            
-
-                // RTP8i
-                func test__036__Presence__enter__should_result_in_an_error_if_Ably_service_determines_that_the_client_is_unidentified() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enter(nil) { error in
-                            expect(error!.message).to(contain("presence message without clientId"))
-                            done()
-                        }
-                    }
-                }
-
-            // RTP9
-            
-
-                // RTP9a
-                func test__037__Presence__update__should_update_the_data_for_the_present_member_with_a_value() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.subscribe(.enter) { member in
-                            expect(member.data).to(beNil())
-                            done()
-                        }
-                        channel.presence.enter(nil)
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.subscribe(.update) { member in
-                            expect(member.data as? NSObject).to(equal("online" as NSObject?))
-                            done()
-                        }
-                        channel.presence.update("online")
-                    }
-                }
-
-                // RTP9a
-                func skipped__test__038__Presence__update__should_update_the_data_for_the_present_member_with_null() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.subscribe(.enter) { member in
-                            expect(member.data as? NSObject).to(equal("online" as NSObject?))
-                            done()
-                        }
-                        channel.presence.enter("online")
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.subscribe(.update) { member in
-                            expect(member.data).to(beNil())
-                            done()
-                        }
-                        channel.presence.update(nil)
-                    }
-                }
-
-            // RTP9
-            
-
-                // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                // RTP9b
-                func skipped__test__039__Presence__update__should_enter_current_client_into_the_channel_if_the_client_was_not_already_entered() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    expect(channel.internal.presenceMap.members).to(haveCount(0))
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.subscribe(.enter) { member in
-                            expect(member.clientId).to(equal("john"))
-                            expect(member.data as? NSObject).to(equal("online" as NSObject?))
-                            done()
-                        }
-                        channel.presence.update("online")
-                    }
-                }
-
-            // RTP9
-            
-
-                // RTP9c
-                func test__040__Presence__update__optionally_a_callback_can_be_provided_that_is_called_for_success() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.update("online") { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
-
-                // RTP9c
-                func test__041__Presence__update__optionally_a_callback_can_be_provided_that_is_called_for_failure() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let protocolError = AblyTests.newErrorProtocolMessage()
-                        channel.once(.attaching) { _ in
-                            AblyTests.queue.async {
-                                channel.internal.onError(protocolError)
-                            }
-                        }
-                        (client.internal.transport as! TestProxyTransport).actionsIgnored += [.attached]
-                        channel.presence.update("online") { error in
-                            expect(error).to(beIdenticalTo(protocolError.error))
-                            done()
-                        }
-                    }
-                }
-
-                // RTP9d
-                func test__042__Presence__update__update_without_an_explicit_PresenceMessage_clientId_should_implicitly_use_the_clientId_of_the_current_connection() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enter("online") { error in
-                            channel.presence.update("offline") { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-                    }
-
-                    let transport = client.internal.transport as! TestProxyTransport
-                    let sent = transport.protocolMessagesSent.filter({ $0.action == .presence })[1].presence![0]
-                    expect(sent.action).to(equal(ARTPresenceAction.update))
-                    expect(sent.clientId).to(beNil())
-
-                    let receivedPresenceProtocolMessages = transport.protocolMessagesReceived.filter({ $0.action == .presence })
-                    let receivedPresenceMessages = receivedPresenceProtocolMessages.flatMap({ $0.presence! })
-                    let received = receivedPresenceMessages.filter({ $0.action == .update })[0]
-                    expect(received.action).to(equal(ARTPresenceAction.update))
-                    expect(received.clientId).to(equal("john"))
-                }
-
-            // RTP10
-            
-
-                // RTP10a
-                func skipped__test__043__Presence__leave__should_leave_the_current_client_from_the_channel_and_the_data_will_be_updated_with_the_value_provided() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.subscribe(.enter) { member in
-                            expect(member.data as? NSObject).to(equal("online" as NSObject?))
-                            done()
-                        }
-                        channel.presence.enter("online")
-                    }
-
-                    expect(channel.internal.presenceMap.members).toEventually(haveCount(1), timeout: testTimeout)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.subscribe(.leave) { member in
-                            expect(member.data as? NSObject).to(equal("offline" as NSObject?))
-                            done()
-                        }
-                        channel.presence.leave("offline")
-                    }
-
-                    expect(channel.internal.presenceMap.members).toEventually(haveCount(0), timeout: testTimeout)
-                }
-
-                // RTP10a
-                func skipped__test__044__Presence__leave__should_leave_the_current_client_with_no_data() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.subscribe(.enter) { member in
-                            expect(member.data as? NSObject).to(equal("online" as NSObject?))
-                            done()
-                        }
-                        channel.presence.enter("online")
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.subscribe(.leave) { member in
-                            expect(member.data as? NSObject).to(equal("online" as NSObject?))
-                            done()
-                        }
-                        channel.presence.leave(nil)
-                    }
-                }
-
-            // RTP2
-            func skipped__test__003__Presence__should_be_used_a_PresenceMap_to_maintain_a_list_of_members() {
-                let options = AblyTests.commonAppSetup()
-                var clientSecondary: ARTRealtime!
-                defer { clientSecondary.dispose(); clientSecondary.close() }
-                clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: 100, options: options)
-
-                let client = AblyTests.newRealtime(options)
-                defer { client.dispose(); client.close() }
-                let channel = client.channels.get("test")
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.attach() { error in
-                        expect(error).to(beNil())
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, error in
+                expect(error).to(beNil())
+                expect(members).to(haveCount(250))
+                done()
+            }
+        }
+    }
+
+    // RTP6
+
+    // RTP6a
+    func test__015__Presence__subscribe__with_no_arguments_should_subscribe_a_listener_to_all_presence_messages() {
+        let options = AblyTests.commonAppSetup()
+
+        let client1 = ARTRealtime(options: options)
+        defer { client1.close() }
+        let channel1 = client1.channels.get("test")
+
+        let client2 = ARTRealtime(options: options)
+        defer { client2.close() }
+        let channel2 = client2.channels.get("test")
+
+        var receivedMembers = [ARTPresenceMessage]()
+        channel1.presence.subscribe { member in
+            receivedMembers.append(member)
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel2.presence.enterClient("john", data: "online") { _ in
+                channel2.presence.updateClient("john", data: "away") { _ in
+                    channel2.presence.leaveClient("john", data: nil) { _ in
                         done()
                     }
                 }
+            }
+        }
 
+        expect(receivedMembers).toEventually(haveCount(3), timeout: testTimeout)
+        if receivedMembers.count != 3 {
+            return
+        }
+
+        expect(receivedMembers[0].action).to(equal(ARTPresenceAction.enter))
+        expect(receivedMembers[0].data as? NSObject).to(equal("online" as NSObject?))
+        expect(receivedMembers[0].clientId).to(equal("john"))
+
+        expect(receivedMembers[1].action).to(equal(ARTPresenceAction.update))
+        expect(receivedMembers[1].data as? NSObject).to(equal("away" as NSObject?))
+        expect(receivedMembers[1].clientId).to(equal("john"))
+
+        expect(receivedMembers[2].action).to(equal(ARTPresenceAction.leave))
+        expect(receivedMembers[2].data as? NSObject).to(equal("away" as NSObject?))
+        expect(receivedMembers[2].clientId).to(equal("john"))
+    }
+
+    // RTP7
+
+    // RTP7a
+    func test__016__Presence__unsubscribe__with_no_arguments_unsubscribes_the_listener_if_previously_subscribed_with_an_action_specific_subscription() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        let listener = channel.presence.subscribe { _ in }!
+        expect(channel.internal.presenceEventEmitter.anyListeners).to(haveCount(1))
+        channel.presence.unsubscribe(listener)
+        expect(channel.internal.presenceEventEmitter.anyListeners).to(haveCount(0))
+    }
+
+    // RTP5
+
+    // RTP5a
+
+    func test__018__Presence__Channel_state_change_side_effects__if_the_channel_enters_the_FAILED_state__all_queued_presence_messages_should_fail_immediately() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            let protocolError = AblyTests.newErrorProtocolMessage()
+            channel.presence.enterClient("user", data: nil) { error in
+                expect(error).to(beIdenticalTo(protocolError.error))
+                expect(channel.presence.internal.pendingPresence).to(haveCount(0))
+                done()
+            }
+            expect(channel.presence.internal.pendingPresence).to(haveCount(1))
+            client.internal.rest.queue.async {
+                channel.internal.onError(protocolError)
+            }
+        }
+    }
+
+    func skipped__test__019__Presence__Channel_state_change_side_effects__if_the_channel_enters_the_FAILED_state__should_clear_the_PresenceMap_including_local_members_and_does_not_emit_any_presence_events() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.presence.enterClient("user", data: nil) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+            channel.presence.subscribe { message in
+                expect(message.clientId).to(equal("user"))
                 channel.presence.unsubscribe()
-                waitUntil(timeout: testTimeout) { done in
-                    channel.presence.get { members, error in
+                partialDone()
+            }
+        }
+
+        expect(channel.internal.presenceMap.members).to(haveCount(1))
+        expect(channel.internal.presenceMap.localMembers).to(haveCount(1))
+
+        channel.subscribe { _ in
+            fail("Shouldn't receive any presence event")
+        }
+        defer { channel.off() }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.failed) { _ in
+                expect(channel.internal.presenceMap.members).to(beEmpty())
+                expect(channel.internal.presenceMap.localMembers).to(beEmpty())
+                done()
+            }
+            AblyTests.queue.async {
+                channel.internal.onError(AblyTests.newErrorProtocolMessage())
+            }
+        }
+    }
+
+    // RTP5a
+
+    func test__020__Presence__Channel_state_change_side_effects__if_the_channel_enters_the_DETACHED_state__all_queued_presence_messages_should_fail_immediately() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.attaching) { _ in
+                channel.detach()
+            }
+            channel.presence.enterClient("user", data: nil) { error in
+                expect(error).toNot(beNil())
+                expect(client.internal.queuedMessages).to(haveCount(0))
+                done()
+            }
+        }
+    }
+
+    func test__021__Presence__Channel_state_change_side_effects__if_the_channel_enters_the_DETACHED_state__should_clear_the_PresenceMap_including_local_members_and_does_not_emit_any_presence_events() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.presence.enterClient("user", data: nil) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+            channel.presence.subscribe { message in
+                expect(message.clientId).to(equal("user"))
+                channel.presence.unsubscribe()
+                partialDone()
+            }
+        }
+
+        expect(channel.internal.presenceMap.members).to(haveCount(1))
+        expect(channel.internal.presenceMap.localMembers).to(haveCount(1))
+
+        channel.subscribe { _ in
+            fail("Shouldn't receive any presence event")
+        }
+        defer { channel.off() }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.once(.detached) { _ in
+                expect(channel.internal.presenceMap.members).to(beEmpty())
+                expect(channel.internal.presenceMap.localMembers).to(beEmpty())
+                done()
+            }
+            channel.detach()
+        }
+    }
+
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    // RTP5b
+    func skipped__test__017__Presence__Channel_state_change_side_effects__if_a_channel_enters_the_ATTACHED_state_then_all_queued_presence_messages_will_be_sent_immediately_and_a_presence_SYNC_may_be_initiated() {
+        let options = AblyTests.commonAppSetup()
+        let client1 = AblyTests.newRealtime(options)
+        defer { client1.dispose(); client1.close() }
+        let channel1 = client1.channels.get(NSUUID().uuidString)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel1.presence.enterClient("Client 1", data: nil) { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+
+        let client2 = AblyTests.newRealtime(options)
+        defer { client2.dispose(); client2.close() }
+        let channel2 = client2.channels.get(channel1.name)
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel2.presence.enterClient("Client 2", data: nil) { error in
+                expect(error).to(beNil())
+                expect(client2.internal.queuedMessages).to(haveCount(0))
+                expect(channel2.state).to(equal(ARTRealtimeChannelState.attached))
+                partialDone()
+            }
+            channel2.presence.subscribe(.enter) { _ in
+                if channel2.presence.syncComplete {
+                    expect(channel2.internal.presenceMap.members).to(haveCount(2))
+                } else {
+                    expect(channel2.internal.presenceMap.members).to(haveCount(1))
+                }
+                channel2.presence.unsubscribe()
+                partialDone()
+            }
+
+            expect(client2.internal.queuedMessages).to(haveCount(1))
+            expect(channel2.presence.syncComplete).to(beFalse())
+            expect(channel2.internal.presenceMap.members).to(haveCount(0))
+        }
+
+        guard let transport = client2.internal.transport as? TestProxyTransport else {
+            fail("Transport should be a test proxy"); return
+        }
+
+        expect(transport.protocolMessagesReceived.filter { $0.action == .sync }).to(haveCount(1))
+
+        expect(channel2.presence.syncComplete).toEventually(beTrue(), timeout: testTimeout)
+        expect(channel2.internal.presenceMap.members).to(haveCount(2))
+    }
+
+    // RTP5f
+
+    func test__022__Presence__Channel_state_change_side_effects__channel_enters_the_SUSPENDED_state__all_queued_presence_messages_should_fail_immediately() {
+        let options = AblyTests.commonAppSetup()
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channelName = NSUUID().uuidString
+        let channel = client.channels.get(channelName)
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(3, done: done)
+            channel.once(.attaching) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                expect(channel.presence.internal.pendingPresence.count) == 1
+                channel.internalAsync { _internal in
+                    _internal.setSuspended(ARTStatus.state(.error, info: ARTErrorInfo.create(withCode: 1234, message: "unknown error")))
+                }
+                partialDone()
+            }
+            channel.once(.suspended) { _ in
+                // All queued presence messages will fail immediately
+                expect(channel.presence.internal.pendingPresence.count) == 0
+                partialDone()
+            }
+            channel.presence.enterClient("tester", data: nil) { error in
+                guard let error = error else {
+                    fail("Error is nil"); partialDone(); return
+                }
+                expect(error.code) == 1234
+                expect(error.message).to(contain("unknown error"))
+                partialDone()
+            }
+        }
+    }
+
+    func test__023__Presence__Channel_state_change_side_effects__channel_enters_the_SUSPENDED_state__should_maintain_the_PresenceMap_and_any_members_present_before_and_after_the_sync_should_not_emit_presence_events() {
+        let options = AblyTests.commonAppSetup()
+        let channelName = NSUUID().uuidString
+
+        var clientMembers: ARTRealtime?
+        clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 3, options: options)
+        defer { clientMembers?.dispose(); clientMembers?.close() }
+
+        options.clientId = "tester"
+        options.tokenDetails = getTestTokenDetails(key: options.key!, clientId: options.clientId, ttl: 5.0)
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get(channelName)
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(3, done: done)
+            channel.presence.enter(nil) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+            channel.presence.get { members, error in
+                expect(error).to(beNil())
+                expect(members).to(haveCount(3))
+                partialDone()
+            }
+            channel.presence.subscribe(.enter) { message in
+                if message.clientId == "tester" {
+                    channel.presence.unsubscribe()
+                    partialDone()
+                }
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(4, done: done)
+            channel.presence.subscribe { presence in
+                expect(presence.action).to(equal(ARTPresenceAction.leave))
+                expect(presence.clientId).to(equal("tester"))
+                partialDone()
+            }
+            channel.once(.suspended) { _ in
+                channel.internalSync { _internal in
+                    expect(_internal.presenceMap.members).to(haveCount(4))
+                    expect(_internal.presenceMap.localMembers).to(haveCount(1))
+                }
+                partialDone()
+            }
+            channel.once(.attached) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                channel.presence.leave(nil) { error in
+                    expect(error).to(beNil())
+                    partialDone()
+                }
+                partialDone()
+            }
+            channel.internalAsync { _internal in
+                _internal.setSuspended(ARTStatus.state(.ok))
+            }
+        }
+
+        channel.presence.unsubscribe()
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, error in
+                expect(error).to(beNil())
+                guard let members = members else {
+                    fail("Members is nil"); done(); return
+                }
+                expect(members).to(haveCount(3))
+                expect(members).to(allPass { (member: ARTPresenceMessage?) in member!.action != .absent })
+                done()
+            }
+        }
+
+        channel.internalSync { _internal in
+            expect(_internal.presenceMap.members).to(haveCount(3))
+            expect(_internal.presenceMap.localMembers).to(beEmpty())
+        }
+    }
+
+    // RTP8
+
+    // RTP8a
+    func skipped__test__024__Presence__enter__should_enter_the_current_client__optionally_with_the_data_provided() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+
+        let client1 = ARTRealtime(options: options)
+        defer { client1.close() }
+        let channel1 = client1.channels.get("test")
+
+        let client2 = ARTRealtime(options: options)
+        defer { client2.close() }
+        let channel2 = client2.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel1.attach { err in
+                expect(err).to(beNil())
+                channel1.presence.subscribe(.enter) { member in
+                    expect(member.clientId).to(equal(options.clientId))
+                    expect(member.data as? NSObject).to(equal("online" as NSObject?))
+                    done()
+                }
+                channel2.presence.enter("online")
+            }
+        }
+    }
+
+    // RTP7
+
+    // RTP7b
+    func test__025__Presence__unsubscribe__with_a_single_action_argument_unsubscribes_the_provided_listener_to_all_presence_messages_for_that_action() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        let listener = channel.presence.subscribe(.present) { _ in }!
+        expect(channel.internal.presenceEventEmitter.listeners).to(haveCount(1))
+        channel.presence.unsubscribe(.present, listener: listener)
+        expect(channel.internal.presenceEventEmitter.listeners).to(haveCount(0))
+    }
+
+    // RTP6
+
+    // RTP6c
+    func test__026__Presence__subscribe__should_implicitly_attach_the_channel() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
+        channel.presence.subscribe { _ in }
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        channel.detach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
+
+        channel.presence.subscribe(.present) { _ in }
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+    }
+
+    // RTP6c
+    func test__027__Presence__subscribe__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get("test")
+        channel.internal.onError(AblyTests.newErrorProtocolMessage())
+        expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.subscribe(attachCallback: { errorInfo in
+                expect(errorInfo).toNot(beNil())
+
+                channel.presence.subscribe(.enter, onAttach: { errorInfo in
+                    expect(errorInfo).toNot(beNil())
+                    done()
+                }) { _ in }
+            }) { _ in }
+        }
+    }
+
+    // RTP6c
+    func test__028__Presence__subscribe__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            let error = AblyTests.newErrorProtocolMessage()
+            channel.presence.subscribe(attachCallback: { errorInfo in
+                expect(errorInfo).toNot(beNil())
+
+                channel.presence.subscribe(.enter, onAttach: { errorInfo in
+                    expect(errorInfo).toNot(beNil())
+                    done()
+                }) { _ in }
+            }) { _ in }
+            AblyTests.queue.async {
+                channel.internal.onError(error)
+            }
+        }
+    }
+
+    // RTP6
+
+    // RTP6b
+    func test__029__Presence__subscribe__with_a_single_action_argument() {
+        let options = AblyTests.commonAppSetup()
+
+        let client1 = ARTRealtime(options: options)
+        defer { client1.close() }
+        let channel1 = client1.channels.get("test")
+
+        let client2 = ARTRealtime(options: options)
+        defer { client2.close() }
+        let channel2 = client2.channels.get("test")
+
+        var count = 0
+        channel1.presence.subscribe(.update) { member in
+            expect(member.action).to(equal(ARTPresenceAction.update))
+            expect(member.clientId).to(equal("john"))
+            expect(member.data as? NSObject).to(equal("away" as NSObject?))
+            count += 1
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel2.presence.enterClient("john", data: "online") { error in
+                expect(error).to(beNil())
+                channel2.presence.updateClient("john", data: "away") { error in
+                    expect(error).to(beNil())
+                    channel2.presence.leaveClient("john", data: nil) { error in
                         expect(error).to(beNil())
-                        guard let members = members else {
-                            fail("Members is nil"); done(); return
-                        }
-                        expect(members.count) == 100
                         done()
                     }
                 }
             }
+        }
 
-            // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-            // RTP2
-            
+        expect(count).toEventually(equal(1), timeout: testTimeout)
+    }
 
-                // RTP2a
-                func skipped__test__045__Presence__PresenceMap__all_incoming_presence_messages_must_be_compared_for_newness_with_the_matching_member_already_in_the_PresenceMap() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channelName = NSUUID().uuidString
-                    let channel = client.channels.get(channelName)
+    // RTP8
 
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channel.presence.subscribe { presence in
-                            expect(presence.clientId).to(equal("tester"))
-                            expect(presence.action).to(equal(.enter))
-                            channel.presence.unsubscribe()
-                            partialDone()
-                        }
-                        channel.presence.enterClient("tester", data: nil) { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                    }
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    // RTP8b
+    func skipped__test__030__Presence__enter__optionally_a_callback_can_be_provided_that_is_called_for_success() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
 
-                    guard let intialPresenceMessage = channel.internal.presenceMap.members["\(channel.internal.connectionId):tester"] else {
-                        fail("Missing Presence message"); return
-                    }
+        let client1 = ARTRealtime(options: options)
+        defer { client1.close() }
+        let channel1 = client1.channels.get("test")
 
-                    expect(intialPresenceMessage.memberKey()).to(equal("\(client.connection.id!):tester"))
+        let client2 = ARTRealtime(options: options)
+        defer { client2.close() }
+        let channel2 = client2.channels.get("test")
 
-                    var compareForNewnessMethodCalls = 0
-                    let hook = ARTPresenceMessage.testSuite_injectIntoClassMethod(#selector(ARTPresenceMessage.isNewerThan(_:))) {
-                        compareForNewnessMethodCalls += 1
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            channel1.presence.subscribe(.enter) { member in
+                expect(member.clientId).to(equal(options.clientId))
+                expect(member.data as? NSObject).to(equal("online" as NSObject?))
+                done()
+            }
+            channel2.presence.enter("online") { error in
+                expect(error).to(beNil())
+            }
+        }
+    }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enterClient("tester", data: nil) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    // RTP8b
+    func skipped__test__031__Presence__enter__optionally_a_callback_can_be_provided_that_is_called_for_failure() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
 
-                    guard let updatedPresenceMessage = channel.internal.presenceMap.members["\(channel.internal.connectionId):tester"] else {
-                        fail("Missing Presence message"); return
-                    }
+        let client1 = ARTRealtime(options: options)
+        defer { client1.close() }
+        let channel1 = client1.channels.get("test")
 
-                    expect(intialPresenceMessage.memberKey()).to(equal(updatedPresenceMessage.memberKey()))
-                    expect(intialPresenceMessage.timestamp).to(beLessThan(updatedPresenceMessage.timestamp))
+        let client2 = ARTRealtime(options: options)
+        defer { client2.close() }
+        let channel2 = client2.channels.get("test")
 
-                    expect(compareForNewnessMethodCalls) == 1
+        waitUntil(timeout: testTimeout) { done in
+            channel1.presence.subscribe(.enter) { _ in
+                fail("shouldn't be called")
+            }
+            let protocolError = AblyTests.newErrorProtocolMessage()
+            channel2.presence.enter("online") { error in
+                expect(error).to(beIdenticalTo(protocolError.error))
+                done()
+            }
+            delay(0.1) {
+                channel2.internal.onError(protocolError)
+            }
+        }
+    }
 
-                    hook?.remove()
+    // RTP8c
+    func test__032__Presence__enter__entering_without_an_explicit_PresenceMessage_clientId_should_implicitly_use_the_clientId_of_the_current_connection() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.presence.enter("online") { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+            channel.presence.subscribe { message in
+                expect(message.clientId).to(equal("john"))
+                channel.presence.unsubscribe()
+                partialDone()
+            }
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+        let sent = transport.protocolMessagesSent.filter { $0.action == .presence }[0].presence![0]
+        expect(sent.action).to(equal(ARTPresenceAction.enter))
+        expect(sent.clientId).to(beNil())
+
+        let received = transport.protocolMessagesReceived.filter { $0.action == .presence }[0].presence![0]
+        expect(received.action).to(equal(ARTPresenceAction.enter))
+        expect(received.clientId).to(equal("john"))
+    }
+
+    // RTP8
+
+    // RTP8f
+    func test__033__Presence__enter__should_result_in_an_error_immediately_if_the_client_is_anonymous() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enter(nil) { error in
+                expect(error!.message).to(contain("attempted to publish presence message without clientId"))
+                done()
+            }
+        }
+    }
+
+    // RTP8
+
+    // RTP8g
+    func test__034__Presence__enter__should_result_in_an_error_immediately_if_the_channel_is_DETACHED() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { _ in
+                channel.detach { _ in done() }
+            }
+        }
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enter(nil) { error in
+                expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
+                done()
+            }
+        }
+    }
+
+    // RTP8g
+    func test__035__Presence__enter__should_result_in_an_error_immediately_if_the_channel_is_FAILED() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            AblyTests.queue.async {
+                channel.internal.onError(AblyTests.newErrorProtocolMessage())
+                done()
+            }
+        }
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enter(nil) { error in
+                expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
+                done()
+            }
+        }
+    }
+
+    // RTP8
+
+    // RTP8i
+    func test__036__Presence__enter__should_result_in_an_error_if_Ably_service_determines_that_the_client_is_unidentified() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enter(nil) { error in
+                expect(error!.message).to(contain("presence message without clientId"))
+                done()
+            }
+        }
+    }
+
+    // RTP9
+
+    // RTP9a
+    func test__037__Presence__update__should_update_the_data_for_the_present_member_with_a_value() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.subscribe(.enter) { member in
+                expect(member.data).to(beNil())
+                done()
+            }
+            channel.presence.enter(nil)
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.subscribe(.update) { member in
+                expect(member.data as? NSObject).to(equal("online" as NSObject?))
+                done()
+            }
+            channel.presence.update("online")
+        }
+    }
+
+    // RTP9a
+    func skipped__test__038__Presence__update__should_update_the_data_for_the_present_member_with_null() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.subscribe(.enter) { member in
+                expect(member.data as? NSObject).to(equal("online" as NSObject?))
+                done()
+            }
+            channel.presence.enter("online")
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.subscribe(.update) { member in
+                expect(member.data).to(beNil())
+                done()
+            }
+            channel.presence.update(nil)
+        }
+    }
+
+    // RTP9
+
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    // RTP9b
+    func skipped__test__039__Presence__update__should_enter_current_client_into_the_channel_if_the_client_was_not_already_entered() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        expect(channel.internal.presenceMap.members).to(haveCount(0))
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.subscribe(.enter) { member in
+                expect(member.clientId).to(equal("john"))
+                expect(member.data as? NSObject).to(equal("online" as NSObject?))
+                done()
+            }
+            channel.presence.update("online")
+        }
+    }
+
+    // RTP9
+
+    // RTP9c
+    func test__040__Presence__update__optionally_a_callback_can_be_provided_that_is_called_for_success() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.update("online") { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RTP9c
+    func test__041__Presence__update__optionally_a_callback_can_be_provided_that_is_called_for_failure() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            let protocolError = AblyTests.newErrorProtocolMessage()
+            channel.once(.attaching) { _ in
+                AblyTests.queue.async {
+                    channel.internal.onError(protocolError)
                 }
+            }
+            (client.internal.transport as! TestProxyTransport).actionsIgnored += [.attached]
+            channel.presence.update("online") { error in
+                expect(error).to(beIdenticalTo(protocolError.error))
+                done()
+            }
+        }
+    }
 
-                // RTP2b
-                
+    // RTP9d
+    func test__042__Presence__update__update_without_an_explicit_PresenceMessage_clientId_should_implicitly_use_the_clientId_of_the_current_connection() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
 
-                    
-                        // RTP2b1
-                        func test__053__Presence__PresenceMap__compare_for_newness__presence_message_has_a_connectionId_which_is_not_an_initial_substring_of_its_id__compares_them_by_timestamp_numerically() {
-                            let options = AblyTests.commonAppSetup()
-                            let now = NSDate()
-                            let channelName = NSUUID().uuidString
-                            var clientMembers: ARTRealtime?
-                            defer { clientMembers?.dispose(); clientMembers?.close() }
-                            clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 101, options: options)
-
-                            let clientSubscribed = AblyTests.newRealtime(options)
-                            defer { clientSubscribed.dispose(); clientSubscribed.close() }
-                            let channelSubscribed = clientSubscribed.channels.get(channelName)
-
-                            let presenceData: [ARTPresenceMessage] = [
-                                ARTPresenceMessage(clientId: "a", action: .enter, connectionId: "one", id: "one:0:0", timestamp: now as Date),
-                                ARTPresenceMessage(clientId: "a", action: .leave, connectionId: "one", id: "fabricated:0:1", timestamp: (now as Date) + 1),
-                                ARTPresenceMessage(clientId: "b", action: .enter, connectionId: "one", id: "one:0:2", timestamp: now as Date),
-                                ARTPresenceMessage(clientId: "b", action: .leave, connectionId: "one", id: "fabricated:0:3", timestamp: (now as Date) - 1),
-                                ARTPresenceMessage(clientId: "c", action: .enter, connectionId: "one", id: "fabricated:0:4", timestamp: now as Date),
-                                ARTPresenceMessage(clientId: "c", action: .leave, connectionId: "one", id: "fabricated:0:5", timestamp: (now as Date) - 1),
-                            ]
-
-                            guard let transport = clientSubscribed.internal.transport as? TestProxyTransport else {
-                                fail("TestProxyTransport is not set"); return
-                            }
-
-                            waitUntil(timeout: testTimeout.multiplied(by: 2)) { done in
-                                transport.setAfterIncomingMessageModifier({ protocolMessage in
-                                    // Receive the first Sync message from Ably service
-                                    if protocolMessage.action == .sync {
-                                        // Inject a fabricated Presence message
-                                        let presenceMessage = ARTProtocolMessage()
-                                        presenceMessage.action = .presence
-                                        presenceMessage.channel = protocolMessage.channel
-                                        presenceMessage.connectionSerial = protocolMessage.connectionSerial + 1
-                                        presenceMessage.timestamp = Date()
-                                        presenceMessage.presence = presenceData
-
-                                        transport.receive(presenceMessage)
-
-                                        // Simulate an end to the sync
-                                        let endSyncMessage = ARTProtocolMessage()
-                                        endSyncMessage.action = .sync
-                                        endSyncMessage.channel = protocolMessage.channel
-                                        endSyncMessage.channelSerial = "validserialprefix:" //with no part after the `:` this indicates the end to the SYNC
-                                        endSyncMessage.connectionSerial = protocolMessage.connectionSerial + 2
-                                        endSyncMessage.timestamp = Date()
-
-                                        transport.setAfterIncomingMessageModifier(nil)
-                                        transport.receive(endSyncMessage)
-
-                                        // Stop the next sync message from Ably service because we already injected the end of the sync
-                                        transport.actionsIgnored = [.sync]
-
-                                        done()
-                                    }
-                                    return protocolMessage
-                                })
-                                channelSubscribed.attach()
-                            }
-
-                            waitUntil(timeout: testTimeout) { done in
-                                channelSubscribed.presence.get { members, error in
-                                    expect(error).to(beNil())
-                                    guard let members = members else {
-                                        fail("Members is nil"); done(); return
-                                    }
-                                    expect(members).to(haveCount(102)) //100 initial members + "b" + "c", client "a" is discarded
-                                    expect(members).to(allPass({ (member: ARTPresenceMessage?) in member!.action != .absent }))
-                                    expect(members.filter{ $0.clientId == "a" }).to(beEmpty())
-                                    expect(members.filter{ $0.clientId == "b" }).to(haveCount(1))
-                                    expect(members.filter{ $0.clientId! == "b" }.first?.timestamp).to(equal(now as Date))
-                                    expect(members.filter{ $0.clientId == "c" }).to(haveCount(1))
-                                    expect(members.filter{ $0.clientId! == "c" }.first?.timestamp).to(equal(now as Date))
-                                    done()
-                                }
-                            }
-                        }
-
-                    // RTP2b2
-                    func test__052__Presence__PresenceMap__compare_for_newness__split_the_id_of_both_presence_messages() {
-                        let options = AblyTests.commonAppSetup()
-                        let now = NSDate()
-                        let channelName = NSUUID().uuidString
-                        var clientMembers: ARTRealtime?
-                        defer { clientMembers?.dispose(); clientMembers?.close() }
-                        clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 101, options: options)
-
-                        let clientSubscribed = AblyTests.newRealtime(options)
-                        defer { clientSubscribed.dispose(); clientSubscribed.close() }
-                        let channelSubscribed = clientSubscribed.channels.get(channelName)
-
-                        let presenceData: [ARTPresenceMessage] = [
-                            ARTPresenceMessage(clientId: "a", action: .enter, connectionId: "one", id: "one:0:0", timestamp: now as Date),
-                            ARTPresenceMessage(clientId: "a", action: .leave, connectionId: "one", id: "one:1:0", timestamp: (now as Date) - 1),
-                            ARTPresenceMessage(clientId: "b", action: .enter, connectionId: "one", id: "one:2:2", timestamp: now as Date),
-                            ARTPresenceMessage(clientId: "b", action: .leave, connectionId: "one", id: "one:2:1", timestamp: (now as Date) + 1),
-                            ARTPresenceMessage(clientId: "c", action: .enter, connectionId: "one", id: "one:4:4", timestamp: now as Date),
-                            ARTPresenceMessage(clientId: "c", action: .leave, connectionId: "one", id: "one:3:5", timestamp: (now as Date) + 1),
-                        ]
-
-                        guard let transport = clientSubscribed.internal.transport as? TestProxyTransport else {
-                            fail("TestProxyTransport is not set"); return
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            transport.setAfterIncomingMessageModifier({ protocolMessage in
-                                // Receive the first Sync message from Ably service
-                                if protocolMessage.action == .sync {
-                                    // Inject a fabricated Presence message
-                                    let presenceMessage = ARTProtocolMessage()
-                                    presenceMessage.action = .presence
-                                    presenceMessage.channel = protocolMessage.channel
-                                    presenceMessage.connectionSerial = protocolMessage.connectionSerial + 1
-                                    presenceMessage.timestamp = Date()
-                                    presenceMessage.presence = presenceData
-
-                                    transport.receive(presenceMessage)
-
-                                    // Simulate an end to the sync
-                                    let endSyncMessage = ARTProtocolMessage()
-                                    endSyncMessage.action = .sync
-                                    endSyncMessage.channel = protocolMessage.channel
-                                    endSyncMessage.channelSerial = "validserialprefix:" //with no part after the `:` this indicates the end to the SYNC
-                                    endSyncMessage.connectionSerial = protocolMessage.connectionSerial + 2
-                                    endSyncMessage.timestamp = Date()
-
-                                    transport.setAfterIncomingMessageModifier(nil)
-                                    transport.receive(endSyncMessage)
-
-                                    // Stop the next sync message from Ably service because we already injected the end of the sync
-                                    transport.actionsIgnored = [.sync]
-
-                                    done()
-                                }
-                                return protocolMessage
-                            })
-                            channelSubscribed.attach()
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channelSubscribed.presence.get { members, error in
-                                expect(error).to(beNil())
-                                guard let members = members else {
-                                    fail("Members is nil"); done(); return
-                                }
-                                expect(members).to(haveCount(102)) //100 initial members + "b" + "c", client "a" is discarded
-                                expect(members).to(allPass({ (member: ARTPresenceMessage?) in member!.action != .absent }))
-                                expect(members.filter{ $0.clientId == "a" }).to(beEmpty())
-                                expect(members.filter{ $0.clientId == "b" }).to(haveCount(1))
-                                expect(members.filter{ $0.clientId! == "b" }.first?.timestamp).to(equal(now as Date))
-                                expect(members.filter{ $0.clientId == "c" }).to(haveCount(1))
-                                expect(members.filter{ $0.clientId! == "c" }.first?.timestamp).to(equal(now as Date))
-                                done()
-                            }
-                        }
-                    }
-
-                // RTP2c
-                
-
-                    // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                    func skipped__test__054__Presence__PresenceMap__all_presence_messages_from_a_SYNC_must_also_be_compared_for_newness_in_the_same_way_as_they_would_from_a_PRESENCE__discard_members_where_messages_have_arrived_before_the_SYNC() {
-                        let options = AblyTests.commonAppSetup()
-                        let timeBeforeSync = NSDate()
-                        let channelName = NSUUID().uuidString
-                        var clientMembers: ARTRealtime?
-                        defer { clientMembers?.dispose(); clientMembers?.close() }
-                        clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 120, options: options)
-
-                        guard let membersConnectionId = clientMembers?.connection.id else {
-                            fail("Members client isn't connected"); return
-                        }
-
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get(channelName)
-
-                        guard let transport = client.internal.transport as? TestProxyTransport else {
-                            fail("TestProxyTransport is not set"); return
-                        }
-
-                        channel.presence.subscribe(.leave) { leave in
-                            expect(leave.clientId).to(equal("user110"))
-                            fail("Should not fire Leave event for member `user110` because it's out of date")
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(3, done: done)
-                            transport.setBeforeIncomingMessageModifier({ protocolMessage in
-                                if protocolMessage.action == .sync {
-                                    let injectLeave = ARTPresenceMessage()
-                                    injectLeave.action = .leave
-                                    injectLeave.connectionId = membersConnectionId
-                                    injectLeave.clientId = "user110"
-                                    injectLeave.timestamp = timeBeforeSync as Date
-                                    protocolMessage.presence?.append(injectLeave)
-                                    transport.setBeforeIncomingMessageModifier(nil)
-                                    partialDone()
-                                }
-                                return protocolMessage
-                            })
-                            channel.internal.presenceMap.testSuite_injectIntoMethod(after: #selector(ARTPresenceMap.endSync)) {
-                                expect(channel.internal.presenceMap.syncInProgress).to(beFalse())
-                                expect(channel.internal.presenceMap.members).to(haveCount(120))
-                                expect(channel.internal.presenceMap.members.filter{ _, presence in presence.clientId == "user110" && presence.action == .present }).to(haveCount(1))
-                                partialDone()
-                            }
-                            channel.attach() { error in
-                                expect(error).to(beNil())
-                                partialDone()
-                            }
-                        }
-                    }
-
-                    // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                    func skipped__test__055__Presence__PresenceMap__all_presence_messages_from_a_SYNC_must_also_be_compared_for_newness_in_the_same_way_as_they_would_from_a_PRESENCE__accept_members_where_message_have_arrived_after_the_SYNC() {
-                        let options = AblyTests.commonAppSetup()
-                        let channelName = NSUUID().uuidString
-                        var clientMembers: ARTRealtime?
-                        defer { clientMembers?.dispose(); clientMembers?.close() }
-                        clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 120, options: options)
-
-                        guard let membersConnectionId = clientMembers?.connection.id else {
-                            fail("Members client isn't connected"); return
-                        }
-
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get(channelName)
-
-                        guard let transport = client.internal.transport as? TestProxyTransport else {
-                            fail("TestProxyTransport is not set"); return
-                        }
-
-                        waitUntil(timeout: testTimeout.multiplied(by: 2)) { done in
-                            let partialDone = AblyTests.splitDone(4, done: done)
-                            channel.presence.subscribe(.leave) { leave in
-                                expect(leave.clientId).to(equal("user110"))
-                                partialDone()
-                            }
-                            transport.setBeforeIncomingMessageModifier({ protocolMessage in
-                                if protocolMessage.action == .sync {
-                                    let injectLeave = ARTPresenceMessage()
-                                    injectLeave.action = .leave
-                                    injectLeave.connectionId = membersConnectionId
-                                    injectLeave.clientId = "user110"
-                                    injectLeave.timestamp = (Date()) + 1
-                                    protocolMessage.presence?.append(injectLeave)
-                                    transport.setBeforeIncomingMessageModifier(nil)
-                                    partialDone()
-                                }
-                                return protocolMessage
-                            })
-                            channel.internal.presenceMap.testSuite_injectIntoMethod(after: #selector(ARTPresenceMap.endSync)) {
-                                expect(channel.internal.presenceMap.syncInProgress).to(beFalse())
-                                expect(channel.internal.presenceMap.members).to(haveCount(119))
-                                expect(channel.internal.presenceMap.members.filter{ _, presence in presence.clientId == "user110" }).to(beEmpty())
-                                partialDone()
-                            }
-                            channel.attach() { error in
-                                expect(error).to(beNil())
-                                partialDone()
-                            }
-                        }
-                    }
-
-                // RTP2d
-                func skipped__test__046__Presence__PresenceMap__if_action_of_ENTER_arrives__it_should_be_added_to_the_presence_map_with_the_action_set_to_PRESENT() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channelName = NSUUID().uuidString
-                    let channel = client.channels.get(channelName)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channel.presence.subscribe(.enter) { _ in
-                            partialDone()
-                        }
-                        channel.presence.enterClient("tester", data: nil) { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                    }
-
-                    expect(channel.internal.presenceMap.members.filter{ _, presence in presence.action == .present }).to(haveCount(1))
-                    expect(channel.internal.presenceMap.members.filter{ _, presence in presence.action == .enter }).to(beEmpty())
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enter("online") { error in
+                channel.presence.update("offline") { error in
+                    expect(error).to(beNil())
+                    done()
                 }
+            }
+        }
 
-                // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                // RTP2d
-                func skipped__test__047__Presence__PresenceMap__if_action_of_UPDATE_arrives__it_should_be_added_to_the_presence_map_with_the_action_set_to_PRESENT() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channelName = NSUUID().uuidString
-                    let channel = client.channels.get(channelName)
+        let transport = client.internal.transport as! TestProxyTransport
+        let sent = transport.protocolMessagesSent.filter { $0.action == .presence }[1].presence![0]
+        expect(sent.action).to(equal(ARTPresenceAction.update))
+        expect(sent.clientId).to(beNil())
 
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(3, done: done)
-                        channel.presence.subscribe(.update) { _ in
-                            partialDone()
-                        }
-                        channel.presence.enterClient("tester", data: nil) { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                        channel.presence.updateClient("tester", data: nil) { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                    }
+        let receivedPresenceProtocolMessages = transport.protocolMessagesReceived.filter { $0.action == .presence }
+        let receivedPresenceMessages = receivedPresenceProtocolMessages.flatMap { $0.presence! }
+        let received = receivedPresenceMessages.filter { $0.action == .update }[0]
+        expect(received.action).to(equal(ARTPresenceAction.update))
+        expect(received.clientId).to(equal("john"))
+    }
 
-                    expect(channel.internal.presenceMap.members).to(haveCount(1))
-                    expect(channel.internal.presenceMap.members.filter{ _, presence in presence.action == .present }).to(haveCount(1))
-                    expect(channel.internal.presenceMap.members.filter{ _, presence in presence.action == .update }).to(beEmpty())
+    // RTP10
+
+    // RTP10a
+    func skipped__test__043__Presence__leave__should_leave_the_current_client_from_the_channel_and_the_data_will_be_updated_with_the_value_provided() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.subscribe(.enter) { member in
+                expect(member.data as? NSObject).to(equal("online" as NSObject?))
+                done()
+            }
+            channel.presence.enter("online")
+        }
+
+        expect(channel.internal.presenceMap.members).toEventually(haveCount(1), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.subscribe(.leave) { member in
+                expect(member.data as? NSObject).to(equal("offline" as NSObject?))
+                done()
+            }
+            channel.presence.leave("offline")
+        }
+
+        expect(channel.internal.presenceMap.members).toEventually(haveCount(0), timeout: testTimeout)
+    }
+
+    // RTP10a
+    func skipped__test__044__Presence__leave__should_leave_the_current_client_with_no_data() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.subscribe(.enter) { member in
+                expect(member.data as? NSObject).to(equal("online" as NSObject?))
+                done()
+            }
+            channel.presence.enter("online")
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.subscribe(.leave) { member in
+                expect(member.data as? NSObject).to(equal("online" as NSObject?))
+                done()
+            }
+            channel.presence.leave(nil)
+        }
+    }
+
+    // RTP2
+    func skipped__test__003__Presence__should_be_used_a_PresenceMap_to_maintain_a_list_of_members() {
+        let options = AblyTests.commonAppSetup()
+        var clientSecondary: ARTRealtime!
+        defer { clientSecondary.dispose(); clientSecondary.close() }
+        clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: 100, options: options)
+
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        channel.presence.unsubscribe()
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, error in
+                expect(error).to(beNil())
+                guard let members = members else {
+                    fail("Members is nil"); done(); return
                 }
+                expect(members.count) == 100
+                done()
+            }
+        }
+    }
 
-                // RTP2d
-                func test__048__Presence__PresenceMap__if_action_of_PRESENT_arrives__it_should_be_added_to_the_presence_map_with_the_action_set_to_PRESENT() {
-                    let options = AblyTests.commonAppSetup()
-                    let channelName = NSUUID().uuidString
-                    var clientMembers: ARTRealtime!
-                    defer { clientMembers.dispose(); clientMembers.close() }
-                    clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 1, options: options)
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    // RTP2
 
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get(channelName)
+    // RTP2a
+    func skipped__test__045__Presence__PresenceMap__all_incoming_presence_messages_must_be_compared_for_newness_with_the_matching_member_already_in_the_PresenceMap() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channelName = NSUUID().uuidString
+        let channel = client.channels.get(channelName)
 
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channel.internal.presenceMap.testSuite_injectIntoMethod(after: #selector(ARTPresenceMap.endSync)) {
-                            expect(channel.internal.presenceMap.syncInProgress).to(beFalse())
-                            partialDone()
-                        }
-                        channel.attach() { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.presence.subscribe { presence in
+                expect(presence.clientId).to(equal("tester"))
+                expect(presence.action).to(equal(.enter))
+                channel.presence.unsubscribe()
+                partialDone()
+            }
+            channel.presence.enterClient("tester", data: nil) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
 
-                    expect(channel.internal.presenceMap.members).to(haveCount(1))
+        guard let intialPresenceMessage = channel.internal.presenceMap.members["\(channel.internal.connectionId):tester"] else {
+            fail("Missing Presence message"); return
+        }
+
+        expect(intialPresenceMessage.memberKey()).to(equal("\(client.connection.id!):tester"))
+
+        var compareForNewnessMethodCalls = 0
+        let hook = ARTPresenceMessage.testSuite_injectIntoClassMethod(#selector(ARTPresenceMessage.isNewerThan(_:))) {
+            compareForNewnessMethodCalls += 1
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enterClient("tester", data: nil) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let updatedPresenceMessage = channel.internal.presenceMap.members["\(channel.internal.connectionId):tester"] else {
+            fail("Missing Presence message"); return
+        }
+
+        expect(intialPresenceMessage.memberKey()).to(equal(updatedPresenceMessage.memberKey()))
+        expect(intialPresenceMessage.timestamp).to(beLessThan(updatedPresenceMessage.timestamp))
+
+        expect(compareForNewnessMethodCalls) == 1
+
+        hook?.remove()
+    }
+
+    // RTP2b
+
+    // RTP2b1
+    func test__053__Presence__PresenceMap__compare_for_newness__presence_message_has_a_connectionId_which_is_not_an_initial_substring_of_its_id__compares_them_by_timestamp_numerically() {
+        let options = AblyTests.commonAppSetup()
+        let now = NSDate()
+        let channelName = NSUUID().uuidString
+        var clientMembers: ARTRealtime?
+        defer { clientMembers?.dispose(); clientMembers?.close() }
+        clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 101, options: options)
+
+        let clientSubscribed = AblyTests.newRealtime(options)
+        defer { clientSubscribed.dispose(); clientSubscribed.close() }
+        let channelSubscribed = clientSubscribed.channels.get(channelName)
+
+        let presenceData: [ARTPresenceMessage] = [
+            ARTPresenceMessage(clientId: "a", action: .enter, connectionId: "one", id: "one:0:0", timestamp: now as Date),
+            ARTPresenceMessage(clientId: "a", action: .leave, connectionId: "one", id: "fabricated:0:1", timestamp: (now as Date) + 1),
+            ARTPresenceMessage(clientId: "b", action: .enter, connectionId: "one", id: "one:0:2", timestamp: now as Date),
+            ARTPresenceMessage(clientId: "b", action: .leave, connectionId: "one", id: "fabricated:0:3", timestamp: (now as Date) - 1),
+            ARTPresenceMessage(clientId: "c", action: .enter, connectionId: "one", id: "fabricated:0:4", timestamp: now as Date),
+            ARTPresenceMessage(clientId: "c", action: .leave, connectionId: "one", id: "fabricated:0:5", timestamp: (now as Date) - 1),
+        ]
+
+        guard let transport = clientSubscribed.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        waitUntil(timeout: testTimeout.multiplied(by: 2)) { done in
+            transport.setAfterIncomingMessageModifier { protocolMessage in
+                // Receive the first Sync message from Ably service
+                if protocolMessage.action == .sync {
+                    // Inject a fabricated Presence message
+                    let presenceMessage = ARTProtocolMessage()
+                    presenceMessage.action = .presence
+                    presenceMessage.channel = protocolMessage.channel
+                    presenceMessage.connectionSerial = protocolMessage.connectionSerial + 1
+                    presenceMessage.timestamp = Date()
+                    presenceMessage.presence = presenceData
+
+                    transport.receive(presenceMessage)
+
+                    // Simulate an end to the sync
+                    let endSyncMessage = ARTProtocolMessage()
+                    endSyncMessage.action = .sync
+                    endSyncMessage.channel = protocolMessage.channel
+                    endSyncMessage.channelSerial = "validserialprefix:" // with no part after the `:` this indicates the end to the SYNC
+                    endSyncMessage.connectionSerial = protocolMessage.connectionSerial + 2
+                    endSyncMessage.timestamp = Date()
+
+                    transport.setAfterIncomingMessageModifier(nil)
+                    transport.receive(endSyncMessage)
+
+                    // Stop the next sync message from Ably service because we already injected the end of the sync
+                    transport.actionsIgnored = [.sync]
+
+                    done()
                 }
+                return protocolMessage
+            }
+            channelSubscribed.attach()
+        }
 
-                // RTP2e
-                func skipped__test__049__Presence__PresenceMap__if_a_SYNC_is_not_in_progress__then_when_a_presence_message_with_an_action_of_LEAVE_arrives__that_memberKey_should_be_deleted_from_the_presence_map__if_present() {
-                    let options = AblyTests.commonAppSetup()
+        waitUntil(timeout: testTimeout) { done in
+            channelSubscribed.presence.get { members, error in
+                expect(error).to(beNil())
+                guard let members = members else {
+                    fail("Members is nil"); done(); return
+                }
+                expect(members).to(haveCount(102)) // 100 initial members + "b" + "c", client "a" is discarded
+                expect(members).to(allPass { (member: ARTPresenceMessage?) in member!.action != .absent })
+                expect(members.filter { $0.clientId == "a" }).to(beEmpty())
+                expect(members.filter { $0.clientId == "b" }).to(haveCount(1))
+                expect(members.filter { $0.clientId! == "b" }.first?.timestamp).to(equal(now as Date))
+                expect(members.filter { $0.clientId == "c" }).to(haveCount(1))
+                expect(members.filter { $0.clientId! == "c" }.first?.timestamp).to(equal(now as Date))
+                done()
+            }
+        }
+    }
 
-                    var clientMembers: ARTRealtime?
-                    defer { clientMembers?.dispose(); clientMembers?.close() }
-                    let channelName = NSUUID().uuidString
-                    clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 20, options: options)
+    // RTP2b2
+    func test__052__Presence__PresenceMap__compare_for_newness__split_the_id_of_both_presence_messages() {
+        let options = AblyTests.commonAppSetup()
+        let now = NSDate()
+        let channelName = NSUUID().uuidString
+        var clientMembers: ARTRealtime?
+        defer { clientMembers?.dispose(); clientMembers?.close() }
+        clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 101, options: options)
 
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get(channelName)
-                    channel.attach()
+        let clientSubscribed = AblyTests.newRealtime(options)
+        defer { clientSubscribed.dispose(); clientSubscribed.close() }
+        let channelSubscribed = clientSubscribed.channels.get(channelName)
 
-                    guard let transport = client.internal.transport as? TestProxyTransport else {
-                        fail("TestProxyTransport is not set"); return
-                    }
-                    waitUntil(timeout: testTimeout) { done in
-                        transport.setListenerAfterProcessingIncomingMessage({ protocolMessage in
-                            if protocolMessage.action == .sync {
-                                done()
-                            }
-                        })
-                    }
+        let presenceData: [ARTPresenceMessage] = [
+            ARTPresenceMessage(clientId: "a", action: .enter, connectionId: "one", id: "one:0:0", timestamp: now as Date),
+            ARTPresenceMessage(clientId: "a", action: .leave, connectionId: "one", id: "one:1:0", timestamp: (now as Date) - 1),
+            ARTPresenceMessage(clientId: "b", action: .enter, connectionId: "one", id: "one:2:2", timestamp: now as Date),
+            ARTPresenceMessage(clientId: "b", action: .leave, connectionId: "one", id: "one:2:1", timestamp: (now as Date) + 1),
+            ARTPresenceMessage(clientId: "c", action: .enter, connectionId: "one", id: "one:4:4", timestamp: now as Date),
+            ARTPresenceMessage(clientId: "c", action: .leave, connectionId: "one", id: "one:3:5", timestamp: (now as Date) + 1),
+        ]
 
-                    expect(channel.internal.presenceMap.syncInProgress).toEventually(beFalse(), timeout: testTimeout)
+        guard let transport = clientSubscribed.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
 
-                    guard let user11MemberKey = channel.internal.presenceMap.members["\(clientMembers?.connection.id ?? ""):user11"]?.memberKey() else {
-                        fail("user11 memberKey is not present"); return
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            transport.setAfterIncomingMessageModifier { protocolMessage in
+                // Receive the first Sync message from Ably service
+                if protocolMessage.action == .sync {
+                    // Inject a fabricated Presence message
+                    let presenceMessage = ARTProtocolMessage()
+                    presenceMessage.action = .presence
+                    presenceMessage.channel = protocolMessage.channel
+                    presenceMessage.connectionSerial = protocolMessage.connectionSerial + 1
+                    presenceMessage.timestamp = Date()
+                    presenceMessage.presence = presenceData
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.subscribe(.leave) { presence in
-                            expect(presence.clientId).to(equal("user11"))
-                            done()
-                        }
-                        clientMembers?.channels.get(channelName).presence.leaveClient("user11", data: nil)
-                    }
-                    channel.presence.unsubscribe()
+                    transport.receive(presenceMessage)
 
-                    channel.internalSync { _internal in
-                        expect(_internal.presenceMap.members.filter{ _, presence in presence.memberKey() == user11MemberKey }).to(beEmpty())
+                    // Simulate an end to the sync
+                    let endSyncMessage = ARTProtocolMessage()
+                    endSyncMessage.action = .sync
+                    endSyncMessage.channel = protocolMessage.channel
+                    endSyncMessage.channelSerial = "validserialprefix:" // with no part after the `:` this indicates the end to the SYNC
+                    endSyncMessage.connectionSerial = protocolMessage.connectionSerial + 2
+                    endSyncMessage.timestamp = Date()
+
+                    transport.setAfterIncomingMessageModifier(nil)
+                    transport.receive(endSyncMessage)
+
+                    // Stop the next sync message from Ably service because we already injected the end of the sync
+                    transport.actionsIgnored = [.sync]
+
+                    done()
+                }
+                return protocolMessage
+            }
+            channelSubscribed.attach()
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channelSubscribed.presence.get { members, error in
+                expect(error).to(beNil())
+                guard let members = members else {
+                    fail("Members is nil"); done(); return
+                }
+                expect(members).to(haveCount(102)) // 100 initial members + "b" + "c", client "a" is discarded
+                expect(members).to(allPass { (member: ARTPresenceMessage?) in member!.action != .absent })
+                expect(members.filter { $0.clientId == "a" }).to(beEmpty())
+                expect(members.filter { $0.clientId == "b" }).to(haveCount(1))
+                expect(members.filter { $0.clientId! == "b" }.first?.timestamp).to(equal(now as Date))
+                expect(members.filter { $0.clientId == "c" }).to(haveCount(1))
+                expect(members.filter { $0.clientId! == "c" }.first?.timestamp).to(equal(now as Date))
+                done()
+            }
+        }
+    }
+
+    // RTP2c
+
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    func skipped__test__054__Presence__PresenceMap__all_presence_messages_from_a_SYNC_must_also_be_compared_for_newness_in_the_same_way_as_they_would_from_a_PRESENCE__discard_members_where_messages_have_arrived_before_the_SYNC() {
+        let options = AblyTests.commonAppSetup()
+        let timeBeforeSync = NSDate()
+        let channelName = NSUUID().uuidString
+        var clientMembers: ARTRealtime?
+        defer { clientMembers?.dispose(); clientMembers?.close() }
+        clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 120, options: options)
+
+        guard let membersConnectionId = clientMembers?.connection.id else {
+            fail("Members client isn't connected"); return
+        }
+
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get(channelName)
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        channel.presence.subscribe(.leave) { leave in
+            expect(leave.clientId).to(equal("user110"))
+            fail("Should not fire Leave event for member `user110` because it's out of date")
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(3, done: done)
+            transport.setBeforeIncomingMessageModifier { protocolMessage in
+                if protocolMessage.action == .sync {
+                    let injectLeave = ARTPresenceMessage()
+                    injectLeave.action = .leave
+                    injectLeave.connectionId = membersConnectionId
+                    injectLeave.clientId = "user110"
+                    injectLeave.timestamp = timeBeforeSync as Date
+                    protocolMessage.presence?.append(injectLeave)
+                    transport.setBeforeIncomingMessageModifier(nil)
+                    partialDone()
+                }
+                return protocolMessage
+            }
+            channel.internal.presenceMap.testSuite_injectIntoMethod(after: #selector(ARTPresenceMap.endSync)) {
+                expect(channel.internal.presenceMap.syncInProgress).to(beFalse())
+                expect(channel.internal.presenceMap.members).to(haveCount(120))
+                expect(channel.internal.presenceMap.members.filter { _, presence in presence.clientId == "user110" && presence.action == .present }).to(haveCount(1))
+                partialDone()
+            }
+            channel.attach { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
+    }
+
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    func skipped__test__055__Presence__PresenceMap__all_presence_messages_from_a_SYNC_must_also_be_compared_for_newness_in_the_same_way_as_they_would_from_a_PRESENCE__accept_members_where_message_have_arrived_after_the_SYNC() {
+        let options = AblyTests.commonAppSetup()
+        let channelName = NSUUID().uuidString
+        var clientMembers: ARTRealtime?
+        defer { clientMembers?.dispose(); clientMembers?.close() }
+        clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 120, options: options)
+
+        guard let membersConnectionId = clientMembers?.connection.id else {
+            fail("Members client isn't connected"); return
+        }
+
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get(channelName)
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        waitUntil(timeout: testTimeout.multiplied(by: 2)) { done in
+            let partialDone = AblyTests.splitDone(4, done: done)
+            channel.presence.subscribe(.leave) { leave in
+                expect(leave.clientId).to(equal("user110"))
+                partialDone()
+            }
+            transport.setBeforeIncomingMessageModifier { protocolMessage in
+                if protocolMessage.action == .sync {
+                    let injectLeave = ARTPresenceMessage()
+                    injectLeave.action = .leave
+                    injectLeave.connectionId = membersConnectionId
+                    injectLeave.clientId = "user110"
+                    injectLeave.timestamp = Date() + 1
+                    protocolMessage.presence?.append(injectLeave)
+                    transport.setBeforeIncomingMessageModifier(nil)
+                    partialDone()
+                }
+                return protocolMessage
+            }
+            channel.internal.presenceMap.testSuite_injectIntoMethod(after: #selector(ARTPresenceMap.endSync)) {
+                expect(channel.internal.presenceMap.syncInProgress).to(beFalse())
+                expect(channel.internal.presenceMap.members).to(haveCount(119))
+                expect(channel.internal.presenceMap.members.filter { _, presence in presence.clientId == "user110" }).to(beEmpty())
+                partialDone()
+            }
+            channel.attach { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
+    }
+
+    // RTP2d
+    func skipped__test__046__Presence__PresenceMap__if_action_of_ENTER_arrives__it_should_be_added_to_the_presence_map_with_the_action_set_to_PRESENT() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channelName = NSUUID().uuidString
+        let channel = client.channels.get(channelName)
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.presence.subscribe(.enter) { _ in
+                partialDone()
+            }
+            channel.presence.enterClient("tester", data: nil) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
+
+        expect(channel.internal.presenceMap.members.filter { _, presence in presence.action == .present }).to(haveCount(1))
+        expect(channel.internal.presenceMap.members.filter { _, presence in presence.action == .enter }).to(beEmpty())
+    }
+
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    // RTP2d
+    func skipped__test__047__Presence__PresenceMap__if_action_of_UPDATE_arrives__it_should_be_added_to_the_presence_map_with_the_action_set_to_PRESENT() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channelName = NSUUID().uuidString
+        let channel = client.channels.get(channelName)
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(3, done: done)
+            channel.presence.subscribe(.update) { _ in
+                partialDone()
+            }
+            channel.presence.enterClient("tester", data: nil) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+            channel.presence.updateClient("tester", data: nil) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
+
+        expect(channel.internal.presenceMap.members).to(haveCount(1))
+        expect(channel.internal.presenceMap.members.filter { _, presence in presence.action == .present }).to(haveCount(1))
+        expect(channel.internal.presenceMap.members.filter { _, presence in presence.action == .update }).to(beEmpty())
+    }
+
+    // RTP2d
+    func test__048__Presence__PresenceMap__if_action_of_PRESENT_arrives__it_should_be_added_to_the_presence_map_with_the_action_set_to_PRESENT() {
+        let options = AblyTests.commonAppSetup()
+        let channelName = NSUUID().uuidString
+        var clientMembers: ARTRealtime!
+        defer { clientMembers.dispose(); clientMembers.close() }
+        clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 1, options: options)
+
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get(channelName)
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.internal.presenceMap.testSuite_injectIntoMethod(after: #selector(ARTPresenceMap.endSync)) {
+                expect(channel.internal.presenceMap.syncInProgress).to(beFalse())
+                partialDone()
+            }
+            channel.attach { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
+
+        expect(channel.internal.presenceMap.members).to(haveCount(1))
+    }
+
+    // RTP2e
+    func skipped__test__049__Presence__PresenceMap__if_a_SYNC_is_not_in_progress__then_when_a_presence_message_with_an_action_of_LEAVE_arrives__that_memberKey_should_be_deleted_from_the_presence_map__if_present() {
+        let options = AblyTests.commonAppSetup()
+
+        var clientMembers: ARTRealtime?
+        defer { clientMembers?.dispose(); clientMembers?.close() }
+        let channelName = NSUUID().uuidString
+        clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 20, options: options)
+
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get(channelName)
+        channel.attach()
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+        waitUntil(timeout: testTimeout) { done in
+            transport.setListenerAfterProcessingIncomingMessage { protocolMessage in
+                if protocolMessage.action == .sync {
+                    done()
+                }
+            }
+        }
+
+        expect(channel.internal.presenceMap.syncInProgress).toEventually(beFalse(), timeout: testTimeout)
+
+        guard let user11MemberKey = channel.internal.presenceMap.members["\(clientMembers?.connection.id ?? ""):user11"]?.memberKey() else {
+            fail("user11 memberKey is not present"); return
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.subscribe(.leave) { presence in
+                expect(presence.clientId).to(equal("user11"))
+                done()
+            }
+            clientMembers?.channels.get(channelName).presence.leaveClient("user11", data: nil)
+        }
+        channel.presence.unsubscribe()
+
+        channel.internalSync { _internal in
+            expect(_internal.presenceMap.members.filter { _, presence in presence.memberKey() == user11MemberKey }).to(beEmpty())
+        }
+    }
+
+    // RTP2f
+    func skipped__test__050__Presence__PresenceMap__if_a_SYNC_is_in_progress__then_when_a_presence_message_with_an_action_of_LEAVE_arrives__it_should_be_stored_in_the_presence_map_with_the_action_set_to_ABSENT() {
+        let options = AblyTests.commonAppSetup()
+        let channelName = NSUUID().uuidString
+
+        var clientMembers: ARTRealtime?
+        defer { clientMembers?.dispose(); clientMembers?.close() }
+        clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 20, options: options)
+
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get(channelName)
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        var hook: AspectToken?
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+
+            channel.presence.subscribe(.leave) { leave in
+                expect(leave.clientId).to(equal("user11"))
+                partialDone()
+            }
+
+            hook = channel.internal.presenceMap.testSuite_getArgument(
+                from: #selector(ARTPresenceMap.internalAdd(_:withSessionId:)),
+                at: 0
+            ) { arg in
+                let m = arg as? ARTPresenceMessage
+                if m?.clientId == "user11", m?.action == .absent {
+                    partialDone()
+                }
+            }
+
+            channel.attach { error in
+                expect(error).to(beNil())
+                expect(channel.internal.presenceMap.syncInProgress).to(beTrue())
+
+                // Inject a fabricated Presence message
+                let leaveMessage = ARTProtocolMessage()
+                leaveMessage.action = .presence
+                leaveMessage.channel = channel.name
+                leaveMessage.connectionSerial = client.connection.internal.serial_nosync() + 1
+                leaveMessage.timestamp = Date()
+                leaveMessage.presence = [
+                    ARTPresenceMessage(clientId: "user11", action: .leave, connectionId: "another", id: "another:123:0", timestamp: Date()),
+                ]
+                transport.receive(leaveMessage)
+            }
+        }
+        hook?.remove()
+        channel.presence.unsubscribe()
+
+        expect(channel.internal.presenceMap.syncInProgress).toEventually(beFalse(), timeout: testTimeout)
+        expect(channel.internal.presenceMap.members.filter { _, presence in presence.action == .leave }).to(beEmpty())
+        expect(channel.internal.presenceMap.members.filter { _, presence in presence.action == .absent }).to(beEmpty())
+
+        // A single clientId may be present multiple times on the same channel via different client connections and that's way user11 is present because user11 presences messages were in distinct connections.
+        expect(channel.internal.presenceMap.members).to(haveCount(20))
+    }
+
+    // RTP2g
+    func skipped__test__051__Presence__PresenceMap__any_incoming_presence_message_that_passes_the_newness_check_should_be_emitted_on_the_Presence_object__with_an_event_name_set_to_its_original_action() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channelName = NSUUID().uuidString
+        let channel = client.channels.get(channelName)
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.presence.enterClient("tester", data: nil) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+            channel.presence.subscribe(.enter) { _ in
+                partialDone()
+            }
+        }
+
+        channel.internalSync { _internal in
+            expect(_internal.presenceMap.members.filter { _, presence in presence.action == .present }).to(haveCount(1))
+            expect(_internal.presenceMap.members.filter { _, presence in presence.action == .enter }).to(beEmpty())
+        }
+    }
+
+    // RTP8
+
+    // RTP8h
+    func test__056__Presence__enter__should_result_in_an_error_if_the_client_does_not_have_required_presence_permission() {
+        let options = AblyTests.commonAppSetup()
+        options.token = getTestToken(clientId: "john", capability: "{ \"cannotpresence:john\":[\"publish\"] }")
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("cannotpresence")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enter(nil) { error in
+                guard let error = error else {
+                    fail("error expected"); done(); return
+                }
+                expect(error.message).to(contain("Channel denied access based on given capability"))
+                done()
+            }
+        }
+    }
+
+    // RTP9
+
+    // RTP9e
+    func test__057__Presence__update__should_result_in_an_error_immediately_if_the_client_is_anonymous() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.update(nil) { error in
+                expect(error!.message).to(contain("attempted to publish presence message without clientId"))
+                done()
+            }
+        }
+    }
+
+    // RTP9e
+    func test__058__Presence__update__should_result_in_an_error_immediately_if_the_channel_is_DETACHED() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        channel.attach()
+        channel.detach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.update(nil) { error in
+                expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
+                done()
+            }
+        }
+    }
+
+    // RTP9e
+    func test__059__Presence__update__should_result_in_an_error_immediately_if_the_channel_is_FAILED() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        AblyTests.queue.async {
+            channel.internal.onError(AblyTests.newErrorProtocolMessage())
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.update(nil) { error in
+                expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
+                done()
+            }
+        }
+    }
+
+    // RTP9e
+    func test__060__Presence__update__should_result_in_an_error_if_the_client_does_not_have_required_presence_permission() {
+        let options = AblyTests.clientOptions()
+        options.token = getTestToken(clientId: "john", capability: "{ \"cannotpresence:john\":[\"publish\"] }")
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("cannotpresence")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.update(nil) { error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error.message).to(contain("Channel denied access based on given capability"))
+                done()
+            }
+        }
+    }
+
+    // RTP9e
+    func test__061__Presence__update__should_result_in_an_error_if_Ably_service_determines_that_the_client_is_unidentified() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.update(nil) { error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error.message).to(contain("presence message without clientId"))
+                done()
+            }
+        }
+    }
+
+    // RTP10
+
+    // RTP10b
+    func test__062__Presence__leave__optionally_a_callback_can_be_provided_that_is_called_for_success() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enter("online") { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.leave("offline") { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RTP10b
+    func test__063__Presence__leave__optionally_a_callback_can_be_provided_that_is_called_for_failure() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enter("online") { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let sentError = ARTErrorInfo.create(withCode: 0, message: "test error")
+            let transport = client.internal.transport as! TestProxyTransport
+            transport.enableReplaceAcksWithNacks(with: sentError)
+            channel.presence.leave("offline") { error in
+                expect(error).to(beIdenticalTo(sentError))
+                transport.disableReplaceAcksWithNacks()
+                done()
+            }
+        }
+    }
+
+    func test__064__Presence__leave__should_raise_an_error_if_client_is_not_present() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.leave("offline") { error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
+                }
+                expect(error.code) == Int(ARTState.noClientId.rawValue)
+                expect(error.message).to(contain("message without clientId"))
+                done()
+            }
+        }
+    }
+
+    // RTP10c
+    func test__065__Presence__leave__entering_without_an_explicit_PresenceMessage_clientId_should_implicitly_use_the_clientId_of_the_current_connection() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enter("online") { error in
+                channel.presence.leave(nil) { error in
+                    expect(error).to(beNil())
+                    done()
+                }
+            }
+        }
+
+        let transport = client.internal.transport as! TestProxyTransport
+
+        let sent = transport.protocolMessagesSent.filter { $0.action == .presence }[1].presence![0]
+        expect(sent.action).to(equal(ARTPresenceAction.leave))
+        expect(sent.clientId).to(beNil())
+
+        let receivedPresenceProtocolMessages = transport.protocolMessagesReceived.filter { $0.action == .presence }
+        let receivedPresenceMessages = receivedPresenceProtocolMessages.flatMap { $0.presence! }
+        let received = receivedPresenceMessages.filter { $0.action == .leave }[0]
+        expect(received.action).to(equal(ARTPresenceAction.leave))
+        expect(received.clientId).to(equal("john"))
+    }
+
+    // RTP10d
+    func test__066__Presence__leave__if_the_client_is_not_currently_ENTERED__Ably_will_respond_with_an_ACK_and_the_request_will_succeed() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channelName = NSUUID().uuidString
+        let channel = client.channels.get(channelName)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.leave(nil) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enter("online") { error in
+                expect(error).to(beNil())
+                channel.presence.leave(nil) { error in
+                    expect(error).to(beNil())
+                    channel.presence.leave(nil) { error in
+                        expect(error).to(beNil())
+                        done()
                     }
                 }
+            }
+        }
+    }
 
-                // RTP2f
-                func skipped__test__050__Presence__PresenceMap__if_a_SYNC_is_in_progress__then_when_a_presence_message_with_an_action_of_LEAVE_arrives__it_should_be_stored_in_the_presence_map_with_the_action_set_to_ABSENT() {
-                    let options = AblyTests.commonAppSetup()
-                    let channelName = NSUUID().uuidString
+    // RTP8
 
-                    var clientMembers: ARTRealtime?
-                    defer { clientMembers?.dispose(); clientMembers?.close() }
-                    clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 20, options: options)
+    // RTP8d
+    func test__067__Presence__enter__implicitly_attaches_the_Channel() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
 
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get(channelName)
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
 
-                    guard let transport = client.internal.transport as? TestProxyTransport else {
-                        fail("TestProxyTransport is not set"); return
-                    }
+        expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enter("online") { error in
+                expect(error).to(beNil())
+                done()
+            }
+            expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+        }
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+    }
 
-                    var hook: AspectToken?
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        
-                        channel.presence.subscribe(.leave) { leave in
-                            expect(leave.clientId).to(equal("user11"))
-                            partialDone()
-                        }
+    // RTP8d
+    func test__068__Presence__enter__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
 
-                        hook = channel.internal.presenceMap.testSuite_getArgument(
-                            from: #selector(ARTPresenceMap.internalAdd(_:withSessionId:)),
-                            at: 0
-                        ) { arg in
-                            let m = arg as? ARTPresenceMessage
-                            if (m?.clientId == "user11" && m?.action == .absent) {
-                                partialDone()
-                            }
-                        }
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
 
-                        channel.attach { error in
-                            expect(error).to(beNil())
-                            expect(channel.internal.presenceMap.syncInProgress).to(beTrue())
+        AblyTests.queue.async {
+            channel.internal.onError(AblyTests.newErrorProtocolMessage())
+        }
 
-                            // Inject a fabricated Presence message
-                            let leaveMessage = ARTProtocolMessage()
-                            leaveMessage.action = .presence
-                            leaveMessage.channel = channel.name
-                            leaveMessage.connectionSerial = client.connection.internal.serial_nosync() + 1
-                            leaveMessage.timestamp = Date()
-                            leaveMessage.presence = [
-                                ARTPresenceMessage(clientId: "user11", action: .leave, connectionId: "another", id: "another:123:0", timestamp: Date())
-                            ]
-                            transport.receive(leaveMessage)
-                        }
-                    }
-                    hook?.remove()
-                    channel.presence.unsubscribe()
-                    
-                    expect(channel.internal.presenceMap.syncInProgress).toEventually(beFalse(), timeout: testTimeout)
-                    expect(channel.internal.presenceMap.members.filter{ _, presence in presence.action == .leave }).to(beEmpty())
-                    expect(channel.internal.presenceMap.members.filter{ _, presence in presence.action == .absent }).to(beEmpty())
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enter("online") { error in
+                expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
+                done()
+            }
+        }
+        expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+    }
 
-                    // A single clientId may be present multiple times on the same channel via different client connections and that's way user11 is present because user11 presences messages were in distinct connections.
-                    expect(channel.internal.presenceMap.members).to(haveCount(20))
+    // RTP8d
+    func test__069__Presence__enter__should_result_in_an_error_if_the_channel_is_in_the_DETACHED_state() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.attach { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+            channel.detach { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
+        expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enter("online") { error in
+                expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
+                done()
+            }
+        }
+    }
+
+    // RTP10
+
+    // RTP10e
+    func test__070__Presence__leave__should_result_in_an_error_immediately_if_the_client_is_anonymous() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.leave(nil) { error in
+                expect(error!.message).to(contain("attempted to publish presence message without clientId"))
+                done()
+            }
+        }
+    }
+
+    // RTP10e
+    func test__071__Presence__leave__should_result_in_an_error_immediately_if_the_channel_is_DETACHED() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enter(nil) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        channel.detach()
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.leave(nil) { error in
+                expect(error!.message).to(contain("invalid channel state"))
+                done()
+            }
+        }
+    }
+
+    // RTP10e
+    func test__072__Presence__leave__should_result_in_an_error_immediately_if_the_channel_is_FAILED() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enter(nil) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        AblyTests.queue.async {
+            channel.internal.onError(AblyTests.newErrorProtocolMessage())
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.leave(nil) { error in
+                expect(error!.message).to(contain("invalid channel state"))
+                done()
+            }
+        }
+    }
+
+    // RTP10e
+    func test__073__Presence__leave__should_result_in_an_error_if_the_client_does_not_have_required_presence_permission() {
+        let options = AblyTests.clientOptions()
+        options.token = getTestToken(clientId: "john", capability: "{ \"cannotpresence:other\":[\"publish\"] }")
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("cannotpresence")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.leaveClient("other", data: nil) { error in
+                expect(error!.message).to(contain("Channel denied access based on given capability"))
+                done()
+            }
+        }
+    }
+
+    // RTP10e
+    func test__074__Presence__leave__should_result_in_an_error_if_Ably_service_determines_that_the_client_is_unidentified() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.leave(nil) { error in
+                expect(error!.message).to(contain("presence message without clientId"))
+                done()
+            }
+        }
+    }
+
+    // RTP6
+
+    // RTP6c
+    func test__075__Presence__subscribe__should_implicitly_attach_the_channel() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
+        channel.presence.subscribe { _ in }
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        channel.detach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
+
+        channel.presence.subscribe(.present) { _ in }
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+    }
+
+    // RTP6c
+    func test__076__Presence__subscribe__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        let protocolError = AblyTests.newErrorProtocolMessage()
+        AblyTests.queue.async {
+            channel.internal.onError(protocolError)
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.subscribe(attachCallback: { error in
+                expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+                expect(error).toNot(beNil())
+                done()
+            }, callback: { _ in
+                fail("Should not be called")
+            })
+        }
+    }
+
+    // RTP6c
+    func test__077__Presence__subscribe__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            let error = AblyTests.newErrorProtocolMessage()
+            channel.presence.subscribe(attachCallback: { error in
+                expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+                expect(error).toNot(beNil())
+                done()
+            }, callback: { _ in
+                fail("Should not be called")
+            })
+            AblyTests.queue.async {
+                channel.internal.onError(error)
+            }
+        }
+    }
+
+    // RTP8
+
+    // RTP8e
+    func test__078__Presence__enter__optional_data_can_be_included_when_entering_a_channel() {
+        let options = AblyTests.commonAppSetup()
+
+        options.clientId = "john"
+        let client1 = ARTRealtime(options: options)
+        defer { client1.close() }
+        let channel1 = client1.channels.get("test")
+
+        options.clientId = "mary"
+        let client2 = ARTRealtime(options: options)
+        defer { client2.close() }
+        let channel2 = client2.channels.get("test")
+
+        let expectedData = ["data": 123]
+
+        waitUntil(timeout: testTimeout) { done in
+            channel1.attach { error in
+                expect(error).to(beNil())
+                let partlyDone = AblyTests.splitDone(2, done: done)
+                channel1.presence.subscribe(.enter) { member in
+                    expect(member.data as? NSObject).to(equal(expectedData as NSObject?))
+                    partlyDone()
                 }
-
-                // RTP2g
-                func skipped__test__051__Presence__PresenceMap__any_incoming_presence_message_that_passes_the_newness_check_should_be_emitted_on_the_Presence_object__with_an_event_name_set_to_its_original_action() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channelName = NSUUID().uuidString
-                    let channel = client.channels.get(channelName)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channel.presence.enterClient("tester", data: nil) { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                        channel.presence.subscribe(.enter) { _ in
-                            partialDone()
-                        }
-                    }
-
-                    channel.internalSync { _internal in
-                        expect(_internal.presenceMap.members.filter{ _, presence in presence.action == .present }).to(haveCount(1))
-                        expect(_internal.presenceMap.members.filter{ _, presence in presence.action == .enter }).to(beEmpty())
-                    }
+                channel2.presence.enter(expectedData) { error in
+                    expect(error).to(beNil())
+                    partlyDone()
                 }
+            }
+        }
+    }
 
-            // RTP8
-            
-                // RTP8h
-                func test__056__Presence__enter__should_result_in_an_error_if_the_client_does_not_have_required_presence_permission() {
-                    let options = AblyTests.commonAppSetup()
-                    options.token = getTestToken(clientId: "john", capability: "{ \"cannotpresence:john\":[\"publish\"] }")
-                    options.clientId = "john"
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("cannotpresence")
+    // RTP8e
+    func test__079__Presence__enter__should_emit_the_data_attribute_in_the_LEAVE_event_when_data_is_provided_when_entering_but_no_data_is_provided_when_leaving() {
+        let options = AblyTests.commonAppSetup()
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enter(nil) { error in
-                            guard let error = error else {
-                                fail("error expected"); done(); return
-                            }
-                            expect(error.message).to(contain("Channel denied access based on given capability"))
-                            done()
-                        }
-                    }
+        options.clientId = "john"
+        let client1 = ARTRealtime(options: options)
+        defer { client1.close() }
+        let channel1 = client1.channels.get("test")
+
+        options.clientId = "mary"
+        let client2 = ARTRealtime(options: options)
+        defer { client2.close() }
+        let channel2 = client2.channels.get("test")
+
+        let expectedData = "data"
+
+        waitUntil(timeout: testTimeout) { done in
+            channel2.presence.enter(expectedData) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel1.attach { err in
+                expect(err).to(beNil())
+                let partlyDone = AblyTests.splitDone(2, done: done)
+                channel1.presence.subscribe(.leave) { member in
+                    expect(member.data as? NSObject).to(equal(expectedData as NSObject?))
+                    partlyDone()
                 }
-
-
-            // RTP9
-            
-
-                // RTP9e
-                func test__057__Presence__update__should_result_in_an_error_immediately_if_the_client_is_anonymous() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.update(nil) { error in
-                            expect(error!.message).to(contain("attempted to publish presence message without clientId"))
-                            done()
-                        }
-                    }
+                channel2.presence.leave(nil) { error in
+                    expect(error).to(beNil())
+                    partlyDone()
                 }
+            }
+        }
+    }
 
-                // RTP9e
-                func test__058__Presence__update__should_result_in_an_error_immediately_if_the_channel_is_DETACHED() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    // RTP17
 
-                    channel.attach()
-                    channel.detach()
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
+    func skipped__test__080__Presence__private_and_internal_PresenceMap_containing_only_members_that_match_the_current_connectionId__any_ENTER__PRESENT__UPDATE_or_LEAVE_event_that_matches_the_current_connectionId_should_be_applied_to_this_object() {
+        let options = AblyTests.commonAppSetup()
+        let channelName = NSUUID().uuidString
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.update(nil) { error in
-                            expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
-                            done()
-                        }
-                    }
+        options.clientId = "a"
+        let clientA = ARTRealtime(options: options)
+        defer { clientA.dispose(); clientA.close() }
+        let channelA = clientA.channels.get(channelName)
+
+        options.clientId = "b"
+        let clientB = ARTRealtime(options: options)
+        defer { clientB.dispose(); clientB.close() }
+        let channelB = clientB.channels.get(channelName)
+
+        // ENTER
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channelA.presence.subscribe { presence in
+                guard let currentConnectionId = clientA.connection.id else {
+                    fail("ClientA should be connected"); partialDone(); return
                 }
-
-                // RTP9e
-                func test__059__Presence__update__should_result_in_an_error_immediately_if_the_channel_is_FAILED() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    AblyTests.queue.async {
-                        channel.internal.onError(AblyTests.newErrorProtocolMessage())
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.update(nil) { error in
-                            expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
-                            done()
-                        }
-                    }
+                expect(presence.action).to(equal(ARTPresenceAction.enter))
+                expect(presence.connectionId).to(equal(currentConnectionId))
+                expect(channelA.internal.presenceMap.members).to(haveCount(1))
+                expect(channelA.internal.presenceMap.localMembers).to(haveCount(1))
+                channelA.presence.unsubscribe()
+                partialDone()
+            }
+            channelB.presence.subscribe { presence in
+                guard let currentConnectionId = clientB.connection.id else {
+                    fail("ClientB should be connected"); partialDone(); return
                 }
+                expect(presence.action).to(equal(ARTPresenceAction.enter) || equal(ARTPresenceAction.present))
+                expect(presence.connectionId).toNot(equal(currentConnectionId))
+                expect(channelB.internal.presenceMap.members).to(haveCount(1))
+                expect(channelB.internal.presenceMap.localMembers).to(haveCount(0))
+                channelB.presence.unsubscribe()
+                partialDone()
+            }
+            channelA.presence.enter(nil)
+        }
 
-                // RTP9e
-                func test__060__Presence__update__should_result_in_an_error_if_the_client_does_not_have_required_presence_permission() {
-                    let options = AblyTests.clientOptions()
-                    options.token = getTestToken(clientId: "john", capability: "{ \"cannotpresence:john\":[\"publish\"] }")
-                    options.clientId = "john"
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("cannotpresence")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.update(nil) { error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.message).to(contain("Channel denied access based on given capability"))
-                            done()
-                        }
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channelA.presence.subscribe { presence in
+                guard let currentConnectionId = clientA.connection.id else {
+                    fail("ClientA should be connected"); partialDone(); return
                 }
-
-                // RTP9e
-                func test__061__Presence__update__should_result_in_an_error_if_Ably_service_determines_that_the_client_is_unidentified() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.update(nil) { error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.message).to(contain("presence message without clientId"))
-                            done()
-                        }
-                    }
+                expect(presence.action).to(equal(ARTPresenceAction.enter))
+                expect(presence.connectionId).toNot(equal(currentConnectionId))
+                expect(channelA.internal.presenceMap.members).to(haveCount(2))
+                expect(channelA.internal.presenceMap.localMembers).to(haveCount(1))
+                channelA.presence.unsubscribe()
+                partialDone()
+            }
+            channelB.presence.subscribe { presence in
+                guard let currentConnectionId = clientB.connection.id else {
+                    fail("ClientB should be connected"); partialDone(); return
                 }
+                expect(presence.action).to(equal(ARTPresenceAction.enter))
+                expect(presence.connectionId).to(equal(currentConnectionId))
+                expect(channelB.internal.presenceMap.members).to(haveCount(2))
+                expect(channelB.internal.presenceMap.localMembers).to(haveCount(1))
+                channelB.presence.unsubscribe()
+                partialDone()
+            }
+            channelB.presence.enter(nil)
+        }
 
-            // RTP10
-            
-
-                // RTP10b
-                func test__062__Presence__leave__optionally_a_callback_can_be_provided_that_is_called_for_success() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enter("online") { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.leave("offline") { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
+        // UPDATE
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channelA.presence.subscribe { presence in
+                guard let currentConnectionId = clientA.connection.id else {
+                    fail("ClientA should be connected"); partialDone(); return
                 }
-
-                // RTP10b
-                func test__063__Presence__leave__optionally_a_callback_can_be_provided_that_is_called_for_failure() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                   waitUntil(timeout: testTimeout) { done in
-                       channel.presence.enter("online") { error in
-                           expect(error).to(beNil())
-                           done()
-                       }
-                   }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let sentError = ARTErrorInfo.create(withCode: 0, message: "test error")
-                        let transport = client.internal.transport as! TestProxyTransport
-                        transport.enableReplaceAcksWithNacks(with: sentError)
-                        channel.presence.leave("offline") { error in
-                            expect(error).to(beIdenticalTo(sentError))
-                            transport.disableReplaceAcksWithNacks()
-                            done()
-                        }
-                    }
+                expect(presence.action).to(equal(ARTPresenceAction.update))
+                expect(presence.data as? String).to(equal("hello"))
+                expect(presence.connectionId).toNot(equal(currentConnectionId))
+                expect(channelA.internal.presenceMap.members).to(haveCount(2))
+                expect(channelA.internal.presenceMap.localMembers).to(haveCount(1))
+                channelA.presence.unsubscribe()
+                partialDone()
+            }
+            channelB.presence.subscribe { presence in
+                guard let currentConnectionId = clientB.connection.id else {
+                    fail("ClientB should be connected"); partialDone(); return
                 }
+                expect(presence.action).to(equal(ARTPresenceAction.update))
+                expect(presence.data as? String).to(equal("hello"))
+                expect(presence.connectionId).to(equal(currentConnectionId))
+                expect(channelB.internal.presenceMap.members).to(haveCount(2))
+                expect(channelB.internal.presenceMap.localMembers).to(haveCount(1))
+                channelB.presence.unsubscribe()
+                partialDone()
+            }
+            channelB.presence.update("hello")
+        }
 
-                func test__064__Presence__leave__should_raise_an_error_if_client_is_not_present() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.leave("offline") { error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.code) == Int(ARTState.noClientId.rawValue)
-                            expect(error.message).to(contain("message without clientId"))
-                            done()
-                        }
-                    }
+        // LEAVE
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channelA.presence.subscribe { presence in
+                guard let currentConnectionId = clientA.connection.id else {
+                    fail("ClientA should be connected"); partialDone(); return
                 }
-
-                // RTP10c
-                func test__065__Presence__leave__entering_without_an_explicit_PresenceMessage_clientId_should_implicitly_use_the_clientId_of_the_current_connection() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enter("online") { error in
-                            channel.presence.leave(nil) { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-                    }
-
-                    let transport = client.internal.transport as! TestProxyTransport
-
-                    let sent = transport.protocolMessagesSent.filter({ $0.action == .presence })[1].presence![0]
-                    expect(sent.action).to(equal(ARTPresenceAction.leave))
-                    expect(sent.clientId).to(beNil())
-
-                    let receivedPresenceProtocolMessages = transport.protocolMessagesReceived.filter({ $0.action == .presence })
-                    let receivedPresenceMessages = receivedPresenceProtocolMessages.flatMap({ $0.presence! })
-                    let received = receivedPresenceMessages.filter({ $0.action == .leave })[0]
-                    expect(received.action).to(equal(ARTPresenceAction.leave))
-                    expect(received.clientId).to(equal("john"))
+                expect(presence.action).to(equal(ARTPresenceAction.leave))
+                expect(presence.data as? String).to(equal("bye"))
+                expect(presence.connectionId).toNot(equal(currentConnectionId))
+                expect(channelA.internal.presenceMap.members).to(haveCount(1))
+                expect(channelA.internal.presenceMap.localMembers).to(haveCount(1))
+                channelA.presence.unsubscribe()
+                partialDone()
+            }
+            channelB.presence.subscribe { presence in
+                guard let currentConnectionId = clientB.connection.id else {
+                    fail("ClientB should be connected"); partialDone(); return
                 }
+                expect(presence.action).to(equal(ARTPresenceAction.leave))
+                expect(presence.data as? String).to(equal("bye"))
+                expect(presence.connectionId).to(equal(currentConnectionId))
+                expect(channelB.internal.presenceMap.members).to(haveCount(1))
+                expect(channelB.internal.presenceMap.localMembers).to(haveCount(0))
+                channelB.presence.unsubscribe()
+                partialDone()
+            }
+            channelB.presence.leave("bye")
+        }
+    }
 
-                // RTP10d
-                func test__066__Presence__leave__if_the_client_is_not_currently_ENTERED__Ably_will_respond_with_an_ACK_and_the_request_will_succeed() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
+    // RTP17a
+    func skipped__test__081__Presence__private_and_internal_PresenceMap_containing_only_members_that_match_the_current_connectionId__all_members_belonging_to_the_current_connection_are_published_as_a_PresenceMessage_on_the_Channel_by_the_server_irrespective_of_whether_the_client_has_permission_to_subscribe_or_the_Channel_is_configured_to_publish_presence_events() {
+        let options = AblyTests.commonAppSetup()
+        let channelName = NSUUID().uuidString
+        let clientId = NSUUID().uuidString
+        options.tokenDetails = getTestTokenDetails(clientId: clientId, capability: "{\"\(channelName)\":[\"presence\",\"publish\"]}")
+        // Prevent channel name to be prefixed by test-*
+        options.channelNamePrefix = nil
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get(channelName)
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.presence.enterClient(clientId, data: nil) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+            channel.presence.subscribe(.enter) { presence in
+                expect(presence.clientId).to(equal(clientId))
+                partialDone()
+            }
+        }
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, error in
+                expect(error).to(beNil())
+                expect(members).to(haveCount(1))
+                expect(channel.internal.presenceMap.members).to(haveCount(1))
+                expect(channel.internal.presenceMap.localMembers).to(haveCount(1))
+                done()
+            }
+        }
+    }
 
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channelName = NSUUID().uuidString
-                    let channel = client.channels.get(channelName)
+    // RTP17b
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.leave(nil) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
+    func skipped__test__082__Presence__private_and_internal_PresenceMap_containing_only_members_that_match_the_current_connectionId__events_applied_to_presence_map__should_be_applied_to_ENTER__PRESENT_or_UPDATE_events_with_a_connectionId_that_matches_the_current_client_s_connectionId() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enter("online") { error in
-                            expect(error).to(beNil())
-                            channel.presence.leave(nil) { error in
-                                expect(error).to(beNil())
-                                channel.presence.leave(nil) { error in
-                                    expect(error).to(beNil())
-                                    done()
-                                }
-                            }
-                        }
-                    }
+        let channel = client.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.presence.subscribe(.enter) { presence in
+                expect(presence.clientId).to(equal("one"))
+                channel.presence.unsubscribe()
+                partialDone()
+            }
+            channel.presence.enterClient("one", data: nil) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
+
+        guard let connectionId = client.connection.id else {
+            fail("connectionId is empty"); return
+        }
+
+        channel.internalSync { _internal in
+            expect(_internal.presenceMap.localMembers).to(haveCount(1))
+        }
+
+        let additionalMember = ARTPresenceMessage(
+            clientId: "two",
+            action: .enter,
+            connectionId: connectionId,
+            id: connectionId + ":0:0"
+        )
+
+        // Inject an additional member into the myMember set, then force a suspended state
+        client.simulateSuspended(beforeSuspension: { done in
+            channel.internal.presenceMap.localMembers.add(additionalMember)
+            done()
+        })
+        expect(client.connection.state).toEventually(equal(.suspended), timeout: testTimeout)
+
+        expect(channel.internal.presenceMap.localMembers).to(haveCount(2))
+
+        channel.internalSync { _internal in
+            expect(_internal.presenceMap.localMembers).to(haveCount(2))
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(3, done: done)
+
+            channel.once(.attached) { stateChange in
+                expect(stateChange.reason).to(beNil())
+                partialDone()
+            }
+
+            // Await Sync
+            channel.internal.presenceMap.onceSyncEnds { _ in
+                // Should remove the "two" member that was added manually because the connectionId
+                // doesn't match and it's not synthesized, it will be re-entered.
+                expect(channel.internal.presenceMap.localMembers).to(haveCount(1))
+
+                partialDone()
+            }
+
+            channel.presence.subscribe(.enter) { presence in
+                expect(presence.clientId).to(equal("two"))
+                channel.presence.unsubscribe()
+                partialDone()
+            }
+
+            // Reconnect
+            client.connect()
+        }
+
+        // Wait for server
+        waitUntil(timeout: testTimeout) { done in
+            delay(1, closure: done)
+        }
+
+        channel.internalAsync { _internal in
+            _internal.sync()
+        }
+
+        expect(channel.presence.syncComplete).to(beFalse())
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { presences, error in
+                expect(error).to(beNil())
+                guard let presences = presences else {
+                    fail("Presences is nil"); done(); return
                 }
+                expect(channel.presence.syncComplete).to(beTrue())
+                expect(presences).to(haveCount(2))
+                expect(presences.map { $0.clientId }).to(contain(["one", "two"]))
+                done()
+            }
+        }
+    }
 
-            // RTP8
-            
+    func skipped__test__083__Presence__private_and_internal_PresenceMap_containing_only_members_that_match_the_current_connectionId__events_applied_to_presence_map__should_be_applied_to_any_LEAVE_event_with_a_connectionId_that_matches_the_current_client_s_connectionId_and_is_not_a_synthesized() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        client.internal.shouldImmediatelyReconnect = false
+        defer { client.dispose(); client.close() }
 
-                // RTP8d
-                func test__067__Presence__enter__implicitly_attaches_the_Channel() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
+        let channel = client.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.presence.subscribe(.enter) { presence in
+                expect(presence.clientId).to(equal("one"))
+                channel.presence.unsubscribe()
+                partialDone()
+            }
+            channel.presence.enterClient("one", data: nil) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
 
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
+        waitUntil(timeout: .seconds(20)) { done in
+            channel.internal.presenceMap.onceSyncEnds { _ in
+                // Synthesized leave
+                expect(channel.internal.presenceMap.localMembers).to(beEmpty())
+                done()
+            }
+            client.internal.onDisconnected()
+        }
 
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enter("online") { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-                    }
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.subscribe(.enter) { presence in
+                // Re-entering...
+                expect(presence.clientId).to(equal("one"))
+                channel.presence.unsubscribe()
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { presences, error in
+                expect(error).to(beNil())
+                guard let presences = presences else {
+                    fail("Presences is nil"); done(); return
                 }
+                expect(channel.internal.presenceMap.syncComplete).to(beTrue())
+                expect(presences).to(haveCount(1))
+                expect(presences.map { $0.clientId }).to(contain(["one"]))
+                done()
+            }
+        }
+    }
 
-                // RTP8d
-                func test__068__Presence__enter__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
+    // RTP15d
+    func test__004__Presence__callback_can_be_provided_that_will_be_called_upon_success() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("room")
 
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enterClient("Client 1", data: nil) { errorInfo in
+                expect(errorInfo).to(beNil())
+                done()
+            }
+        }
+    }
 
-                    AblyTests.queue.async {
-                        channel.internal.onError(AblyTests.newErrorProtocolMessage())
-                    }
+    // RTP15d
+    func test__005__Presence__callback_can_be_provided_that_will_be_called_upon_failure() {
+        let options = AblyTests.clientOptions()
+        options.token = getTestToken(capability: "{ \"room\":[\"subscribe\"] }")
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("private-room")
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enter("online") { error in
-                            expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
-                            done()
-                        }
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enterClient("Client 1", data: nil) { errorInfo in
+                guard let errorInfo = errorInfo else {
+                    fail("ErrorInfo is empty"); done()
+                    return
+                }
+                expect(errorInfo.code).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
+                done()
+            }
+        }
+    }
+
+    // RTP15c
+    func test__006__Presence__should_also_ensure_that_using_updateClient_has_no_side_effects_on_a_client_that_has_entered_normally_using_Presence_enter() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enter(nil) { error in
+                expect(error).to(beNil())
+                channel.presence.updateClient("john", data: "mobile") { error in
+                    expect(error).to(beNil())
+                    done()
+                }
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, _ in
+                expect(members!.first!.data as? String).to(equal("mobile"))
+                done()
+            }
+        }
+    }
+
+    enum TestCase_ReusableTestsTestPresencePerformMethod {
+        case should_implicitly_attach_the_Channel
+        case should_result_in_an_error_if_the_channel_is_in_the_FAILED_state
+        case should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state
+    }
+
+    // RTP15e
+    func reusableTestsTestPresencePerformMethod(testCase: TestCase_ReusableTestsTestPresencePerformMethod, beforeEach contextBeforeEach: (() -> Void)? = nil, afterEach contextAfterEach: (() -> Void)? = nil, _ performMethod: @escaping (ARTRealtimePresence, ((ARTErrorInfo?) -> Void)?) -> Void) {
+        func test__should_implicitly_attach_the_Channel() {
+            contextBeforeEach?()
+
+            let client = ARTRealtime(options: AblyTests.commonAppSetup())
+            defer { client.dispose(); client.close() }
+            let channel = client.channels.get("test")
+
+            expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
+            waitUntil(timeout: testTimeout) { done in
+                // Call: enterClient, updateClient and leaveClient
+                performMethod(channel.presence) { errorInfo in
+                    expect(errorInfo).to(beNil())
+                    done()
+                }
+                expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+            }
+            expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+
+            contextAfterEach?()
+        }
+
+        func test__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
+            contextBeforeEach?()
+
+            let client = ARTRealtime(options: AblyTests.commonAppSetup())
+            defer { client.dispose(); client.close() }
+            let channel = client.channels.get("test")
+
+            let expectedErrorMessage = "Something has failed"
+            AblyTests.queue.async {
+                channel.internal.onError(AblyTests.newErrorProtocolMessage(message: expectedErrorMessage))
+            }
+
+            waitUntil(timeout: testTimeout) { done in
+                // Call: enterClient, updateClient and leaveClient
+                performMethod(channel.presence) { error in
+                    expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
                     expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+                    guard let reason = channel.errorReason else {
+                        fail("Reason is empty"); done(); return
+                    }
+                    expect(reason.message).to(equal(expectedErrorMessage))
+                    done()
                 }
+            }
 
-                // RTP8d
-                func test__069__Presence__enter__should_result_in_an_error_if_the_channel_is_in_the_DETACHED_state() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
+            contextAfterEach?()
+        }
 
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
+        func test__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
+            contextBeforeEach?()
 
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channel.attach { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                        channel.detach { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                    }
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
+            let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+            defer { client.dispose(); client.close() }
+            let channel = client.channels.get("test")
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enter("online") { error in
-                            expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
-                            done()
-                        }
-                    }
-                }
-
-            // RTP10
-            
-
-                // RTP10e
-                func test__070__Presence__leave__should_result_in_an_error_immediately_if_the_client_is_anonymous() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.leave(nil) { error in
-                            expect(error!.message).to(contain("attempted to publish presence message without clientId"))
-                            done()
-                        }
-                    }
-                }
-
-                // RTP10e
-                func test__071__Presence__leave__should_result_in_an_error_immediately_if_the_channel_is_DETACHED() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enter(nil) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    channel.detach()
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.leave(nil) { error in
-                            expect(error!.message).to(contain("invalid channel state"))
-                            done()
-                        }
-                    }
-                }
-
-                // RTP10e
-                func test__072__Presence__leave__should_result_in_an_error_immediately_if_the_channel_is_FAILED() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john"
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enter(nil) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
+            waitUntil(timeout: testTimeout) { done in
+                let error = AblyTests.newErrorProtocolMessage()
+                channel.once(.attaching) { _ in
                     AblyTests.queue.async {
-                        channel.internal.onError(AblyTests.newErrorProtocolMessage())
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.leave(nil) { error in
-                            expect(error!.message).to(contain("invalid channel state"))
-                            done()
-                        }
+                        channel.internal.onError(error)
                     }
                 }
-
-                // RTP10e
-                func test__073__Presence__leave__should_result_in_an_error_if_the_client_does_not_have_required_presence_permission() {
-                    let options = AblyTests.clientOptions()
-                    options.token = getTestToken(clientId: "john", capability: "{ \"cannotpresence:other\":[\"publish\"] }")
-                    options.clientId = "john"
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("cannotpresence")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.leaveClient("other", data: nil) { error in
-                            expect(error!.message).to(contain("Channel denied access based on given capability"))
-                            done()
-                        }
-                    }
-                }
-
-                // RTP10e
-                func test__074__Presence__leave__should_result_in_an_error_if_Ably_service_determines_that_the_client_is_unidentified() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.leave(nil) { error in
-                            expect(error!.message).to(contain("presence message without clientId"))
-                            done()
-                        }
-                    }
-                }
-
-            // RTP6
-            
-
-                // RTP6c
-                func test__075__Presence__subscribe__should_implicitly_attach_the_channel() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
-                    channel.presence.subscribe { _ in }
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
-                    channel.detach()
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
-
-                    channel.presence.subscribe(.present) { _ in }
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-                }
-
-                // RTP6c
-                func test__076__Presence__subscribe__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    let protocolError = AblyTests.newErrorProtocolMessage()
-                    AblyTests.queue.async {
-                        channel.internal.onError(protocolError)
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.subscribe(attachCallback: { error in
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-                            expect(error).toNot(beNil())
-                            done()
-                        }, callback: { member in
-                            fail("Should not be called")
-                        })
-                    }
-                }
-
-                // RTP6c
-                func test__077__Presence__subscribe__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let error = AblyTests.newErrorProtocolMessage()
-                        channel.presence.subscribe(attachCallback: { error in
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-                            expect(error).toNot(beNil())
-                            done()
-                        }, callback: { member in
-                            fail("Should not be called")
-                        })
-                        AblyTests.queue.async {
-                            channel.internal.onError(error)
-                        }
-                    }
-                }
-
-            // RTP8
-            
-
-                // RTP8e
-                func test__078__Presence__enter__optional_data_can_be_included_when_entering_a_channel() {
-                    let options = AblyTests.commonAppSetup()
-
-                    options.clientId = "john"
-                    let client1 = ARTRealtime(options: options)
-                    defer { client1.close() }
-                    let channel1 = client1.channels.get("test")
-
-                    options.clientId = "mary"
-                    let client2 = ARTRealtime(options: options)
-                    defer { client2.close() }
-                    let channel2 = client2.channels.get("test")
-
-                    let expectedData = ["data":123]
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel1.attach { error in
-                            expect(error).to(beNil())
-                            let partlyDone = AblyTests.splitDone(2, done: done)
-                            channel1.presence.subscribe(.enter) { member in
-                                expect(member.data as? NSObject).to(equal(expectedData as NSObject?))
-                                partlyDone()
-                            }
-                            channel2.presence.enter(expectedData) { error in
-                                expect(error).to(beNil())
-                                partlyDone()
-                            }
-                        }
-                    }
-                }
-
-                // RTP8e
-                func test__079__Presence__enter__should_emit_the_data_attribute_in_the_LEAVE_event_when_data_is_provided_when_entering_but_no_data_is_provided_when_leaving() {
-                    let options = AblyTests.commonAppSetup()
-
-                    options.clientId = "john"
-                    let client1 = ARTRealtime(options: options)
-                    defer { client1.close() }
-                    let channel1 = client1.channels.get("test")
-
-                    options.clientId = "mary"
-                    let client2 = ARTRealtime(options: options)
-                    defer { client2.close() }
-                    let channel2 = client2.channels.get("test")
-
-                    let expectedData = "data"
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel2.presence.enter(expectedData) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel1.attach { err in
-                            expect(err).to(beNil())
-                            let partlyDone = AblyTests.splitDone(2, done: done)
-                            channel1.presence.subscribe(.leave) { member in
-                                expect(member.data as? NSObject).to(equal(expectedData as NSObject?))
-                                partlyDone()
-                            }
-                            channel2.presence.leave(nil) { error in
-                                expect(error).to(beNil())
-                                partlyDone()
-                            }
-                        }
-                    }
-                }
-
-            // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-            // RTP17
-            
-
-                func skipped__test__080__Presence__private_and_internal_PresenceMap_containing_only_members_that_match_the_current_connectionId__any_ENTER__PRESENT__UPDATE_or_LEAVE_event_that_matches_the_current_connectionId_should_be_applied_to_this_object() {
-                    let options = AblyTests.commonAppSetup()
-                    let channelName = NSUUID().uuidString
-
-                    options.clientId = "a"
-                    let clientA = ARTRealtime(options: options)
-                    defer { clientA.dispose(); clientA.close() }
-                    let channelA = clientA.channels.get(channelName)
-
-                    options.clientId = "b"
-                    let clientB = ARTRealtime(options: options)
-                    defer { clientB.dispose(); clientB.close() }
-                    let channelB = clientB.channels.get(channelName)
-
-                    // ENTER
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channelA.presence.subscribe { presence in
-                            guard let currentConnectionId = clientA.connection.id else {
-                                fail("ClientA should be connected"); partialDone(); return
-                            }
-                            expect(presence.action).to(equal(ARTPresenceAction.enter))
-                            expect(presence.connectionId).to(equal(currentConnectionId))
-                            expect(channelA.internal.presenceMap.members).to(haveCount(1))
-                            expect(channelA.internal.presenceMap.localMembers).to(haveCount(1))
-                            channelA.presence.unsubscribe()
-                            partialDone()
-                        }
-                        channelB.presence.subscribe { presence in
-                            guard let currentConnectionId = clientB.connection.id else {
-                                fail("ClientB should be connected"); partialDone(); return
-                            }
-                            expect(presence.action).to(equal(ARTPresenceAction.enter) || equal(ARTPresenceAction.present))
-                            expect(presence.connectionId).toNot(equal(currentConnectionId))
-                            expect(channelB.internal.presenceMap.members).to(haveCount(1))
-                            expect(channelB.internal.presenceMap.localMembers).to(haveCount(0))
-                            channelB.presence.unsubscribe()
-                            partialDone()
-                        }
-                        channelA.presence.enter(nil)
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channelA.presence.subscribe { presence in
-                            guard let currentConnectionId = clientA.connection.id else {
-                                fail("ClientA should be connected"); partialDone(); return
-                            }
-                            expect(presence.action).to(equal(ARTPresenceAction.enter))
-                            expect(presence.connectionId).toNot(equal(currentConnectionId))
-                            expect(channelA.internal.presenceMap.members).to(haveCount(2))
-                            expect(channelA.internal.presenceMap.localMembers).to(haveCount(1))
-                            channelA.presence.unsubscribe()
-                            partialDone()
-                        }
-                        channelB.presence.subscribe { presence in
-                            guard let currentConnectionId = clientB.connection.id else {
-                                fail("ClientB should be connected"); partialDone(); return
-                            }
-                            expect(presence.action).to(equal(ARTPresenceAction.enter))
-                            expect(presence.connectionId).to(equal(currentConnectionId))
-                            expect(channelB.internal.presenceMap.members).to(haveCount(2))
-                            expect(channelB.internal.presenceMap.localMembers).to(haveCount(1))
-                            channelB.presence.unsubscribe()
-                            partialDone()
-                        }
-                        channelB.presence.enter(nil)
-                    }
-
-                    // UPDATE
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channelA.presence.subscribe { presence in
-                            guard let currentConnectionId = clientA.connection.id else {
-                                fail("ClientA should be connected"); partialDone(); return
-                            }
-                            expect(presence.action).to(equal(ARTPresenceAction.update))
-                            expect(presence.data as? String).to(equal("hello"))
-                            expect(presence.connectionId).toNot(equal(currentConnectionId))
-                            expect(channelA.internal.presenceMap.members).to(haveCount(2))
-                            expect(channelA.internal.presenceMap.localMembers).to(haveCount(1))
-                            channelA.presence.unsubscribe()
-                            partialDone()
-                        }
-                        channelB.presence.subscribe { presence in
-                            guard let currentConnectionId = clientB.connection.id else {
-                                fail("ClientB should be connected"); partialDone(); return
-                            }
-                            expect(presence.action).to(equal(ARTPresenceAction.update))
-                            expect(presence.data as? String).to(equal("hello"))
-                            expect(presence.connectionId).to(equal(currentConnectionId))
-                            expect(channelB.internal.presenceMap.members).to(haveCount(2))
-                            expect(channelB.internal.presenceMap.localMembers).to(haveCount(1))
-                            channelB.presence.unsubscribe()
-                            partialDone()
-                        }
-                        channelB.presence.update("hello")
-                    }
-
-                    // LEAVE
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channelA.presence.subscribe { presence in
-                            guard let currentConnectionId = clientA.connection.id else {
-                                fail("ClientA should be connected"); partialDone(); return
-                            }
-                            expect(presence.action).to(equal(ARTPresenceAction.leave))
-                            expect(presence.data as? String).to(equal("bye"))
-                            expect(presence.connectionId).toNot(equal(currentConnectionId))
-                            expect(channelA.internal.presenceMap.members).to(haveCount(1))
-                            expect(channelA.internal.presenceMap.localMembers).to(haveCount(1))
-                            channelA.presence.unsubscribe()
-                            partialDone()
-                        }
-                        channelB.presence.subscribe { presence in
-                            guard let currentConnectionId = clientB.connection.id else {
-                                fail("ClientB should be connected"); partialDone(); return
-                            }
-                            expect(presence.action).to(equal(ARTPresenceAction.leave))
-                            expect(presence.data as? String).to(equal("bye"))
-                            expect(presence.connectionId).to(equal(currentConnectionId))
-                            expect(channelB.internal.presenceMap.members).to(haveCount(1))
-                            expect(channelB.internal.presenceMap.localMembers).to(haveCount(0))
-                            channelB.presence.unsubscribe()
-                            partialDone()
-                        }
-                        channelB.presence.leave("bye")
-                    }
-                }
-
-                // RTP17a
-                func skipped__test__081__Presence__private_and_internal_PresenceMap_containing_only_members_that_match_the_current_connectionId__all_members_belonging_to_the_current_connection_are_published_as_a_PresenceMessage_on_the_Channel_by_the_server_irrespective_of_whether_the_client_has_permission_to_subscribe_or_the_Channel_is_configured_to_publish_presence_events() {
-                    let options = AblyTests.commonAppSetup()
-                    let channelName = NSUUID().uuidString
-                    let clientId = NSUUID().uuidString
-                    options.tokenDetails = getTestTokenDetails(clientId: clientId, capability: "{\"\(channelName)\":[\"presence\",\"publish\"]}")
-                    // Prevent channel name to be prefixed by test-*
-                    options.channelNamePrefix = nil
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get(channelName)
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channel.presence.enterClient(clientId, data: nil) { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                        channel.presence.subscribe(.enter) { presence in
-                            expect(presence.clientId).to(equal(clientId))
-                            partialDone()
-                        }
-                    }
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.get { members, error in
-                            expect(error).to(beNil())
-                            expect(members).to(haveCount(1))
-                            expect(channel.internal.presenceMap.members).to(haveCount(1))
-                            expect(channel.internal.presenceMap.localMembers).to(haveCount(1))
-                            done()
-                        }
-                    }
-                }
-
-                // RTP17b
-                
-
-                    func skipped__test__082__Presence__private_and_internal_PresenceMap_containing_only_members_that_match_the_current_connectionId__events_applied_to_presence_map__should_be_applied_to_ENTER__PRESENT_or_UPDATE_events_with_a_connectionId_that_matches_the_current_client_s_connectionId() {
-                        let options = AblyTests.commonAppSetup()
-                        let client = ARTRealtime(options: options)
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("foo")
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            channel.presence.subscribe(.enter) { presence in
-                                expect(presence.clientId).to(equal("one"))
-                                channel.presence.unsubscribe()
-                                partialDone()
-                            }
-                            channel.presence.enterClient("one", data: nil) { error in
-                                expect(error).to(beNil())
-                                partialDone()
-                            }
-                        }
-
-                        guard let connectionId = client.connection.id else {
-                            fail("connectionId is empty"); return
-                        }
-
-                        channel.internalSync { _internal in
-                            expect(_internal.presenceMap.localMembers).to(haveCount(1))
-                        }
-
-                        let additionalMember = ARTPresenceMessage(
-                            clientId: "two",
-                            action: .enter,
-                            connectionId: connectionId,
-                            id: connectionId + ":0:0"
-                        )
-
-                        // Inject an additional member into the myMember set, then force a suspended state
-                        client.simulateSuspended(beforeSuspension: { done in
-                            channel.internal.presenceMap.localMembers.add(additionalMember)
-                            done()
-                        })
-                        expect(client.connection.state).toEventually(equal(.suspended), timeout: testTimeout)
-
-                        expect(channel.internal.presenceMap.localMembers).to(haveCount(2))
-                        
-                        channel.internalSync { _internal in
-                            expect(_internal.presenceMap.localMembers).to(haveCount(2))
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(3, done: done)
-
-                            channel.once(.attached) { stateChange in
-                                expect(stateChange.reason).to(beNil())
-                                partialDone()
-                            }
-
-                            // Await Sync
-                            channel.internal.presenceMap.onceSyncEnds { _ in
-                                // Should remove the "two" member that was added manually because the connectionId
-                                //doesn't match and it's not synthesized, it will be re-entered.
-                                expect(channel.internal.presenceMap.localMembers).to(haveCount(1))
-
-                                partialDone()
-                            }
-
-                            channel.presence.subscribe(.enter) { presence in
-                                expect(presence.clientId).to(equal("two"))
-                                channel.presence.unsubscribe()
-                                partialDone()
-                            }
-
-                            // Reconnect
-                            client.connect()
-                        }
-
-                        // Wait for server
-                        waitUntil(timeout: testTimeout) { done in
-                            delay(1, closure: done)
-                        }
-
-                        channel.internalAsync { _internal in
-                            _internal.sync()
-                        }
-
-                        expect(channel.presence.syncComplete).to(beFalse())
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.presence.get { presences, error in
-                                expect(error).to(beNil())
-                                guard let presences = presences else {
-                                    fail("Presences is nil"); done(); return
-                                }
-                                expect(channel.presence.syncComplete).to(beTrue())
-                                expect(presences).to(haveCount(2))
-                                expect(presences.map({$0.clientId})).to(contain(["one", "two"]))
-                                done()
-                            }
-                        }
-                    }
-
-                    func skipped__test__083__Presence__private_and_internal_PresenceMap_containing_only_members_that_match_the_current_connectionId__events_applied_to_presence_map__should_be_applied_to_any_LEAVE_event_with_a_connectionId_that_matches_the_current_client_s_connectionId_and_is_not_a_synthesized() {
-                        let options = AblyTests.commonAppSetup()
-                        let client = ARTRealtime(options: options)
-                        client.internal.shouldImmediatelyReconnect = false
-                        defer { client.dispose(); client.close() }
-
-                        let channel = client.channels.get("foo")
-                        waitUntil(timeout: testTimeout) { done in
-                            let partialDone = AblyTests.splitDone(2, done: done)
-                            channel.presence.subscribe(.enter) { presence in
-                                expect(presence.clientId).to(equal("one"))
-                                channel.presence.unsubscribe()
-                                partialDone()
-                            }
-                            channel.presence.enterClient("one", data: nil) { error in
-                                expect(error).to(beNil())
-                                partialDone()
-                            }
-                        }
-
-                        waitUntil(timeout: .seconds(20)) { done in
-                            channel.internal.presenceMap.onceSyncEnds { _ in
-                                // Synthesized leave
-                                expect(channel.internal.presenceMap.localMembers).to(beEmpty())
-                                done()
-                            }
-                            client.internal.onDisconnected()
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.presence.subscribe(.enter) { presence in
-                                // Re-entering...
-                                expect(presence.clientId).to(equal("one"))
-                                channel.presence.unsubscribe()
-                                done()
-                            }
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.presence.get { presences, error in
-                                expect(error).to(beNil())
-                                guard let presences = presences else {
-                                    fail("Presences is nil"); done(); return
-                                }
-                                expect(channel.internal.presenceMap.syncComplete).to(beTrue())
-                                expect(presences).to(haveCount(1))
-                                expect(presences.map({$0.clientId})).to(contain(["one"]))
-                                done()
-                            }
-                        }
-                    }
-
-            // RTP15d
-            func test__004__Presence__callback_can_be_provided_that_will_be_called_upon_success() {
-                let options = AblyTests.commonAppSetup()
-                let client = ARTRealtime(options: options)
-                defer { client.dispose(); client.close() }
-                let channel = client.channels.get("room")
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.presence.enterClient("Client 1", data: nil) { errorInfo in
-                        expect(errorInfo).to(beNil())
-                        done()
-                    }
+                (client.internal.transport as! TestProxyTransport).actionsIgnored += [.attached]
+                // Call: enterClient, updateClient and leaveClient
+                performMethod(channel.presence) { errorInfo in
+                    expect(errorInfo).to(equal(error.error))
+                    done()
                 }
             }
 
-            // RTP15d
-            func test__005__Presence__callback_can_be_provided_that_will_be_called_upon_failure() {
-                let options = AblyTests.clientOptions()
-                options.token = getTestToken(capability: "{ \"room\":[\"subscribe\"] }")
-                let client = ARTRealtime(options: options)
-                defer { client.dispose(); client.close() }
-                let channel = client.channels.get("private-room")
+            contextAfterEach?()
+        }
 
-                waitUntil(timeout: testTimeout) { done in
-                    channel.presence.enterClient("Client 1", data: nil) { errorInfo in
-                        guard let errorInfo = errorInfo else {
-                            fail("ErrorInfo is empty"); done()
-                            return
-                        }
-                        expect(errorInfo.code).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
-                        done()
-                    }
+        switch testCase {
+        case .should_implicitly_attach_the_Channel:
+            test__should_implicitly_attach_the_Channel()
+        case .should_result_in_an_error_if_the_channel_is_in_the_FAILED_state:
+            test__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state()
+        case .should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state:
+            test__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state()
+        }
+    }
+
+    func reusableTestsWrapper__Presence__enterClient__reusableTestsTestPresencePerformMethod(testCase: TestCase_ReusableTestsTestPresencePerformMethod) {
+        reusableTestsTestPresencePerformMethod(testCase: testCase) { $0.enterClient("john", data: nil, callback: $1) }
+    }
+
+    func test__084__Presence__enterClient__should_implicitly_attach_the_Channel() {
+        reusableTestsWrapper__Presence__enterClient__reusableTestsTestPresencePerformMethod(testCase: .should_implicitly_attach_the_Channel)
+    }
+
+    func test__085__Presence__enterClient__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
+        reusableTestsWrapper__Presence__enterClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_is_in_the_FAILED_state)
+    }
+
+    func test__086__Presence__enterClient__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
+        reusableTestsWrapper__Presence__enterClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state)
+    }
+
+    func reusableTestsWrapper__Presence__updateClient__reusableTestsTestPresencePerformMethod(testCase: TestCase_ReusableTestsTestPresencePerformMethod) {
+        reusableTestsTestPresencePerformMethod(testCase: testCase) { $0.updateClient("john", data: nil, callback: $1) }
+    }
+
+    func test__087__Presence__updateClient__should_implicitly_attach_the_Channel() {
+        reusableTestsWrapper__Presence__updateClient__reusableTestsTestPresencePerformMethod(testCase: .should_implicitly_attach_the_Channel)
+    }
+
+    func test__088__Presence__updateClient__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
+        reusableTestsWrapper__Presence__updateClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_is_in_the_FAILED_state)
+    }
+
+    func test__089__Presence__updateClient__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
+        reusableTestsWrapper__Presence__updateClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state)
+    }
+
+    func reusableTestsWrapper__Presence__leaveClient__reusableTestsTestPresencePerformMethod(testCase: TestCase_ReusableTestsTestPresencePerformMethod) {
+        reusableTestsTestPresencePerformMethod(testCase: testCase) { $0.leaveClient("john", data: nil, callback: $1) }
+    }
+
+    func test__090__Presence__leaveClient__should_implicitly_attach_the_Channel() {
+        reusableTestsWrapper__Presence__leaveClient__reusableTestsTestPresencePerformMethod(testCase: .should_implicitly_attach_the_Channel)
+    }
+
+    func test__091__Presence__leaveClient__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
+        reusableTestsWrapper__Presence__leaveClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_is_in_the_FAILED_state)
+    }
+
+    func test__092__Presence__leaveClient__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
+        reusableTestsWrapper__Presence__leaveClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state)
+    }
+
+    // RTP15f
+    func test__007__Presence__should_indicate_an_error_if_the_client_is_identified_and_has_a_valid_clientId_and_the_clientId_argument_does_not_match_the_client_s_clientId() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enter("browser") { error in
+                expect(error).to(beNil())
+                channel.presence.updateClient("tester", data: "mobile") { error in
+                    expect(error!.message).to(contain("mismatched clientId"))
+                    done()
                 }
             }
+        }
 
-            // RTP15c
-            func test__006__Presence__should_also_ensure_that_using_updateClient_has_no_side_effects_on_a_client_that_has_entered_normally_using_Presence_enter() {
-                let options = AblyTests.commonAppSetup()
-                options.clientId = "john"
-                let client = ARTRealtime(options: options)
-                defer { client.dispose(); client.close() }
-                let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, _ in
+                expect(members?.first?.data as? String).to(equal("browser"))
+                done()
+            }
+        }
+    }
 
-                waitUntil(timeout: testTimeout) { done in
-                    channel.presence.enter(nil) { error in
-                        expect(error).to(beNil())
-                        channel.presence.updateClient("john", data:"mobile") { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
+    // RTP16
 
-                waitUntil(timeout: testTimeout) { done in
-                    channel.presence.get() { members, error in
-                        expect(members!.first!.data as? String).to(equal("mobile"))
-                        done()
-                    }
+    // RTP16a
+    func test__093__Presence__Connection_state_conditions__all_presence_messages_are_published_immediately_if_the_connection_is_CONNECTED() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enterClient("user", data: nil) { error in
+                expect(error).to(beNil())
+                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+                expect(client.internal.queuedMessages).to(haveCount(0))
+                done()
+            }
+            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connecting))
+            expect(client.internal.queuedMessages).to(haveCount(1))
+        }
+    }
+
+    // RTP16b
+    func test__094__Presence__Connection_state_conditions__all_presence_messages_will_be_queued_and_delivered_as_soon_as_the_connection_state_returns_to_CONNECTED() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        expect(client.internal.options.queueMessages).to(beTrue())
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { _ in
+                client.internal.onDisconnected()
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enterClient("user", data: nil) { error in
+                expect(error).to(beNil())
+                expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
+                expect(client.internal.queuedMessages).to(haveCount(0))
+                done()
+            }
+            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.disconnected))
+            expect(client.internal.queuedMessages).to(haveCount(1))
+        }
+    }
+
+    // RTP16b
+    func test__095__Presence__Connection_state_conditions__all_presence_messages_will_be_lost_if_queueMessages_has_been_explicitly_set_to_false() {
+        let options = AblyTests.commonAppSetup()
+        options.queueMessages = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        expect(client.internal.options.queueMessages).to(beFalse())
+
+        expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { _ in
+                client.internal.onDisconnected()
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enterClient("user", data: nil) { error in
+                expect(error).toNot(beNil())
+                done()
+            }
+            expect(client.internal.queuedMessages).to(haveCount(0))
+        }
+    }
+
+    // RTP16c
+    func test__096__Presence__Connection_state_conditions__should_result_in_an_error_if_the_connection_state_is_INITIALIZED_and_queueMessages_has_been_explicitly_set_to_false() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        options.queueMessages = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.initialized))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enterClient("user", data: nil) { error in
+                expect(error?.code).to(equal(ARTErrorCode.invalidTransportHandle.intValue))
+                expect(channel.presence.internal.pendingPresence).to(haveCount(0))
+                done()
+            }
+            expect(channel.presence.internal.pendingPresence).to(haveCount(0))
+        }
+    }
+
+    func test__097__Presence__Connection_state_conditions__should_result_in_an_error_if_the_connection_state_is__suspended() {
+        testResultsInErrorWithConnectionState(.suspended) { client in
+            AblyTests.queue.async {
+                client.internal.onSuspended()
+            }
+        }
+    }
+
+    func test__098__Presence__Connection_state_conditions__should_result_in_an_error_if_the_connection_state_is__closed() {
+        testResultsInErrorWithConnectionState(.closed) { client in
+            client.close()
+        }
+    }
+
+    func test__099__Presence__Connection_state_conditions__should_result_in_an_error_if_the_connection_state_is__failed() {
+        testResultsInErrorWithConnectionState(.failed) { client in
+            AblyTests.queue.async {
+                client.internal.onError(AblyTests.newErrorProtocolMessage())
+            }
+        }
+    }
+
+    // RTP11
+
+    func test__106__Presence__get__query__waitForSync_should_be_true_by_default() {
+        expect(ARTRealtimePresenceQuery().waitForSync).to(beTrue())
+    }
+
+    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    // RTP11a
+    func skipped__test__100__Presence__get__should_return_a_list_of_current_members_on_the_channel() {
+        let options = AblyTests.commonAppSetup()
+
+        var disposable = [ARTRealtime]()
+        defer {
+            for clientItem in disposable {
+                clientItem.dispose()
+                clientItem.close()
+            }
+        }
+
+        let expectedData = "online"
+
+        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 150, data: expectedData as AnyObject?, options: options)]
+
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        let hook = ARTRealtimePresenceQuery.testSuite_injectIntoClassMethod(#selector(ARTRealtimePresenceQuery.init as () -> ARTRealtimePresenceQuery)) { // Default initialiser: referring to the no-parameter variant of `init` as one of several overloaded methods requires an explicit `as <signature>` cast
+        }
+        defer { hook?.remove() }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, error in
+                expect(error).to(beNil())
+                expect(members).to(haveCount(150))
+                expect(members!.first).to(beAnInstanceOf(ARTPresenceMessage.self))
+                expect(members).to(allPass { member in
+                    NSRegularExpression.match(member!.clientId, pattern: "^user(\\d+)$")
+                        && (member!.data as? String) == expectedData
+                })
+                done()
+            }
+        }
+    }
+
+    // RTP11b
+    func test__101__Presence__get__should_implicitly_attach_the_channel() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { membersPage, error in
+                expect(error).to(beNil())
+                expect(membersPage).toNot(beNil())
+                done()
+            }
+            expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
+        }
+        expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
+    }
+
+    // RTP11b
+    func test__102__Presence__get__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        let pm = AblyTests.newErrorProtocolMessage()
+        AblyTests.queue.async {
+            channel.internal.onError(pm)
+        }
+
+        guard let protocolError = pm.error else {
+            fail("Protocol error is empty"); return
+        }
+        guard let channelError = channel.errorReason else {
+            fail("Channel error is empty"); return
+        }
+        expect(channelError.message).to(equal(protocolError.message))
+        expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, error in
+                expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
+                expect(channel.errorReason).to(equal(protocolError))
+                expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+                expect(members).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RTP11b
+    func test__103__Presence__get__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            let pm = AblyTests.newErrorProtocolMessage()
+            guard let protocolError = pm.error else {
+                fail("Protocol error is empty"); done(); return
+            }
+            (client.internal.transport as! TestProxyTransport).actionsIgnored += [.attached]
+            channel.once(.attaching) { _ in
+                AblyTests.queue.async {
+                    channel.internal.onError(pm)
                 }
             }
-enum TestCase_ReusableTestsTestPresencePerformMethod {
-case should_implicitly_attach_the_Channel
-case should_result_in_an_error_if_the_channel_is_in_the_FAILED_state
-case should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state
-}
-
-
-            // RTP15e
-            func reusableTestsTestPresencePerformMethod(testCase: TestCase_ReusableTestsTestPresencePerformMethod, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil, _ performMethod: @escaping (ARTRealtimePresence, Optional<(ARTErrorInfo?)->Void>)->()) {
-                func test__should_implicitly_attach_the_Channel() {
-contextBeforeEach?()
-
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-                    
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
-                    waitUntil(timeout: testTimeout) { done in
-                        //Call: enterClient, updateClient and leaveClient
-                        performMethod(channel.presence) { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            done()
-                        }
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-                    }
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
-
-contextAfterEach?()
-
+            channel.presence.get { members, error in
+                guard let error = error else {
+                    fail("Error is empty"); done(); return
                 }
-                
-                func test__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
-contextBeforeEach?()
-
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-                    
-                    let expectedErrorMessage = "Something has failed"
-                    AblyTests.queue.async {
-                        channel.internal.onError(AblyTests.newErrorProtocolMessage(message: expectedErrorMessage))
-                    }
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        //Call: enterClient, updateClient and leaveClient
-                        performMethod(channel.presence) { error in
-                            expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-                            guard let reason = channel.errorReason else {
-                                fail("Reason is empty"); done(); return
-                            }
-                            expect(reason.message).to(equal(expectedErrorMessage))
-                            done()
-                        }
-                    }
-
-contextAfterEach?()
-
-                }
-                
-                func test__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
-contextBeforeEach?()
-
-                    let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        let error = AblyTests.newErrorProtocolMessage()
-                        channel.once(.attaching) { _ in
-                            AblyTests.queue.async {
-                                channel.internal.onError(error)
-                            }
-                        }
-                        (client.internal.transport as! TestProxyTransport).actionsIgnored += [.attached]
-                        //Call: enterClient, updateClient and leaveClient
-                        performMethod(channel.presence) { errorInfo in
-                            expect(errorInfo).to(equal(error.error))
-                            done()
-                        }
-                    }
-
-contextAfterEach?()
-
-                }
-
-switch testCase  {
-case .should_implicitly_attach_the_Channel:
-    test__should_implicitly_attach_the_Channel()
-case .should_result_in_an_error_if_the_channel_is_in_the_FAILED_state:
-    test__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state()
-case .should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state:
-    test__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state()
-}
-
+                expect(error.message).to(equal(protocolError.message))
+                expect(members).to(beNil())
+                done()
             }
-            
-            
-                func reusableTestsWrapper__Presence__enterClient__reusableTestsTestPresencePerformMethod(testCase: TestCase_ReusableTestsTestPresencePerformMethod) {
-                reusableTestsTestPresencePerformMethod (testCase: testCase){ $0.enterClient("john", data: nil, callback: $1) }}
-func test__084__Presence__enterClient__should_implicitly_attach_the_Channel() {
-reusableTestsWrapper__Presence__enterClient__reusableTestsTestPresencePerformMethod(testCase: .should_implicitly_attach_the_Channel)
-}
+        }
 
-func test__085__Presence__enterClient__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
-reusableTestsWrapper__Presence__enterClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_is_in_the_FAILED_state)
-}
+        expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
+    }
 
-func test__086__Presence__enterClient__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
-reusableTestsWrapper__Presence__enterClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state)
-}
+    // RTP11b
+    func test__104__Presence__get__should_result_in_an_error_if_the_channel_is_in_the_DETACHED_state() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
 
-            
-            
-                func reusableTestsWrapper__Presence__updateClient__reusableTestsTestPresencePerformMethod(testCase: TestCase_ReusableTestsTestPresencePerformMethod) {
-                reusableTestsTestPresencePerformMethod (testCase: testCase){ $0.updateClient("john", data: nil, callback: $1) }}
-func test__087__Presence__updateClient__should_implicitly_attach_the_Channel() {
-reusableTestsWrapper__Presence__updateClient__reusableTestsTestPresencePerformMethod(testCase: .should_implicitly_attach_the_Channel)
-}
-
-func test__088__Presence__updateClient__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
-reusableTestsWrapper__Presence__updateClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_is_in_the_FAILED_state)
-}
-
-func test__089__Presence__updateClient__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
-reusableTestsWrapper__Presence__updateClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state)
-}
-
-            
-            
-                func reusableTestsWrapper__Presence__leaveClient__reusableTestsTestPresencePerformMethod(testCase: TestCase_ReusableTestsTestPresencePerformMethod) {
-                reusableTestsTestPresencePerformMethod (testCase: testCase){ $0.leaveClient("john", data: nil, callback: $1) }}
-func test__090__Presence__leaveClient__should_implicitly_attach_the_Channel() {
-reusableTestsWrapper__Presence__leaveClient__reusableTestsTestPresencePerformMethod(testCase: .should_implicitly_attach_the_Channel)
-}
-
-func test__091__Presence__leaveClient__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
-reusableTestsWrapper__Presence__leaveClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_is_in_the_FAILED_state)
-}
-
-func test__092__Presence__leaveClient__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
-reusableTestsWrapper__Presence__leaveClient__reusableTestsTestPresencePerformMethod(testCase: .should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state)
-}
-
-
-            // RTP15f
-            func test__007__Presence__should_indicate_an_error_if_the_client_is_identified_and_has_a_valid_clientId_and_the_clientId_argument_does_not_match_the_client_s_clientId() {
-                let options = AblyTests.commonAppSetup()
-                options.clientId = "john"
-                let client = ARTRealtime(options: options)
-                defer { client.dispose(); client.close() }
-                let channel = client.channels.get("test")
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.presence.enter("browser") { error in
-                        expect(error).to(beNil())
-                        channel.presence.updateClient("tester", data:"mobile") { error in
-                            expect(error!.message).to(contain("mismatched clientId"))
-                            done()
-                        }
-                    }
-                }
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.presence.get() { members, error in
-                        expect(members?.first?.data as? String).to(equal("browser"))
-                        done()
-                    }
-                }
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach()
+            channel.detach { error in
+                expect(error).to(beNil())
+                done()
             }
+        }
 
-            // RTP16
-            
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, error in
+                expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
+                expect(members).to(beNil())
+                expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
+                done()
+            }
+        }
+    }
 
-                // RTP16a
-                func test__093__Presence__Connection_state_conditions__all_presence_messages_are_published_immediately_if_the_connection_is_CONNECTED() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
+    // RTP11b
+    func test__105__Presence__get__should_result_in_an_error_if_the_channel_moves_to_the_DETACHED_state() {
+        let options = AblyTests.commonAppSetup()
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enterClient("user", data: nil) { error in
-                            expect(error).to(beNil())
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                            expect(client.internal.queuedMessages).to(haveCount(0))
-                            done()
-                        }
-                        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connecting))
-                        expect(client.internal.queuedMessages).to(haveCount(1))
-                    }
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        var clientMembers: ARTRealtime?
+        defer { clientMembers?.dispose(); clientMembers?.close() }
+        clientMembers = AblyTests.addMembersSequentiallyToChannel("test", members: 120, options: options)
+
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            channel.presence.get { members, error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
                 }
+                expect(error.message).to(equal("channel is being DETACHED"))
+                expect(members).to(beNil())
+                partialDone()
+            }
+            channel.detach { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
 
-                // RTP16b
-                func test__094__Presence__Connection_state_conditions__all_presence_messages_will_be_queued_and_delivered_as_soon_as_the_connection_state_returns_to_CONNECTED() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-                    expect(client.internal.options.queueMessages).to(beTrue())
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
+    }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { _ in
-                            client.internal.onDisconnected()
-                            done()
-                        }
-                    }
+    // RTP11d
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enterClient("user", data: nil) { error in
-                            expect(error).to(beNil())
-                            expect(client.connection.state).to(equal(ARTRealtimeConnectionState.connected))
-                            expect(client.internal.queuedMessages).to(haveCount(0))
-                            done()
-                        }
-                        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.disconnected))
-                        expect(client.internal.queuedMessages).to(haveCount(1))
-                    }
-                }
+    func test__107__Presence__get__If_the_Channel_is_in_the_SUSPENDED_state_then__by_default__results_in_an_error() {
+        testSuspendedStateResultsInError { channel, callback in
+            channel.presence.get(callback)
+        }
+    }
 
-                // RTP16b
-                func test__095__Presence__Connection_state_conditions__all_presence_messages_will_be_lost_if_queueMessages_has_been_explicitly_set_to_false() {
-                    let options = AblyTests.commonAppSetup()
-                    options.queueMessages = false
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-                    expect(client.internal.options.queueMessages).to(beFalse())
+    func test__108__Presence__get__If_the_Channel_is_in_the_SUSPENDED_state_then__if_waitForSync_is_true__results_in_an_error() {
+        testSuspendedStateResultsInError { channel, callback in
+            let params = ARTRealtimePresenceQuery()
+            params.waitForSync = true
+            channel.presence.get(params, callback: callback)
+        }
+    }
 
-                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+    func test__109__Presence__get__If_the_Channel_is_in_the_SUSPENDED_state_then__if_waitForSync_is_false__returns_the_members_in_the_current_PresenceMap() {
+        let (channel, client) = getSuspendedChannel()
+        defer { client.dispose(); client.close() }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { _ in
-                            client.internal.onDisconnected()
-                            done()
-                        }
-                    }
+        var msgs = [String: ARTPresenceMessage]()
+        for i in 0 ..< 3 {
+            let msg = ARTPresenceMessage(clientId: "client\(i)", action: .present, connectionId: "foo", id: "foo:0:0")
+            msgs[msg.clientId!] = msg
+            channel.internal.presenceMap.internalAdd(msg)
+        }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enterClient("user", data: nil) { error in
-                            expect(error).toNot(beNil())
-                            done()
-                        }
-                        expect(client.internal.queuedMessages).to(haveCount(0))
-                    }
-                }
+        channel.presence.get(getParams) { result, err in
+            expect(err).to(beNil())
+            expect(result).toNot(beNil())
+            guard let result = result else {
+                return
+            }
+            var resultByClient = [String: ARTPresenceMessage]()
+            for msg in result {
+                resultByClient[msg.clientId ?? "(no clientId)"] = msg
+            }
+            expect(resultByClient).to(equal(msgs))
+        }
+    }
 
-                // RTP16c
-                func test__096__Presence__Connection_state_conditions__should_result_in_an_error_if_the_connection_state_is_INITIALIZED_and_queueMessages_has_been_explicitly_set_to_false() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    options.queueMessages = false
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
+    // RTP11c
 
-                    expect(client.connection.state).to(equal(ARTRealtimeConnectionState.initialized))
+    // RTP11c1
+    func skipped__test__110__Presence__get__Query__set_of_params___waitForSync_is_true__should_wait_until_SYNC_is_complete_before_returning_a_list_of_members() {
+        let options = AblyTests.commonAppSetup()
+        var clientSecondary: ARTRealtime!
+        defer { clientSecondary.dispose(); clientSecondary.close() }
+        clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: 150, options: options)
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enterClient("user", data: nil) { error in
-                            expect(error?.code).to(equal(ARTErrorCode.invalidTransportHandle.intValue))
-                            expect(channel.presence.internal.pendingPresence).to(haveCount(0))
-                            done()
-                        }
-                        expect(channel.presence.internal.pendingPresence).to(haveCount(0))
-                    }
-                }
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
 
-                func test__097__Presence__Connection_state_conditions__should_result_in_an_error_if_the_connection_state_is__suspended() {
-                    testResultsInErrorWithConnectionState(.suspended) { client in
-                        AblyTests.queue.async {
-                            client.internal.onSuspended()
-                        }
-                    }
-                }
-                
-                func test__098__Presence__Connection_state_conditions__should_result_in_an_error_if_the_connection_state_is__closed() {
-                    testResultsInErrorWithConnectionState(.closed) { client in
-                        client.close()
-                    }
-                }
-                
-                func test__099__Presence__Connection_state_conditions__should_result_in_an_error_if_the_connection_state_is__failed() {
-                    testResultsInErrorWithConnectionState(.failed) { client in
-                        AblyTests.queue.async {
-                            client.internal.onError(AblyTests.newErrorProtocolMessage())
-                        }
-                    }
-                }
+        let query = ARTRealtimePresenceQuery()
+        expect(query.waitForSync).to(beTrue())
 
-            // RTP11
-            
-
-                
-                    func test__106__Presence__get__query__waitForSync_should_be_true_by_default() {
-                        expect(ARTRealtimePresenceQuery().waitForSync).to(beTrue())
-                    }
-                
-                // FIXME Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-                // RTP11a
-                func skipped__test__100__Presence__get__should_return_a_list_of_current_members_on_the_channel() {
-                    let options = AblyTests.commonAppSetup()
-
-                    var disposable = [ARTRealtime]()
-                    defer {
-                        for clientItem in disposable {
-                            clientItem.dispose()
-                            clientItem.close()
-                        }
-                    }
-
-                    let expectedData = "online"
-
-                    disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 150, data:expectedData as AnyObject?, options: options)]
-
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    let hook = ARTRealtimePresenceQuery.testSuite_injectIntoClassMethod(#selector(ARTRealtimePresenceQuery.init as () -> ARTRealtimePresenceQuery)) { // Default initialiser: referring to the no-parameter variant of `init` as one of several overloaded methods requires an explicit `as <signature>` cast
-                    }
-                    defer { hook?.remove() }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.get { members, error in
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                let transport = client.internal.transport as! TestProxyTransport
+                transport.setListenerBeforeProcessingIncomingMessage { protocolMessage in
+                    if protocolMessage.action == .sync {
+                        expect(protocolMessage.presence!.count).to(equal(100))
+                        channel.presence.get(query) { members, error in
                             expect(error).to(beNil())
                             expect(members).to(haveCount(150))
-                            expect(members!.first).to(beAnInstanceOf(ARTPresenceMessage.self))
-                            expect(members).to(allPass({ member in
-                                return NSRegularExpression.match(member!.clientId, pattern: "^user(\\d+)$")
-                                    && (member!.data as? String) == expectedData
-                            }))
                             done()
                         }
-                    }
-
-                }
-
-                // RTP11b
-                func test__101__Presence__get__should_implicitly_attach_the_channel() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.initialized))
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.get() { membersPage, error in
-                            expect(error).to(beNil())
-                            expect(membersPage).toNot(beNil())
-                            done()
-                        }
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-                    }
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.attached))
-                }
-
-                // RTP11b
-                func test__102__Presence__get__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    let pm = AblyTests.newErrorProtocolMessage()
-                    AblyTests.queue.async {
-                        channel.internal.onError(pm)
-                    }
-
-                    guard let protocolError = pm.error else {
-                        fail("Protocol error is empty"); return
-                    }
-                    guard let channelError = channel.errorReason else {
-                        fail("Channel error is empty"); return
-                    }
-                    expect(channelError.message).to(equal(protocolError.message))
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.get() { members, error in
-                            expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
-                            expect(channel.errorReason).to(equal(protocolError))
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-                            expect(members).to(beNil())
-                            done()
-                        }
+                        transport.setListenerBeforeProcessingIncomingMessage(nil)
                     }
                 }
-
-                // RTP11b
-                func test__103__Presence__get__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
-                    let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        let pm = AblyTests.newErrorProtocolMessage()
-                        guard let protocolError = pm.error else {
-                            fail("Protocol error is empty"); done(); return
-                        }
-                        (client.internal.transport as! TestProxyTransport).actionsIgnored += [.attached]
-                        channel.once(.attaching) { _ in
-                            AblyTests.queue.async {
-                                channel.internal.onError(pm)
-                            }
-                        }
-                        channel.presence.get() { members, error in
-                            guard let error = error else {
-                                fail("Error is empty"); done(); return
-                            }
-                            expect(error.message).to(equal(protocolError.message))
-                            expect(members).to(beNil())
-                            done()
-                        }
-                    }
-
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-                }
-
-                // RTP11b
-                func test__104__Presence__get__should_result_in_an_error_if_the_channel_is_in_the_DETACHED_state() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach()
-                        channel.detach() { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.get() { members, error in
-                            expect(error?.code).to(equal(ARTErrorCode.channelOperationFailedInvalidState.intValue))
-                            expect(members).to(beNil())
-                            expect(channel.state).to(equal(ARTRealtimeChannelState.detached))
-                            done()
-                        }
-                    }
-                }
-
-                // RTP11b
-                func test__105__Presence__get__should_result_in_an_error_if_the_channel_moves_to_the_DETACHED_state() {
-                    let options = AblyTests.commonAppSetup()
-
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-
-                    var clientMembers: ARTRealtime?
-                    defer { clientMembers?.dispose(); clientMembers?.close() }
-                    clientMembers = AblyTests.addMembersSequentiallyToChannel("test", members: 120, options: options)
-
-                    let channel = client.channels.get("test")
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(2, done: done)
-                        channel.presence.get() { members, error in
-                            guard let error = error else {
-                                fail("Error is nil"); done(); return
-                            }
-                            expect(error.message).to(equal("channel is being DETACHED"))
-                            expect(members).to(beNil())
-                            partialDone()
-                        }
-                        channel.detach() { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                    }
-
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
-                }
-                
-                // RTP11d
-                
-                    
-                    
-                        func test__107__Presence__get__If_the_Channel_is_in_the_SUSPENDED_state_then__by_default__results_in_an_error() {
-                            testSuspendedStateResultsInError { channel, callback in
-                                channel.presence.get(callback)
-                            }
-                        }
-                    
-                    
-                        func test__108__Presence__get__If_the_Channel_is_in_the_SUSPENDED_state_then__if_waitForSync_is_true__results_in_an_error() {
-                            testSuspendedStateResultsInError { channel, callback in
-                                let params = ARTRealtimePresenceQuery()
-                                params.waitForSync = true
-                                channel.presence.get(params, callback: callback)
-                            }
-                        }
-                    
-                    
-                        
-                        func test__109__Presence__get__If_the_Channel_is_in_the_SUSPENDED_state_then__if_waitForSync_is_false__returns_the_members_in_the_current_PresenceMap() {
-                            let (channel, client) = getSuspendedChannel()
-                            defer { client.dispose(); client.close() }
-                            
-                            var msgs = [String: ARTPresenceMessage]()
-                            for i in 0..<3 {
-                                let msg = ARTPresenceMessage(clientId: "client\(i)", action: .present, connectionId: "foo", id: "foo:0:0")
-                                msgs[msg.clientId!] = msg
-                                channel.internal.presenceMap.internalAdd(msg)
-                            }
-                            
-                            channel.presence.get(getParams) { result, err in
-                                expect(err).to(beNil())
-                                expect(result).toNot(beNil())
-                                guard let result = result else {
-                                    return
-                                }
-                                var resultByClient = [String: ARTPresenceMessage]()
-                                for msg in result {
-                                    resultByClient[msg.clientId ?? "(no clientId)"] = msg
-                                }
-                                expect(resultByClient).to(equal(msgs))
-                            }
-                        }
-
-                // RTP11c
-                
-
-                    // RTP11c1
-                    func skipped__test__110__Presence__get__Query__set_of_params___waitForSync_is_true__should_wait_until_SYNC_is_complete_before_returning_a_list_of_members() {
-                        let options = AblyTests.commonAppSetup()
-                        var clientSecondary: ARTRealtime!
-                        defer { clientSecondary.dispose(); clientSecondary.close() }
-                        clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: 150, options: options)
-
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-
-                        let query = ARTRealtimePresenceQuery()
-                        expect(query.waitForSync).to(beTrue())
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach() { error in
-                                expect(error).to(beNil())
-                                let transport = client.internal.transport as! TestProxyTransport
-                                transport.setListenerBeforeProcessingIncomingMessage({ protocolMessage in
-                                    if protocolMessage.action == .sync {
-                                        expect(protocolMessage.presence!.count).to(equal(100))
-                                        channel.presence.get(query) { members, error in
-                                            expect(error).to(beNil())
-                                            expect(members).to(haveCount(150))
-                                            done()
-                                        }
-                                        transport.setListenerBeforeProcessingIncomingMessage(nil)
-                                    }
-                                })
-                            }
-                        }
-                    }
-
-                    // RTP11c1
-                    func test__111__Presence__get__Query__set_of_params___waitForSync_is_false__should_return_immediately_the_known_set_of_presence_members() {
-                        let options = AblyTests.commonAppSetup()
-                        var clientSecondary: ARTRealtime!
-                        defer { clientSecondary.dispose(); clientSecondary.close() }
-                        clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: 150, options: options)
-
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-                        let channel = client.channels.get("test")
-
-                        let query = ARTRealtimePresenceQuery()
-                        query.waitForSync = false
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach() { error in
-                                expect(error).to(beNil())
-                                let transport = client.internal.transport as! TestProxyTransport
-                                transport.setListenerBeforeProcessingIncomingMessage({ message in
-                                    if message.action == .sync {
-                                        // Ignore next SYNC so that the sync process never finishes.
-                                        transport.actionsIgnored += [.sync]
-                                        done()
-                                    }
-                                })
-                            }
-                        }
-                        
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.presence.get(query) { members, error in
-                                expect(error).to(beNil())
-                                expect(members).to(haveCount(100))
-                                done()
-                            }
-                        }
-                    }
-
-                    // RTP11c2
-                    func test__112__Presence__get__Query__set_of_params___should_return_members_filtered_by_clientId() {
-                        let options = AblyTests.commonAppSetup()
-                        let now = NSDate()
-
-                        let client = AblyTests.newRealtime(options)
-                        defer { client.dispose(); client.close() }
-                        let channelName = NSUUID().uuidString
-                        let channel = client.channels.get(channelName)
-
-                        let presenceData: [ARTPresenceMessage] = [
-                            ARTPresenceMessage(clientId: "a", action: .enter, connectionId: "one", id: "one:0:0", timestamp: now as Date),
-                            ARTPresenceMessage(clientId: "a", action: .leave, connectionId: "one", id: "fabricated:0:1", timestamp: (now as Date) + 1),
-                            ARTPresenceMessage(clientId: "b", action: .enter, connectionId: "one", id: "one:0:2", timestamp: now as Date),
-                            ARTPresenceMessage(clientId: "b", action: .leave, connectionId: "one", id: "fabricated:0:3", timestamp: (now as Date) - 1),
-                            ARTPresenceMessage(clientId: "c", action: .enter, connectionId: "one", id: "fabricated:0:4", timestamp: now as Date),
-                            ARTPresenceMessage(clientId: "c", action: .leave, connectionId: "one", id: "fabricated:0:5", timestamp: (now as Date) - 1),
-                        ]
-
-                        guard let transport = client.internal.transport as? TestProxyTransport else {
-                            fail("TestProxyTransport is not set"); return
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach() { error in
-                                expect(error).to(beNil())
-
-                                // Inject a fabricated Presence message
-                                let presenceMessage = ARTProtocolMessage()
-                                presenceMessage.action = .presence
-                                presenceMessage.channel = channel.name
-                                presenceMessage.timestamp = Date()
-                                presenceMessage.presence = presenceData
-
-                                transport.receive(presenceMessage)
-
-                                done()
-                            }
-                        }
-
-                        let query = ARTRealtimePresenceQuery()
-                        query.clientId = "b"
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.presence.get(query) { members, error in
-                                expect(error).to(beNil())
-                                guard let members = members else {
-                                    fail("Members is nil"); done(); return
-                                }
-                                expect(members).to(haveCount(1))
-                                expect(members).to(allPass({ (member: ARTPresenceMessage?) in member!.action != .absent }))
-                                expect(members.filter{ $0.clientId == "a" }).to(beEmpty())
-                                expect(members.filter{ $0.clientId == "b" }).to(haveCount(1))
-                                expect(members.filter{ $0.clientId == "c" }).to(beEmpty())
-                                done()
-                            }
-                        }
-                    }
-
-                    // RTP11c3
-                    func test__113__Presence__get__Query__set_of_params___should_return_members_filtered_by_connectionId() {
-                        let options = AblyTests.commonAppSetup()
-                        let now = NSDate()
-                        let channelName = NSUUID().uuidString
-                        var clientMembers: ARTRealtime?
-                        defer { clientMembers?.dispose(); clientMembers?.close() }
-                        clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 101, options: options)
-
-                        let clientSubscribed = AblyTests.newRealtime(options)
-                        defer { clientSubscribed.dispose(); clientSubscribed.close() }
-                        let channelSubscribed = clientSubscribed.channels.get(channelName)
-
-                        let presenceData: [ARTPresenceMessage] = [
-                            ARTPresenceMessage(clientId: "a", action: .enter, connectionId: "one", id: "one:0:0", timestamp: now as Date),
-                            ARTPresenceMessage(clientId: "a", action: .leave, connectionId: "one", id: "fabricated:0:1", timestamp: (now as Date) + 1),
-                            ARTPresenceMessage(clientId: "b", action: .enter, connectionId: "one", id: "one:0:2", timestamp: now as Date),
-                            ARTPresenceMessage(clientId: "b", action: .leave, connectionId: "one", id: "fabricated:0:3", timestamp: (now as Date) - 1),
-                            ARTPresenceMessage(clientId: "c", action: .enter, connectionId: "one", id: "fabricated:0:4", timestamp: now as Date),
-                            ARTPresenceMessage(clientId: "c", action: .leave, connectionId: "one", id: "fabricated:0:5", timestamp: (now as Date) - 1),
-                        ]
-
-                        guard let transport = clientSubscribed.internal.transport as? TestProxyTransport else {
-                            fail("TestProxyTransport is not set"); return
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            transport.setAfterIncomingMessageModifier({ protocolMessage in
-                                // Receive the first Sync message from Ably service
-                                if protocolMessage.action == .sync {
-                                    // Inject a fabricated Presence message
-                                    let presenceMessage = ARTProtocolMessage()
-                                    presenceMessage.action = .presence
-                                    presenceMessage.channel = protocolMessage.channel
-                                    presenceMessage.connectionSerial = protocolMessage.connectionSerial + 1
-                                    presenceMessage.timestamp = Date()
-                                    presenceMessage.presence = presenceData
-
-                                    transport.receive(presenceMessage)
-
-                                    // Simulate an end to the sync
-                                    let endSyncMessage = ARTProtocolMessage()
-                                    endSyncMessage.action = .sync
-                                    endSyncMessage.channel = protocolMessage.channel
-                                    endSyncMessage.channelSerial = "validserialprefix:" //with no part after the `:` this indicates the end to the SYNC
-                                    endSyncMessage.connectionSerial = protocolMessage.connectionSerial + 2
-                                    endSyncMessage.timestamp = Date()
-
-                                    transport.setAfterIncomingMessageModifier(nil)
-                                    transport.receive(endSyncMessage)
-
-                                    // Stop the next sync message from Ably service because we already injected the end of the sync
-                                    transport.actionsIgnored = [.sync]
-
-                                    done()
-                                }
-                                return protocolMessage
-                            })
-                            channelSubscribed.attach()
-                        }
-
-                        let query = ARTRealtimePresenceQuery()
-                        query.connectionId = "one"
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channelSubscribed.presence.get(query) { members, error in
-                                expect(error).to(beNil())
-                                guard let members = members else {
-                                    fail("Members is nil"); done(); return
-                                }
-                                expect(members).to(haveCount(2))
-                                expect(members).to(allPass({ (member: ARTPresenceMessage?) in member!.action != .absent }))
-                                expect(members.filter{ $0.clientId == "a" }).to(beEmpty())
-                                expect(members.filter{ $0.clientId == "b" }).to(haveCount(1))
-                                expect(members.filter{ $0.clientId == "c" }).to(haveCount(1))
-                                done()
-                            }
-                        }
-                    }
-
-            // RTP12
-            
-
-                // RTP12a
-                func test__114__Presence__history__should_support_all_the_same_params_as_Rest() {
-                    let options = AblyTests.commonAppSetup()
-
-                    let rest = ARTRest(options: options)
-
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.dispose(); realtime.close() }
-
-                    let channelRest = rest.channels.get("test")
-                    let channelRealtime = realtime.channels.get("test")
-
-                    var restPresenceHistoryMethodWasCalled = false
-
-                    let hookRest = channelRest.presence.internal.testSuite_injectIntoMethod(after: #selector(ARTRestPresenceInternal.history(_:callback:))) {
-                        restPresenceHistoryMethodWasCalled = true
-                    }
-                    defer { hookRest.remove() }
-
-                    let hookRealtime = channelRealtime.presence.internal.testSuite_injectIntoMethod(after: #selector(ARTRestPresenceInternal.history(_:callback:))) {
-                        restPresenceHistoryMethodWasCalled = true
-                    }
-                    defer { hookRealtime.remove() }
-
-                    let queryRealtime = ARTRealtimeHistoryQuery()
-                    queryRealtime.start = Date()
-                    queryRealtime.end = Date()
-                    queryRealtime.direction = .forwards
-                    queryRealtime.limit = 50
-
-                    let queryRest = queryRealtime as ARTDataQuery
-
-                    waitUntil(timeout: testTimeout) { done in
-                        expect {
-                            try channelRest.presence.history(queryRest) { _, _ in
-                                done()
-                            }
-                        }.toNot(throwError() { err in fail("\(err)"); done() })
-                    }
-                    expect(restPresenceHistoryMethodWasCalled).to(beTrue())
-                    restPresenceHistoryMethodWasCalled = false
-
-                    waitUntil(timeout: testTimeout) { done in
-                        expect {
-                            try channelRealtime.presence.history(queryRealtime) { _, _ in
-                                done()
-                            }
-                        }.toNot(throwError() { err in fail("\(err)"); done() })
-                    }
-                    expect(restPresenceHistoryMethodWasCalled).to(beTrue())
-                }
-
-            // RTP12
-            
-
-                // RTP12c, RTP12d
-                func test__115__Presence__history__should_return_a_PaginatedResult_page() {
-                    let options = AblyTests.commonAppSetup()
-
-                    var clientSecondary: ARTRealtime!
-                    defer { clientSecondary.dispose(); clientSecondary.close() }
-
-                    let expectedData = ["x", "y"]
-                    let expectedPattern = "^user(\\d+)$"
-                    clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: 150, data: expectedData as AnyObject?, options: options)
-
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.history { membersPage, error in
-                            expect(error).to(beNil())
-                            guard let membersPage = membersPage else {
-                                fail("membersPage is empty"); done(); return
-                            }
-                            expect(membersPage).to(beAnInstanceOf(ARTPaginatedResult<ARTPresenceMessage>.self))
-                            expect(membersPage.items).to(haveCount(100))
-
-                            let members = membersPage.items 
-                            expect(members).to(allPass({ member in
-                                return NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                                    && (member!.data as! [String]) == expectedData
-                            }))
-
-                            expect(membersPage.hasNext).to(beTrue())
-                            expect(membersPage.isLast).to(beFalse())
-
-                            membersPage.next { nextPage, error in
-                                expect(error).to(beNil())
-                                guard let nextPage = nextPage else {
-                                    fail("nextPage is empty"); done(); return
-                                }
-                                expect(nextPage).to(beAnInstanceOf(ARTPaginatedResult<ARTPresenceMessage>.self))
-                                expect(nextPage.items).to(haveCount(50))
-
-                                let members = nextPage.items 
-                                expect(members).to(allPass({ member in
-                                    return NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                                        && (member!.data as! [String]) == expectedData
-                                }))
-
-                                expect(nextPage.hasNext).to(beFalse())
-                                expect(nextPage.isLast).to(beTrue())
-                                done()
-                            }
-                        }
-                    }
-                }
-
-            // RTP13
-            func skipped__test__008__Presence__Presence_syncComplete_returns_true_if_the_initial_SYNC_operation_has_completed() {
-                let options = AblyTests.commonAppSetup()
-
-                var disposable = [ARTRealtime]()
-                defer {
-                    for clientItem in disposable {
-                        clientItem.dispose()
-                        clientItem.close()
-                    }
-                }
-
-                disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 250, options: options)]
-
-                let client = AblyTests.newRealtime(options)
-                defer { client.dispose(); client.close() }
-                let channel = client.channels.get("test")
-                channel.attach()
-
-                expect(channel.presence.syncComplete).to(beFalse())
-                expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-
+            }
+        }
+    }
+
+    // RTP11c1
+    func test__111__Presence__get__Query__set_of_params___waitForSync_is_false__should_return_immediately_the_known_set_of_presence_members() {
+        let options = AblyTests.commonAppSetup()
+        var clientSecondary: ARTRealtime!
+        defer { clientSecondary.dispose(); clientSecondary.close() }
+        clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: 150, options: options)
+
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        let query = ARTRealtimePresenceQuery()
+        query.waitForSync = false
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
                 let transport = client.internal.transport as! TestProxyTransport
-                transport.setListenerBeforeProcessingIncomingMessage({ protocolMessage in
-                    if protocolMessage.action == .sync {
-                        expect(channel.presence.internal.syncComplete_nosync()).to(beFalse())
+                transport.setListenerBeforeProcessingIncomingMessage { message in
+                    if message.action == .sync {
+                        // Ignore next SYNC so that the sync process never finishes.
+                        transport.actionsIgnored += [.sync]
+                        done()
                     }
+                }
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get(query) { members, error in
+                expect(error).to(beNil())
+                expect(members).to(haveCount(100))
+                done()
+            }
+        }
+    }
+
+    // RTP11c2
+    func test__112__Presence__get__Query__set_of_params___should_return_members_filtered_by_clientId() {
+        let options = AblyTests.commonAppSetup()
+        let now = NSDate()
+
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channelName = NSUUID().uuidString
+        let channel = client.channels.get(channelName)
+
+        let presenceData: [ARTPresenceMessage] = [
+            ARTPresenceMessage(clientId: "a", action: .enter, connectionId: "one", id: "one:0:0", timestamp: now as Date),
+            ARTPresenceMessage(clientId: "a", action: .leave, connectionId: "one", id: "fabricated:0:1", timestamp: (now as Date) + 1),
+            ARTPresenceMessage(clientId: "b", action: .enter, connectionId: "one", id: "one:0:2", timestamp: now as Date),
+            ARTPresenceMessage(clientId: "b", action: .leave, connectionId: "one", id: "fabricated:0:3", timestamp: (now as Date) - 1),
+            ARTPresenceMessage(clientId: "c", action: .enter, connectionId: "one", id: "fabricated:0:4", timestamp: now as Date),
+            ARTPresenceMessage(clientId: "c", action: .leave, connectionId: "one", id: "fabricated:0:5", timestamp: (now as Date) - 1),
+        ]
+
+        guard let transport = client.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+
+                // Inject a fabricated Presence message
+                let presenceMessage = ARTProtocolMessage()
+                presenceMessage.action = .presence
+                presenceMessage.channel = channel.name
+                presenceMessage.timestamp = Date()
+                presenceMessage.presence = presenceData
+
+                transport.receive(presenceMessage)
+
+                done()
+            }
+        }
+
+        let query = ARTRealtimePresenceQuery()
+        query.clientId = "b"
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get(query) { members, error in
+                expect(error).to(beNil())
+                guard let members = members else {
+                    fail("Members is nil"); done(); return
+                }
+                expect(members).to(haveCount(1))
+                expect(members).to(allPass { (member: ARTPresenceMessage?) in member!.action != .absent })
+                expect(members.filter { $0.clientId == "a" }).to(beEmpty())
+                expect(members.filter { $0.clientId == "b" }).to(haveCount(1))
+                expect(members.filter { $0.clientId == "c" }).to(beEmpty())
+                done()
+            }
+        }
+    }
+
+    // RTP11c3
+    func test__113__Presence__get__Query__set_of_params___should_return_members_filtered_by_connectionId() {
+        let options = AblyTests.commonAppSetup()
+        let now = NSDate()
+        let channelName = NSUUID().uuidString
+        var clientMembers: ARTRealtime?
+        defer { clientMembers?.dispose(); clientMembers?.close() }
+        clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 101, options: options)
+
+        let clientSubscribed = AblyTests.newRealtime(options)
+        defer { clientSubscribed.dispose(); clientSubscribed.close() }
+        let channelSubscribed = clientSubscribed.channels.get(channelName)
+
+        let presenceData: [ARTPresenceMessage] = [
+            ARTPresenceMessage(clientId: "a", action: .enter, connectionId: "one", id: "one:0:0", timestamp: now as Date),
+            ARTPresenceMessage(clientId: "a", action: .leave, connectionId: "one", id: "fabricated:0:1", timestamp: (now as Date) + 1),
+            ARTPresenceMessage(clientId: "b", action: .enter, connectionId: "one", id: "one:0:2", timestamp: now as Date),
+            ARTPresenceMessage(clientId: "b", action: .leave, connectionId: "one", id: "fabricated:0:3", timestamp: (now as Date) - 1),
+            ARTPresenceMessage(clientId: "c", action: .enter, connectionId: "one", id: "fabricated:0:4", timestamp: now as Date),
+            ARTPresenceMessage(clientId: "c", action: .leave, connectionId: "one", id: "fabricated:0:5", timestamp: (now as Date) - 1),
+        ]
+
+        guard let transport = clientSubscribed.internal.transport as? TestProxyTransport else {
+            fail("TestProxyTransport is not set"); return
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            transport.setAfterIncomingMessageModifier { protocolMessage in
+                // Receive the first Sync message from Ably service
+                if protocolMessage.action == .sync {
+                    // Inject a fabricated Presence message
+                    let presenceMessage = ARTProtocolMessage()
+                    presenceMessage.action = .presence
+                    presenceMessage.channel = protocolMessage.channel
+                    presenceMessage.connectionSerial = protocolMessage.connectionSerial + 1
+                    presenceMessage.timestamp = Date()
+                    presenceMessage.presence = presenceData
+
+                    transport.receive(presenceMessage)
+
+                    // Simulate an end to the sync
+                    let endSyncMessage = ARTProtocolMessage()
+                    endSyncMessage.action = .sync
+                    endSyncMessage.channel = protocolMessage.channel
+                    endSyncMessage.channelSerial = "validserialprefix:" // with no part after the `:` this indicates the end to the SYNC
+                    endSyncMessage.connectionSerial = protocolMessage.connectionSerial + 2
+                    endSyncMessage.timestamp = Date()
+
+                    transport.setAfterIncomingMessageModifier(nil)
+                    transport.receive(endSyncMessage)
+
+                    // Stop the next sync message from Ably service because we already injected the end of the sync
+                    transport.actionsIgnored = [.sync]
+
+                    done()
+                }
+                return protocolMessage
+            }
+            channelSubscribed.attach()
+        }
+
+        let query = ARTRealtimePresenceQuery()
+        query.connectionId = "one"
+
+        waitUntil(timeout: testTimeout) { done in
+            channelSubscribed.presence.get(query) { members, error in
+                expect(error).to(beNil())
+                guard let members = members else {
+                    fail("Members is nil"); done(); return
+                }
+                expect(members).to(haveCount(2))
+                expect(members).to(allPass { (member: ARTPresenceMessage?) in member!.action != .absent })
+                expect(members.filter { $0.clientId == "a" }).to(beEmpty())
+                expect(members.filter { $0.clientId == "b" }).to(haveCount(1))
+                expect(members.filter { $0.clientId == "c" }).to(haveCount(1))
+                done()
+            }
+        }
+    }
+
+    // RTP12
+
+    // RTP12a
+    func test__114__Presence__history__should_support_all_the_same_params_as_Rest() {
+        let options = AblyTests.commonAppSetup()
+
+        let rest = ARTRest(options: options)
+
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+
+        let channelRest = rest.channels.get("test")
+        let channelRealtime = realtime.channels.get("test")
+
+        var restPresenceHistoryMethodWasCalled = false
+
+        let hookRest = channelRest.presence.internal.testSuite_injectIntoMethod(after: #selector(ARTRestPresenceInternal.history(_:callback:))) {
+            restPresenceHistoryMethodWasCalled = true
+        }
+        defer { hookRest.remove() }
+
+        let hookRealtime = channelRealtime.presence.internal.testSuite_injectIntoMethod(after: #selector(ARTRestPresenceInternal.history(_:callback:))) {
+            restPresenceHistoryMethodWasCalled = true
+        }
+        defer { hookRealtime.remove() }
+
+        let queryRealtime = ARTRealtimeHistoryQuery()
+        queryRealtime.start = Date()
+        queryRealtime.end = Date()
+        queryRealtime.direction = .forwards
+        queryRealtime.limit = 50
+
+        let queryRest = queryRealtime as ARTDataQuery
+
+        waitUntil(timeout: testTimeout) { done in
+            expect {
+                try channelRest.presence.history(queryRest) { _, _ in
+                    done()
+                }
+            }.toNot(throwError { err in fail("\(err)"); done() })
+        }
+        expect(restPresenceHistoryMethodWasCalled).to(beTrue())
+        restPresenceHistoryMethodWasCalled = false
+
+        waitUntil(timeout: testTimeout) { done in
+            expect {
+                try channelRealtime.presence.history(queryRealtime) { _, _ in
+                    done()
+                }
+            }.toNot(throwError { err in fail("\(err)"); done() })
+        }
+        expect(restPresenceHistoryMethodWasCalled).to(beTrue())
+    }
+
+    // RTP12
+
+    // RTP12c, RTP12d
+    func test__115__Presence__history__should_return_a_PaginatedResult_page() {
+        let options = AblyTests.commonAppSetup()
+
+        var clientSecondary: ARTRealtime!
+        defer { clientSecondary.dispose(); clientSecondary.close() }
+
+        let expectedData = ["x", "y"]
+        let expectedPattern = "^user(\\d+)$"
+        clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: 150, data: expectedData as AnyObject?, options: options)
+
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.history { membersPage, error in
+                expect(error).to(beNil())
+                guard let membersPage = membersPage else {
+                    fail("membersPage is empty"); done(); return
+                }
+                expect(membersPage).to(beAnInstanceOf(ARTPaginatedResult<ARTPresenceMessage>.self))
+                expect(membersPage.items).to(haveCount(100))
+
+                let members = membersPage.items
+                expect(members).to(allPass { member in
+                    NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
+                        && (member!.data as! [String]) == expectedData
                 })
 
-                expect(channel.presence.syncComplete).toEventually(beTrue(), timeout: testTimeout)
-                expect(transport.protocolMessagesReceived.filter({ $0.action == .sync })).to(haveCount(3))
+                expect(membersPage.hasNext).to(beTrue())
+                expect(membersPage.isLast).to(beFalse())
+
+                membersPage.next { nextPage, error in
+                    expect(error).to(beNil())
+                    guard let nextPage = nextPage else {
+                        fail("nextPage is empty"); done(); return
+                    }
+                    expect(nextPage).to(beAnInstanceOf(ARTPaginatedResult<ARTPresenceMessage>.self))
+                    expect(nextPage.items).to(haveCount(50))
+
+                    let members = nextPage.items
+                    expect(members).to(allPass { member in
+                        NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
+                            && (member!.data as! [String]) == expectedData
+                    })
+
+                    expect(nextPage.hasNext).to(beFalse())
+                    expect(nextPage.isLast).to(beTrue())
+                    done()
+                }
             }
+        }
+    }
 
-            // RTP14
-            
+    // RTP13
+    func skipped__test__008__Presence__Presence_syncComplete_returns_true_if_the_initial_SYNC_operation_has_completed() {
+        let options = AblyTests.commonAppSetup()
 
-                // RTP14a, RTP14b, RTP14c, RTP14d
-                func skipped__test__116__Presence__enterClient__enters_into_presence_on_a_channel_on_behalf_of_another_clientId() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-                    expect(channel.internal.presenceMap.members).to(haveCount(0))
+        var disposable = [ARTRealtime]()
+        defer {
+            for clientItem in disposable {
+                clientItem.dispose()
+                clientItem.close()
+            }
+        }
 
-                    let expectedData = ["test":1]
+        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 250, options: options)]
 
-                    var encodeNumberOfCalls = 0
-                    let hookEncode = channel.internal.dataEncoder.testSuite_injectIntoMethod(after: #selector(ARTDataEncoder.encode(_:))) {
-                        encodeNumberOfCalls += 1
-                    }
-                    defer { hookEncode.remove() }
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        channel.attach()
 
-                    var decodeNumberOfCalls = 0
-                    let hookDecode = channel.internal.dataEncoder.testSuite_injectIntoMethod(after: #selector(ARTDataEncoder.decode(_:encoding:))) {
-                        decodeNumberOfCalls += 1
-                    }
-                    defer { hookDecode.remove() }
+        expect(channel.presence.syncComplete).to(beFalse())
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
 
+        let transport = client.internal.transport as! TestProxyTransport
+        transport.setListenerBeforeProcessingIncomingMessage { protocolMessage in
+            if protocolMessage.action == .sync {
+                expect(channel.presence.internal.syncComplete_nosync()).to(beFalse())
+            }
+        }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.enterClient("test", data: expectedData)  { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
+        expect(channel.presence.syncComplete).toEventually(beTrue(), timeout: testTimeout)
+        expect(transport.protocolMessagesReceived.filter { $0.action == .sync }).to(haveCount(3))
+    }
 
-                    channel.presence.enterClient("john", data: nil)
-                    channel.presence.enterClient("sara", data: nil)
-                    expect(channel.internal.presenceMap.members).toEventually(haveCount(3), timeout: testTimeout)
+    // RTP14
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.get() { members, error in
-                            guard let members = members?.reduce([String:ARTPresenceMessage](), { (dictionary, item) in
-                                return dictionary + [item.clientId ?? "":item]
-                            }) else { fail("No members"); done(); return }
+    // RTP14a, RTP14b, RTP14c, RTP14d
+    func skipped__test__116__Presence__enterClient__enters_into_presence_on_a_channel_on_behalf_of_another_clientId() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get("test")
+        expect(channel.internal.presenceMap.members).to(haveCount(0))
 
-                            expect(members["test"]!.data as? NSDictionary).to(equal(expectedData as NSDictionary?))
-                            expect(members["john"]).toNot(beNil())
-                            expect(members["sara"]).toNot(beNil())
-                            done()
-                        }
-                    }
+        let expectedData = ["test": 1]
 
-                    expect(encodeNumberOfCalls).to(equal(1))
-                    expect(decodeNumberOfCalls).to(equal(1))
+        var encodeNumberOfCalls = 0
+        let hookEncode = channel.internal.dataEncoder.testSuite_injectIntoMethod(after: #selector(ARTDataEncoder.encode(_:))) {
+            encodeNumberOfCalls += 1
+        }
+        defer { hookEncode.remove() }
+
+        var decodeNumberOfCalls = 0
+        let hookDecode = channel.internal.dataEncoder.testSuite_injectIntoMethod(after: #selector(ARTDataEncoder.decode(_:encoding:))) {
+            decodeNumberOfCalls += 1
+        }
+        defer { hookDecode.remove() }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.enterClient("test", data: expectedData) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        channel.presence.enterClient("john", data: nil)
+        channel.presence.enterClient("sara", data: nil)
+        expect(channel.internal.presenceMap.members).toEventually(haveCount(3), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, _ in
+                guard let members = members?.reduce([String: ARTPresenceMessage](), { dictionary, item in
+                    dictionary + [item.clientId ?? "": item]
+                }) else { fail("No members"); done(); return }
+
+                expect(members["test"]!.data as? NSDictionary).to(equal(expectedData as NSDictionary?))
+                expect(members["john"]).toNot(beNil())
+                expect(members["sara"]).toNot(beNil())
+                done()
+            }
+        }
+
+        expect(encodeNumberOfCalls).to(equal(1))
+        expect(decodeNumberOfCalls).to(equal(1))
+    }
+
+    // RTP14d
+    func test__117__Presence__enterClient__should_be_present_all_the_registered_members_on_a_presence_channel() {
+        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+        defer { client.dispose(); client.close() }
+        let channelName = NSUUID().uuidString
+        let channel = client.channels.get(channelName)
+
+        let john = "john"
+        let max = "max"
+
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(4, done: done)
+            channel.presence.subscribe { message in
+                expect(message.clientId).to(satisfyAnyOf(equal(john), equal(max)))
+                partialDone()
+            }
+            channel.presence.enterClient(john, data: nil) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+            channel.presence.enterClient(max, data: nil) { error in
+                expect(error).to(beNil())
+                partialDone()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { members, error in
+                expect(error).to(beNil())
+                guard let members = members else {
+                    fail("Members is nil"); done(); return
                 }
+                expect(members).to(haveCount(2))
+                let clientIds = members.map { $0.clientId }
+                // Cannot guarantee the order
+                expect(clientIds).to(equal([john, max]) || equal([max, john]))
+                done()
+            }
+        }
+    }
 
-                // RTP14d
-                func test__117__Presence__enterClient__should_be_present_all_the_registered_members_on_a_presence_channel() {
-                    let client = ARTRealtime(options: AblyTests.commonAppSetup())
-                    defer { client.dispose(); client.close() }
-                    let channelName = NSUUID().uuidString
-                    let channel = client.channels.get(channelName)
+    // TP3a
+    func test__118__Presence__presence_message_attributes__if_the_presence_message_does_not_contain_an_id__it_should_be_set_to_protocolMsgId_index() {
+        let options = AblyTests.commonAppSetup()
+        options.autoConnect = false
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
 
-                    let john = "john"
-                    let max = "max"
+        let protocolMessage = ARTProtocolMessage()
+        protocolMessage.id = "protocolId"
+        let presenceMessage = ARTPresenceMessage()
+        presenceMessage.clientId = "clientId"
+        presenceMessage.action = .enter
+        protocolMessage.presence = [presenceMessage]
 
-                    waitUntil(timeout: testTimeout) { done in
-                        let partialDone = AblyTests.splitDone(4, done: done)
-                        channel.presence.subscribe { message in
-                            expect(message.clientId).to(satisfyAnyOf(equal(john), equal(max)))
-                            partialDone()
-                        }
-                        channel.presence.enterClient(john, data: nil) { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                        channel.presence.enterClient(max, data: nil) { error in
-                            expect(error).to(beNil())
-                            partialDone()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.get { members, error in
-                            expect(error).to(beNil())
-                            guard let members = members else {
-                                fail("Members is nil"); done(); return
-                            }
-                            expect(members).to(haveCount(2))
-                            let clientIds = members.map({ $0.clientId })
-                            // Cannot guarantee the order
-                            expect(clientIds).to(equal([john, max]) || equal([max, john]))
-                            done()
-                        }
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                let channel = client.channels.get(NSUUID().uuidString)
+                channel.presence.subscribe(.enter) { message in
+                    expect(message.id).to(equal("protocolId:0"))
+                    done()
                 }
-            
-            
-                
-                // TP3a
-                func test__118__Presence__presence_message_attributes__if_the_presence_message_does_not_contain_an_id__it_should_be_set_to_protocolMsgId_index() {
-                    let options = AblyTests.commonAppSetup()
-                    options.autoConnect = false
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-
-                    let protocolMessage = ARTProtocolMessage()
-                    protocolMessage.id = "protocolId"
-                    let presenceMessage = ARTPresenceMessage()
-                    presenceMessage.clientId = "clientId"
-                    presenceMessage.action = .enter
-                    protocolMessage.presence = [presenceMessage]
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        client.connection.once(.connected) { _ in
-                            let channel = client.channels.get(NSUUID().uuidString)
-                            channel.presence.subscribe(.enter) { message in
-                                expect(message.id).to(equal("protocolId:0"))
-                                done()
-                            }
-                            AblyTests.queue.async {
-                                channel.internal.onPresence(protocolMessage)
-                            }
-                        }
-                        client.connect()
-                    }
+                AblyTests.queue.async {
+                    channel.internal.onPresence(protocolMessage)
                 }
+            }
+            client.connect()
+        }
+    }
 }

--- a/Spec/RealtimeClientPresence.swift
+++ b/Spec/RealtimeClientPresence.swift
@@ -2,7 +2,7 @@ import Ably
 import Aspects
 import Foundation
 import Nimble
-import Quick
+import XCTest
 
 private let channelName = NSUUID().uuidString
 

--- a/Spec/RestClient.swift
+++ b/Spec/RestClient.swift
@@ -1,6 +1,6 @@
 import Ably
 import Nimble
-import Quick
+ import XCTest
 
 private var testHTTPExecutor: TestProxyHTTPExecutor!
 

--- a/Spec/RestClient.swift
+++ b/Spec/RestClient.swift
@@ -2,2163 +2,2125 @@ import Ably
 import Nimble
 import Quick
 
+private var testHTTPExecutor: TestProxyHTTPExecutor!
 
-        private var testHTTPExecutor: TestProxyHTTPExecutor!
-                    
-                    private func testOptionsGiveBasicAuthFalse(_ caseSetter: (ARTAuthOptions) -> Void) {
-                        let options = ARTClientOptions()
-                        caseSetter(options)
-                        
-                        let client = ARTRest(options: options)
-                        
-                        expect(client.auth.internal.options.isBasicAuth()).to(beFalse())
-                    }
-                    private let expectedHostOrder = [4, 3, 0, 2, 1]
+private func testOptionsGiveBasicAuthFalse(_ caseSetter: (ARTAuthOptions) -> Void) {
+    let options = ARTClientOptions()
+    caseSetter(options)
 
-                    private let originalARTFallback_shuffleArray = ARTFallback_shuffleArray
+    let client = ARTRest(options: options)
 
-                    private let _fallbackHosts = ["f.ably-realtime.com", "g.ably-realtime.com", "h.ably-realtime.com", "i.ably-realtime.com", "j.ably-realtime.com"]
-
-                    private func testUsesAlternativeHost(_ caseTest: FakeNetworkResponse) {
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: caseTest, resetAfter: 1)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "nil") { _ in
-                                done()
-                            }
-                        }
-
-                        expect(testHTTPExecutor.requests).to(haveCount(2))
-                        if testHTTPExecutor.requests.count != 2 {
-                            return
-                        }
-                        expect(NSRegularExpression.match(testHTTPExecutor.requests[0].url!.absoluteString, pattern: "//rest.ably.io")).to(beTrue())
-                        expect(NSRegularExpression.match(testHTTPExecutor.requests[1].url!.absoluteString, pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                    }
-                    
-                    private func testStoresSuccessfulFallbackHostAsDefaultHost(_ caseTest: FakeNetworkResponse) {
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: caseTest, resetAfter: 1)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "nil") { _ in
-                                done()
-                            }
-                        }
-
-                        expect(testHTTPExecutor.requests).to(haveCount(2))
-                        expect(NSRegularExpression.match(testHTTPExecutor.requests[0].url!.host, pattern: "rest.ably.io")).to(beTrue())
-                        expect(NSRegularExpression.match(testHTTPExecutor.requests[1].url!.host, pattern: "[a-e].ably-realtime.com")).to(beTrue())
-                        
-                        //#1 Store fallback used to request
-                        let usedFallbackURL = testHTTPExecutor.requests[1].url!
-                        
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "nil") { _ in
-                                done()
-                            }
-                        }
-                        
-                        let reusedURL = testHTTPExecutor.requests[2].url!
-                        
-                        // Reuse host has to be equal previous (stored #1) fallback host
-                        expect(testHTTPExecutor.requests).to(haveCount(3))
-                        expect(usedFallbackURL.host).to(equal(reusedURL.host))
-                    }
-                        
-                        private func testRestoresDefaultPrimaryHostAfterTimeoutExpires(_ caseTest: FakeNetworkResponse) {
-                            let options = ARTClientOptions(key: "xxxx:xxxx")
-                            options.logLevel = .debug
-                            let client = ARTRest(options: options)
-                            let mockHTTP = MockHTTP(logger: options.logHandler)
-                            testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                            client.internal.httpExecutor = testHTTPExecutor
-                            mockHTTP.setNetworkState(network: caseTest, resetAfter: 1)
-                            let channel = client.channels.get("test-fallback-retry-timeout")
-                            
-                            waitUntil(timeout: testTimeout) { done in
-                                channel.publish(nil, data: "nil") { _ in
-                                    done()
-                                }
-                            }
-                            
-                            waitUntil(timeout: testTimeout) { done in
-                                delay(1.1) {
-                                    channel.publish(nil, data: "nil") { _ in
-                                        done()
-                                    }
-                                }
-                            }
-                            
-                            expect(testHTTPExecutor.requests).to(haveCount(3))
-                            expect(testHTTPExecutor.requests[2].url!.host).to(equal("rest.ably.io"))
-                        }
-
-                        private func testUsesAnotherFallbackHost(_ caseTest: FakeNetworkResponse) {
-                            let options = ARTClientOptions(key: "xxxx:xxxx")
-                            options.logLevel = .debug
-                            let client = ARTRest(options: options)
-                            let mockHTTP = MockHTTP(logger: options.logHandler)
-                            testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                            client.internal.httpExecutor = testHTTPExecutor
-                            mockHTTP.setNetworkState(network: caseTest, resetAfter: 2)
-                            let channel = client.channels.get("test-fallback-retry-timeout")
-                            
-                            waitUntil(timeout: testTimeout) { done in
-                                channel.publish(nil, data: "nil") { _ in
-                                    done()
-                                }
-                            }
-                            
-                            expect(testHTTPExecutor.requests).to(haveCount(3))
-                            expect(NSRegularExpression.match(testHTTPExecutor.requests[1].url!.host, pattern: "[a-e].ably-realtime.com")).to(beTrue())
-                            expect(NSRegularExpression.match(testHTTPExecutor.requests[2].url!.host, pattern: "[a-e].ably-realtime.com")).to(beTrue())
-                            expect(testHTTPExecutor.requests[1].url!.host).toNot(equal(testHTTPExecutor.requests[2].url!.host))
-                        }
-
-class RestClient: XCTestCase {
-
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = testHTTPExecutor
-    let _ = expectedHostOrder
-    let _ = originalARTFallback_shuffleArray
-    let _ = _fallbackHosts
-
-    return super.defaultTestSuite
+    expect(client.auth.internal.options.isBasicAuth()).to(beFalse())
 }
 
-        
-            // G4
-            func test__001__RestClient__All_REST_requests_should_include_the_current_API_version() {
-                let options = AblyTests.commonAppSetup()
-                let client = ARTRest(options: options)
-                testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                client.internal.httpExecutor = testHTTPExecutor
-                let channel = client.channels.get("test")
-                waitUntil(timeout: testTimeout) { done in
-                    channel.publish(nil, data: "message") { error in
-                        expect(error).to(beNil())
-                        let version = testHTTPExecutor.requests.first!.allHTTPHeaderFields?["X-Ably-Version"]
-                        
-                        // This test should not directly validate version against ARTDefault.version(), as
-                        // ultimately the version header has been derived from that value.
-                        expect(version).to(equal("1.2"))
-                        
-                        done()
-                    }
-                }
+private let expectedHostOrder = [4, 3, 0, 2, 1]
+
+private let originalARTFallback_shuffleArray = ARTFallback_shuffleArray
+
+private let _fallbackHosts = ["f.ably-realtime.com", "g.ably-realtime.com", "h.ably-realtime.com", "i.ably-realtime.com", "j.ably-realtime.com"]
+
+private func testUsesAlternativeHost(_ caseTest: FakeNetworkResponse) {
+    let options = ARTClientOptions(key: "xxxx:xxxx")
+    let client = ARTRest(options: options)
+    let mockHTTP = MockHTTP(logger: options.logHandler)
+    testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+    client.internal.httpExecutor = testHTTPExecutor
+    mockHTTP.setNetworkState(network: caseTest, resetAfter: 1)
+    let channel = client.channels.get("test")
+
+    waitUntil(timeout: testTimeout) { done in
+        channel.publish(nil, data: "nil") { _ in
+            done()
+        }
+    }
+
+    expect(testHTTPExecutor.requests).to(haveCount(2))
+    if testHTTPExecutor.requests.count != 2 {
+        return
+    }
+    expect(NSRegularExpression.match(testHTTPExecutor.requests[0].url!.absoluteString, pattern: "//rest.ably.io")).to(beTrue())
+    expect(NSRegularExpression.match(testHTTPExecutor.requests[1].url!.absoluteString, pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+}
+
+private func testStoresSuccessfulFallbackHostAsDefaultHost(_ caseTest: FakeNetworkResponse) {
+    let options = ARTClientOptions(key: "xxxx:xxxx")
+    let client = ARTRest(options: options)
+    let mockHTTP = MockHTTP(logger: options.logHandler)
+    testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+    client.internal.httpExecutor = testHTTPExecutor
+    mockHTTP.setNetworkState(network: caseTest, resetAfter: 1)
+    let channel = client.channels.get("test")
+
+    waitUntil(timeout: testTimeout) { done in
+        channel.publish(nil, data: "nil") { _ in
+            done()
+        }
+    }
+
+    expect(testHTTPExecutor.requests).to(haveCount(2))
+    expect(NSRegularExpression.match(testHTTPExecutor.requests[0].url!.host, pattern: "rest.ably.io")).to(beTrue())
+    expect(NSRegularExpression.match(testHTTPExecutor.requests[1].url!.host, pattern: "[a-e].ably-realtime.com")).to(beTrue())
+
+    // #1 Store fallback used to request
+    let usedFallbackURL = testHTTPExecutor.requests[1].url!
+
+    waitUntil(timeout: testTimeout) { done in
+        channel.publish(nil, data: "nil") { _ in
+            done()
+        }
+    }
+
+    let reusedURL = testHTTPExecutor.requests[2].url!
+
+    // Reuse host has to be equal previous (stored #1) fallback host
+    expect(testHTTPExecutor.requests).to(haveCount(3))
+    expect(usedFallbackURL.host).to(equal(reusedURL.host))
+}
+
+private func testRestoresDefaultPrimaryHostAfterTimeoutExpires(_ caseTest: FakeNetworkResponse) {
+    let options = ARTClientOptions(key: "xxxx:xxxx")
+    options.logLevel = .debug
+    let client = ARTRest(options: options)
+    let mockHTTP = MockHTTP(logger: options.logHandler)
+    testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+    client.internal.httpExecutor = testHTTPExecutor
+    mockHTTP.setNetworkState(network: caseTest, resetAfter: 1)
+    let channel = client.channels.get("test-fallback-retry-timeout")
+
+    waitUntil(timeout: testTimeout) { done in
+        channel.publish(nil, data: "nil") { _ in
+            done()
+        }
+    }
+
+    waitUntil(timeout: testTimeout) { done in
+        delay(1.1) {
+            channel.publish(nil, data: "nil") { _ in
+                done()
             }
+        }
+    }
 
-            // RSC1
-            
-                func test__015__RestClient__initializer__should_accept_an_API_key() {
-                    let options = AblyTests.commonAppSetup()
-                    
-                    let client = ARTRest(key: options.key!)
-                    client.internal.prioritizedHost = options.restHost
+    expect(testHTTPExecutor.requests).to(haveCount(3))
+    expect(testHTTPExecutor.requests[2].url!.host).to(equal("rest.ably.io"))
+}
 
-                    let publishTask = publishTestMessage(client)
+private func testUsesAnotherFallbackHost(_ caseTest: FakeNetworkResponse) {
+    let options = ARTClientOptions(key: "xxxx:xxxx")
+    options.logLevel = .debug
+    let client = ARTRest(options: options)
+    let mockHTTP = MockHTTP(logger: options.logHandler)
+    testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+    client.internal.httpExecutor = testHTTPExecutor
+    mockHTTP.setNetworkState(network: caseTest, resetAfter: 2)
+    let channel = client.channels.get("test-fallback-retry-timeout")
 
-                    expect(publishTask.error).toEventually(beNil(), timeout: testTimeout)
+    waitUntil(timeout: testTimeout) { done in
+        channel.publish(nil, data: "nil") { _ in
+            done()
+        }
+    }
+
+    expect(testHTTPExecutor.requests).to(haveCount(3))
+    expect(NSRegularExpression.match(testHTTPExecutor.requests[1].url!.host, pattern: "[a-e].ably-realtime.com")).to(beTrue())
+    expect(NSRegularExpression.match(testHTTPExecutor.requests[2].url!.host, pattern: "[a-e].ably-realtime.com")).to(beTrue())
+    expect(testHTTPExecutor.requests[1].url!.host).toNot(equal(testHTTPExecutor.requests[2].url!.host))
+}
+
+class RestClient: XCTestCase {
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = testHTTPExecutor
+        _ = expectedHostOrder
+        _ = originalARTFallback_shuffleArray
+        _ = _fallbackHosts
+
+        return super.defaultTestSuite
+    }
+
+    // G4
+    func test__001__RestClient__All_REST_requests_should_include_the_current_API_version() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { error in
+                expect(error).to(beNil())
+                let version = testHTTPExecutor.requests.first!.allHTTPHeaderFields?["X-Ably-Version"]
+
+                // This test should not directly validate version against ARTDefault.version(), as
+                // ultimately the version header has been derived from that value.
+                expect(version).to(equal("1.2"))
+
+                done()
+            }
+        }
+    }
+
+    // RSC1
+
+    func test__015__RestClient__initializer__should_accept_an_API_key() {
+        let options = AblyTests.commonAppSetup()
+
+        let client = ARTRest(key: options.key!)
+        client.internal.prioritizedHost = options.restHost
+
+        let publishTask = publishTestMessage(client)
+
+        expect(publishTask.error).toEventually(beNil(), timeout: testTimeout)
+    }
+
+    func test__016__RestClient__initializer__should_throw_when_provided_an_invalid_key() {
+        expect { ARTRest(key: "invalid_key") }.to(raiseException())
+    }
+
+    func test__017__RestClient__initializer__should_result_in_error_status_when_provided_a_bad_key() {
+        let client = ARTRest(key: "fake:key")
+
+        let publishTask = publishTestMessage(client, failOnError: false)
+
+        expect(publishTask.error?.code).toEventually(equal(ARTErrorCode.invalidCredential.intValue), timeout: testTimeout)
+    }
+
+    func test__018__RestClient__initializer__should_accept_a_token() {
+        ARTClientOptions.setDefaultEnvironment(getEnvironment())
+        defer { ARTClientOptions.setDefaultEnvironment(nil) }
+
+        let client = ARTRest(token: getTestToken())
+        let publishTask = publishTestMessage(client)
+        expect(publishTask.error).toEventually(beNil(), timeout: testTimeout)
+    }
+
+    func test__019__RestClient__initializer__should_accept_an_options_object() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRest(options: options)
+
+        let publishTask = publishTestMessage(client)
+
+        expect(publishTask.error).toEventually(beNil(), timeout: testTimeout)
+    }
+
+    func test__020__RestClient__initializer__should_accept_an_options_object_with_token_authentication() {
+        let options = AblyTests.clientOptions(requestToken: true)
+        let client = ARTRest(options: options)
+
+        let publishTask = publishTestMessage(client)
+
+        expect(publishTask.error).toEventually(beNil(), timeout: testTimeout)
+    }
+
+    func test__021__RestClient__initializer__should_result_in_error_status_when_provided_a_bad_token() {
+        let options = AblyTests.clientOptions()
+        options.token = "invalid_token"
+        let client = ARTRest(options: options)
+
+        let publishTask = publishTestMessage(client, failOnError: false)
+
+        expect(publishTask.error?.code).toEventually(equal(ARTErrorCode.invalidCredential.intValue), timeout: testTimeout)
+    }
+
+    // RSC2
+    func test__022__RestClient__logging__should_output_to_the_system_log_and_the_log_level_should_be_Warn() {
+        ARTClientOptions.setDefaultEnvironment(getEnvironment())
+        defer {
+            ARTClientOptions.setDefaultEnvironment(nil)
+        }
+
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.logHandler = ARTLog(capturingOutput: true)
+        let client = ARTRest(options: options)
+
+        client.internal.logger.log("This is a warning", with: .warn)
+
+        expect(client.internal.logger.logLevel).to(equal(ARTLogLevel.warn))
+        guard let line = options.logHandler.captured.last else {
+            fail("didn't log line.")
+            return
+        }
+        expect(line.level).to(equal(ARTLogLevel.warn))
+        expect(line.toString()).to(equal("WARN: This is a warning"))
+    }
+
+    // RSC3
+    func test__023__RestClient__logging__should_have_a_mutable_log_level() {
+        let options = AblyTests.commonAppSetup()
+        options.logHandler = ARTLog(capturingOutput: true)
+        let client = ARTRest(options: options)
+        client.internal.logger.logLevel = .error
+
+        let logTime = NSDate()
+        client.internal.logger.log("This is a warning", with: .warn)
+
+        let logs = options.logHandler.captured.filter { !$0.date.isBefore(logTime as Date) }
+        expect(logs).to(beEmpty())
+    }
+
+    // RSC4
+    func test__024__RestClient__logging__should_accept_a_custom_logger() {
+        enum Log {
+            static var interceptedLog: (String, ARTLogLevel) = ("", .none)
+        }
+        class MyLogger: ARTLog {
+            override func log(_ message: String, with level: ARTLogLevel) {
+                Log.interceptedLog = (message, level)
+            }
+        }
+
+        let options = AblyTests.commonAppSetup()
+        let customLogger = MyLogger()
+        options.logHandler = customLogger
+        options.logLevel = .verbose
+        let client = ARTRest(options: options)
+
+        client.internal.logger.log("This is a warning", with: .warn)
+
+        expect(Log.interceptedLog.0).to(equal("This is a warning"))
+        expect(Log.interceptedLog.1).to(equal(ARTLogLevel.warn))
+
+        expect(client.internal.logger.logLevel).to(equal(customLogger.logLevel))
+    }
+
+    // RSC11
+
+    // RSC11a
+    func test__025__RestClient__endpoint__should_accept_a_custom_host_and_send_requests_to_the_specified_host() {
+        let options = ARTClientOptions(key: "fake:key")
+        options.restHost = "fake.ably.io"
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+
+        publishTestMessage(client, failOnError: false)
+
+        expect(testHTTPExecutor.requests.first?.url?.host).toEventually(equal("fake.ably.io"), timeout: testTimeout)
+    }
+
+    func test__026__RestClient__endpoint__should_ignore_an_environment_when_restHost_is_customized() {
+        let options = ARTClientOptions(key: "fake:key")
+        options.environment = "test"
+        options.restHost = "fake.ably.io"
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+
+        publishTestMessage(client, failOnError: false)
+
+        expect(testHTTPExecutor.requests.first?.url?.host).toEventually(equal("fake.ably.io"), timeout: testTimeout)
+    }
+
+    // RSC11b
+    func test__027__RestClient__endpoint__should_accept_an_environment_when_restHost_is_left_unchanged() {
+        let options = ARTClientOptions(key: "fake:key")
+        options.environment = "myEnvironment"
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+
+        publishTestMessage(client, failOnError: false)
+
+        expect(testHTTPExecutor.requests.first?.url?.host).toEventually(equal("myEnvironment-rest.ably.io"), timeout: testTimeout)
+    }
+
+    func test__028__RestClient__endpoint__should_default_to_https___rest_ably_io() {
+        let options = ARTClientOptions(key: "fake:key")
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+
+        publishTestMessage(client, failOnError: false)
+
+        expect(testHTTPExecutor.requests.first?.url?.absoluteString).toEventually(beginWith("https://rest.ably.io"), timeout: testTimeout)
+    }
+
+    func test__029__RestClient__endpoint__should_connect_over_plain_http____when_tls_is_off() {
+        let options = AblyTests.clientOptions(requestToken: true)
+        options.tls = false
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+
+        publishTestMessage(client, failOnError: false)
+
+        expect(testHTTPExecutor.requests.first?.url?.scheme).toEventually(equal("http"), timeout: testTimeout)
+    }
+
+    // RSC11b
+    func test__030__RestClient__endpoint__should_not_prepend_the_environment_if_environment_is_configured_as__production_() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.environment = "production"
+        let client = ARTRest(options: options)
+        expect(client.internal.options.restHost).to(equal(ARTDefault.restHost()))
+        expect(client.internal.options.realtimeHost).to(equal(ARTDefault.realtimeHost()))
+    }
+
+    // RSC13
+
+    func test__031__RestClient__should_use_the_the_connection_and_request_timeouts_specified__timeout_for_any_single_HTTP_request_and_response() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.restHost = "10.255.255.1" // non-routable IP address
+        expect(options.httpRequestTimeout).to(equal(10.0)) // Seconds
+        options.httpRequestTimeout = 1.0
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            let start = NSDate()
+            channel.publish(nil, data: "message") { error in
+                let end = NSDate()
+                expect(end.timeIntervalSince(start as Date)).to(beCloseTo(options.httpRequestTimeout, within: 0.5))
+                expect(error).toNot(beNil())
+                if let error = error {
+                    expect(error.code).to(satisfyAnyOf(equal(-1001 /* Timed Out */ ), equal(-1004 /* Cannot Connect To Host */ )))
                 }
+                done()
+            }
+        }
+    }
 
-                func test__016__RestClient__initializer__should_throw_when_provided_an_invalid_key() {
-                    expect{ ARTRest(key: "invalid_key") }.to(raiseException())
+    func test__032__RestClient__should_use_the_the_connection_and_request_timeouts_specified__max_number_of_fallback_hosts() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        expect(options.httpMaxRetryCount).to(equal(3))
+        options.httpMaxRetryCount = 1
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+
+        var totalRetry: UInt = 0
+        testHTTPExecutor.setListenerAfterRequest { request in
+            if NSRegularExpression.match(request.url!.absoluteString, pattern: "//[a-e].ably-realtime.com") {
+                totalRetry += 1
+            }
+        }
+
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "nil") { _ in
+                done()
+            }
+        }
+        expect(totalRetry).to(equal(options.httpMaxRetryCount))
+    }
+
+    func test__033__RestClient__should_use_the_the_connection_and_request_timeouts_specified__max_elapsed_time_in_which_fallback_host_retries_for_HTTP_requests_will_be_attempted() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        expect(options.httpMaxRetryDuration).to(equal(15.0)) // Seconds
+        options.httpMaxRetryDuration = 1.0
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .requestTimeout(timeout: 0.1))
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            let start = Date()
+            channel.publish(nil, data: "nil") { _ in
+                let end = Date()
+                expect(end.timeIntervalSince(start)).to(beCloseTo(options.httpMaxRetryDuration, within: 0.9))
+                done()
+            }
+        }
+    }
+
+    // RSC5
+    func test__002__RestClient__should_provide_access_to_the_AuthOptions_object_passed_in_ClientOptions() {
+        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let client = ARTRest(options: options)
+
+        let authOptions = client.auth.internal.options
+
+        expect(authOptions == options).to(beTrue())
+    }
+
+    // RSC12
+    func test__003__RestClient__REST_endpoint_host_should_be_configurable_in_the_Client_constructor_with_the_option_restHost() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        expect(options.restHost).to(equal("rest.ably.io"))
+        options.restHost = "rest.ably.test"
+        expect(options.restHost).to(equal("rest.ably.test"))
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        waitUntil(timeout: testTimeout) { done in
+            client.channels.get("test").publish(nil, data: "message") { error in
+                expect(error).toNot(beNil())
+                done()
+            }
+        }
+        expect(testHTTPExecutor.requests.first!.url!.absoluteString).to(contain("//rest.ably.test"))
+    }
+
+    // RSC16
+
+    func test__034__RestClient__time__should_return_server_time() {
+        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let client = ARTRest(options: options)
+
+        var time: NSDate?
+
+        client.time { date, _ in
+            time = date as NSDate? as NSDate?
+        }
+
+        expect(time?.timeIntervalSince1970).toEventually(beCloseTo(NSDate().timeIntervalSince1970, within: 60), timeout: testTimeout)
+    }
+
+    // RSC7, RSC18
+    func test__004__RestClient__should_send_requests_over_http_and_https() {
+        let options = AblyTests.commonAppSetup()
+
+        let clientHttps = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        clientHttps.internal.httpExecutor = testHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            publishTestMessage(clientHttps) { _ in
+                done()
+            }
+        }
+
+        let requestUrlA = testHTTPExecutor.requests.first!.url!
+        expect(requestUrlA.scheme).to(equal("https"))
+
+        options.clientId = "client_http"
+        options.useTokenAuth = true
+        options.tls = false
+        let clientHttp = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        clientHttp.internal.httpExecutor = testHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            publishTestMessage(clientHttp) { _ in
+                done()
+            }
+        }
+
+        let requestUrlB = testHTTPExecutor.requests.last!.url!
+        expect(requestUrlB.scheme).to(equal("http"))
+    }
+
+    // RSC9
+    func test__005__RestClient__should_use_Auth_to_manage_authentication() {
+        let options = AblyTests.clientOptions()
+        guard let testTokenDetails = getTestTokenDetails() else {
+            fail("No test token details"); return
+        }
+        options.tokenDetails = testTokenDetails
+        options.authCallback = { _, completion in
+            completion(testTokenDetails, nil)
+        }
+
+        let client = ARTRest(options: options)
+        expect(client.auth).to(beAnInstanceOf(ARTAuth.self))
+
+        waitUntil(timeout: testTimeout) { done in
+            client.auth.authorize(nil, options: nil) { tokenDetails, error in
+                if let e = error {
+                    XCTFail(e.localizedDescription)
+                    done()
+                    return
                 }
-
-                func test__017__RestClient__initializer__should_result_in_error_status_when_provided_a_bad_key() {
-                    let client = ARTRest(key: "fake:key")
-
-                    let publishTask = publishTestMessage(client, failOnError: false)
-
-                    expect(publishTask.error?.code).toEventually(equal(ARTErrorCode.invalidCredential.intValue), timeout:testTimeout)
+                guard let tokenDetails = tokenDetails else {
+                    XCTFail("expected tokenDetails to not be nil when error is nil")
+                    done()
+                    return
                 }
+                expect(tokenDetails.token).to(equal(testTokenDetails.token))
+                done()
+            }
+        }
+    }
 
-                func test__018__RestClient__initializer__should_accept_a_token() {
-                    ARTClientOptions.setDefaultEnvironment(getEnvironment())
-                    defer { ARTClientOptions.setDefaultEnvironment(nil) }
+    // RSC10
+    func test__006__RestClient__should_request_another_token_after_current_one_is_no_longer_valid() {
+        let options = AblyTests.commonAppSetup()
+        options.token = getTestToken(ttl: 0.5)
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        let auth = client.auth
 
-                    let client = ARTRest(token: getTestToken())
-                    let publishTask = publishTestMessage(client)
-                    expect(publishTask.error).toEventually(beNil(), timeout: testTimeout)
-                }
+        waitUntil(timeout: testTimeout) { done in
+            delay(1.0) {
+                client.channels.get("test").history { result, error in
+                    expect(error).to(beNil())
+                    expect(result).toNot(beNil())
 
-                func test__019__RestClient__initializer__should_accept_an_options_object() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRest(options: options)
-
-                    let publishTask = publishTestMessage(client)
-
-                    expect(publishTask.error).toEventually(beNil(), timeout: testTimeout)
-                }
-
-                func test__020__RestClient__initializer__should_accept_an_options_object_with_token_authentication() {
-                    let options = AblyTests.clientOptions(requestToken: true)
-                    let client = ARTRest(options: options)
-
-                    let publishTask = publishTestMessage(client)
-
-                    expect(publishTask.error).toEventually(beNil(), timeout: testTimeout)
-                }
-
-                func test__021__RestClient__initializer__should_result_in_error_status_when_provided_a_bad_token() {
-                    let options = AblyTests.clientOptions()
-                    options.token = "invalid_token"
-                    let client = ARTRest(options: options)
-
-                    let publishTask = publishTestMessage(client, failOnError: false)
-
-                    expect(publishTask.error?.code).toEventually(equal(ARTErrorCode.invalidCredential.intValue), timeout: testTimeout)
-                }
-
-            
-                // RSC2
-                func test__022__RestClient__logging__should_output_to_the_system_log_and_the_log_level_should_be_Warn() {
-                    ARTClientOptions.setDefaultEnvironment(getEnvironment())
-                    defer {
-                        ARTClientOptions.setDefaultEnvironment(nil)
-                    }
-
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.logHandler = ARTLog(capturingOutput: true)
-                    let client = ARTRest(options: options)
-
-                    client.internal.logger.log("This is a warning", with: .warn)
-
-                    expect(client.internal.logger.logLevel).to(equal(ARTLogLevel.warn))
-                    guard let line = options.logHandler.captured.last else {
-                        fail("didn't log line.")
+                    guard let headerErrorCode = testHTTPExecutor.responses.first?.value(forHTTPHeaderField: "X-Ably-Errorcode") else {
+                        fail("X-Ably-Errorcode not found"); done()
                         return
                     }
-                    expect(line.level).to(equal(ARTLogLevel.warn))
-                    expect(line.toString()).to(equal("WARN: This is a warning"))
+                    expect(Int(headerErrorCode)).to(equal(ARTErrorCode.tokenExpired.intValue))
+
+                    // Different token
+                    expect(auth.tokenDetails!.token).toNot(equal(options.token))
+                    done()
                 }
-
-                // RSC3
-                func test__023__RestClient__logging__should_have_a_mutable_log_level() {
-                    let options = AblyTests.commonAppSetup()
-                    options.logHandler = ARTLog(capturingOutput: true)
-                    let client = ARTRest(options: options)
-                    client.internal.logger.logLevel = .error
-
-                    let logTime = NSDate()
-                    client.internal.logger.log("This is a warning", with: .warn)
-
-                    let logs = options.logHandler.captured.filter({!$0.date.isBefore(logTime as Date)})
-                    expect(logs).to(beEmpty())
-                }
-
-                // RSC4
-                func test__024__RestClient__logging__should_accept_a_custom_logger() {
-                    struct Log {
-                        static var interceptedLog: (String, ARTLogLevel) = ("", .none)
-                    }
-                    class MyLogger : ARTLog {
-                        override func log(_ message: String, with level: ARTLogLevel) {
-                            Log.interceptedLog = (message, level)
-                        }
-                    }
-
-                    let options = AblyTests.commonAppSetup()
-                    let customLogger = MyLogger()
-                    options.logHandler = customLogger
-                    options.logLevel = .verbose
-                    let client = ARTRest(options: options)
-
-                    client.internal.logger.log("This is a warning", with: .warn)
-                    
-                    expect(Log.interceptedLog.0).to(equal("This is a warning"))
-                    expect(Log.interceptedLog.1).to(equal(ARTLogLevel.warn))
-                    
-                    expect(client.internal.logger.logLevel).to(equal(customLogger.logLevel))
-                }
-
-            // RSC11
-            
-
-                // RSC11a
-                func test__025__RestClient__endpoint__should_accept_a_custom_host_and_send_requests_to_the_specified_host() {
-                    let options = ARTClientOptions(key: "fake:key")
-                    options.restHost = "fake.ably.io"
-                    let client = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    client.internal.httpExecutor = testHTTPExecutor
-                    
-                    publishTestMessage(client, failOnError: false)
-                    
-                    expect(testHTTPExecutor.requests.first?.url?.host).toEventually(equal("fake.ably.io"), timeout: testTimeout)
-                }
-
-                func test__026__RestClient__endpoint__should_ignore_an_environment_when_restHost_is_customized() {
-                    let options = ARTClientOptions(key: "fake:key")
-                    options.environment = "test"
-                    options.restHost = "fake.ably.io"
-                    let client = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    client.internal.httpExecutor = testHTTPExecutor
-
-                    publishTestMessage(client, failOnError: false)
-
-                    expect(testHTTPExecutor.requests.first?.url?.host).toEventually(equal("fake.ably.io"), timeout: testTimeout)
-                }
-
-                // RSC11b
-                func test__027__RestClient__endpoint__should_accept_an_environment_when_restHost_is_left_unchanged() {
-                    let options = ARTClientOptions(key: "fake:key")
-                    options.environment = "myEnvironment"
-                    let client = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    client.internal.httpExecutor = testHTTPExecutor
-                    
-                    publishTestMessage(client, failOnError: false)
-                    
-                    expect(testHTTPExecutor.requests.first?.url?.host).toEventually(equal("myEnvironment-rest.ably.io"), timeout: testTimeout)
-                }
-                
-                func test__028__RestClient__endpoint__should_default_to_https___rest_ably_io() {
-                    let options = ARTClientOptions(key: "fake:key")
-                    let client = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    client.internal.httpExecutor = testHTTPExecutor
-                    
-                    publishTestMessage(client, failOnError: false)
-                    
-                    expect(testHTTPExecutor.requests.first?.url?.absoluteString).toEventually(beginWith("https://rest.ably.io"), timeout: testTimeout)
-                }
-                
-                func test__029__RestClient__endpoint__should_connect_over_plain_http____when_tls_is_off() {
-                    let options = AblyTests.clientOptions(requestToken: true)
-                    options.tls = false
-                    let client = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    client.internal.httpExecutor = testHTTPExecutor
-                    
-                    publishTestMessage(client, failOnError: false)
-                    
-                    expect(testHTTPExecutor.requests.first?.url?.scheme).toEventually(equal("http"), timeout: testTimeout)
-                }
-
-                // RSC11b
-                func test__030__RestClient__endpoint__should_not_prepend_the_environment_if_environment_is_configured_as__production_() {
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.environment = "production"
-                    let client = ARTRest(options: options)
-                    expect(client.internal.options.restHost).to(equal(ARTDefault.restHost()))
-                    expect(client.internal.options.realtimeHost).to(equal(ARTDefault.realtimeHost()))
-                }
-
-            // RSC13
-            
-
-                func test__031__RestClient__should_use_the_the_connection_and_request_timeouts_specified__timeout_for_any_single_HTTP_request_and_response() {
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.restHost = "10.255.255.1" //non-routable IP address
-                    expect(options.httpRequestTimeout).to(equal(10.0)) //Seconds
-                    options.httpRequestTimeout = 1.0
-                    let client = ARTRest(options: options)
-                    let channel = client.channels.get("test")
-                    waitUntil(timeout: testTimeout) { done in
-                        let start = NSDate()
-                        channel.publish(nil, data: "message") { error in
-                            let end = NSDate()
-                            expect(end.timeIntervalSince(start as Date)).to(beCloseTo(options.httpRequestTimeout, within: 0.5))
-                            expect(error).toNot(beNil())
-                            if let error = error {
-                                expect((error ).code).to(satisfyAnyOf(equal(-1001 /*Timed Out*/), equal(-1004 /*Cannot Connect To Host*/)))
-                            }
-                            done()
-                        }
-                    }
-                }
-
-                func test__032__RestClient__should_use_the_the_connection_and_request_timeouts_specified__max_number_of_fallback_hosts() {
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    expect(options.httpMaxRetryCount).to(equal(3))
-                    options.httpMaxRetryCount = 1
-                    let client = ARTRest(options: options)
-                    let mockHTTP = MockHTTP(logger: options.logHandler)
-                    testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                    client.internal.httpExecutor = testHTTPExecutor
-                    mockHTTP.setNetworkState(network: .hostUnreachable)
-
-                    var totalRetry: UInt = 0
-                    testHTTPExecutor.setListenerAfterRequest({ request in
-                        if NSRegularExpression.match(request.url!.absoluteString, pattern: "//[a-e].ably-realtime.com") {
-                            totalRetry += 1
-                        }
-                    })
-
-                    let channel = client.channels.get("test")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: "nil") { _ in
-                            done()
-                        }
-                    }
-                    expect(totalRetry).to(equal(options.httpMaxRetryCount))
-                }
-
-                func test__033__RestClient__should_use_the_the_connection_and_request_timeouts_specified__max_elapsed_time_in_which_fallback_host_retries_for_HTTP_requests_will_be_attempted() {
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    expect(options.httpMaxRetryDuration).to(equal(15.0)) //Seconds
-                    options.httpMaxRetryDuration = 1.0
-                    let client = ARTRest(options: options)
-                    let mockHTTP = MockHTTP(logger: options.logHandler)
-                    testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                    client.internal.httpExecutor = testHTTPExecutor
-                    mockHTTP.setNetworkState(network: .requestTimeout(timeout: 0.1))
-                    let channel = client.channels.get("test")
-                    waitUntil(timeout: testTimeout) { done in
-                        let start = Date()
-                        channel.publish(nil, data: "nil") { _ in
-                            let end = Date()
-                            expect(end.timeIntervalSince(start)).to(beCloseTo(options.httpMaxRetryDuration, within: 0.9))
-                            done()
-                        }
-                    }
-                }
-
-            // RSC5
-            func test__002__RestClient__should_provide_access_to_the_AuthOptions_object_passed_in_ClientOptions() {
-                let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
-                let client = ARTRest(options: options)
-                
-                let authOptions = client.auth.internal.options
-
-                expect(authOptions == options).to(beTrue())
             }
+        }
+    }
 
-            // RSC12
-            func test__003__RestClient__REST_endpoint_host_should_be_configurable_in_the_Client_constructor_with_the_option_restHost() {
-                let options = ARTClientOptions(key: "xxxx:xxxx")
-                expect(options.restHost).to(equal("rest.ably.io"))
-                options.restHost = "rest.ably.test"
-                expect(options.restHost).to(equal("rest.ably.test"))
-                let client = ARTRest(options: options)
-                testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                client.internal.httpExecutor = testHTTPExecutor
-                waitUntil(timeout: testTimeout) { done in
-                    client.channels.get("test").publish(nil, data: "message") { error in
-                        expect(error).toNot(beNil())
-                        done()
-                    }
+    // RSC10
+    func test__007__RestClient__should_result_in_an_error_when_user_does_not_have_sufficient_permissions() {
+        let options = AblyTests.clientOptions()
+        options.token = getTestToken(capability: "{ \"main\":[\"subscribe\"] }")
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            client.channels.get("test").history { result, error in
+                guard let errorCode = error?.code else {
+                    fail("Error is empty"); done()
+                    return
                 }
-                expect(testHTTPExecutor.requests.first!.url!.absoluteString).to(contain("//rest.ably.test"))
+                expect(errorCode).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
+                expect(result).to(beNil())
+
+                guard let headerErrorCode = testHTTPExecutor.responses.first?.value(forHTTPHeaderField: "X-Ably-Errorcode") else {
+                    fail("X-Ably-Errorcode not found"); done()
+                    return
+                }
+                expect(Int(headerErrorCode)).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
+                done()
             }
-            
-            // RSC16
-            
-                func test__034__RestClient__time__should_return_server_time() {
-                    let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
-                    let client = ARTRest(options: options)
-                    
-                    var time: NSDate?
+        }
+    }
 
-                    client.time({ date, error in
-                        time = date as NSDate? as NSDate?
-                    })
-                    
-                    expect(time?.timeIntervalSince1970).toEventually(beCloseTo(NSDate().timeIntervalSince1970, within: 60), timeout: testTimeout)
-                }
+    // RSC14
 
-            // RSC7, RSC18
-            func test__004__RestClient__should_send_requests_over_http_and_https() {
-                let options = AblyTests.commonAppSetup()
-
-                let clientHttps = ARTRest(options: options)
-                testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                clientHttps.internal.httpExecutor = testHTTPExecutor
-
-                waitUntil(timeout: testTimeout) { done in
-                    publishTestMessage(clientHttps) { error in
-                        done()
-                    }
-                }
-
-                let requestUrlA = testHTTPExecutor.requests.first!.url!
-                expect(requestUrlA.scheme).to(equal("https"))
-
-                options.clientId = "client_http"
-                options.useTokenAuth = true
-                options.tls = false
-                let clientHttp = ARTRest(options: options)
-                testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                clientHttp.internal.httpExecutor = testHTTPExecutor
-
-                waitUntil(timeout: testTimeout) { done in
-                    publishTestMessage(clientHttp) { error in
-                        done()
-                    }
-                }
-
-                let requestUrlB = testHTTPExecutor.requests.last!.url!
-                expect(requestUrlB.scheme).to(equal("http"))
+    // RSC14a
+    func test__035__RestClient__Authentication__should_support_basic_authentication_when_an_API_key_is_provided_with_the_key_option() {
+        let options = AblyTests.commonAppSetup()
+        guard let components = options.key?.components(separatedBy: ":"), let keyName = components.first, let keySecret = components.last else {
+            fail("Invalid API key: \(options.key ?? "nil")"); return
+        }
+        ARTClientOptions.setDefaultEnvironment(getEnvironment())
+        defer {
+            ARTClientOptions.setDefaultEnvironment(nil)
+        }
+        let rest = ARTRest(key: "\(keyName):\(keySecret)")
+        waitUntil(timeout: testTimeout) { done in
+            rest.channels.get("foo").publish(nil, data: "testing") { error in
+                expect(error).to(beNil())
+                done()
             }
+        }
+    }
 
-            // RSC9
-            func test__005__RestClient__should_use_Auth_to_manage_authentication() {
+    // RSC14b
+
+    func test__038__RestClient__Authentication__basic_authentication_flag__should_be_true_when_initialized_with_a_key() {
+        let client = ARTRest(key: "key:secret")
+        expect(client.auth.internal.options.isBasicAuth()).to(beTrue())
+    }
+
+    func test__039__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__useTokenAuth_is_set() {
+        testOptionsGiveBasicAuthFalse { $0.useTokenAuth = true; $0.key = "fake:key" }
+    }
+
+    func test__040__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__authUrl_is_set() {
+        testOptionsGiveBasicAuthFalse { $0.authUrl = URL(string: "http://test.com") }
+    }
+
+    func test__041__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__authCallback_is_set() {
+        testOptionsGiveBasicAuthFalse { $0.authCallback = { _, _ in } }
+    }
+
+    func test__042__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__tokenDetails_is_set() {
+        testOptionsGiveBasicAuthFalse { $0.tokenDetails = ARTTokenDetails(token: "token") }
+    }
+
+    func test__043__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__token_is_set() {
+        testOptionsGiveBasicAuthFalse { $0.token = "token" }
+    }
+
+    func test__044__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__key_is_set() {
+        testOptionsGiveBasicAuthFalse { $0.tokenDetails = ARTTokenDetails(token: "token"); $0.key = "fake:key" }
+    }
+
+    // RSC14c
+    func test__036__RestClient__Authentication__should_error_when_expired_token_and_no_means_to_renew() {
+        let client = ARTRest(options: AblyTests.commonAppSetup())
+        let auth = client.auth
+
+        let tokenParams = ARTTokenParams()
+        tokenParams.ttl = 3.0 // Seconds
+
+        guard let options: ARTClientOptions = (AblyTests.waitFor(timeout: testTimeout) { value in
+            auth.requestToken(tokenParams, with: nil) { tokenDetails, error in
+                if let e = error {
+                    XCTFail(e.localizedDescription)
+                    value(nil)
+                    return
+                }
+
+                guard let currentTokenDetails = tokenDetails else {
+                    XCTFail("expected tokenDetails not to be nil when error is nil")
+                    value(nil)
+                    return
+                }
+
                 let options = AblyTests.clientOptions()
-                guard let testTokenDetails = getTestTokenDetails() else {
-                    fail("No test token details"); return
-                }
-                options.tokenDetails = testTokenDetails
-                options.authCallback = { tokenParams, completion in
-                    completion(testTokenDetails, nil)
-                }
+                options.key = client.internal.options.key
 
-                let client = ARTRest(options: options)
-                expect(client.auth).to(beAnInstanceOf(ARTAuth.self))
+                // Expired token
+                options.tokenDetails = ARTTokenDetails(
+                    token: currentTokenDetails.token,
+                    expires: currentTokenDetails.expires!.addingTimeInterval(testTimeout.toTimeInterval()),
+                    issued: currentTokenDetails.issued,
+                    capability: currentTokenDetails.capability,
+                    clientId: currentTokenDetails.clientId
+                )
 
-                waitUntil(timeout: testTimeout) { done in
-                    client.auth.authorize(nil, options: nil) { tokenDetails, error in
-                        if let e = error {
-                            XCTFail(e.localizedDescription)
-                            done()
-                            return
-                        }
-                        guard let tokenDetails = tokenDetails else {
-                            XCTFail("expected tokenDetails to not be nil when error is nil")
-                            done()
-                            return
-                        }
-                        expect(tokenDetails.token).to(equal(testTokenDetails.token))
-                        done()
+                options.authUrl = URL(string: "http://test-auth.ably.io")
+                value(options)
+            }
+        }) else {
+            return
+        }
+
+        let rest = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = testHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            // Delay for token expiration
+            delay(TimeInterval(truncating: tokenParams.ttl!)) {
+                // [40140, 40150) - token expired and will not recover because authUrl is invalid
+                publishTestMessage(rest) { error in
+                    guard let errorCode = testHTTPExecutor.responses.first?.value(forHTTPHeaderField: "X-Ably-Errorcode") else {
+                        fail("expected X-Ably-Errorcode header in request")
+                        return
                     }
+                    expect(Int(errorCode)).to(beGreaterThanOrEqualTo(ARTErrorCode.tokenErrorUnspecified.intValue))
+                    expect(Int(errorCode)).to(beLessThan(ARTErrorCode.connectionLimitsExceeded.intValue))
+                    expect(error).toNot(beNil())
+                    done()
                 }
             }
+        }
+    }
 
-            // RSC10
-            func test__006__RestClient__should_request_another_token_after_current_one_is_no_longer_valid() {
-                let options = AblyTests.commonAppSetup()
-                options.token = getTestToken(ttl: 0.5)
-                let client = ARTRest(options: options)
-                testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                client.internal.httpExecutor = testHTTPExecutor
-                let auth = client.auth
+    // RSC14d
+    func test__037__RestClient__Authentication__should_renew_the_token_when_it_has_expired() {
+        let client = ARTRest(options: AblyTests.commonAppSetup())
+        let auth = client.auth
 
-                waitUntil(timeout: testTimeout) { done in
-                    delay(1.0) {
-                        client.channels.get("test").history { result, error in
-                            expect(error).to(beNil())
-                            expect(result).toNot(beNil())
+        let tokenParams = ARTTokenParams()
+        tokenParams.ttl = 3.0 // Seconds
 
-                            guard let headerErrorCode = testHTTPExecutor.responses.first?.value(forHTTPHeaderField: "X-Ably-Errorcode") else {
-                                fail("X-Ably-Errorcode not found"); done();
-                                return
-                            }
-                            expect(Int(headerErrorCode)).to(equal(ARTErrorCode.tokenExpired.intValue))
-
-                            // Different token
-                            expect(auth.tokenDetails!.token).toNot(equal(options.token))
-                            done()
-                        }
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            auth.requestToken(tokenParams, with: nil) { tokenDetails, error in
+                if let e = error {
+                    XCTFail(e.localizedDescription)
+                    done()
+                    return
                 }
-            }
 
-            // RSC10
-            func test__007__RestClient__should_result_in_an_error_when_user_does_not_have_sufficient_permissions() {
+                guard let currentTokenDetails = tokenDetails else {
+                    XCTFail("expected tokenDetails not to be nil when error is nil")
+                    done()
+                    return
+                }
+
                 let options = AblyTests.clientOptions()
-                options.token = getTestToken(capability: "{ \"main\":[\"subscribe\"] }")
-                let client = ARTRest(options: options)
-                testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                client.internal.httpExecutor = testHTTPExecutor
-
-                waitUntil(timeout: testTimeout) { done in
-                    client.channels.get("test").history { result, error in
-                        guard let errorCode = error?.code else {
-                            fail("Error is empty"); done();
-                            return
-                        }
-                        expect(errorCode).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
-                        expect(result).to(beNil())
-
-                        guard let headerErrorCode = testHTTPExecutor.responses.first?.value(forHTTPHeaderField: "X-Ably-Errorcode") else {
-                            fail("X-Ably-Errorcode not found"); done();
-                            return
-                        }
-                        expect(Int(headerErrorCode)).to(equal(ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue))
-                        done()
-                    }
-                }
-            }
-
-            // RSC14
-            
-
-                // RSC14a
-                func test__035__RestClient__Authentication__should_support_basic_authentication_when_an_API_key_is_provided_with_the_key_option() {
-                    let options = AblyTests.commonAppSetup()
-                    guard let components = options.key?.components(separatedBy: ":"), let keyName = components.first, let keySecret = components.last else {
-                        fail("Invalid API key: \(options.key ?? "nil")"); return
-                    }
-                    ARTClientOptions.setDefaultEnvironment(getEnvironment())
-                    defer {
-                        ARTClientOptions.setDefaultEnvironment(nil)
-                    }
-                    let rest = ARTRest(key: "\(keyName):\(keySecret)")
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.channels.get("foo").publish(nil, data: "testing") { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
-
-                // RSC14b
-                
-                    func test__038__RestClient__Authentication__basic_authentication_flag__should_be_true_when_initialized_with_a_key() {
-                        let client = ARTRest(key: "key:secret")
-                        expect(client.auth.internal.options.isBasicAuth()).to(beTrue())
-                    }
-                    
-                    func test__039__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__useTokenAuth_is_set() {
-                        testOptionsGiveBasicAuthFalse { $0.useTokenAuth = true; $0.key = "fake:key" }
-                    }
-                    
-                    func test__040__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__authUrl_is_set() {
-                        testOptionsGiveBasicAuthFalse { $0.authUrl = URL(string: "http://test.com") }
-                    }
-                    
-                    func test__041__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__authCallback_is_set() {
-                        testOptionsGiveBasicAuthFalse { $0.authCallback = { _, _ in return } }
-                    }
-                    
-                    func test__042__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__tokenDetails_is_set() {
-                        testOptionsGiveBasicAuthFalse { $0.tokenDetails = ARTTokenDetails(token: "token") }
-                    }
-
-                    func test__043__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__token_is_set() {
-                        testOptionsGiveBasicAuthFalse { $0.token = "token" }
-                    }
-                    
-                    func test__044__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__key_is_set() {
-                        testOptionsGiveBasicAuthFalse { $0.tokenDetails = ARTTokenDetails(token: "token"); $0.key = "fake:key" }
-                    }
-
-                // RSC14c
-                func test__036__RestClient__Authentication__should_error_when_expired_token_and_no_means_to_renew() {
-                    let client = ARTRest(options: AblyTests.commonAppSetup())
-                    let auth = client.auth
-
-                    let tokenParams = ARTTokenParams()
-                    tokenParams.ttl = 3.0 //Seconds
-
-                    guard let options: ARTClientOptions = (AblyTests.waitFor(timeout: testTimeout) { value in
-                        auth.requestToken(tokenParams, with: nil) { tokenDetails, error in
-                            if let e = error {
-                                XCTFail(e.localizedDescription)
-                                value(nil)
-                                return
-                            }
-
-                            guard let currentTokenDetails = tokenDetails else {
-                                XCTFail("expected tokenDetails not to be nil when error is nil")
-                                value(nil)
-                                return
-                            }
-
-                            let options = AblyTests.clientOptions()
-                            options.key = client.internal.options.key
-
-                            // Expired token
-                            options.tokenDetails = ARTTokenDetails(
-                                token: currentTokenDetails.token,
-                                expires: currentTokenDetails.expires!.addingTimeInterval(testTimeout.toTimeInterval()),
-                                issued: currentTokenDetails.issued,
-                                capability: currentTokenDetails.capability,
-                                clientId: currentTokenDetails.clientId)
-
-                            options.authUrl = URL(string: "http://test-auth.ably.io")
-                            value(options)
-                        }
-                    }) else {
-                        return
-                    }
-
-                    let rest = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    rest.internal.httpExecutor = testHTTPExecutor
-
-                    waitUntil(timeout: testTimeout) { done in
-                        // Delay for token expiration
-                        delay(TimeInterval(truncating: tokenParams.ttl!)) {
-                            // [40140, 40150) - token expired and will not recover because authUrl is invalid
-                            publishTestMessage(rest) { error in
-                                guard let errorCode = testHTTPExecutor.responses.first?.value(forHTTPHeaderField: "X-Ably-Errorcode") else {
-                                    fail("expected X-Ably-Errorcode header in request")
-                                    return
-                                }
-                                expect(Int(errorCode)).to(beGreaterThanOrEqualTo(ARTErrorCode.tokenErrorUnspecified.intValue))
-                                expect(Int(errorCode)).to(beLessThan(ARTErrorCode.connectionLimitsExceeded.intValue))
-                                expect(error).toNot(beNil())
-                                done()
-                            }
-                        }
-                    }
-                }
-
-                // RSC14d
-                func test__037__RestClient__Authentication__should_renew_the_token_when_it_has_expired() {
-                    let client = ARTRest(options: AblyTests.commonAppSetup())
-                    let auth = client.auth
-
-                    let tokenParams = ARTTokenParams()
-                    tokenParams.ttl = 3.0 //Seconds
-
-                    waitUntil(timeout: testTimeout) { done in
-                        auth.requestToken(tokenParams, with: nil) { tokenDetails, error in
-                            if let e = error {
-                                XCTFail(e.localizedDescription)
-                                done()
-                                return
-                            }
-
-                            guard let currentTokenDetails = tokenDetails else {
-                                XCTFail("expected tokenDetails not to be nil when error is nil")
-                                done()
-                                return
-                            }
-
-                            let options = AblyTests.clientOptions()
-                            options.key = client.internal.options.key
-
-                            // Expired token
-                            options.tokenDetails = ARTTokenDetails(
-                                token: currentTokenDetails.token,
-                                expires: currentTokenDetails.expires!.addingTimeInterval(testTimeout.toTimeInterval()),
-                                issued: currentTokenDetails.issued,
-                                capability: currentTokenDetails.capability,
-                                clientId: currentTokenDetails.clientId)
-
-                            let rest = ARTRest(options: options)
-                            testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                            rest.internal.httpExecutor = testHTTPExecutor
-
-                            // Delay for token expiration
-                            delay(TimeInterval(truncating: tokenParams.ttl!)) {
-                                // [40140, 40150) - token expired and will not recover because authUrl is invalid
-                                publishTestMessage(rest) { error in
-                                    guard let errorCode = testHTTPExecutor.responses.first?.value(forHTTPHeaderField: "X-Ably-Errorcode") else {
-                                        fail("expected X-Ably-Errorcode header in request")
-                                        return
-                                    }
-                                    expect(Int(errorCode)).to(beGreaterThanOrEqualTo(ARTErrorCode.tokenErrorUnspecified.intValue))
-                                    expect(Int(errorCode)).to(beLessThan(ARTErrorCode.connectionLimitsExceeded.intValue))
-                                    expect(error).to(beNil())
-                                    expect(rest.auth.tokenDetails!.token).toNot(equal(currentTokenDetails.token))
-                                    done()
-                                }
-                            }
-                        }
-                    }
-                }
-
-            // RSC15
-            
-
-                // TO3k7
-                
-
-                    func test__051__RestClient__Host_Fallback__fallbackHostsUseDefault_option__allows_the_default_fallback_hosts_to_be_used_when__environment__is_not_production() {
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.environment = "not-production"
-                        options.fallbackHostsUseDefault = true
-
-                        let client = ARTRest(options: options)
-                        expect(client.internal.options.fallbackHostsUseDefault).to(beTrue())
-                        // Not production
-                        expect(client.internal.options.environment).toNot(beNil())
-                        expect(client.internal.options.environment).toNot(equal("production"))
-
-                        let hosts = ARTFallbackHosts.hosts(from: client.internal.options)
-                        let fallback = ARTFallback(fallbackHosts: hosts)
-                        expect(fallback.hosts).to(haveCount(ARTDefault.fallbackHosts().count))
-
-                        ARTDefault.fallbackHosts().forEach() {
-                            expect(fallback.hosts).to(contain($0))
-                        }
-                    }
-
-                    func test__052__RestClient__Host_Fallback__fallbackHostsUseDefault_option__allows_the_default_fallback_hosts_to_be_used_when_a_custom_Realtime_or_REST_host_endpoint_is_being_used() {
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.restHost = "fake1.ably.io"
-                        options.realtimeHost = "fake2.ably.io"
-                        options.fallbackHostsUseDefault = true
-
-                        let client = ARTRest(options: options)
-                        expect(client.internal.options.fallbackHostsUseDefault).to(beTrue())
-                        // Custom
-                        expect(client.internal.options.restHost).toNot(equal(ARTDefault.restHost()))
-                        expect(client.internal.options.realtimeHost).toNot(equal(ARTDefault.realtimeHost()))
-
-                        let hosts = ARTFallbackHosts.hosts(from: client.internal.options)
-                        let fallback = ARTFallback(fallbackHosts: hosts)
-                        expect(fallback.hosts).to(haveCount(ARTDefault.fallbackHosts().count))
-
-                        ARTDefault.fallbackHosts().forEach() {
-                            expect(fallback.hosts).to(contain($0))
-                        }
-                    }
-
-                    func test__053__RestClient__Host_Fallback__fallbackHostsUseDefault_option__should_be_inactive_by_default() {
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        expect(options.fallbackHostsUseDefault).to(beFalse())
-                    }
-
-                    func test__054__RestClient__Host_Fallback__fallbackHostsUseDefault_option__should_never_accept_to_configure__fallbackHost__and_set__fallbackHostsUseDefault__to__true_() {
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        expect(options.fallbackHosts).to(beNil())
-                        expect(options.fallbackHostsUseDefault).to(beFalse())
-
-                        expect{ options.fallbackHosts = [] }.toNot(raiseException())
-
-                        expect{ options.fallbackHostsUseDefault = true }.to(raiseException(named: ARTFallbackIncompatibleOptionsException))
-
-                        options.fallbackHosts = nil
-
-                        expect{ options.fallbackHostsUseDefault = true }.toNot(raiseException())
-
-                        expect { options.fallbackHosts = ["fake.ably.io"] }.to(raiseException(named: ARTFallbackIncompatibleOptionsException))
-                    }
-
-                // RSC15b
-                
-
-                    // RSC15b1
-                    func test__055__RestClient__Host_Fallback__Fallback_behavior__should_be_applied_when_restHost__port_and_tlsPort_has_not_been_set_to_an_explicit_value() {
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: .hostUnreachable, resetAfter: 2)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "") { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        let requests = testHTTPExecutor.requests
-                        expect(requests).to(haveCount(3))
-                        let capturedURLs = requests.map { $0.url!.absoluteString }
-                        expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//rest.ably.io")).to(beTrue())
-                        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                        expect(NSRegularExpression.match(capturedURLs.at(2), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                    }
-
-                    // RSC15b1
-                    func test__056__RestClient__Host_Fallback__Fallback_behavior__should_NOT_be_applied_when_ClientOptions_restHost_has_been_set() {
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.restHost = "fake.ably.io"
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: .hostUnreachable)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "") { error in
-                                expect(error?.message).to(contain("hostname could not be found"))
-                                done()
-                            }
-                        }
-
-                        let requests = testHTTPExecutor.requests
-                        expect(requests).to(haveCount(1))
-                        let capturedURLs = requests.map { $0.url!.absoluteString }
-                        expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//fake.ably.io")).to(beTrue())
-                    }
-
-                    // RSC15b1
-                    func test__057__RestClient__Host_Fallback__Fallback_behavior__should_NOT_be_applied_when_ClientOptions_port_has_been_set() {
-                        let options = ARTClientOptions(token: "xxxx")
-                        options.tls = false
-                        options.port = 999
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: .hostUnreachable)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "") { error in
-                                expect(error?.message).to(contain("hostname could not be found"))
-                                done()
-                            }
-                        }
-
-                        let requests = testHTTPExecutor.requests
-                        expect(requests).to(haveCount(1))
-                        let capturedURLs = requests.map { $0.url!.absoluteString }
-                        expect(capturedURLs.at(0)).to(beginWith("http://rest.ably.io:999"))
-                    }
-
-                    // RSC15b1
-                    func test__058__RestClient__Host_Fallback__Fallback_behavior__should_NOT_be_applied_when_ClientOptions_tlsPort_has_been_set() {
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.tlsPort = 999
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: .hostUnreachable)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "") { error in
-                                expect(error?.message).to(contain("hostname could not be found"))
-                                done()
-                            }
-                        }
-
-                        let requests = testHTTPExecutor.requests
-                        expect(requests).to(haveCount(1))
-                        let capturedURLs = requests.map { $0.url!.absoluteString }
-                        expect(capturedURLs.at(0)).to(beginWith("https://rest.ably.io:999"))
-                    }
-
-                    // RSC15b2
-                    func test__059__RestClient__Host_Fallback__Fallback_behavior__should_be_applied_when_ClientOptions_fallbackHosts_is_provided() {
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.fallbackHosts = ["a.cocoa.ably", "b.cocoa.ably"]
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: .hostUnreachable)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "") { error in
-                                expect(error?.message).to(contain("hostname could not be found"))
-                                done()
-                            }
-                        }
-
-                        expect(testHTTPExecutor.requests).to(haveCount(3))
-                        let capturedURLs = testHTTPExecutor.requests.map { $0.url!.absoluteString }
-                        expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//rest.ably.io")).to(beTrue())
-                        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//[a-b].cocoa.ably")).to(beTrue())
-                        expect(NSRegularExpression.match(capturedURLs.at(2), pattern: "//[a-b].cocoa.ably")).to(beTrue())
-                    }
-
-                    // RSC15b3, RSC15g4
-                    func test__060__RestClient__Host_Fallback__Fallback_behavior__should_be_applied_when_ClientOptions_fallbackHosts_is_not_provided_and_deprecated_fallbackHostsUseDefault_is_on() {
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.fallbackHostsUseDefault = true
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: .hostUnreachable, resetAfter: 2)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "") { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        expect(testHTTPExecutor.requests).to(haveCount(3))
-                        let capturedURLs = testHTTPExecutor.requests.map { $0.url!.absoluteString }
-                        expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//rest.ably.io")).to(beTrue())
-                        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                        expect(NSRegularExpression.match(capturedURLs.at(2), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                    }
-
-                // RSC15k
-                func test__045__RestClient__Host_Fallback__failing_HTTP_requests_with_custom_endpoint_should_result_in_an_error_immediately() {
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.restHost = "fake.ably.io"
-                    let client = ARTRest(options: options)
-                    let mockHTTP = MockHTTP(logger: options.logHandler)
-                    testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                    client.internal.httpExecutor = testHTTPExecutor
-                    mockHTTP.setNetworkState(network: .hostUnreachable)
-                    let channel = client.channels.get("test")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: "message") { error in
-                            expect(error?.message).to(contain("hostname could not be found"))
-                            done()
-                        }
-                    }
-                    expect(testHTTPExecutor.requests).to(haveCount(1))
-                }
-
-                // RSC15g
-                
-
-                    // RSC15g1
-                    func test__061__RestClient__Host_Fallback__fallback_hosts_list_and_priorities__should_use_ClientOptions_fallbackHosts_when_list_is_provided() {
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.fallbackHosts = ["f.ably-realtime.com"]
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: .hostUnreachable)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "") { error in
-                                expect(error?.message).to(contain("hostname could not be found"))
-                                done()
-                            }
-                        }
-
-                        expect(testHTTPExecutor.requests).to(haveCount(2))
-                        let capturedURLs = testHTTPExecutor.requests.compactMap { $0.url?.absoluteString }
-                        expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//rest.ably.io")).to(beTrue())
-                        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//f.ably-realtime.com")).to(beTrue())
-                    }
-
-                    // RSC15g2
-                    func test__062__RestClient__Host_Fallback__fallback_hosts_list_and_priorities__should_use_environment_fallback_hosts_when_ClientOptions_environment_is_set_to_a_value_other_than__production__and_ClientOptions_fallbackHosts_is_not_set() {
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.environment = "test"
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: .hostUnreachable, resetAfter: 2)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "") { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        expect(testHTTPExecutor.requests).to(haveCount(3))
-                        let capturedURLs = testHTTPExecutor.requests.compactMap { $0.url?.absoluteString }
-                        expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//test-rest.ably.io")).to(beTrue())
-                        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//test-[a-e]-fallback.ably-realtime.com")).to(beTrue())
-                        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//test-[a-e]-fallback.ably-realtime.com")).to(beTrue())
-                    }
-
-                    // RSC15g2
-                    func test__063__RestClient__Host_Fallback__fallback_hosts_list_and_priorities__should_NOT_use_environment_fallback_hosts_when_ClientOptions_environment_is_set_to__production_() {
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.environment = "production"
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: .hostUnreachable)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "") { error in
-                                expect(error?.message).to(contain("hostname could not be found"))
-                                done()
-                            }
-                        }
-
-                        expect(testHTTPExecutor.requests).to(haveCount(4))
-                        let capturedURLs = testHTTPExecutor.requests.compactMap { $0.url?.absoluteString }
-                        expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//rest.ably.io")).to(beTrue())
-                        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                        expect(NSRegularExpression.match(capturedURLs.at(2), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                        expect(NSRegularExpression.match(capturedURLs.at(3), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                    }
-
-                    // RSC15g3
-                    func test__064__RestClient__Host_Fallback__fallback_hosts_list_and_priorities__should_use_default_fallback_hosts_when_both_ClientOptions_fallbackHosts_and_ClientOptions_environment_are_not_set() {
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.environment = ""
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: .hostUnreachable)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "") { error in
-                                expect(error?.message).to(contain("hostname could not be found"))
-                                done()
-                            }
-                        }
-
-                        expect(testHTTPExecutor.requests).to(haveCount(4))
-                        let capturedURLs = testHTTPExecutor.requests.compactMap { $0.url?.absoluteString }
-                        expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//rest.ably.io")).to(beTrue())
-                        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                        expect(NSRegularExpression.match(capturedURLs.at(2), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                        expect(NSRegularExpression.match(capturedURLs.at(3), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                    }
-
-                // RSC15g4
-                func test__046__RestClient__Host_Fallback__applies_when_ClientOptions_fallbackHostsUseDefault_is_true() {
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.environment = "test"
-                    options.fallbackHostsUseDefault = true
-                    let client = ARTRest(options: options)
-                    let mockHTTP = MockHTTP(logger: options.logHandler)
-                    testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                    client.internal.httpExecutor = testHTTPExecutor
-                    mockHTTP.setNetworkState(network: .hostUnreachable, resetAfter: 1)
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: "nil") { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    expect(testHTTPExecutor.requests).to(haveCount(2))
-                    let capturedURLs = testHTTPExecutor.requests.map { $0.url!.absoluteString }
-                    expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                }
-
-                // RSC15g1
-                func test__047__RestClient__Host_Fallback__won_t_apply_fallback_hosts_if_ClientOptions_fallbackHosts_array_is_empty() {
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.fallbackHosts = [] //to test TO3k6
-                    let client = ARTRest(options: options)
-                    let mockHTTP = MockHTTP(logger: options.logHandler)
-                    testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                    client.internal.httpExecutor = testHTTPExecutor
-                    mockHTTP.setNetworkState(network: .hostUnreachable)
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: "nil") { _ in
-                            done()
-                        }
-                    }
-
-                    expect(testHTTPExecutor.requests).to(haveCount(1))
-                    let capturedURLs = testHTTPExecutor.requests.map { $0.url!.absoluteString }
-                    expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//rest.ably.io")).to(beTrue())
-                }
-
-                // RSC15g3
-                func test__048__RestClient__Host_Fallback__won_t_apply_custom_fallback_hosts_if_ClientOptions_fallbackHosts_and_ClientOptions_environment_are_not_set__use_defaults_instead() {
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.fallbackHosts = nil
-                    let client = ARTRest(options: options)
-                    let mockHTTP = MockHTTP(logger: options.logHandler)
-                    testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                    client.internal.httpExecutor = testHTTPExecutor
-                    mockHTTP.setNetworkState(network: .hostUnreachable, resetAfter: 1)
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: "nil") { _ in
-                            done()
-                        }
-                    }
-
-                    expect(testHTTPExecutor.requests).to(haveCount(2))
-                    if testHTTPExecutor.requests.count < 2 {
-                        return
-                    }
-
-                    let capturedURLs = testHTTPExecutor.requests.map { $0.url!.absoluteString }
-                    expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                }
-
-                // RSC15e
-                func test__049__RestClient__Host_Fallback__every_new_HTTP_request_is_first_attempted_to_the_default_primary_host_rest_ably_io() {
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.httpMaxRetryCount = 1
-                    let client = ARTRest(options: options)
-                    let mockHTTP = MockHTTP(logger: options.logHandler)
-                    testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                    client.internal.httpExecutor = testHTTPExecutor
-                    mockHTTP.setNetworkState(network: .hostUnreachable, resetAfter: 1)
-                    let channel = client.channels.get("test")
-
-                    // RSC15j exception
-                    ARTDefault.setFallbackRetryTimeout(1)
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: "nil") { _ in
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        // RSC15j exception
-                        delay(1.1) {
-                            channel.publish(nil, data: "nil") { _ in
-                                done()
-                            }
-                        }
-                    }
-
-                    expect(testHTTPExecutor.requests).to(haveCount(3))
-                    expect(NSRegularExpression.match(testHTTPExecutor.requests.at(0)?.url?.absoluteString, pattern: "//\(ARTDefault.restHost())")).to(beTrue())
-                    expect(NSRegularExpression.match(testHTTPExecutor.requests.at(1)?.url?.absoluteString, pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                    expect(NSRegularExpression.match(testHTTPExecutor.requests.at(2)?.url?.absoluteString, pattern: "//\(ARTDefault.restHost())")).to(beTrue())
-                }
-
-                // RSC15a
-                
-
-                    func beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order() {
-                        ARTFallback_shuffleArray = { array in
-                            let arranged = expectedHostOrder.reversed().map { array[$0] }
-                            for (i, element) in arranged.enumerated() {
-                                array[i] = element
-                            }
-                        }
-                    }
-
-                    func afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order() {
-                        ARTFallback_shuffleArray = originalARTFallback_shuffleArray
-                    }
-
-                    // RSC15h
-                    func test__065__RestClient__Host_Fallback__retry_hosts_in_random_order__default_fallback_hosts_should_match__a_e__ably_realtime_com() {
-beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                        let defaultFallbackHosts = ARTDefault.fallbackHosts()
-                        defaultFallbackHosts.forEach { host in
-                            expect(host).to(match("[a-e].ably-realtime.com"))
-                        }
-                        expect(defaultFallbackHosts).to(haveCount(5))
-
-afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                    }
-
-                    // RSC15i
-                    func test__066__RestClient__Host_Fallback__retry_hosts_in_random_order__environment_fallback_hosts_have_the_format__environment___a_e__fallback_ably_realtime_com() {
-beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                        let environmentFallbackHosts = ARTDefault.fallbackHosts(withEnvironment: "sandbox")
-                        environmentFallbackHosts.forEach { host in
-                            expect(host).to(match("sandbox-[a-e]-fallback.ably-realtime.com"))
-                        }
-                        expect(environmentFallbackHosts).to(haveCount(5))
-
-afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                    }
-
-                    func test__067__RestClient__Host_Fallback__retry_hosts_in_random_order__until_httpMaxRetryCount_has_been_reached() {
-beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        let client = ARTRest(options: options)
-                        options.httpMaxRetryCount = 3
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: .hostUnreachable)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "nil") { _ in
-                                done()
-                            }
-                        }
-
-                        expect(testHTTPExecutor.requests).to(haveCount(Int(1 + options.httpMaxRetryCount)))
-
-                        let extractHostname = { (request: URLRequest) in
-                            NSRegularExpression.extract(request.url!.absoluteString, pattern: "[a-e].ably-realtime.com")
-                        }
-                        let resultFallbackHosts = testHTTPExecutor.requests.compactMap(extractHostname)
-                        let expectedFallbackHosts = Array(expectedHostOrder.map({ ARTDefault.fallbackHosts()[$0] })[0..<Int(options.httpMaxRetryCount)])
-
-                        expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
-
-afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                    }
-
-                    func test__068__RestClient__Host_Fallback__retry_hosts_in_random_order__use_custom_fallback_hosts_if_set() {
-beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.httpMaxRetryCount = 10
-                        let customFallbackHosts = ["j.ably-realtime.com",
-                                                   "i.ably-realtime.com",
-                                                   "h.ably-realtime.com",
-                                                   "g.ably-realtime.com",
-                                                   "f.ably-realtime.com"]
-                        options.fallbackHosts = customFallbackHosts
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: .hostUnreachable)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "nil") { _ in
-                                done()
-                            }
-                        }
-
-                        expect(testHTTPExecutor.requests).to(haveCount(customFallbackHosts.count + 1))
-
-                        let extractHostname = { (request: URLRequest) in
-                            NSRegularExpression.extract(request.url!.absoluteString, pattern: "[f-j].ably-realtime.com")
-                        }
-                        let resultFallbackHosts = testHTTPExecutor.requests.compactMap(extractHostname)
-                        let expectedFallbackHosts = expectedHostOrder.map { customFallbackHosts[$0] }
-
-                        expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
-
-afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                    }
-
-                    func test__069__RestClient__Host_Fallback__retry_hosts_in_random_order__until_all_fallback_hosts_have_been_tried() {
-beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.httpMaxRetryCount = 10
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: .hostUnreachable)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "nil") { _ in
-                                done()
-                            }
-                        }
-
-                        expect(testHTTPExecutor.requests).to(haveCount(ARTDefault.fallbackHosts().count + 1))
-
-                        let extractHostname = { (request: URLRequest) in
-                            NSRegularExpression.extract(request.url!.absoluteString, pattern: "[a-e].ably-realtime.com")
-                        }
-                        let resultFallbackHosts = testHTTPExecutor.requests.compactMap(extractHostname)
-                        let expectedFallbackHosts = expectedHostOrder.map { ARTDefault.fallbackHosts()[$0] }
-
-                        expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
-
-afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                    }
-
-                    func test__070__RestClient__Host_Fallback__retry_hosts_in_random_order__until_httpMaxRetryCount_has_been_reached__if_custom_fallback_hosts_are_provided_in_ClientOptions_fallbackHosts__then_they_will_be_used_instead() {
-beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.httpMaxRetryCount = 4
-                        options.fallbackHosts = _fallbackHosts
-
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: .hostUnreachable)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "nil") { _ in
-                                done()
-                            }
-                        }
-
-                        expect(testHTTPExecutor.requests).to(haveCount(Int(1 + options.httpMaxRetryCount)))
-                        expect((testHTTPExecutor.requests.count) < (_fallbackHosts.count + 1)).to(beTrue())
-
-                        let extractHostname = { (request: URLRequest) in
-                            NSRegularExpression.extract(request.url!.absoluteString, pattern: "[f-j].ably-realtime.com")
-                        }
-                        let resultFallbackHosts = testHTTPExecutor.requests.compactMap(extractHostname)
-                        let expectedFallbackHosts = Array(expectedHostOrder.map({ _fallbackHosts[$0] })[0..<Int(options.httpMaxRetryCount)])
-
-                        expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
-
-afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                    }
-                    
-                    func test__071__RestClient__Host_Fallback__retry_hosts_in_random_order__until_all_fallback_hosts_have_been_tried__if_custom_fallback_hosts_are_provided_in_ClientOptions_fallbackHosts__then_they_will_be_used_instead() {
-beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.httpMaxRetryCount = 10
-                        options.fallbackHosts = _fallbackHosts
-
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: .hostUnreachable)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "nil") { _ in
-                                done()
-                            }
-                        }
-
-                        expect(testHTTPExecutor.requests).to(haveCount(ARTDefault.fallbackHosts().count + 1))
-
-                        let extractHostname = { (request: URLRequest) in
-                            NSRegularExpression.extract(request.url!.absoluteString, pattern: "[f-j].ably-realtime.com")
-                        }
-                        
-                        let resultFallbackHosts = testHTTPExecutor.requests.compactMap(extractHostname)
-                        let expectedFallbackHosts = expectedHostOrder.map { _fallbackHosts[$0] }
-                
-                        expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
-
-afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                    }
-                    
-                    func test__072__RestClient__Host_Fallback__retry_hosts_in_random_order__all_fallback_requests_headers_should_contain__Host__header_with_fallback_host_address() {
-beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.httpMaxRetryCount = 10
-                        options.fallbackHosts = _fallbackHosts
-                        
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: .hostUnreachable)
-                        let channel = client.channels.get("test")
-                        
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "nil") { _ in
-                                done()
-                            }
-                        }
-                        
-                        expect(testHTTPExecutor.requests).to(haveCount(ARTDefault.fallbackHosts().count + 1))
-                        
-                        let fallbackRequests = testHTTPExecutor.requests.filter {
-                            NSRegularExpression.match($0.url!.absoluteString, pattern: "[f-j].ably-realtime.com")
-                        }
-                        
-                        let fallbackRequestsWithHostHeader = fallbackRequests.filter {
-                            $0.allHTTPHeaderFields!["Host"] == $0.url?.host
-                        }
-                                            
-                        expect(fallbackRequests.count).to(be(fallbackRequestsWithHostHeader.count))
-
-afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                    }
-                    
-                    func test__073__RestClient__Host_Fallback__retry_hosts_in_random_order__if_an_empty_array_of_fallback_hosts_is_provided__then_fallback_host_functionality_is_disabled() {
-beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                        let options = ARTClientOptions(key: "xxxx:xxxx")
-                        options.httpMaxRetryCount = 5
-                        options.fallbackHosts = []
-
-                        let client = ARTRest(options: options)
-                        let mockHTTP = MockHTTP(logger: options.logHandler)
-                        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                        client.internal.httpExecutor = testHTTPExecutor
-                        mockHTTP.setNetworkState(network: .hostUnreachable)
-                        let channel = client.channels.get("test")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "nil") { _ in
-                                done()
-                            }
-                        }
-
-                        expect(testHTTPExecutor.requests).to(haveCount(1))
-                        expect(NSRegularExpression.match(testHTTPExecutor.requests[0].url!.absoluteString, pattern: "//rest.ably.io")).to(beTrue())
-
-afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
-
-                    }
-
-                // RSC15d
-                
-                    
-                    func test__074__RestClient__Host_Fallback__should_use_an_alternative_host_when___hostUnreachable() {
-                        testUsesAlternativeHost(.hostUnreachable)
-                    }
-                    
-                    func test__075__RestClient__Host_Fallback__should_use_an_alternative_host_when___requestTimeout_timeout__0_1_() {
-                        testUsesAlternativeHost(.requestTimeout(timeout: 0.1))
-                    }
-                    
-                    func test__076__RestClient__Host_Fallback__should_use_an_alternative_host_when___hostInternalError_code__501_() {
-                        testUsesAlternativeHost(.hostInternalError(code: 501))
-                    }
-
-                // RSC15d
-                func test__050__RestClient__Host_Fallback__should_not_use_an_alternative_host_when_the_client_receives_an_bad_request() {
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    let client = ARTRest(options: options)
-                    let mockHTTP = MockHTTP(logger: options.logHandler)
-                    testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                    client.internal.httpExecutor = testHTTPExecutor
-                    mockHTTP.setNetworkState(network: .host400BadRequest, resetAfter: 1)
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: "nil") { _ in
-                            done()
-                        }
-                    }
-
-                    expect(testHTTPExecutor.requests).to(haveCount(1))
-                    expect(NSRegularExpression.match(testHTTPExecutor.requests[0].url!.absoluteString, pattern: "//rest.ably.io")).to(beTrue())
-                }
-                
-                // RSC15f
-                
-                    
-                    func test__077__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host___hostUnreachable() {
-                        testStoresSuccessfulFallbackHostAsDefaultHost(.hostUnreachable)
-                    }
-                    
-                    func test__078__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host___requestTimeout_timeout__0_1_() {
-                        testStoresSuccessfulFallbackHostAsDefaultHost(.requestTimeout(timeout: 0.1))
-                    }
-                    
-                    func test__079__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host___hostInternalError_code__501_() {
-                        testStoresSuccessfulFallbackHostAsDefaultHost(.hostInternalError(code: 501))
-                    }
-                    
-                    
-                        
-                        func beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired() {
-                            ARTDefault.setFallbackRetryTimeout(1.0)
-                        }
-                        
-                        func test__080__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired___hostUnreachable() {
-beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired()
-
-                            testRestoresDefaultPrimaryHostAfterTimeoutExpires(.hostUnreachable)
-                        }
-                        
-                        func test__081__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired___requestTimeout_timeout__0_1_() {
-beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired()
-
-                            testRestoresDefaultPrimaryHostAfterTimeoutExpires(.requestTimeout(timeout: 0.1))
-                        }
-                        
-                        func test__082__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired___hostInternalError_code__501_() {
-beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired()
-
-                            testRestoresDefaultPrimaryHostAfterTimeoutExpires(.hostInternalError(code: 501))
-                        }
-                    
-                    
-                            
-                        func beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded() {
-                            ARTDefault.setFallbackRetryTimeout(10)
-                        }
-                        
-                        func test__083__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded___hostUnreachable() {
-beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded()
-
-                            testUsesAnotherFallbackHost(.hostUnreachable)
-                        }
-                        
-                        func test__084__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded___requestTimeout_timeout__0_1_() {
-beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded()
-
-                            testUsesAnotherFallbackHost(.requestTimeout(timeout: 0.1))
-                        }
-                        
-                        func test__085__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded___hostInternalError_code__501_() {
-beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded()
-
-                            testUsesAnotherFallbackHost(.hostInternalError(code: 501))
-                        }
-
-            // RSC8a
-            func test__008__RestClient__should_use_MsgPack_binary_protocol() {
-                let options = AblyTests.commonAppSetup()
-                expect(options.useBinaryProtocol).to(beTrue())
+                options.key = client.internal.options.key
+
+                // Expired token
+                options.tokenDetails = ARTTokenDetails(
+                    token: currentTokenDetails.token,
+                    expires: currentTokenDetails.expires!.addingTimeInterval(testTimeout.toTimeInterval()),
+                    issued: currentTokenDetails.issued,
+                    capability: currentTokenDetails.capability,
+                    clientId: currentTokenDetails.clientId
+                )
 
                 let rest = ARTRest(options: options)
                 testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
                 rest.internal.httpExecutor = testHTTPExecutor
-                waitUntil(timeout: testTimeout) { done in
-                    rest.channels.get("test").publish(nil, data: "message") { error in
+
+                // Delay for token expiration
+                delay(TimeInterval(truncating: tokenParams.ttl!)) {
+                    // [40140, 40150) - token expired and will not recover because authUrl is invalid
+                    publishTestMessage(rest) { error in
+                        guard let errorCode = testHTTPExecutor.responses.first?.value(forHTTPHeaderField: "X-Ably-Errorcode") else {
+                            fail("expected X-Ably-Errorcode header in request")
+                            return
+                        }
+                        expect(Int(errorCode)).to(beGreaterThanOrEqualTo(ARTErrorCode.tokenErrorUnspecified.intValue))
+                        expect(Int(errorCode)).to(beLessThan(ARTErrorCode.connectionLimitsExceeded.intValue))
+                        expect(error).to(beNil())
+                        expect(rest.auth.tokenDetails!.token).toNot(equal(currentTokenDetails.token))
                         done()
                     }
                 }
-
-                switch extractBodyAsMsgPack(testHTTPExecutor.requests.first) {
-                case .failure(let error):
-                    fail(error)
-                default: break
-                }
-
-                let realtime = AblyTests.newRealtime(options)
-                defer { realtime.close() }
-                waitUntil(timeout: testTimeout) { done in
-                    realtime.channels.get("test").publish(nil, data: "message") { error in
-                        done()
-                    }
-                }
-
-                let transport = realtime.internal.transport as! TestProxyTransport
-                let jsonArray = transport.rawDataSent.map({ AblyTests.msgpackToJSON($0) })
-                let messageJson = jsonArray.filter({ item in item["action"] == 15 }).last!
-                expect(messageJson["messages"][0]["data"].string).to(equal("message"))
             }
+        }
+    }
 
-            // RSC8b
-            func test__009__RestClient__should_use_JSON_text_protocol() {
-                let options = AblyTests.commonAppSetup()
-                options.useBinaryProtocol = false
+    // RSC15
 
+    // TO3k7
+
+    func test__051__RestClient__Host_Fallback__fallbackHostsUseDefault_option__allows_the_default_fallback_hosts_to_be_used_when__environment__is_not_production() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.environment = "not-production"
+        options.fallbackHostsUseDefault = true
+
+        let client = ARTRest(options: options)
+        expect(client.internal.options.fallbackHostsUseDefault).to(beTrue())
+        // Not production
+        expect(client.internal.options.environment).toNot(beNil())
+        expect(client.internal.options.environment).toNot(equal("production"))
+
+        let hosts = ARTFallbackHosts.hosts(from: client.internal.options)
+        let fallback = ARTFallback(fallbackHosts: hosts)
+        expect(fallback.hosts).to(haveCount(ARTDefault.fallbackHosts().count))
+
+        ARTDefault.fallbackHosts().forEach {
+            expect(fallback.hosts).to(contain($0))
+        }
+    }
+
+    func test__052__RestClient__Host_Fallback__fallbackHostsUseDefault_option__allows_the_default_fallback_hosts_to_be_used_when_a_custom_Realtime_or_REST_host_endpoint_is_being_used() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.restHost = "fake1.ably.io"
+        options.realtimeHost = "fake2.ably.io"
+        options.fallbackHostsUseDefault = true
+
+        let client = ARTRest(options: options)
+        expect(client.internal.options.fallbackHostsUseDefault).to(beTrue())
+        // Custom
+        expect(client.internal.options.restHost).toNot(equal(ARTDefault.restHost()))
+        expect(client.internal.options.realtimeHost).toNot(equal(ARTDefault.realtimeHost()))
+
+        let hosts = ARTFallbackHosts.hosts(from: client.internal.options)
+        let fallback = ARTFallback(fallbackHosts: hosts)
+        expect(fallback.hosts).to(haveCount(ARTDefault.fallbackHosts().count))
+
+        ARTDefault.fallbackHosts().forEach {
+            expect(fallback.hosts).to(contain($0))
+        }
+    }
+
+    func test__053__RestClient__Host_Fallback__fallbackHostsUseDefault_option__should_be_inactive_by_default() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        expect(options.fallbackHostsUseDefault).to(beFalse())
+    }
+
+    func test__054__RestClient__Host_Fallback__fallbackHostsUseDefault_option__should_never_accept_to_configure__fallbackHost__and_set__fallbackHostsUseDefault__to__true_() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        expect(options.fallbackHosts).to(beNil())
+        expect(options.fallbackHostsUseDefault).to(beFalse())
+
+        expect { options.fallbackHosts = [] }.toNot(raiseException())
+
+        expect { options.fallbackHostsUseDefault = true }.to(raiseException(named: ARTFallbackIncompatibleOptionsException))
+
+        options.fallbackHosts = nil
+
+        expect { options.fallbackHostsUseDefault = true }.toNot(raiseException())
+
+        expect { options.fallbackHosts = ["fake.ably.io"] }.to(raiseException(named: ARTFallbackIncompatibleOptionsException))
+    }
+
+    // RSC15b
+
+    // RSC15b1
+    func test__055__RestClient__Host_Fallback__Fallback_behavior__should_be_applied_when_restHost__port_and_tlsPort_has_not_been_set_to_an_explicit_value() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable, resetAfter: 2)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "") { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        let requests = testHTTPExecutor.requests
+        expect(requests).to(haveCount(3))
+        let capturedURLs = requests.map { $0.url!.absoluteString }
+        expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//rest.ably.io")).to(beTrue())
+        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+        expect(NSRegularExpression.match(capturedURLs.at(2), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+    }
+
+    // RSC15b1
+    func test__056__RestClient__Host_Fallback__Fallback_behavior__should_NOT_be_applied_when_ClientOptions_restHost_has_been_set() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.restHost = "fake.ably.io"
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "") { error in
+                expect(error?.message).to(contain("hostname could not be found"))
+                done()
+            }
+        }
+
+        let requests = testHTTPExecutor.requests
+        expect(requests).to(haveCount(1))
+        let capturedURLs = requests.map { $0.url!.absoluteString }
+        expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//fake.ably.io")).to(beTrue())
+    }
+
+    // RSC15b1
+    func test__057__RestClient__Host_Fallback__Fallback_behavior__should_NOT_be_applied_when_ClientOptions_port_has_been_set() {
+        let options = ARTClientOptions(token: "xxxx")
+        options.tls = false
+        options.port = 999
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "") { error in
+                expect(error?.message).to(contain("hostname could not be found"))
+                done()
+            }
+        }
+
+        let requests = testHTTPExecutor.requests
+        expect(requests).to(haveCount(1))
+        let capturedURLs = requests.map { $0.url!.absoluteString }
+        expect(capturedURLs.at(0)).to(beginWith("http://rest.ably.io:999"))
+    }
+
+    // RSC15b1
+    func test__058__RestClient__Host_Fallback__Fallback_behavior__should_NOT_be_applied_when_ClientOptions_tlsPort_has_been_set() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.tlsPort = 999
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "") { error in
+                expect(error?.message).to(contain("hostname could not be found"))
+                done()
+            }
+        }
+
+        let requests = testHTTPExecutor.requests
+        expect(requests).to(haveCount(1))
+        let capturedURLs = requests.map { $0.url!.absoluteString }
+        expect(capturedURLs.at(0)).to(beginWith("https://rest.ably.io:999"))
+    }
+
+    // RSC15b2
+    func test__059__RestClient__Host_Fallback__Fallback_behavior__should_be_applied_when_ClientOptions_fallbackHosts_is_provided() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.fallbackHosts = ["a.cocoa.ably", "b.cocoa.ably"]
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "") { error in
+                expect(error?.message).to(contain("hostname could not be found"))
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(3))
+        let capturedURLs = testHTTPExecutor.requests.map { $0.url!.absoluteString }
+        expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//rest.ably.io")).to(beTrue())
+        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//[a-b].cocoa.ably")).to(beTrue())
+        expect(NSRegularExpression.match(capturedURLs.at(2), pattern: "//[a-b].cocoa.ably")).to(beTrue())
+    }
+
+    // RSC15b3, RSC15g4
+    func test__060__RestClient__Host_Fallback__Fallback_behavior__should_be_applied_when_ClientOptions_fallbackHosts_is_not_provided_and_deprecated_fallbackHostsUseDefault_is_on() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.fallbackHostsUseDefault = true
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable, resetAfter: 2)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "") { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(3))
+        let capturedURLs = testHTTPExecutor.requests.map { $0.url!.absoluteString }
+        expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//rest.ably.io")).to(beTrue())
+        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+        expect(NSRegularExpression.match(capturedURLs.at(2), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+    }
+
+    // RSC15k
+    func test__045__RestClient__Host_Fallback__failing_HTTP_requests_with_custom_endpoint_should_result_in_an_error_immediately() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.restHost = "fake.ably.io"
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { error in
+                expect(error?.message).to(contain("hostname could not be found"))
+                done()
+            }
+        }
+        expect(testHTTPExecutor.requests).to(haveCount(1))
+    }
+
+    // RSC15g
+
+    // RSC15g1
+    func test__061__RestClient__Host_Fallback__fallback_hosts_list_and_priorities__should_use_ClientOptions_fallbackHosts_when_list_is_provided() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.fallbackHosts = ["f.ably-realtime.com"]
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "") { error in
+                expect(error?.message).to(contain("hostname could not be found"))
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(2))
+        let capturedURLs = testHTTPExecutor.requests.compactMap { $0.url?.absoluteString }
+        expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//rest.ably.io")).to(beTrue())
+        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//f.ably-realtime.com")).to(beTrue())
+    }
+
+    // RSC15g2
+    func test__062__RestClient__Host_Fallback__fallback_hosts_list_and_priorities__should_use_environment_fallback_hosts_when_ClientOptions_environment_is_set_to_a_value_other_than__production__and_ClientOptions_fallbackHosts_is_not_set() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.environment = "test"
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable, resetAfter: 2)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "") { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(3))
+        let capturedURLs = testHTTPExecutor.requests.compactMap { $0.url?.absoluteString }
+        expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//test-rest.ably.io")).to(beTrue())
+        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//test-[a-e]-fallback.ably-realtime.com")).to(beTrue())
+        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//test-[a-e]-fallback.ably-realtime.com")).to(beTrue())
+    }
+
+    // RSC15g2
+    func test__063__RestClient__Host_Fallback__fallback_hosts_list_and_priorities__should_NOT_use_environment_fallback_hosts_when_ClientOptions_environment_is_set_to__production_() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.environment = "production"
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "") { error in
+                expect(error?.message).to(contain("hostname could not be found"))
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(4))
+        let capturedURLs = testHTTPExecutor.requests.compactMap { $0.url?.absoluteString }
+        expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//rest.ably.io")).to(beTrue())
+        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+        expect(NSRegularExpression.match(capturedURLs.at(2), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+        expect(NSRegularExpression.match(capturedURLs.at(3), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+    }
+
+    // RSC15g3
+    func test__064__RestClient__Host_Fallback__fallback_hosts_list_and_priorities__should_use_default_fallback_hosts_when_both_ClientOptions_fallbackHosts_and_ClientOptions_environment_are_not_set() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.environment = ""
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "") { error in
+                expect(error?.message).to(contain("hostname could not be found"))
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(4))
+        let capturedURLs = testHTTPExecutor.requests.compactMap { $0.url?.absoluteString }
+        expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//rest.ably.io")).to(beTrue())
+        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+        expect(NSRegularExpression.match(capturedURLs.at(2), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+        expect(NSRegularExpression.match(capturedURLs.at(3), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+    }
+
+    // RSC15g4
+    func test__046__RestClient__Host_Fallback__applies_when_ClientOptions_fallbackHostsUseDefault_is_true() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.environment = "test"
+        options.fallbackHostsUseDefault = true
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable, resetAfter: 1)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "nil") { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(2))
+        let capturedURLs = testHTTPExecutor.requests.map { $0.url!.absoluteString }
+        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+    }
+
+    // RSC15g1
+    func test__047__RestClient__Host_Fallback__won_t_apply_fallback_hosts_if_ClientOptions_fallbackHosts_array_is_empty() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.fallbackHosts = [] // to test TO3k6
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "nil") { _ in
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(1))
+        let capturedURLs = testHTTPExecutor.requests.map { $0.url!.absoluteString }
+        expect(NSRegularExpression.match(capturedURLs.at(0), pattern: "//rest.ably.io")).to(beTrue())
+    }
+
+    // RSC15g3
+    func test__048__RestClient__Host_Fallback__won_t_apply_custom_fallback_hosts_if_ClientOptions_fallbackHosts_and_ClientOptions_environment_are_not_set__use_defaults_instead() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.fallbackHosts = nil
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable, resetAfter: 1)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "nil") { _ in
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(2))
+        if testHTTPExecutor.requests.count < 2 {
+            return
+        }
+
+        let capturedURLs = testHTTPExecutor.requests.map { $0.url!.absoluteString }
+        expect(NSRegularExpression.match(capturedURLs.at(1), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+    }
+
+    // RSC15e
+    func test__049__RestClient__Host_Fallback__every_new_HTTP_request_is_first_attempted_to_the_default_primary_host_rest_ably_io() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.httpMaxRetryCount = 1
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable, resetAfter: 1)
+        let channel = client.channels.get("test")
+
+        // RSC15j exception
+        ARTDefault.setFallbackRetryTimeout(1)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "nil") { _ in
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            // RSC15j exception
+            delay(1.1) {
+                channel.publish(nil, data: "nil") { _ in
+                    done()
+                }
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(3))
+        expect(NSRegularExpression.match(testHTTPExecutor.requests.at(0)?.url?.absoluteString, pattern: "//\(ARTDefault.restHost())")).to(beTrue())
+        expect(NSRegularExpression.match(testHTTPExecutor.requests.at(1)?.url?.absoluteString, pattern: "//[a-e].ably-realtime.com")).to(beTrue())
+        expect(NSRegularExpression.match(testHTTPExecutor.requests.at(2)?.url?.absoluteString, pattern: "//\(ARTDefault.restHost())")).to(beTrue())
+    }
+
+    // RSC15a
+
+    func beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order() {
+        ARTFallback_shuffleArray = { array in
+            let arranged = expectedHostOrder.reversed().map { array[$0] }
+            for (i, element) in arranged.enumerated() {
+                array[i] = element
+            }
+        }
+    }
+
+    func afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order() {
+        ARTFallback_shuffleArray = originalARTFallback_shuffleArray
+    }
+
+    // RSC15h
+    func test__065__RestClient__Host_Fallback__retry_hosts_in_random_order__default_fallback_hosts_should_match__a_e__ably_realtime_com() {
+        beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
+        let defaultFallbackHosts = ARTDefault.fallbackHosts()
+        defaultFallbackHosts.forEach { host in
+            expect(host).to(match("[a-e].ably-realtime.com"))
+        }
+        expect(defaultFallbackHosts).to(haveCount(5))
+
+        afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+    }
+
+    // RSC15i
+    func test__066__RestClient__Host_Fallback__retry_hosts_in_random_order__environment_fallback_hosts_have_the_format__environment___a_e__fallback_ably_realtime_com() {
+        beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
+        let environmentFallbackHosts = ARTDefault.fallbackHosts(withEnvironment: "sandbox")
+        environmentFallbackHosts.forEach { host in
+            expect(host).to(match("sandbox-[a-e]-fallback.ably-realtime.com"))
+        }
+        expect(environmentFallbackHosts).to(haveCount(5))
+
+        afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+    }
+
+    func test__067__RestClient__Host_Fallback__retry_hosts_in_random_order__until_httpMaxRetryCount_has_been_reached() {
+        beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        let client = ARTRest(options: options)
+        options.httpMaxRetryCount = 3
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "nil") { _ in
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(Int(1 + options.httpMaxRetryCount)))
+
+        let extractHostname = { (request: URLRequest) in
+            NSRegularExpression.extract(request.url!.absoluteString, pattern: "[a-e].ably-realtime.com")
+        }
+        let resultFallbackHosts = testHTTPExecutor.requests.compactMap(extractHostname)
+        let expectedFallbackHosts = Array(expectedHostOrder.map { ARTDefault.fallbackHosts()[$0] }[0 ..< Int(options.httpMaxRetryCount)])
+
+        expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
+
+        afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+    }
+
+    func test__068__RestClient__Host_Fallback__retry_hosts_in_random_order__use_custom_fallback_hosts_if_set() {
+        beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.httpMaxRetryCount = 10
+        let customFallbackHosts = ["j.ably-realtime.com",
+                                   "i.ably-realtime.com",
+                                   "h.ably-realtime.com",
+                                   "g.ably-realtime.com",
+                                   "f.ably-realtime.com"]
+        options.fallbackHosts = customFallbackHosts
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "nil") { _ in
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(customFallbackHosts.count + 1))
+
+        let extractHostname = { (request: URLRequest) in
+            NSRegularExpression.extract(request.url!.absoluteString, pattern: "[f-j].ably-realtime.com")
+        }
+        let resultFallbackHosts = testHTTPExecutor.requests.compactMap(extractHostname)
+        let expectedFallbackHosts = expectedHostOrder.map { customFallbackHosts[$0] }
+
+        expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
+
+        afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+    }
+
+    func test__069__RestClient__Host_Fallback__retry_hosts_in_random_order__until_all_fallback_hosts_have_been_tried() {
+        beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.httpMaxRetryCount = 10
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "nil") { _ in
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(ARTDefault.fallbackHosts().count + 1))
+
+        let extractHostname = { (request: URLRequest) in
+            NSRegularExpression.extract(request.url!.absoluteString, pattern: "[a-e].ably-realtime.com")
+        }
+        let resultFallbackHosts = testHTTPExecutor.requests.compactMap(extractHostname)
+        let expectedFallbackHosts = expectedHostOrder.map { ARTDefault.fallbackHosts()[$0] }
+
+        expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
+
+        afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+    }
+
+    func test__070__RestClient__Host_Fallback__retry_hosts_in_random_order__until_httpMaxRetryCount_has_been_reached__if_custom_fallback_hosts_are_provided_in_ClientOptions_fallbackHosts__then_they_will_be_used_instead() {
+        beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.httpMaxRetryCount = 4
+        options.fallbackHosts = _fallbackHosts
+
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "nil") { _ in
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(Int(1 + options.httpMaxRetryCount)))
+        expect((testHTTPExecutor.requests.count) < (_fallbackHosts.count + 1)).to(beTrue())
+
+        let extractHostname = { (request: URLRequest) in
+            NSRegularExpression.extract(request.url!.absoluteString, pattern: "[f-j].ably-realtime.com")
+        }
+        let resultFallbackHosts = testHTTPExecutor.requests.compactMap(extractHostname)
+        let expectedFallbackHosts = Array(expectedHostOrder.map { _fallbackHosts[$0] }[0 ..< Int(options.httpMaxRetryCount)])
+
+        expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
+
+        afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+    }
+
+    func test__071__RestClient__Host_Fallback__retry_hosts_in_random_order__until_all_fallback_hosts_have_been_tried__if_custom_fallback_hosts_are_provided_in_ClientOptions_fallbackHosts__then_they_will_be_used_instead() {
+        beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.httpMaxRetryCount = 10
+        options.fallbackHosts = _fallbackHosts
+
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "nil") { _ in
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(ARTDefault.fallbackHosts().count + 1))
+
+        let extractHostname = { (request: URLRequest) in
+            NSRegularExpression.extract(request.url!.absoluteString, pattern: "[f-j].ably-realtime.com")
+        }
+
+        let resultFallbackHosts = testHTTPExecutor.requests.compactMap(extractHostname)
+        let expectedFallbackHosts = expectedHostOrder.map { _fallbackHosts[$0] }
+
+        expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
+
+        afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+    }
+
+    func test__072__RestClient__Host_Fallback__retry_hosts_in_random_order__all_fallback_requests_headers_should_contain__Host__header_with_fallback_host_address() {
+        beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.httpMaxRetryCount = 10
+        options.fallbackHosts = _fallbackHosts
+
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "nil") { _ in
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(ARTDefault.fallbackHosts().count + 1))
+
+        let fallbackRequests = testHTTPExecutor.requests.filter {
+            NSRegularExpression.match($0.url!.absoluteString, pattern: "[f-j].ably-realtime.com")
+        }
+
+        let fallbackRequestsWithHostHeader = fallbackRequests.filter {
+            $0.allHTTPHeaderFields!["Host"] == $0.url?.host
+        }
+
+        expect(fallbackRequests.count).to(be(fallbackRequestsWithHostHeader.count))
+
+        afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+    }
+
+    func test__073__RestClient__Host_Fallback__retry_hosts_in_random_order__if_an_empty_array_of_fallback_hosts_is_provided__then_fallback_host_functionality_is_disabled() {
+        beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.httpMaxRetryCount = 5
+        options.fallbackHosts = []
+
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "nil") { _ in
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(1))
+        expect(NSRegularExpression.match(testHTTPExecutor.requests[0].url!.absoluteString, pattern: "//rest.ably.io")).to(beTrue())
+
+        afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+    }
+
+    // RSC15d
+
+    func test__074__RestClient__Host_Fallback__should_use_an_alternative_host_when___hostUnreachable() {
+        testUsesAlternativeHost(.hostUnreachable)
+    }
+
+    func test__075__RestClient__Host_Fallback__should_use_an_alternative_host_when___requestTimeout_timeout__0_1_() {
+        testUsesAlternativeHost(.requestTimeout(timeout: 0.1))
+    }
+
+    func test__076__RestClient__Host_Fallback__should_use_an_alternative_host_when___hostInternalError_code__501_() {
+        testUsesAlternativeHost(.hostInternalError(code: 501))
+    }
+
+    // RSC15d
+    func test__050__RestClient__Host_Fallback__should_not_use_an_alternative_host_when_the_client_receives_an_bad_request() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .host400BadRequest, resetAfter: 1)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "nil") { _ in
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests).to(haveCount(1))
+        expect(NSRegularExpression.match(testHTTPExecutor.requests[0].url!.absoluteString, pattern: "//rest.ably.io")).to(beTrue())
+    }
+
+    // RSC15f
+
+    func test__077__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host___hostUnreachable() {
+        testStoresSuccessfulFallbackHostAsDefaultHost(.hostUnreachable)
+    }
+
+    func test__078__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host___requestTimeout_timeout__0_1_() {
+        testStoresSuccessfulFallbackHostAsDefaultHost(.requestTimeout(timeout: 0.1))
+    }
+
+    func test__079__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host___hostInternalError_code__501_() {
+        testStoresSuccessfulFallbackHostAsDefaultHost(.hostInternalError(code: 501))
+    }
+
+    func beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired() {
+        ARTDefault.setFallbackRetryTimeout(1.0)
+    }
+
+    func test__080__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired___hostUnreachable() {
+        beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired()
+
+        testRestoresDefaultPrimaryHostAfterTimeoutExpires(.hostUnreachable)
+    }
+
+    func test__081__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired___requestTimeout_timeout__0_1_() {
+        beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired()
+
+        testRestoresDefaultPrimaryHostAfterTimeoutExpires(.requestTimeout(timeout: 0.1))
+    }
+
+    func test__082__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired___hostInternalError_code__501_() {
+        beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired()
+
+        testRestoresDefaultPrimaryHostAfterTimeoutExpires(.hostInternalError(code: 501))
+    }
+
+    func beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded() {
+        ARTDefault.setFallbackRetryTimeout(10)
+    }
+
+    func test__083__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded___hostUnreachable() {
+        beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded()
+
+        testUsesAnotherFallbackHost(.hostUnreachable)
+    }
+
+    func test__084__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded___requestTimeout_timeout__0_1_() {
+        beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded()
+
+        testUsesAnotherFallbackHost(.requestTimeout(timeout: 0.1))
+    }
+
+    func test__085__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded___hostInternalError_code__501_() {
+        beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded()
+
+        testUsesAnotherFallbackHost(.hostInternalError(code: 501))
+    }
+
+    // RSC8a
+    func test__008__RestClient__should_use_MsgPack_binary_protocol() {
+        let options = AblyTests.commonAppSetup()
+        expect(options.useBinaryProtocol).to(beTrue())
+
+        let rest = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = testHTTPExecutor
+        waitUntil(timeout: testTimeout) { done in
+            rest.channels.get("test").publish(nil, data: "message") { _ in
+                done()
+            }
+        }
+
+        switch extractBodyAsMsgPack(testHTTPExecutor.requests.first) {
+        case let .failure(error):
+            fail(error)
+        default: break
+        }
+
+        let realtime = AblyTests.newRealtime(options)
+        defer { realtime.close() }
+        waitUntil(timeout: testTimeout) { done in
+            realtime.channels.get("test").publish(nil, data: "message") { _ in
+                done()
+            }
+        }
+
+        let transport = realtime.internal.transport as! TestProxyTransport
+        let jsonArray = transport.rawDataSent.map { AblyTests.msgpackToJSON($0) }
+        let messageJson = jsonArray.filter { item in item["action"] == 15 }.last!
+        expect(messageJson["messages"][0]["data"].string).to(equal("message"))
+    }
+
+    // RSC8b
+    func test__009__RestClient__should_use_JSON_text_protocol() {
+        let options = AblyTests.commonAppSetup()
+        options.useBinaryProtocol = false
+
+        let rest = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = testHTTPExecutor
+        waitUntil(timeout: testTimeout) { done in
+            rest.channels.get("test").publish(nil, data: "message") { _ in
+                done()
+            }
+        }
+
+        switch extractBodyAsJSON(testHTTPExecutor.requests.first) {
+        case let .failure(error):
+            fail(error)
+        default: break
+        }
+
+        let realtime = AblyTests.newRealtime(options)
+        defer { realtime.close() }
+        waitUntil(timeout: testTimeout) { done in
+            realtime.channels.get("test").publish(nil, data: "message") { _ in
+                done()
+            }
+        }
+
+        let transport = realtime.internal.transport as! TestProxyTransport
+        let object = try! JSONSerialization.jsonObject(with: transport.rawDataSent.first!, options: JSONSerialization.ReadingOptions(rawValue: 0))
+        expect(JSONSerialization.isValidJSONObject(object)).to(beTrue())
+    }
+
+    // RSC7a
+    func test__010__RestClient__X_Ably_Version_must_be_included_in_all_REST_requests() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        waitUntil(timeout: testTimeout) { done in
+            client.channels.get("test").publish(nil, data: "message") { error in
+                expect(error).to(beNil())
+                guard let headerAblyVersion = testHTTPExecutor.requests.first?.allHTTPHeaderFields?["X-Ably-Version"] else {
+                    fail("X-Ably-Version header not found"); done()
+                    return
+                }
+
+                // This test should not directly validate version against ARTDefault.version(), as
+                // ultimately the version header has been derived from that value.
+                expect(headerAblyVersion).to(equal("1.2"))
+
+                done()
+            }
+        }
+    }
+
+    // RSC7b (Deprecated in favor of RCS7d)
+
+    // RSC7d
+    func test__011__RestClient__The_Agent_library_identifier_is_composed_of_a_series_of_key__value__entries_joined_by_spaces() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "message") { error in
+                expect(error).to(beNil())
+                let headerAgent = testHTTPExecutor.requests.first!.allHTTPHeaderFields?["Ably-Agent"]
+                let ablyAgent = options.agents()
+                expect(headerAgent).to(equal(ablyAgent))
+                expect(headerAgent!.hasPrefix("ably-cocoa/1.2.7")).to(beTrue())
+                done()
+            }
+        }
+    }
+
+    // https://github.com/ably/ably-cocoa/issues/117
+    func test__012__RestClient__should_indicate_an_error_if_there_is_no_way_to_renew_the_token() {
+        let options = AblyTests.clientOptions()
+        options.token = getTestToken(ttl: 0.1)
+        let client = ARTRest(options: options)
+        waitUntil(timeout: testTimeout) { done in
+            delay(0.1) {
+                client.channels.get("test").publish(nil, data: "message") { error in
+                    guard let error = error else {
+                        fail("Error is empty"); done()
+                        return
+                    }
+                    expect(error.code).to(equal(Int(ARTState.requestTokenFailed.rawValue)))
+                    expect(error.message).to(contain("no means to renew the token is provided"))
+                    done()
+                }
+            }
+        }
+    }
+
+    // https://github.com/ably/ably-cocoa/issues/577
+    func test__013__RestClient__background_behaviour() {
+        let options = AblyTests.commonAppSetup()
+        waitUntil(timeout: testTimeout) { done in
+            URLSession.shared.dataTask(with: URL(string: "https://ably.io")!) { _, _, _ in
                 let rest = ARTRest(options: options)
-                testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                rest.internal.httpExecutor = testHTTPExecutor
-                waitUntil(timeout: testTimeout) { done in
-                    rest.channels.get("test").publish(nil, data: "message") { error in
-                        done()
-                    }
+                rest.channels.get("foo").history { _, _ in
+                    done()
                 }
+            }.resume()
+        }
+    }
 
-                switch extractBodyAsJSON(testHTTPExecutor.requests.first) {
-                case .failure(let error):
-                    fail(error)
-                default: break
+    // https://github.com/ably/ably-cocoa/issues/589
+    func test__014__RestClient__client_should_handle_error_messages_in_plaintext_and_HTML_format() {
+        let request = URLRequest(url: URL(string: "https://www.example.com")!)
+        waitUntil(timeout: testTimeout) { done in
+            let rest = ARTRest(key: "xxxx:xxxx")
+            rest.internal.execute(request, completion: { response, _, error in
+                guard let contentType = response?.allHeaderFields["Content-Type"] as? String else {
+                    fail("Response should have a Content-Type"); done(); return
                 }
-
-                let realtime = AblyTests.newRealtime(options)
-                defer { realtime.close() }
-                waitUntil(timeout: testTimeout) { done in
-                    realtime.channels.get("test").publish(nil, data: "message") { error in
-                        done()
-                    }
+                expect(contentType).to(contain("text/html"))
+                guard let error = error as? ARTErrorInfo else {
+                    fail("Error is nil"); done(); return
                 }
+                expect(error.statusCode) == 200
+                expect(error.message.lengthOfBytes(using: String.Encoding.utf8)) == 1000
+                done()
+            })
+        }
+    }
 
-                let transport = realtime.internal.transport as! TestProxyTransport
-                let object = try! JSONSerialization.jsonObject(with: transport.rawDataSent.first!, options: JSONSerialization.ReadingOptions(rawValue: 0))
-                expect(JSONSerialization.isValidJSONObject(object)).to(beTrue())
+    // RSC19
+
+    // RSC19a
+
+    func test__086__RestClient__request__method_signature_and_arguments__should_add_query_parameters() {
+        let rest = ARTRest(key: "xxxx:xxxx")
+        let mockHttpExecutor = MockHTTPExecutor()
+        rest.internal.httpExecutor = mockHttpExecutor
+        let params = ["foo": "1"]
+
+        waitUntil(timeout: testTimeout) { done in
+            do {
+                try rest.request("patch", path: "feature", params: params, body: nil, headers: nil) { paginatedResult, error in
+                    expect(error).to(beNil())
+                    expect(paginatedResult).toNot(beNil())
+                    done()
+                }
+            } catch {
+                fail(error.localizedDescription)
+                done()
             }
+        }
 
-            // RSC7a
-            func test__010__RestClient__X_Ably_Version_must_be_included_in_all_REST_requests() {
-                let options = AblyTests.commonAppSetup()
-                let client = ARTRest(options: options)
-                testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                client.internal.httpExecutor = testHTTPExecutor
-                waitUntil(timeout: testTimeout) { done in
-                    client.channels.get("test").publish(nil, data: "message") { error in
-                        expect(error).to(beNil())
-                        guard let headerAblyVersion = testHTTPExecutor.requests.first?.allHTTPHeaderFields?["X-Ably-Version"] else {
-                            fail("X-Ably-Version header not found"); done()
-                            return
-                        }
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("No requests found")
+            return
+        }
 
-                        // This test should not directly validate version against ARTDefault.version(), as
-                        // ultimately the version header has been derived from that value.
-                        expect(headerAblyVersion).to(equal("1.2"))
+        guard let url = request.url, url.absoluteString == "https://rest.ably.io:443/feature?foo=1" else {
+            fail("should have a \"/feature\" URL with query \(params)"); return
+        }
+        expect(request.httpMethod) == "patch"
 
-                        done()
-                    }
+        guard let acceptHeaderValue = request.allHTTPHeaderFields?["Accept"] else {
+            fail("Accept HTTP Header is missing"); return
+        }
+        expect(acceptHeaderValue).to(equal("application/x-msgpack,application/json"))
+    }
+
+    func test__087__RestClient__request__method_signature_and_arguments__should_add_a_HTTP_body() {
+        let rest = ARTRest(key: "xxxx:xxxx")
+        let mockHttpExecutor = MockHTTPExecutor()
+        rest.internal.httpExecutor = mockHttpExecutor
+        let bodyDict = ["blockchain": true]
+
+        waitUntil(timeout: testTimeout) { done in
+            do {
+                try rest.request("post", path: "feature", params: nil, body: bodyDict, headers: nil) { paginatedResult, error in
+                    expect(error).to(beNil())
+                    expect(paginatedResult).toNot(beNil())
+                    done()
                 }
+            } catch {
+                fail(error.localizedDescription)
+                done()
             }
-            
-            // RSC7b (Deprecated in favor of RCS7d)
+        }
 
-            // RSC7d
-            func test__011__RestClient__The_Agent_library_identifier_is_composed_of_a_series_of_key__value__entries_joined_by_spaces() {
-                let options = AblyTests.commonAppSetup()
-                let client = ARTRest(options: options)
-                testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                client.internal.httpExecutor = testHTTPExecutor
-                let channel = client.channels.get("test")
-                waitUntil(timeout: testTimeout) { done in
-                    channel.publish(nil, data: "message") { error in
-                        expect(error).to(beNil())
-                        let headerAgent = testHTTPExecutor.requests.first!.allHTTPHeaderFields?["Ably-Agent"]
-                        let ablyAgent = options.agents()
-                        expect(headerAgent).to(equal(ablyAgent))
-                        expect(headerAgent!.hasPrefix("ably-cocoa/1.2.7")).to(beTrue())
-                        done()
-                    }
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("No requests found")
+            return
+        }
+        guard let rawBody = request.httpBody else {
+            fail("should have a body"); return
+        }
+
+        let decodedBody: Any
+        do {
+            decodedBody = try rest.internal.defaultEncoder.decode(rawBody)
+        } catch {
+            fail("decode failure: \(error)"); return
+        }
+
+        guard let body = decodedBody as? NSDictionary else {
+            fail("body is invalid"); return
+        }
+        expect(body.value(forKey: "blockchain") as? Bool).to(beTrue())
+    }
+
+    func test__088__RestClient__request__method_signature_and_arguments__should_add_a_HTTP_header() {
+        let rest = ARTRest(key: "xxxx:xxxx")
+        let mockHttpExecutor = MockHTTPExecutor()
+        rest.internal.httpExecutor = mockHttpExecutor
+        let headers = ["X-foo": "ok"]
+
+        waitUntil(timeout: testTimeout) { done in
+            do {
+                try rest.request("get", path: "feature", params: nil, body: nil, headers: headers) { paginatedResult, error in
+                    expect(error).to(beNil())
+                    expect(paginatedResult).toNot(beNil())
+                    done()
                 }
+            } catch {
+                fail(error.localizedDescription)
+                done()
             }
+        }
 
-            // https://github.com/ably/ably-cocoa/issues/117
-            func test__012__RestClient__should_indicate_an_error_if_there_is_no_way_to_renew_the_token() {
-                let options = AblyTests.clientOptions()
-                options.token = getTestToken(ttl: 0.1)
-                let client = ARTRest(options: options)
-                waitUntil(timeout: testTimeout) { done in
-                    delay(0.1) {
-                        client.channels.get("test").publish(nil, data: "message") { error in
-                            guard let error = error else {
-                                fail("Error is empty"); done()
-                                return
-                            }
-                            expect((error ).code).to(equal(Int(ARTState.requestTokenFailed.rawValue)))
-                            expect(error.message).to(contain("no means to renew the token is provided"))
-                            done()
-                        }
-                    }
-                }
+        guard let request = mockHttpExecutor.requests.first else {
+            fail("No requests found")
+            return
+        }
+
+        let authorization = request.allHTTPHeaderFields?["X-foo"]
+        expect(authorization).to(equal("ok"))
+    }
+
+    func test__089__RestClient__request__method_signature_and_arguments__should_error_if_method_is_invalid() {
+        let rest = ARTRest(key: "xxxx:xxxx")
+        let mockHTTPExecutor = MockHTTPExecutor()
+        rest.internal.httpExecutor = mockHTTPExecutor
+
+        do {
+            try rest.request("A", path: "feature", params: nil, body: nil, headers: nil) { _, _ in
+                fail("Completion closure should not be called")
             }
+        } catch let error as NSError {
+            expect(error.code).to(equal(ARTCustomRequestError.invalidMethod.rawValue))
+            expect(error.localizedDescription).to(contain("Method isn't valid"))
+        }
 
-            // https://github.com/ably/ably-cocoa/issues/577
-            func test__013__RestClient__background_behaviour() {
-                let options = AblyTests.commonAppSetup()
-                waitUntil(timeout: testTimeout) { done in
-                  URLSession.shared.dataTask(with: URL(string:"https://ably.io")!) { _ , _ , _  in
-                        let rest = ARTRest(options: options)
-                    rest.channels.get("foo").history { _ , _  in
-                            done()
-                        }
-                    }.resume()
-                }
+        do {
+            try rest.request("", path: "feature", params: nil, body: nil, headers: nil) { _, _ in
+                fail("Completion closure should not be called")
             }
+        } catch let error as NSError {
+            expect(error.code).to(equal(ARTCustomRequestError.invalidMethod.rawValue))
+            expect(error.localizedDescription).to(contain("Method isn't valid"))
+        }
+    }
 
-            // https://github.com/ably/ably-cocoa/issues/589
-            func test__014__RestClient__client_should_handle_error_messages_in_plaintext_and_HTML_format() {
-                let request = URLRequest(url: URL(string: "https://www.example.com")!)
-                waitUntil(timeout: testTimeout) { done in
-                    let rest = ARTRest(key: "xxxx:xxxx")
-                    rest.internal.execute(request, completion: { response, data, error in
-                        guard let contentType = response?.allHeaderFields["Content-Type"] as? String else {
-                            fail("Response should have a Content-Type"); done(); return
-                        }
-                        expect(contentType).to(contain("text/html"))
-                        guard let error = error as? ARTErrorInfo else {
-                            fail("Error is nil"); done(); return
-                        }
-                        expect(error.statusCode) == 200
-                        expect(error.message.lengthOfBytes(using: String.Encoding.utf8)) == 1000
-                        done()
-                    })
-                }
+    func test__090__RestClient__request__method_signature_and_arguments__should_error_if_path_is_invalid() {
+        let rest = ARTRest(key: "xxxx:xxxx")
+        let mockHTTPExecutor = MockHTTPExecutor()
+        rest.internal.httpExecutor = mockHTTPExecutor
+
+        do {
+            try rest.request("get", path: "new feature", params: nil, body: nil, headers: nil) { _, _ in
+                fail("Completion closure should not be called")
             }
-            
-            // RSC19
-            
+        } catch let error as NSError {
+            expect(error.code).to(equal(ARTCustomRequestError.invalidPath.rawValue))
+            expect(error.localizedDescription).to(contain("Path isn't valid"))
+        }
 
-                // RSC19a
-                
-                    func test__086__RestClient__request__method_signature_and_arguments__should_add_query_parameters() {
-                        let rest = ARTRest(key: "xxxx:xxxx")
-                        let mockHttpExecutor = MockHTTPExecutor()
-                        rest.internal.httpExecutor = mockHttpExecutor
-                        let params = ["foo": "1"]
+        do {
+            try rest.request("get", path: "", params: nil, body: nil, headers: nil) { _, _ in
+                fail("Completion closure should not be called")
+            }
+        } catch let error as NSError {
+            expect(error.code).to(equal(ARTCustomRequestError.invalidPath.rawValue))
+            expect(error.localizedDescription).to(contain("Path cannot be empty"))
+        }
+    }
 
-                        waitUntil(timeout: testTimeout) { done in
-                            do {
-                                try rest.request("patch", path: "feature", params: params, body: nil, headers: nil) { paginatedResult, error in
-                                    expect(error).to(beNil())
-                                    expect(paginatedResult).toNot(beNil())
-                                    done()
-                                }
-                            }
-                            catch {
-                                fail(error.localizedDescription)
-                                done()
-                            }
-                        }
+    func test__091__RestClient__request__method_signature_and_arguments__should_error_if_body_is_not_a_Dictionary_or_an_Array() {
+        let rest = ARTRest(key: "xxxx:xxxx")
+        let mockHttpExecutor = MockHTTPExecutor()
+        rest.internal.httpExecutor = mockHttpExecutor
 
-                        guard let request = mockHttpExecutor.requests.first else {
-                            fail("No requests found")
-                            return
-                        }
+        do {
+            try rest.request("get", path: "feature", params: nil, body: mockHttpExecutor, headers: nil) { _, _ in
+                fail("Completion closure should not be called")
+            }
+        } catch let error as NSError {
+            expect(error.code).to(equal(ARTCustomRequestError.invalidBody.rawValue))
+            expect(error.localizedDescription).to(contain("should be a Dictionary or an Array"))
+        }
+    }
 
-                        guard let url = request.url, url.absoluteString == "https://rest.ably.io:443/feature?foo=1" else {
-                            fail("should have a \"/feature\" URL with query \(params)"); return
-                        }
-                        expect(request.httpMethod) == "patch"
+    func test__092__RestClient__request__method_signature_and_arguments__should_do_a_request_and_receive_a_valid_response() {
+        let options = AblyTests.commonAppSetup()
+        let rest = ARTRest(options: options)
+        let channel = rest.channels.get("request-method-test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish("a", data: nil) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
 
-                        guard let acceptHeaderValue = request.allHTTPHeaderFields?["Accept"] else {
-                            fail("Accept HTTP Header is missing"); return
-                        }
-                        expect(acceptHeaderValue).to(equal("application/x-msgpack,application/json"))
+        let proxyHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = proxyHTTPExecutor
+
+        var httpPaginatedResponse: ARTHTTPPaginatedResponse!
+        waitUntil(timeout: testTimeout) { done in
+            do {
+                try rest.request("get", path: "/channels/\(channel.name)", params: nil, body: nil, headers: nil) { paginatedResponse, error in
+                    expect(error).to(beNil())
+                    guard let paginatedResponse = paginatedResponse else {
+                        fail("PaginatedResult is empty"); done(); return
                     }
-
-                    func test__087__RestClient__request__method_signature_and_arguments__should_add_a_HTTP_body() {
-                        let rest = ARTRest(key: "xxxx:xxxx")
-                        let mockHttpExecutor = MockHTTPExecutor()
-                        rest.internal.httpExecutor = mockHttpExecutor
-                        let bodyDict = ["blockchain": true]
-
-                        waitUntil(timeout: testTimeout) { done in
-                            do {
-                                try rest.request("post", path: "feature", params: nil, body: bodyDict, headers: nil) { paginatedResult, error in
-                                    expect(error).to(beNil())
-                                    expect(paginatedResult).toNot(beNil())
-                                    done()
-                                }
-                            }
-                            catch {
-                                fail(error.localizedDescription)
-                                done()
-                            }
-                        }
-
-                        guard let request = mockHttpExecutor.requests.first else {
-                            fail("No requests found")
-                            return
-                        }
-                        guard let rawBody = request.httpBody else {
-                            fail("should have a body"); return
-                        }
-
-                        let decodedBody: Any
-                        do {
-                            decodedBody = try rest.internal.defaultEncoder.decode(rawBody)
-                        }
-                        catch {
-                            fail("decode failure: \(error)"); return
-                        }
-
-                        guard let body = decodedBody as? NSDictionary else {
-                            fail("body is invalid"); return
-                        }
-                        expect(body.value(forKey: "blockchain") as? Bool).to(beTrue())
+                    expect(paginatedResponse.items.count) == 1
+                    guard let channelDetailsDict = paginatedResponse.items.first else {
+                        fail("PaginatedResult first element is missing"); done(); return
                     }
-
-                    func test__088__RestClient__request__method_signature_and_arguments__should_add_a_HTTP_header() {
-                        let rest = ARTRest(key: "xxxx:xxxx")
-                        let mockHttpExecutor = MockHTTPExecutor()
-                        rest.internal.httpExecutor = mockHttpExecutor
-                        let headers = ["X-foo": "ok"]
-
-                        waitUntil(timeout: testTimeout) { done in
-                            do {
-                                try rest.request("get", path: "feature", params: nil, body: nil, headers: headers) { paginatedResult, error in
-                                    expect(error).to(beNil())
-                                    expect(paginatedResult).toNot(beNil())
-                                    done()
-                                }
-                            }
-                            catch {
-                                fail(error.localizedDescription)
-                                done()
-                            }
-                        }
-
-                        guard let request = mockHttpExecutor.requests.first else {
-                            fail("No requests found")
-                            return
-                        }
-
-                        let authorization = request.allHTTPHeaderFields?["X-foo"]
-                        expect(authorization).to(equal("ok"))
-                    }
-
-                    func test__089__RestClient__request__method_signature_and_arguments__should_error_if_method_is_invalid() {
-                        let rest = ARTRest(key: "xxxx:xxxx")
-                        let mockHTTPExecutor = MockHTTPExecutor()
-                        rest.internal.httpExecutor = mockHTTPExecutor
-
-                        do {
-                            try rest.request("A", path: "feature", params: nil, body: nil, headers: nil) { paginatedResult, error in
-                                fail("Completion closure should not be called")
-                            }
-                        }
-                        catch let error as NSError {
-                            expect(error.code).to(equal(ARTCustomRequestError.invalidMethod.rawValue))
-                            expect(error.localizedDescription).to(contain("Method isn't valid"))
-                        }
-
-                        do {
-                            try rest.request("", path: "feature", params: nil, body: nil, headers: nil) { paginatedResult, error in
-                                fail("Completion closure should not be called")
-                            }
-                        }
-                        catch let error as NSError {
-                            expect(error.code).to(equal(ARTCustomRequestError.invalidMethod.rawValue))
-                            expect(error.localizedDescription).to(contain("Method isn't valid"))
-                        }
-                    }
-
-                    func test__090__RestClient__request__method_signature_and_arguments__should_error_if_path_is_invalid() {
-                        let rest = ARTRest(key: "xxxx:xxxx")
-                        let mockHTTPExecutor = MockHTTPExecutor()
-                        rest.internal.httpExecutor = mockHTTPExecutor
-
-                        do {
-                            try rest.request("get", path: "new feature", params: nil, body: nil, headers: nil) { paginatedResult, error in
-                                fail("Completion closure should not be called")
-                            }
-                        }
-                        catch let error as NSError {
-                            expect(error.code).to(equal(ARTCustomRequestError.invalidPath.rawValue))
-                            expect(error.localizedDescription).to(contain("Path isn't valid"))
-                        }
-
-                        do {
-                            try rest.request("get", path: "", params: nil, body: nil, headers: nil) { paginatedResult, error in
-                                fail("Completion closure should not be called")
-                            }
-                        }
-                        catch let error as NSError {
-                            expect(error.code).to(equal(ARTCustomRequestError.invalidPath.rawValue))
-                            expect(error.localizedDescription).to(contain("Path cannot be empty"))
-                        }
-                    }
-
-                    func test__091__RestClient__request__method_signature_and_arguments__should_error_if_body_is_not_a_Dictionary_or_an_Array() {
-                        let rest = ARTRest(key: "xxxx:xxxx")
-                        let mockHttpExecutor = MockHTTPExecutor()
-                        rest.internal.httpExecutor = mockHttpExecutor
-
-                        do {
-                            try rest.request("get", path: "feature", params: nil, body: mockHttpExecutor, headers: nil) { paginatedResult, error in
-                                fail("Completion closure should not be called")
-                            }
-                        }
-                        catch let error as NSError {
-                            expect(error.code).to(equal(ARTCustomRequestError.invalidBody.rawValue))
-                            expect(error.localizedDescription).to(contain("should be a Dictionary or an Array"))
-                        }
-                    }
-
-                    func test__092__RestClient__request__method_signature_and_arguments__should_do_a_request_and_receive_a_valid_response() {
-                        let options = AblyTests.commonAppSetup()
-                        let rest = ARTRest(options: options)
-                        let channel = rest.channels.get("request-method-test")
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish("a", data: nil) { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        let proxyHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                        rest.internal.httpExecutor = proxyHTTPExecutor
-
-                        var httpPaginatedResponse: ARTHTTPPaginatedResponse!
-                        waitUntil(timeout: testTimeout) { done in
-                            do {
-                                try rest.request("get", path: "/channels/\(channel.name)", params: nil, body: nil, headers: nil) { paginatedResponse, error in
-                                    expect(error).to(beNil())
-                                    guard let paginatedResponse = paginatedResponse else {
-                                        fail("PaginatedResult is empty"); done(); return
-                                    }
-                                    expect(paginatedResponse.items.count) == 1
-                                    guard let channelDetailsDict = paginatedResponse.items.first else {
-                                        fail("PaginatedResult first element is missing"); done(); return
-                                    }
-                                    expect(channelDetailsDict.value(forKey: "channelId") as? String).to(equal(channel.name))
-                                    expect(paginatedResponse.hasNext) == false
-                                    expect(paginatedResponse.isLast) == true
-                                    expect(paginatedResponse.statusCode) == 200
-                                    expect(paginatedResponse.success) == true
-                                    expect(paginatedResponse.errorCode) == 0
-                                    expect(paginatedResponse.errorMessage).to(beNil())
-                                    expect(paginatedResponse.headers).toNot(beEmpty())
-                                    httpPaginatedResponse = paginatedResponse
-                                    done()
-                                }
-                            }
-                            catch {
-                                fail(error.localizedDescription)
-                                done()
-                            }
-                        }
-
-                        guard let response = proxyHTTPExecutor.responses.first else {
-                            fail("No responses found")
-                            return
-                        }
-
-                        expect(response.statusCode) == httpPaginatedResponse.statusCode
-                        expect(response.allHeaderFields as NSDictionary) == httpPaginatedResponse.headers
-                    }
-
-                    func test__093__RestClient__request__method_signature_and_arguments__should_handle_response_failures() {
-                        let options = AblyTests.commonAppSetup()
-                        let rest = ARTRest(options: options)
-                        let channel = rest.channels.get("request-method-test")
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish("a", data: nil) { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        let proxyHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                        rest.internal.httpExecutor = proxyHTTPExecutor
-
-                        waitUntil(timeout: testTimeout) { done in
-                            do {
-                                try rest.request("get", path: "feature", params: nil, body: nil, headers: nil) { paginatedResponse, error in
-                                    expect(error).to(beNil())
-                                    guard let paginatedResponse = paginatedResponse else {
-                                        fail("PaginatedResult is empty"); done(); return
-                                    }
-                                    expect(paginatedResponse.items.count) == 0
-                                    expect(paginatedResponse.hasNext) == false
-                                    expect(paginatedResponse.isLast) == true
-                                    expect(paginatedResponse.statusCode) == 404
-                                    expect(paginatedResponse.success) == false
-                                    expect(paginatedResponse.errorCode) == ARTErrorCode.notFound.intValue
-                                    expect(paginatedResponse.errorMessage).to(contain("Could not find path"))
-                                    expect(paginatedResponse.headers).toNot(beEmpty())
-                                    expect(paginatedResponse.headers["X-Ably-Errorcode"] as? String).to(equal("\(ARTErrorCode.notFound.intValue)"))
-                                    done()
-                                }
-                            }
-                            catch {
-                                fail(error.localizedDescription)
-                                done()
-                            }
-                        }
-
-                        guard let response = proxyHTTPExecutor.responses.first else {
-                            fail("No responses found")
-                            return
-                        }
-
-                        expect(response.statusCode) == 404
-                        expect(response.value(forHTTPHeaderField: "X-Ably-Errorcode")).to(equal("\(ARTErrorCode.notFound.intValue)"))
-                    }
-
-            
-                // RSA4e
-                func test__094__RestClient__if_in_the_course_of_a_REST_request_an_attempt_to_authenticate_using_authUrl_fails_due_to_a_timeout__the_request_should_result_in_an_error_with_code_40170__statusCode_401__and_a_suitable_error_message() {
-                    let options = AblyTests.commonAppSetup()
-                    let token = getTestToken()
-                    options.httpRequestTimeout = 3 // short timeout to make it fail faster
-                    options.authUrl = URL(string: "http://10.255.255.1")!
-                    options.authParams = [URLQueryItem]()
-                    options.authParams?.append(URLQueryItem(name: "type", value: "text"))
-                    options.authParams?.append(URLQueryItem(name: "body", value: token))
-
-                    let client = ARTRest(options: options)
-                    waitUntil(timeout: testTimeout) { done in
-                        let channel = client.channels.get("test-channel")
-                        channel.publish("test", data: "test-data") { error in
-                            guard let error = error else {
-                                fail("Error should not be empty")
-                                done()
-                                return
-                            }
-                            expect(error.statusCode).to(equal(401))
-                            expect(error.code).to(equal(ARTErrorCode.errorFromClientTokenCallback.intValue))
-                            expect(error.message).to(contain("Error in requesting auth token"))
-                            done()
-                        }
-                    }
+                    expect(channelDetailsDict.value(forKey: "channelId") as? String).to(equal(channel.name))
+                    expect(paginatedResponse.hasNext) == false
+                    expect(paginatedResponse.isLast) == true
+                    expect(paginatedResponse.statusCode) == 200
+                    expect(paginatedResponse.success) == true
+                    expect(paginatedResponse.errorCode) == 0
+                    expect(paginatedResponse.errorMessage).to(beNil())
+                    expect(paginatedResponse.headers).toNot(beEmpty())
+                    httpPaginatedResponse = paginatedResponse
+                    done()
                 }
+            } catch {
+                fail(error.localizedDescription)
+                done()
+            }
+        }
 
-            // RSC7c
-            
+        guard let response = proxyHTTPExecutor.responses.first else {
+            fail("No responses found")
+            return
+        }
 
-                func test__095__RestClient__request_IDs__should_add__request_id__query_parameter() {
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.addRequestIds = true
+        expect(response.statusCode) == httpPaginatedResponse.statusCode
+        expect(response.allHeaderFields as NSDictionary) == httpPaginatedResponse.headers
+    }
 
-                    let restA = ARTRest(options: options)
-                    let mockHttpExecutor = MockHTTPExecutor()
-                    restA.internal.httpExecutor = mockHttpExecutor
-                    waitUntil(timeout: testTimeout) { done in
-                        restA.channels.get("foo").publish(nil, data: "something") { error in
-                            expect(error).to(beNil())
-                            guard let url = mockHttpExecutor.requests.first?.url else {
-                                fail("No requests found")
-                                return
-                            }
-                            expect(url.query).to(contain("request_id"))
-                            done()
-                        }
+    func test__093__RestClient__request__method_signature_and_arguments__should_handle_response_failures() {
+        let options = AblyTests.commonAppSetup()
+        let rest = ARTRest(options: options)
+        let channel = rest.channels.get("request-method-test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish("a", data: nil) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        let proxyHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = proxyHTTPExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            do {
+                try rest.request("get", path: "feature", params: nil, body: nil, headers: nil) { paginatedResponse, error in
+                    expect(error).to(beNil())
+                    guard let paginatedResponse = paginatedResponse else {
+                        fail("PaginatedResult is empty"); done(); return
                     }
-
-                    mockHttpExecutor.reset()
-
-                    options.addRequestIds = false
-                    let restB = ARTRest(options: options)
-                    restB.internal.httpExecutor = mockHttpExecutor
-                    waitUntil(timeout: testTimeout) { done in
-                        restB.channels.get("foo").publish(nil, data: "something") { error in
-                            expect(error).to(beNil())
-                            expect(mockHttpExecutor.requests).to(haveCount(1))
-                            guard let url = mockHttpExecutor.requests.first?.url else {
-                                fail("No requests found")
-                                return
-                            }
-                            expect(url.query).to(beNil())
-                            done()
-                        }
-                    }
+                    expect(paginatedResponse.items.count) == 0
+                    expect(paginatedResponse.hasNext) == false
+                    expect(paginatedResponse.isLast) == true
+                    expect(paginatedResponse.statusCode) == 404
+                    expect(paginatedResponse.success) == false
+                    expect(paginatedResponse.errorCode) == ARTErrorCode.notFound.intValue
+                    expect(paginatedResponse.errorMessage).to(contain("Could not find path"))
+                    expect(paginatedResponse.headers).toNot(beEmpty())
+                    expect(paginatedResponse.headers["X-Ably-Errorcode"] as? String).to(equal("\(ARTErrorCode.notFound.intValue)"))
+                    done()
                 }
+            } catch {
+                fail(error.localizedDescription)
+                done()
+            }
+        }
 
-                func test__096__RestClient__request_IDs__should_remain_the_same_if_a_request_is_retried_to_a_fallback_host() {
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.httpMaxRetryCount = 5
-                    options.addRequestIds = true
-                    options.logLevel = .debug
+        guard let response = proxyHTTPExecutor.responses.first else {
+            fail("No responses found")
+            return
+        }
 
-                    let client = ARTRest(options: options)
-                    let mockHTTP = MockHTTP(logger: options.logHandler)
-                    testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
-                    client.internal.httpExecutor = testHTTPExecutor
-                    mockHTTP.setNetworkState(network: .hostUnreachable)
+        expect(response.statusCode) == 404
+        expect(response.value(forHTTPHeaderField: "X-Ably-Errorcode")).to(equal("\(ARTErrorCode.notFound.intValue)"))
+    }
 
-                    var fallbackRequests: [URLRequest] = []
-                    testHTTPExecutor.setListenerAfterRequest({ request in
-                        if NSRegularExpression.match(request.url!.absoluteString, pattern: "//[a-e].ably-realtime.com") {
-                            fallbackRequests += [request]
-                        }
-                    })
+    // RSA4e
+    func test__094__RestClient__if_in_the_course_of_a_REST_request_an_attempt_to_authenticate_using_authUrl_fails_due_to_a_timeout__the_request_should_result_in_an_error_with_code_40170__statusCode_401__and_a_suitable_error_message() {
+        let options = AblyTests.commonAppSetup()
+        let token = getTestToken()
+        options.httpRequestTimeout = 3 // short timeout to make it fail faster
+        options.authUrl = URL(string: "http://10.255.255.1")!
+        options.authParams = [URLQueryItem]()
+        options.authParams?.append(URLQueryItem(name: "type", value: "text"))
+        options.authParams?.append(URLQueryItem(name: "body", value: token))
 
-                    var requestId: String = ""
-                    let channel = client.channels.get("test")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: "something") { error in
-                            guard let error = error else {
-                                fail("Expecting an error"); done(); return
-                            }
-                            guard let firstRequestId = extractURLQueryValue(testHTTPExecutor.requests.first?.url, key: "request_id") else {
-                                fail("First request attempt doesn't have the 'request_id'."); return
-                            }
-                            requestId = firstRequestId
-                            expect(error.message).to(contain(requestId))
-                            done()
-                        }
-                    }
-
-                    expect(fallbackRequests).toNot(beEmpty())
-                    expect(fallbackRequests).to(allPass { extractURLQueryValue($0?.url, key: "request_id") == requestId })
+        let client = ARTRest(options: options)
+        waitUntil(timeout: testTimeout) { done in
+            let channel = client.channels.get("test-channel")
+            channel.publish("test", data: "test-data") { error in
+                guard let error = error else {
+                    fail("Error should not be empty")
+                    done()
+                    return
                 }
-                
-                func test__097__RestClient__request_IDs__ErrorInfo_should_have__requestId__property() {
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.addRequestIds = true
+                expect(error.statusCode).to(equal(401))
+                expect(error.code).to(equal(ARTErrorCode.errorFromClientTokenCallback.intValue))
+                expect(error.message).to(contain("Error in requesting auth token"))
+                done()
+            }
+        }
+    }
 
-                    let rest = ARTRest(options: options)
-                    let mockHttpExecutor = MockHTTPExecutor()
-                    mockHttpExecutor.simulateIncomingErrorOnNextRequest(NSError(domain: "ably-test", code: ARTErrorCode.invalidMessageDataOrEncoding.intValue, userInfo: ["Message":"Ably test message"]))
-                    rest.internal.httpExecutor = mockHttpExecutor
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        rest.channels.get("foo").publish(nil, data: "something") { error in
-                            expect(error).toNot(beNil())
-                            expect(error?.requestId).toNot(beNil())
-                            done()
-                        }
-                    }
+    // RSC7c
+
+    func test__095__RestClient__request_IDs__should_add__request_id__query_parameter() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.addRequestIds = true
+
+        let restA = ARTRest(options: options)
+        let mockHttpExecutor = MockHTTPExecutor()
+        restA.internal.httpExecutor = mockHttpExecutor
+        waitUntil(timeout: testTimeout) { done in
+            restA.channels.get("foo").publish(nil, data: "something") { error in
+                expect(error).to(beNil())
+                guard let url = mockHttpExecutor.requests.first?.url else {
+                    fail("No requests found")
+                    return
                 }
+                expect(url.query).to(contain("request_id"))
+                done()
+            }
+        }
+
+        mockHttpExecutor.reset()
+
+        options.addRequestIds = false
+        let restB = ARTRest(options: options)
+        restB.internal.httpExecutor = mockHttpExecutor
+        waitUntil(timeout: testTimeout) { done in
+            restB.channels.get("foo").publish(nil, data: "something") { error in
+                expect(error).to(beNil())
+                expect(mockHttpExecutor.requests).to(haveCount(1))
+                guard let url = mockHttpExecutor.requests.first?.url else {
+                    fail("No requests found")
+                    return
+                }
+                expect(url.query).to(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__096__RestClient__request_IDs__should_remain_the_same_if_a_request_is_retried_to_a_fallback_host() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.httpMaxRetryCount = 5
+        options.addRequestIds = true
+        options.logLevel = .debug
+
+        let client = ARTRest(options: options)
+        let mockHTTP = MockHTTP(logger: options.logHandler)
+        testHTTPExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        mockHTTP.setNetworkState(network: .hostUnreachable)
+
+        var fallbackRequests: [URLRequest] = []
+        testHTTPExecutor.setListenerAfterRequest { request in
+            if NSRegularExpression.match(request.url!.absoluteString, pattern: "//[a-e].ably-realtime.com") {
+                fallbackRequests += [request]
+            }
+        }
+
+        var requestId: String = ""
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: "something") { error in
+                guard let error = error else {
+                    fail("Expecting an error"); done(); return
+                }
+                guard let firstRequestId = extractURLQueryValue(testHTTPExecutor.requests.first?.url, key: "request_id") else {
+                    fail("First request attempt doesn't have the 'request_id'."); return
+                }
+                requestId = firstRequestId
+                expect(error.message).to(contain(requestId))
+                done()
+            }
+        }
+
+        expect(fallbackRequests).toNot(beEmpty())
+        expect(fallbackRequests).to(allPass { extractURLQueryValue($0?.url, key: "request_id") == requestId })
+    }
+
+    func test__097__RestClient__request_IDs__ErrorInfo_should_have__requestId__property() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.addRequestIds = true
+
+        let rest = ARTRest(options: options)
+        let mockHttpExecutor = MockHTTPExecutor()
+        mockHttpExecutor.simulateIncomingErrorOnNextRequest(NSError(domain: "ably-test", code: ARTErrorCode.invalidMessageDataOrEncoding.intValue, userInfo: ["Message": "Ably test message"]))
+        rest.internal.httpExecutor = mockHttpExecutor
+
+        waitUntil(timeout: testTimeout) { done in
+            rest.channels.get("foo").publish(nil, data: "something") { error in
+                expect(error).toNot(beNil())
+                expect(error?.requestId).toNot(beNil())
+                done()
+            }
+        }
+    }
 }

--- a/Spec/RestClient.swift
+++ b/Spec/RestClient.swift
@@ -127,7 +127,7 @@ import Quick
                             expect(testHTTPExecutor.requests[1].url!.host).toNot(equal(testHTTPExecutor.requests[2].url!.host))
                         }
 
-class RestClient: QuickSpec {
+class RestClient: XCTestCase {
 
 // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
 override class var defaultTestSuite : XCTestSuite {
@@ -139,11 +139,9 @@ override class var defaultTestSuite : XCTestSuite {
     return super.defaultTestSuite
 }
 
-    override func spec() {
-
-        describe("RestClient") {
+        
             // G4
-            it("All REST requests should include the current API version") {
+            func test__001__RestClient__All_REST_requests_should_include_the_current_API_version() {
                 let options = AblyTests.commonAppSetup()
                 let client = ARTRest(options: options)
                 testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
@@ -164,8 +162,8 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSC1
-            context("initializer") {
-                it("should accept an API key") {
+            
+                func test__015__RestClient__initializer__should_accept_an_API_key() {
                     let options = AblyTests.commonAppSetup()
                     
                     let client = ARTRest(key: options.key!)
@@ -176,11 +174,11 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(publishTask.error).toEventually(beNil(), timeout: testTimeout)
                 }
 
-                it("should throw when provided an invalid key") {
+                func test__016__RestClient__initializer__should_throw_when_provided_an_invalid_key() {
                     expect{ ARTRest(key: "invalid_key") }.to(raiseException())
                 }
 
-                it("should result in error status when provided a bad key") {
+                func test__017__RestClient__initializer__should_result_in_error_status_when_provided_a_bad_key() {
                     let client = ARTRest(key: "fake:key")
 
                     let publishTask = publishTestMessage(client, failOnError: false)
@@ -188,7 +186,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(publishTask.error?.code).toEventually(equal(ARTErrorCode.invalidCredential.intValue), timeout:testTimeout)
                 }
 
-                it("should accept a token") {
+                func test__018__RestClient__initializer__should_accept_a_token() {
                     ARTClientOptions.setDefaultEnvironment(getEnvironment())
                     defer { ARTClientOptions.setDefaultEnvironment(nil) }
 
@@ -197,7 +195,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(publishTask.error).toEventually(beNil(), timeout: testTimeout)
                 }
 
-                it("should accept an options object") {
+                func test__019__RestClient__initializer__should_accept_an_options_object() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRest(options: options)
 
@@ -206,7 +204,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(publishTask.error).toEventually(beNil(), timeout: testTimeout)
                 }
 
-                it("should accept an options object with token authentication") {
+                func test__020__RestClient__initializer__should_accept_an_options_object_with_token_authentication() {
                     let options = AblyTests.clientOptions(requestToken: true)
                     let client = ARTRest(options: options)
 
@@ -215,7 +213,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(publishTask.error).toEventually(beNil(), timeout: testTimeout)
                 }
 
-                it("should result in error status when provided a bad token") {
+                func test__021__RestClient__initializer__should_result_in_error_status_when_provided_a_bad_token() {
                     let options = AblyTests.clientOptions()
                     options.token = "invalid_token"
                     let client = ARTRest(options: options)
@@ -224,11 +222,10 @@ override class var defaultTestSuite : XCTestSuite {
 
                     expect(publishTask.error?.code).toEventually(equal(ARTErrorCode.invalidCredential.intValue), timeout: testTimeout)
                 }
-            }
 
-            context("logging") {
+            
                 // RSC2
-                it("should output to the system log and the log level should be Warn") {
+                func test__022__RestClient__logging__should_output_to_the_system_log_and_the_log_level_should_be_Warn() {
                     ARTClientOptions.setDefaultEnvironment(getEnvironment())
                     defer {
                         ARTClientOptions.setDefaultEnvironment(nil)
@@ -250,7 +247,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSC3
-                it("should have a mutable log level") {
+                func test__023__RestClient__logging__should_have_a_mutable_log_level() {
                     let options = AblyTests.commonAppSetup()
                     options.logHandler = ARTLog(capturingOutput: true)
                     let client = ARTRest(options: options)
@@ -264,7 +261,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSC4
-                it("should accept a custom logger") {
+                func test__024__RestClient__logging__should_accept_a_custom_logger() {
                     struct Log {
                         static var interceptedLog: (String, ARTLogLevel) = ("", .none)
                     }
@@ -287,13 +284,12 @@ override class var defaultTestSuite : XCTestSuite {
                     
                     expect(client.internal.logger.logLevel).to(equal(customLogger.logLevel))
                 }
-            }
 
             // RSC11
-            context("endpoint") {
+            
 
                 // RSC11a
-                it("should accept a custom host and send requests to the specified host") {
+                func test__025__RestClient__endpoint__should_accept_a_custom_host_and_send_requests_to_the_specified_host() {
                     let options = ARTClientOptions(key: "fake:key")
                     options.restHost = "fake.ably.io"
                     let client = ARTRest(options: options)
@@ -305,7 +301,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(testHTTPExecutor.requests.first?.url?.host).toEventually(equal("fake.ably.io"), timeout: testTimeout)
                 }
 
-                it("should ignore an environment when restHost is customized") {
+                func test__026__RestClient__endpoint__should_ignore_an_environment_when_restHost_is_customized() {
                     let options = ARTClientOptions(key: "fake:key")
                     options.environment = "test"
                     options.restHost = "fake.ably.io"
@@ -319,7 +315,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSC11b
-                it("should accept an environment when restHost is left unchanged") {
+                func test__027__RestClient__endpoint__should_accept_an_environment_when_restHost_is_left_unchanged() {
                     let options = ARTClientOptions(key: "fake:key")
                     options.environment = "myEnvironment"
                     let client = ARTRest(options: options)
@@ -331,7 +327,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(testHTTPExecutor.requests.first?.url?.host).toEventually(equal("myEnvironment-rest.ably.io"), timeout: testTimeout)
                 }
                 
-                it("should default to https://rest.ably.io") {
+                func test__028__RestClient__endpoint__should_default_to_https___rest_ably_io() {
                     let options = ARTClientOptions(key: "fake:key")
                     let client = ARTRest(options: options)
                     testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
@@ -342,7 +338,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(testHTTPExecutor.requests.first?.url?.absoluteString).toEventually(beginWith("https://rest.ably.io"), timeout: testTimeout)
                 }
                 
-                it("should connect over plain http:// when tls is off") {
+                func test__029__RestClient__endpoint__should_connect_over_plain_http____when_tls_is_off() {
                     let options = AblyTests.clientOptions(requestToken: true)
                     options.tls = false
                     let client = ARTRest(options: options)
@@ -355,7 +351,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSC11b
-                it("should not prepend the environment if environment is configured as @production@") {
+                func test__030__RestClient__endpoint__should_not_prepend_the_environment_if_environment_is_configured_as__production_() {
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.environment = "production"
                     let client = ARTRest(options: options)
@@ -363,12 +359,10 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(client.internal.options.realtimeHost).to(equal(ARTDefault.realtimeHost()))
                 }
 
-            }
-
             // RSC13
-            context("should use the the connection and request timeouts specified") {
+            
 
-                it("timeout for any single HTTP request and response") {
+                func test__031__RestClient__should_use_the_the_connection_and_request_timeouts_specified__timeout_for_any_single_HTTP_request_and_response() {
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.restHost = "10.255.255.1" //non-routable IP address
                     expect(options.httpRequestTimeout).to(equal(10.0)) //Seconds
@@ -389,7 +383,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("max number of fallback hosts") {
+                func test__032__RestClient__should_use_the_the_connection_and_request_timeouts_specified__max_number_of_fallback_hosts() {
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     expect(options.httpMaxRetryCount).to(equal(3))
                     options.httpMaxRetryCount = 1
@@ -415,7 +409,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(totalRetry).to(equal(options.httpMaxRetryCount))
                 }
 
-                it("max elapsed time in which fallback host retries for HTTP requests will be attempted") {
+                func test__033__RestClient__should_use_the_the_connection_and_request_timeouts_specified__max_elapsed_time_in_which_fallback_host_retries_for_HTTP_requests_will_be_attempted() {
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     expect(options.httpMaxRetryDuration).to(equal(15.0)) //Seconds
                     options.httpMaxRetryDuration = 1.0
@@ -434,10 +428,9 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
             // RSC5
-            it("should provide access to the AuthOptions object passed in ClientOptions") {
+            func test__002__RestClient__should_provide_access_to_the_AuthOptions_object_passed_in_ClientOptions() {
                 let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
                 let client = ARTRest(options: options)
                 
@@ -447,7 +440,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSC12
-            it("REST endpoint host should be configurable in the Client constructor with the option restHost") {
+            func test__003__RestClient__REST_endpoint_host_should_be_configurable_in_the_Client_constructor_with_the_option_restHost() {
                 let options = ARTClientOptions(key: "xxxx:xxxx")
                 expect(options.restHost).to(equal("rest.ably.io"))
                 options.restHost = "rest.ably.test"
@@ -465,8 +458,8 @@ override class var defaultTestSuite : XCTestSuite {
             }
             
             // RSC16
-            context("time") {
-                it("should return server time") {
+            
+                func test__034__RestClient__time__should_return_server_time() {
                     let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
                     let client = ARTRest(options: options)
                     
@@ -478,10 +471,9 @@ override class var defaultTestSuite : XCTestSuite {
                     
                     expect(time?.timeIntervalSince1970).toEventually(beCloseTo(NSDate().timeIntervalSince1970, within: 60), timeout: testTimeout)
                 }
-            }
 
             // RSC7, RSC18
-            it("should send requests over http and https") {
+            func test__004__RestClient__should_send_requests_over_http_and_https() {
                 let options = AblyTests.commonAppSetup()
 
                 let clientHttps = ARTRest(options: options)
@@ -515,7 +507,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSC9
-            it("should use Auth to manage authentication") {
+            func test__005__RestClient__should_use_Auth_to_manage_authentication() {
                 let options = AblyTests.clientOptions()
                 guard let testTokenDetails = getTestTokenDetails() else {
                     fail("No test token details"); return
@@ -547,7 +539,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSC10
-            it("should request another token after current one is no longer valid") {
+            func test__006__RestClient__should_request_another_token_after_current_one_is_no_longer_valid() {
                 let options = AblyTests.commonAppSetup()
                 options.token = getTestToken(ttl: 0.5)
                 let client = ARTRest(options: options)
@@ -576,7 +568,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSC10
-            it("should result in an error when user does not have sufficient permissions") {
+            func test__007__RestClient__should_result_in_an_error_when_user_does_not_have_sufficient_permissions() {
                 let options = AblyTests.clientOptions()
                 options.token = getTestToken(capability: "{ \"main\":[\"subscribe\"] }")
                 let client = ARTRest(options: options)
@@ -603,10 +595,10 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSC14
-            context("Authentication") {
+            
 
                 // RSC14a
-                it("should support basic authentication when an API key is provided with the key option") {
+                func test__035__RestClient__Authentication__should_support_basic_authentication_when_an_API_key_is_provided_with_the_key_option() {
                     let options = AblyTests.commonAppSetup()
                     guard let components = options.key?.components(separatedBy: ":"), let keyName = components.first, let keySecret = components.last else {
                         fail("Invalid API key: \(options.key ?? "nil")"); return
@@ -625,39 +617,38 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSC14b
-                context("basic authentication flag") {
-                    it("should be true when initialized with a key") {
+                
+                    func test__038__RestClient__Authentication__basic_authentication_flag__should_be_true_when_initialized_with_a_key() {
                         let client = ARTRest(key: "key:secret")
                         expect(client.auth.internal.options.isBasicAuth()).to(beTrue())
                     }
                     
-                    it("should be false when options’ useTokenAuth is set") {
+                    func test__039__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__useTokenAuth_is_set() {
                         testOptionsGiveBasicAuthFalse { $0.useTokenAuth = true; $0.key = "fake:key" }
                     }
                     
-                    it("should be false when options’ authUrl is set") {
+                    func test__040__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__authUrl_is_set() {
                         testOptionsGiveBasicAuthFalse { $0.authUrl = URL(string: "http://test.com") }
                     }
                     
-                    it("should be false when options’ authCallback is set") {
+                    func test__041__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__authCallback_is_set() {
                         testOptionsGiveBasicAuthFalse { $0.authCallback = { _, _ in return } }
                     }
                     
-                    it("should be false when options’ tokenDetails is set") {
+                    func test__042__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__tokenDetails_is_set() {
                         testOptionsGiveBasicAuthFalse { $0.tokenDetails = ARTTokenDetails(token: "token") }
                     }
 
-                    it("should be false when options’ token is set") {
+                    func test__043__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__token_is_set() {
                         testOptionsGiveBasicAuthFalse { $0.token = "token" }
                     }
                     
-                    it("should be false when options’ key is set") {
+                    func test__044__RestClient__Authentication__basic_authentication_flag__should_be_false_when_options__key_is_set() {
                         testOptionsGiveBasicAuthFalse { $0.tokenDetails = ARTTokenDetails(token: "token"); $0.key = "fake:key" }
                     }
-                }
 
                 // RSC14c
-                it("should error when expired token and no means to renew") {
+                func test__036__RestClient__Authentication__should_error_when_expired_token_and_no_means_to_renew() {
                     let client = ARTRest(options: AblyTests.commonAppSetup())
                     let auth = client.auth
 
@@ -719,7 +710,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSC14d
-                it("should renew the token when it has expired") {
+                func test__037__RestClient__Authentication__should_renew_the_token_when_it_has_expired() {
                     let client = ARTRest(options: AblyTests.commonAppSetup())
                     let auth = client.auth
 
@@ -773,15 +764,14 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
             // RSC15
-            context("Host Fallback") {
+            
 
                 // TO3k7
-                context("fallbackHostsUseDefault option") {
+                
 
-                    it("allows the default fallback hosts to be used when @environment@ is not production") {
+                    func test__051__RestClient__Host_Fallback__fallbackHostsUseDefault_option__allows_the_default_fallback_hosts_to_be_used_when__environment__is_not_production() {
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         options.environment = "not-production"
                         options.fallbackHostsUseDefault = true
@@ -801,7 +791,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("allows the default fallback hosts to be used when a custom Realtime or REST host endpoint is being used") {
+                    func test__052__RestClient__Host_Fallback__fallbackHostsUseDefault_option__allows_the_default_fallback_hosts_to_be_used_when_a_custom_Realtime_or_REST_host_endpoint_is_being_used() {
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         options.restHost = "fake1.ably.io"
                         options.realtimeHost = "fake2.ably.io"
@@ -822,12 +812,12 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("should be inactive by default") {
+                    func test__053__RestClient__Host_Fallback__fallbackHostsUseDefault_option__should_be_inactive_by_default() {
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         expect(options.fallbackHostsUseDefault).to(beFalse())
                     }
 
-                    it("should never accept to configure @fallbackHost@ and set @fallbackHostsUseDefault@ to @true@") {
+                    func test__054__RestClient__Host_Fallback__fallbackHostsUseDefault_option__should_never_accept_to_configure__fallbackHost__and_set__fallbackHostsUseDefault__to__true_() {
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         expect(options.fallbackHosts).to(beNil())
                         expect(options.fallbackHostsUseDefault).to(beFalse())
@@ -843,13 +833,11 @@ override class var defaultTestSuite : XCTestSuite {
                         expect { options.fallbackHosts = ["fake.ably.io"] }.to(raiseException(named: ARTFallbackIncompatibleOptionsException))
                     }
 
-                }
-
                 // RSC15b
-                context("Fallback behavior") {
+                
 
                     // RSC15b1
-                    it("should be applied when restHost, port and tlsPort has not been set to an explicit value") {
+                    func test__055__RestClient__Host_Fallback__Fallback_behavior__should_be_applied_when_restHost__port_and_tlsPort_has_not_been_set_to_an_explicit_value() {
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         let client = ARTRest(options: options)
                         let mockHTTP = MockHTTP(logger: options.logHandler)
@@ -874,7 +862,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSC15b1
-                    it("should NOT be applied when ClientOptions.restHost has been set") {
+                    func test__056__RestClient__Host_Fallback__Fallback_behavior__should_NOT_be_applied_when_ClientOptions_restHost_has_been_set() {
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         options.restHost = "fake.ably.io"
                         let client = ARTRest(options: options)
@@ -898,7 +886,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSC15b1
-                    it("should NOT be applied when ClientOptions.port has been set") {
+                    func test__057__RestClient__Host_Fallback__Fallback_behavior__should_NOT_be_applied_when_ClientOptions_port_has_been_set() {
                         let options = ARTClientOptions(token: "xxxx")
                         options.tls = false
                         options.port = 999
@@ -923,7 +911,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSC15b1
-                    it("should NOT be applied when ClientOptions.tlsPort has been set") {
+                    func test__058__RestClient__Host_Fallback__Fallback_behavior__should_NOT_be_applied_when_ClientOptions_tlsPort_has_been_set() {
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         options.tlsPort = 999
                         let client = ARTRest(options: options)
@@ -947,7 +935,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSC15b2
-                    it("should be applied when ClientOptions.fallbackHosts is provided") {
+                    func test__059__RestClient__Host_Fallback__Fallback_behavior__should_be_applied_when_ClientOptions_fallbackHosts_is_provided() {
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         options.fallbackHosts = ["a.cocoa.ably", "b.cocoa.ably"]
                         let client = ARTRest(options: options)
@@ -972,7 +960,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSC15b3, RSC15g4
-                    it("should be applied when ClientOptions.fallbackHosts is not provided and deprecated fallbackHostsUseDefault is on") {
+                    func test__060__RestClient__Host_Fallback__Fallback_behavior__should_be_applied_when_ClientOptions_fallbackHosts_is_not_provided_and_deprecated_fallbackHostsUseDefault_is_on() {
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         options.fallbackHostsUseDefault = true
                         let client = ARTRest(options: options)
@@ -996,10 +984,8 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(NSRegularExpression.match(capturedURLs.at(2), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
                     }
 
-                }
-
                 // RSC15k
-                it("failing HTTP requests with custom endpoint should result in an error immediately") {
+                func test__045__RestClient__Host_Fallback__failing_HTTP_requests_with_custom_endpoint_should_result_in_an_error_immediately() {
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.restHost = "fake.ably.io"
                     let client = ARTRest(options: options)
@@ -1018,10 +1004,10 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSC15g
-                context("fallback hosts list and priorities") {
+                
 
                     // RSC15g1
-                    it("should use ClientOptions.fallbackHosts when list is provided") {
+                    func test__061__RestClient__Host_Fallback__fallback_hosts_list_and_priorities__should_use_ClientOptions_fallbackHosts_when_list_is_provided() {
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         options.fallbackHosts = ["f.ably-realtime.com"]
                         let client = ARTRest(options: options)
@@ -1045,7 +1031,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSC15g2
-                    it("should use environment fallback hosts when ClientOptions.environment is set to a value other than 'production' and ClientOptions.fallbackHosts is not set") {
+                    func test__062__RestClient__Host_Fallback__fallback_hosts_list_and_priorities__should_use_environment_fallback_hosts_when_ClientOptions_environment_is_set_to_a_value_other_than__production__and_ClientOptions_fallbackHosts_is_not_set() {
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         options.environment = "test"
                         let client = ARTRest(options: options)
@@ -1070,7 +1056,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSC15g2
-                    it("should NOT use environment fallback hosts when ClientOptions.environment is set to 'production'") {
+                    func test__063__RestClient__Host_Fallback__fallback_hosts_list_and_priorities__should_NOT_use_environment_fallback_hosts_when_ClientOptions_environment_is_set_to__production_() {
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         options.environment = "production"
                         let client = ARTRest(options: options)
@@ -1096,7 +1082,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSC15g3
-                    it("should use default fallback hosts when both ClientOptions.fallbackHosts and ClientOptions.environment are not set") {
+                    func test__064__RestClient__Host_Fallback__fallback_hosts_list_and_priorities__should_use_default_fallback_hosts_when_both_ClientOptions_fallbackHosts_and_ClientOptions_environment_are_not_set() {
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         options.environment = ""
                         let client = ARTRest(options: options)
@@ -1121,10 +1107,8 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(NSRegularExpression.match(capturedURLs.at(3), pattern: "//[a-e].ably-realtime.com")).to(beTrue())
                     }
 
-                }
-
                 // RSC15g4
-                it("applies when ClientOptions#fallbackHostsUseDefault is true") {
+                func test__046__RestClient__Host_Fallback__applies_when_ClientOptions_fallbackHostsUseDefault_is_true() {
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.environment = "test"
                     options.fallbackHostsUseDefault = true
@@ -1148,7 +1132,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSC15g1
-                it("won't apply fallback hosts if ClientOptions#fallbackHosts array is empty") {
+                func test__047__RestClient__Host_Fallback__won_t_apply_fallback_hosts_if_ClientOptions_fallbackHosts_array_is_empty() {
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.fallbackHosts = [] //to test TO3k6
                     let client = ARTRest(options: options)
@@ -1170,7 +1154,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSC15g3
-                it("won't apply custom fallback hosts if ClientOptions#fallbackHosts and ClientOptions#environment are not set, use defaults instead") {
+                func test__048__RestClient__Host_Fallback__won_t_apply_custom_fallback_hosts_if_ClientOptions_fallbackHosts_and_ClientOptions_environment_are_not_set__use_defaults_instead() {
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.fallbackHosts = nil
                     let client = ARTRest(options: options)
@@ -1196,7 +1180,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSC15e
-                it("every new HTTP request is first attempted to the default primary host rest.ably.io") {
+                func test__049__RestClient__Host_Fallback__every_new_HTTP_request_is_first_attempted_to_the_default_primary_host_rest_ably_io() {
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.httpMaxRetryCount = 1
                     let client = ARTRest(options: options)
@@ -1231,9 +1215,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSC15a
-                context("retry hosts in random order") {
+                
 
-                    beforeEach {
+                    func beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order() {
                         ARTFallback_shuffleArray = { array in
                             let arranged = expectedHostOrder.reversed().map { array[$0] }
                             for (i, element) in arranged.enumerated() {
@@ -1242,29 +1226,41 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    afterEach {
+                    func afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order() {
                         ARTFallback_shuffleArray = originalARTFallback_shuffleArray
                     }
 
                     // RSC15h
-                    it("default fallback hosts should match [a-e].ably-realtime.com") {
+                    func test__065__RestClient__Host_Fallback__retry_hosts_in_random_order__default_fallback_hosts_should_match__a_e__ably_realtime_com() {
+beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                         let defaultFallbackHosts = ARTDefault.fallbackHosts()
                         defaultFallbackHosts.forEach { host in
                             expect(host).to(match("[a-e].ably-realtime.com"))
                         }
                         expect(defaultFallbackHosts).to(haveCount(5))
+
+afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                     }
 
                     // RSC15i
-                    it("environment fallback hosts have the format [environment]-[a-e]-fallback.ably-realtime.com") {
+                    func test__066__RestClient__Host_Fallback__retry_hosts_in_random_order__environment_fallback_hosts_have_the_format__environment___a_e__fallback_ably_realtime_com() {
+beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                         let environmentFallbackHosts = ARTDefault.fallbackHosts(withEnvironment: "sandbox")
                         environmentFallbackHosts.forEach { host in
                             expect(host).to(match("sandbox-[a-e]-fallback.ably-realtime.com"))
                         }
                         expect(environmentFallbackHosts).to(haveCount(5))
+
+afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                     }
 
-                    it("until httpMaxRetryCount has been reached") {
+                    func test__067__RestClient__Host_Fallback__retry_hosts_in_random_order__until_httpMaxRetryCount_has_been_reached() {
+beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         let client = ARTRest(options: options)
                         options.httpMaxRetryCount = 3
@@ -1289,9 +1285,14 @@ override class var defaultTestSuite : XCTestSuite {
                         let expectedFallbackHosts = Array(expectedHostOrder.map({ ARTDefault.fallbackHosts()[$0] })[0..<Int(options.httpMaxRetryCount)])
 
                         expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
+
+afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                     }
 
-                    it("use custom fallback hosts if set") {
+                    func test__068__RestClient__Host_Fallback__retry_hosts_in_random_order__use_custom_fallback_hosts_if_set() {
+beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         options.httpMaxRetryCount = 10
                         let customFallbackHosts = ["j.ably-realtime.com",
@@ -1322,9 +1323,14 @@ override class var defaultTestSuite : XCTestSuite {
                         let expectedFallbackHosts = expectedHostOrder.map { customFallbackHosts[$0] }
 
                         expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
+
+afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                     }
 
-                    it("until all fallback hosts have been tried") {
+                    func test__069__RestClient__Host_Fallback__retry_hosts_in_random_order__until_all_fallback_hosts_have_been_tried() {
+beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         options.httpMaxRetryCount = 10
                         let client = ARTRest(options: options)
@@ -1349,9 +1355,14 @@ override class var defaultTestSuite : XCTestSuite {
                         let expectedFallbackHosts = expectedHostOrder.map { ARTDefault.fallbackHosts()[$0] }
 
                         expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
+
+afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                     }
 
-                    it("until httpMaxRetryCount has been reached, if custom fallback hosts are provided in ClientOptions#fallbackHosts, then they will be used instead") {
+                    func test__070__RestClient__Host_Fallback__retry_hosts_in_random_order__until_httpMaxRetryCount_has_been_reached__if_custom_fallback_hosts_are_provided_in_ClientOptions_fallbackHosts__then_they_will_be_used_instead() {
+beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         options.httpMaxRetryCount = 4
                         options.fallbackHosts = _fallbackHosts
@@ -1379,9 +1390,14 @@ override class var defaultTestSuite : XCTestSuite {
                         let expectedFallbackHosts = Array(expectedHostOrder.map({ _fallbackHosts[$0] })[0..<Int(options.httpMaxRetryCount)])
 
                         expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
+
+afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                     }
                     
-                    it("until all fallback hosts have been tried, if custom fallback hosts are provided in ClientOptions#fallbackHosts, then they will be used instead") {
+                    func test__071__RestClient__Host_Fallback__retry_hosts_in_random_order__until_all_fallback_hosts_have_been_tried__if_custom_fallback_hosts_are_provided_in_ClientOptions_fallbackHosts__then_they_will_be_used_instead() {
+beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         options.httpMaxRetryCount = 10
                         options.fallbackHosts = _fallbackHosts
@@ -1409,9 +1425,14 @@ override class var defaultTestSuite : XCTestSuite {
                         let expectedFallbackHosts = expectedHostOrder.map { _fallbackHosts[$0] }
                 
                         expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
+
+afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                     }
                     
-                    it("all fallback requests headers should contain `Host` header with fallback host address") {
+                    func test__072__RestClient__Host_Fallback__retry_hosts_in_random_order__all_fallback_requests_headers_should_contain__Host__header_with_fallback_host_address() {
+beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         options.httpMaxRetryCount = 10
                         options.fallbackHosts = _fallbackHosts
@@ -1440,9 +1461,14 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                                             
                         expect(fallbackRequests.count).to(be(fallbackRequestsWithHostHeader.count))
+
+afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                     }
                     
-                    it("if an empty array of fallback hosts is provided, then fallback host functionality is disabled") {
+                    func test__073__RestClient__Host_Fallback__retry_hosts_in_random_order__if_an_empty_array_of_fallback_hosts_is_provided__then_fallback_host_functionality_is_disabled() {
+beforeEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         options.httpMaxRetryCount = 5
                         options.fallbackHosts = []
@@ -1462,27 +1488,28 @@ override class var defaultTestSuite : XCTestSuite {
 
                         expect(testHTTPExecutor.requests).to(haveCount(1))
                         expect(NSRegularExpression.match(testHTTPExecutor.requests[0].url!.absoluteString, pattern: "//rest.ably.io")).to(beTrue())
+
+afterEach__RestClient__Host_Fallback__retry_hosts_in_random_order()
+
                     }
-                }
 
                 // RSC15d
-                context("should use an alternative host when") {
+                
                     
-                    it(".hostUnreachable") {
+                    func test__074__RestClient__Host_Fallback__should_use_an_alternative_host_when___hostUnreachable() {
                         testUsesAlternativeHost(.hostUnreachable)
                     }
                     
-                    it(".requestTimeout(timeout: 0.1)") {
+                    func test__075__RestClient__Host_Fallback__should_use_an_alternative_host_when___requestTimeout_timeout__0_1_() {
                         testUsesAlternativeHost(.requestTimeout(timeout: 0.1))
                     }
                     
-                    it(".hostInternalError(code: 501)") {
+                    func test__076__RestClient__Host_Fallback__should_use_an_alternative_host_when___hostInternalError_code__501_() {
                         testUsesAlternativeHost(.hostInternalError(code: 501))
                     }
-                }
 
                 // RSC15d
-                it("should not use an alternative host when the client receives an bad request") {
+                func test__050__RestClient__Host_Fallback__should_not_use_an_alternative_host_when_the_client_receives_an_bad_request() {
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     let client = ARTRest(options: options)
                     let mockHTTP = MockHTTP(logger: options.logHandler)
@@ -1502,63 +1529,70 @@ override class var defaultTestSuite : XCTestSuite {
                 }
                 
                 // RSC15f
-                context("should store successful fallback host as default host") {
+                
                     
-                    it(".hostUnreachable") {
+                    func test__077__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host___hostUnreachable() {
                         testStoresSuccessfulFallbackHostAsDefaultHost(.hostUnreachable)
                     }
                     
-                    it(".requestTimeout(timeout: 0.1)") {
+                    func test__078__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host___requestTimeout_timeout__0_1_() {
                         testStoresSuccessfulFallbackHostAsDefaultHost(.requestTimeout(timeout: 0.1))
                     }
                     
-                    it(".hostInternalError(code: 501)") {
+                    func test__079__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host___hostInternalError_code__501_() {
                         testStoresSuccessfulFallbackHostAsDefaultHost(.hostInternalError(code: 501))
                     }
                     
-                    context("should restore default primary host after fallbackRetryTimeout expired") {
+                    
                         
-                        beforeEach {
+                        func beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired() {
                             ARTDefault.setFallbackRetryTimeout(1.0)
                         }
                         
-                        it(".hostUnreachable") {
+                        func test__080__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired___hostUnreachable() {
+beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired()
+
                             testRestoresDefaultPrimaryHostAfterTimeoutExpires(.hostUnreachable)
                         }
                         
-                        it(".requestTimeout(timeout: 0.1)") {
+                        func test__081__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired___requestTimeout_timeout__0_1_() {
+beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired()
+
                             testRestoresDefaultPrimaryHostAfterTimeoutExpires(.requestTimeout(timeout: 0.1))
                         }
                         
-                        it(".hostInternalError(code: 501)") {
+                        func test__082__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired___hostInternalError_code__501_() {
+beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_restore_default_primary_host_after_fallbackRetryTimeout_expired()
+
                             testRestoresDefaultPrimaryHostAfterTimeoutExpires(.hostInternalError(code: 501))
                         }
-                    }
                     
-                    context("should use another fallback host if previous fallback request failed and store it as default if current fallback request succseeded") {
+                    
                             
-                        beforeEach {
+                        func beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded() {
                             ARTDefault.setFallbackRetryTimeout(10)
                         }
                         
-                        it(".hostUnreachable") {
+                        func test__083__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded___hostUnreachable() {
+beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded()
+
                             testUsesAnotherFallbackHost(.hostUnreachable)
                         }
                         
-                        it(".requestTimeout(timeout: 0.1)") {
+                        func test__084__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded___requestTimeout_timeout__0_1_() {
+beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded()
+
                             testUsesAnotherFallbackHost(.requestTimeout(timeout: 0.1))
                         }
                         
-                        it(".hostInternalError(code: 501)") {
+                        func test__085__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded___hostInternalError_code__501_() {
+beforeEach__RestClient__Host_Fallback__should_store_successful_fallback_host_as_default_host__should_use_another_fallback_host_if_previous_fallback_request_failed_and_store_it_as_default_if_current_fallback_request_succseeded()
+
                             testUsesAnotherFallbackHost(.hostInternalError(code: 501))
                         }
-                    }
-
-                }
-            }
 
             // RSC8a
-            it("should use MsgPack binary protocol") {
+            func test__008__RestClient__should_use_MsgPack_binary_protocol() {
                 let options = AblyTests.commonAppSetup()
                 expect(options.useBinaryProtocol).to(beTrue())
 
@@ -1592,7 +1626,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSC8b
-            it("should use JSON text protocol") {
+            func test__009__RestClient__should_use_JSON_text_protocol() {
                 let options = AblyTests.commonAppSetup()
                 options.useBinaryProtocol = false
 
@@ -1625,7 +1659,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSC7a
-            it("X-Ably-Version must be included in all REST requests") {
+            func test__010__RestClient__X_Ably_Version_must_be_included_in_all_REST_requests() {
                 let options = AblyTests.commonAppSetup()
                 let client = ARTRest(options: options)
                 testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
@@ -1650,7 +1684,7 @@ override class var defaultTestSuite : XCTestSuite {
             // RSC7b (Deprecated in favor of RCS7d)
 
             // RSC7d
-            it("The Agent library identifier is composed of a series of key[/value] entries joined by spaces") {
+            func test__011__RestClient__The_Agent_library_identifier_is_composed_of_a_series_of_key__value__entries_joined_by_spaces() {
                 let options = AblyTests.commonAppSetup()
                 let client = ARTRest(options: options)
                 testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
@@ -1669,7 +1703,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // https://github.com/ably/ably-cocoa/issues/117
-            it("should indicate an error if there is no way to renew the token") {
+            func test__012__RestClient__should_indicate_an_error_if_there_is_no_way_to_renew_the_token() {
                 let options = AblyTests.clientOptions()
                 options.token = getTestToken(ttl: 0.1)
                 let client = ARTRest(options: options)
@@ -1689,7 +1723,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // https://github.com/ably/ably-cocoa/issues/577
-            it("background behaviour") {
+            func test__013__RestClient__background_behaviour() {
                 let options = AblyTests.commonAppSetup()
                 waitUntil(timeout: testTimeout) { done in
                   URLSession.shared.dataTask(with: URL(string:"https://ably.io")!) { _ , _ , _  in
@@ -1702,7 +1736,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // https://github.com/ably/ably-cocoa/issues/589
-            it("client should handle error messages in plaintext and HTML format") {
+            func test__014__RestClient__client_should_handle_error_messages_in_plaintext_and_HTML_format() {
                 let request = URLRequest(url: URL(string: "https://www.example.com")!)
                 waitUntil(timeout: testTimeout) { done in
                     let rest = ARTRest(key: "xxxx:xxxx")
@@ -1722,11 +1756,11 @@ override class var defaultTestSuite : XCTestSuite {
             }
             
             // RSC19
-            context("request") {
+            
 
                 // RSC19a
-                context("method signature and arguments") {
-                    it("should add query parameters") {
+                
+                    func test__086__RestClient__request__method_signature_and_arguments__should_add_query_parameters() {
                         let rest = ARTRest(key: "xxxx:xxxx")
                         let mockHttpExecutor = MockHTTPExecutor()
                         rest.internal.httpExecutor = mockHttpExecutor
@@ -1762,7 +1796,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(acceptHeaderValue).to(equal("application/x-msgpack,application/json"))
                     }
 
-                    it("should add a HTTP body") {
+                    func test__087__RestClient__request__method_signature_and_arguments__should_add_a_HTTP_body() {
                         let rest = ARTRest(key: "xxxx:xxxx")
                         let mockHttpExecutor = MockHTTPExecutor()
                         rest.internal.httpExecutor = mockHttpExecutor
@@ -1804,7 +1838,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(body.value(forKey: "blockchain") as? Bool).to(beTrue())
                     }
 
-                    it("should add a HTTP header") {
+                    func test__088__RestClient__request__method_signature_and_arguments__should_add_a_HTTP_header() {
                         let rest = ARTRest(key: "xxxx:xxxx")
                         let mockHttpExecutor = MockHTTPExecutor()
                         rest.internal.httpExecutor = mockHttpExecutor
@@ -1833,7 +1867,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(authorization).to(equal("ok"))
                     }
 
-                    it("should error if method is invalid") {
+                    func test__089__RestClient__request__method_signature_and_arguments__should_error_if_method_is_invalid() {
                         let rest = ARTRest(key: "xxxx:xxxx")
                         let mockHTTPExecutor = MockHTTPExecutor()
                         rest.internal.httpExecutor = mockHTTPExecutor
@@ -1859,7 +1893,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("should error if path is invalid") {
+                    func test__090__RestClient__request__method_signature_and_arguments__should_error_if_path_is_invalid() {
                         let rest = ARTRest(key: "xxxx:xxxx")
                         let mockHTTPExecutor = MockHTTPExecutor()
                         rest.internal.httpExecutor = mockHTTPExecutor
@@ -1885,7 +1919,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("should error if body is not a Dictionary or an Array") {
+                    func test__091__RestClient__request__method_signature_and_arguments__should_error_if_body_is_not_a_Dictionary_or_an_Array() {
                         let rest = ARTRest(key: "xxxx:xxxx")
                         let mockHttpExecutor = MockHTTPExecutor()
                         rest.internal.httpExecutor = mockHttpExecutor
@@ -1901,7 +1935,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("should do a request and receive a valid response") {
+                    func test__092__RestClient__request__method_signature_and_arguments__should_do_a_request_and_receive_a_valid_response() {
                         let options = AblyTests.commonAppSetup()
                         let rest = ARTRest(options: options)
                         let channel = rest.channels.get("request-method-test")
@@ -1954,7 +1988,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(response.allHeaderFields as NSDictionary) == httpPaginatedResponse.headers
                     }
 
-                    it("should handle response failures") {
+                    func test__093__RestClient__request__method_signature_and_arguments__should_handle_response_failures() {
                         let options = AblyTests.commonAppSetup()
                         let rest = ARTRest(options: options)
                         let channel = rest.channels.get("request-method-test")
@@ -2001,13 +2035,10 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(response.statusCode) == 404
                         expect(response.value(forHTTPHeaderField: "X-Ably-Errorcode")).to(equal("\(ARTErrorCode.notFound.intValue)"))
                     }
-                }
 
-            }
-
-            context("if in the course of a REST request an attempt to authenticate using authUrl fails due to a timeout") {
+            
                 // RSA4e
-                it("the request should result in an error with code 40170, statusCode 401, and a suitable error message") {
+                func test__094__RestClient__if_in_the_course_of_a_REST_request_an_attempt_to_authenticate_using_authUrl_fails_due_to_a_timeout__the_request_should_result_in_an_error_with_code_40170__statusCode_401__and_a_suitable_error_message() {
                     let options = AblyTests.commonAppSetup()
                     let token = getTestToken()
                     options.httpRequestTimeout = 3 // short timeout to make it fail faster
@@ -2032,12 +2063,11 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
             // RSC7c
-            context("request IDs") {
+            
 
-                it("should add 'request_id' query parameter") {
+                func test__095__RestClient__request_IDs__should_add__request_id__query_parameter() {
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.addRequestIds = true
 
@@ -2075,7 +2105,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("should remain the same if a request is retried to a fallback host") {
+                func test__096__RestClient__request_IDs__should_remain_the_same_if_a_request_is_retried_to_a_fallback_host() {
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.httpMaxRetryCount = 5
                     options.addRequestIds = true
@@ -2114,7 +2144,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(fallbackRequests).to(allPass { extractURLQueryValue($0?.url, key: "request_id") == requestId })
                 }
                 
-                it("ErrorInfo should have `requestId` property") {
+                func test__097__RestClient__request_IDs__ErrorInfo_should_have__requestId__property() {
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.addRequestIds = true
 
@@ -2131,9 +2161,4 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-
-            }
-
-        } // RestClient
-    }
 }

--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -1,901 +1,915 @@
 import Ably
+import Foundation
 import Nimble
 import Quick
-import Foundation
 import SwiftyJSON
 
-        private var client: ARTRest!
-        private var channel: ARTRestChannel!
-        private var testHTTPExecutor: TestProxyHTTPExecutor!
-                private let channelName = "test-message-size"
+private var client: ARTRest!
+private var channel: ARTRestChannel!
+private var testHTTPExecutor: TestProxyHTTPExecutor!
+private let channelName = "test-message-size"
 
-                private func assertMessagePayloadId(id: String?, expectedSerial: String) {
-                    guard let id = id else {
-                        fail("Message.id from payload is nil"); return
-                    }
+private func assertMessagePayloadId(id: String?, expectedSerial: String) {
+    guard let id = id else {
+        fail("Message.id from payload is nil"); return
+    }
 
-                    let idParts = id.split(separator: ":")
+    let idParts = id.split(separator: ":")
 
-                    if idParts.count != 2 {
-                        fail("Message.id from payload should have baseId and serial separated by a colon"); return
-                    }
+    if idParts.count != 2 {
+        fail("Message.id from payload should have baseId and serial separated by a colon"); return
+    }
 
-                    let baseId = String(idParts[0])
-                    let serial = String(idParts[1])
+    let baseId = String(idParts[0])
+    let serial = String(idParts[1])
 
-                    guard let baseIdData = Data(base64Encoded: baseId) else {
-                        fail("BaseId should be a base64 encoded string"); return
-                    }
+    guard let baseIdData = Data(base64Encoded: baseId) else {
+        fail("BaseId should be a base64 encoded string"); return
+    }
 
-                    expect(baseIdData.bytes.count) == 9
-                    expect(serial).to(equal(expectedSerial))
-                }
-            private let presenceFixtures = appSetupJson["post_apps"]["channels"][0]["presence"]
-
-            private let text = "John"
-            private let integer = "5"
-            private let decimal = "65.33"
-            private let dictionary = ["number": 3, "name": "John"] as [String : Any]
-            private let array = ["John", "Mary"]
-            private let binaryData = "123456".data(using: .utf8)!
-
-                private func testSupportsAESEncryptionWithKeyLength(_ encryptionKeyLength: UInt) {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRest(options: options)
-                    client.internal.httpExecutor = testHTTPExecutor
-                    
-                    let params: ARTCipherParams = ARTCrypto.getDefaultParams([
-                        "key": ARTCrypto.generateRandomKey(encryptionKeyLength)
-                    ])
-                    expect(params.algorithm).to(equal("AES"))
-                    expect(params.keyLength).to(equal(encryptionKeyLength))
-                    expect(params.mode).to(equal("CBC"))
-                    
-                    let channelOptions = ARTChannelOptions(cipher: params)
-                    let channel = client.channels.get("test", options: channelOptions)
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish("test", data: "message1") { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                    
-                    guard let httpBody = testHTTPExecutor.requests.last?.httpBody else {
-                        fail("HTTPBody is empty")
-                        return
-                    }
-                    let httpBodyAsJSON = AblyTests.msgpackToJSON(httpBody)
-                    expect(httpBodyAsJSON["encoding"].string).to(equal("utf-8/cipher+aes-\(encryptionKeyLength)-cbc/base64"))
-                    expect(httpBodyAsJSON["name"].string).to(equal("test"))
-                    expect(httpBodyAsJSON["data"].string).toNot(equal("message1"))
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.history { result, error in
-                            expect(error).to(beNil())
-                            guard let result = result else {
-                                fail("PaginatedResult is empty"); done()
-                                return
-                            }
-                            expect(result.hasNext).to(beFalse())
-                            expect(result.isLast).to(beTrue())
-                            let items = result.items
-                            if result.items.isEmpty {
-                                fail("PaginatedResult has no items"); done()
-                                return
-                            }
-                            expect(items[0].name).to(equal("test"))
-                            expect(items[0].data as? String).to(equal("message1"))
-                            done()
-                        }
-                    }
-                }
-
-class RestClientChannel: XCTestCase {
-
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = client
-    let _ = channel
-    let _ = testHTTPExecutor
-    let _ = channelName
-    let _ = presenceFixtures
-    let _ = text
-    let _ = integer
-    let _ = decimal
-    let _ = dictionary
-    let _ = array
-    let _ = binaryData
-
-    return super.defaultTestSuite
+    expect(baseIdData.bytes.count) == 9
+    expect(serial).to(equal(expectedSerial))
 }
 
-            struct PublishArgs {
-                static let name = "foo"
-                static let data = "bar"
+private let presenceFixtures = appSetupJson["post_apps"]["channels"][0]["presence"]
+
+private let text = "John"
+private let integer = "5"
+private let decimal = "65.33"
+private let dictionary = ["number": 3, "name": "John"] as [String: Any]
+private let array = ["John", "Mary"]
+private let binaryData = "123456".data(using: .utf8)!
+
+private func testSupportsAESEncryptionWithKeyLength(_ encryptionKeyLength: UInt) {
+    let options = AblyTests.commonAppSetup()
+    let client = ARTRest(options: options)
+    client.internal.httpExecutor = testHTTPExecutor
+
+    let params: ARTCipherParams = ARTCrypto.getDefaultParams([
+        "key": ARTCrypto.generateRandomKey(encryptionKeyLength),
+    ])
+    expect(params.algorithm).to(equal("AES"))
+    expect(params.keyLength).to(equal(encryptionKeyLength))
+    expect(params.mode).to(equal("CBC"))
+
+    let channelOptions = ARTChannelOptions(cipher: params)
+    let channel = client.channels.get("test", options: channelOptions)
+
+    waitUntil(timeout: testTimeout) { done in
+        channel.publish("test", data: "message1") { error in
+            expect(error).to(beNil())
+            done()
+        }
+    }
+
+    guard let httpBody = testHTTPExecutor.requests.last?.httpBody else {
+        fail("HTTPBody is empty")
+        return
+    }
+    let httpBodyAsJSON = AblyTests.msgpackToJSON(httpBody)
+    expect(httpBodyAsJSON["encoding"].string).to(equal("utf-8/cipher+aes-\(encryptionKeyLength)-cbc/base64"))
+    expect(httpBodyAsJSON["name"].string).to(equal("test"))
+    expect(httpBodyAsJSON["data"].string).toNot(equal("message1"))
+
+    waitUntil(timeout: testTimeout) { done in
+        channel.history { result, error in
+            expect(error).to(beNil())
+            guard let result = result else {
+                fail("PaginatedResult is empty"); done()
+                return
             }
-
-            struct TestCase {
-                let value: Any?
-                let expected: JSON
+            expect(result.hasNext).to(beFalse())
+            expect(result.isLast).to(beTrue())
+            let items = result.items
+            if result.items.isEmpty {
+                fail("PaginatedResult has no items"); done()
+                return
             }
+            expect(items[0].name).to(equal("test"))
+            expect(items[0].data as? String).to(equal("message1"))
+            done()
+        }
+    }
+}
 
-        override func setUp() {
-super.setUp()
+class RestClientChannel: XCTestCase {
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = client
+        _ = channel
+        _ = testHTTPExecutor
+        _ = channelName
+        _ = presenceFixtures
+        _ = text
+        _ = integer
+        _ = decimal
+        _ = dictionary
+        _ = array
+        _ = binaryData
 
+        return super.defaultTestSuite
+    }
 
-            let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
-            client = ARTRest(options: options)
-            channel = client.channels.get(ProcessInfo.processInfo.globallyUniqueString)
-            testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+    enum PublishArgs {
+        static let name = "foo"
+        static let data = "bar"
+    }
+
+    struct TestCase {
+        let value: Any?
+        let expected: JSON
+    }
+
+    override func setUp() {
+        super.setUp()
+
+        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        client = ARTRest(options: options)
+        channel = client.channels.get(ProcessInfo.processInfo.globallyUniqueString)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+    }
+
+    // RSL1
+
+    // RSL1b
+
+    func test__005__publish__with_name_and_data_arguments__publishes_the_message_and_invokes_callback_with_success() {
+        var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
+        var publishedMessage: ARTMessage?
+
+        channel.publish(PublishArgs.name, data: PublishArgs.data) { error in
+            publishError = error
+            channel.history { result, _ in
+                publishedMessage = result?.items.first
+            }
         }
 
-        // RSL1
-        
+        expect(publishError).toEventually(beNil(), timeout: testTimeout)
+        expect(publishedMessage?.name).toEventually(equal(PublishArgs.name), timeout: testTimeout)
+        expect(publishedMessage?.data as? String).toEventually(equal(PublishArgs.data), timeout: testTimeout)
+    }
 
-            // RSL1b
-            
-                func test__005__publish__with_name_and_data_arguments__publishes_the_message_and_invokes_callback_with_success() {
-                    var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
-                    var publishedMessage: ARTMessage?
+    // RSL1b, RSL1e
 
-                    channel.publish(PublishArgs.name, data: PublishArgs.data) { error in
-                        publishError = error
-                        channel.history { result, _ in
-                            publishedMessage = result?.items.first
-                        }
-                    }
+    func test__006__publish__with_name_only__publishes_the_message_and_invokes_callback_with_success() {
+        var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "io.ably.XCTest", code: -1, userInfo: nil))
+        var publishedMessage: ARTMessage?
 
-                    expect(publishError).toEventually(beNil(), timeout: testTimeout)
-                    expect(publishedMessage?.name).toEventually(equal(PublishArgs.name), timeout: testTimeout)
-                    expect(publishedMessage?.data as? String).toEventually(equal(PublishArgs.data), timeout: testTimeout)
-                }
+        channel.publish(PublishArgs.name, data: nil) { error in
+            publishError = error
+            channel.history { result, _ in
+                publishedMessage = result?.items.first
+            }
+        }
 
-            // RSL1b, RSL1e
-            
-                func test__006__publish__with_name_only__publishes_the_message_and_invokes_callback_with_success() {
-                    var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "io.ably.XCTest", code: -1, userInfo: nil))
-                    var publishedMessage: ARTMessage?
+        expect(publishError).toEventually(beNil(), timeout: testTimeout)
+        expect(publishedMessage?.name).toEventually(equal(PublishArgs.name), timeout: testTimeout)
+        expect(publishedMessage?.data).toEventually(beNil(), timeout: testTimeout)
+    }
 
-                    channel.publish(PublishArgs.name, data: nil) { error in
-                        publishError = error
-                        channel.history { result, _ in
-                            publishedMessage = result?.items.first
-                        }
-                    }
+    // RSL1b, RSL1e
 
-                    expect(publishError).toEventually(beNil(), timeout: testTimeout)
-                    expect(publishedMessage?.name).toEventually(equal(PublishArgs.name), timeout: testTimeout)
-                    expect(publishedMessage?.data).toEventually(beNil(), timeout: testTimeout)
-                }
+    func test__007__publish__with_data_only__publishes_the_message_and_invokes_callback_with_success() {
+        var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
+        var publishedMessage: ARTMessage?
 
-            // RSL1b, RSL1e
-            
-                func test__007__publish__with_data_only__publishes_the_message_and_invokes_callback_with_success() {
-                    var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
-                    var publishedMessage: ARTMessage?
+        channel.publish(nil, data: PublishArgs.data) { error in
+            publishError = error
+            channel.history { result, _ in
+                publishedMessage = result?.items.first
+            }
+        }
 
-                    channel.publish(nil, data: PublishArgs.data) { error in
-                        publishError = error
-                        channel.history { result, _ in
-                            publishedMessage = result?.items.first
-                        }
-                    }
+        expect(publishError).toEventually(beNil(), timeout: testTimeout)
+        expect(publishedMessage?.name).toEventually(beNil(), timeout: testTimeout)
+        expect(publishedMessage?.data as? String).toEventually(equal(PublishArgs.data), timeout: testTimeout)
+    }
 
-                    expect(publishError).toEventually(beNil(), timeout: testTimeout)
-                    expect(publishedMessage?.name).toEventually(beNil(), timeout: testTimeout)
-                    expect(publishedMessage?.data as? String).toEventually(equal(PublishArgs.data), timeout: testTimeout)
-                }
+    // RSL1b, RSL1e
 
-            // RSL1b, RSL1e
-            
-                func test__008__publish__with_neither_name_nor_data__publishes_the_message_and_invokes_callback_with_success() {
-                    var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
-                    var publishedMessage: ARTMessage?
+    func test__008__publish__with_neither_name_nor_data__publishes_the_message_and_invokes_callback_with_success() {
+        var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
+        var publishedMessage: ARTMessage?
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: nil) { error in
-                            publishError = error
-                            channel.history { result, _ in
-                                publishedMessage = result?.items.first
-                                done()
-                            }
-                        }
-                    }
-
-                    expect(publishError).to(beNil())
-                    expect(publishedMessage?.name).to(beNil())
-                    expect(publishedMessage?.data).to(beNil())
-                }
-
-            
-                func test__009__publish__with_a_Message_object__publishes_the_message_and_invokes_callback_with_success() {
-                    var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
-                    var publishedMessage: ARTMessage?
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish([ARTMessage(name: PublishArgs.name, data: PublishArgs.data)]) { error in
-                            publishError = error
-                            channel.history { result, _ in
-                                publishedMessage = result?.items.first
-                                done()
-                            }
-                        }
-                    }
-
-                    expect(publishError).to(beNil())
-                    expect(publishedMessage?.name).to(equal(PublishArgs.name))
-                    expect(publishedMessage?.data as? String).to(equal(PublishArgs.data))
-                }
-
-            // RSL1c
-            
-                func test__010__publish__with_an_array_of_Message_objects__publishes_the_messages_in_a_single_request_and_invokes_callback_with_success() {
-                    let oldExecutor = client.internal.httpExecutor
-                    defer { client.internal.httpExecutor = oldExecutor}
-                    client.internal.httpExecutor = testHTTPExecutor
-
-                    var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
-                    var publishedMessages: [ARTMessage] = []
-
-                    let messages = [
-                        ARTMessage(name: "bar", data: "foo"),
-                        ARTMessage(name: "bat", data: "baz")
-                    ]
-                    channel.publish(messages) { error in
-                        publishError = error
-                        client.internal.httpExecutor = oldExecutor
-                        channel.history { result, _ in
-                            if let items = result?.items {
-                                publishedMessages.append(contentsOf:items)
-                            }
-                        }
-                    }
-
-                    expect(publishError).toEventually(beNil(), timeout: testTimeout)
-                    expect(publishedMessages.count).toEventually(equal(messages.count), timeout: testTimeout)
-                    for (i, publishedMessage) in publishedMessages.reversed().enumerated() {
-                        expect(publishedMessage.data as? NSObject).to(equal(messages[i].data as? NSObject))
-                        expect(publishedMessage.name).to(equal(messages[i].name))
-                    }
-                    expect(testHTTPExecutor.requests.count).to(equal(1))
-                }
-
-            // RSL1f
-            
-                // RSL1f1
-                func test__011__publish__Unidentified_clients_using_Basic_Auth__should_publish_message_with_the_provided_clientId() {
-                    let client = ARTRest(options: AblyTests.commonAppSetup())
-                    let channel = client.channels.get("test")
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish([ARTMessage(name: nil, data: "message", clientId: "tester")]) { error in
-                            expect(error).to(beNil())
-                            expect(client.auth.internal.method).to(equal(ARTAuthMethod.basic))
-                            channel.history { page, error in
-                                expect(error).to(beNil())
-                                guard let page = page else {
-                                    fail("Page is empty"); done(); return
-                                }
-                                guard let item = page.items.first else {
-                                    fail("First item does not exist"); done(); return
-                                }
-                                expect(item.clientId).to(equal("tester"))
-                                done()
-                            }
-                        }
-                    }
-                }
-
-            // RSA7e
-            
-
-                // RSA7e1
-                func test__012__publish__ClientOptions_clientId__should_include_the_clientId_as_a_querystring_parameter_in_realtime_connection_requests() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john-doe"
-                    let client = AblyTests.newRealtime(options)
-                    defer { client.dispose(); client.close() }
-                    waitUntil(timeout: testTimeout) { done in
-                        client.channels.get("RSA7e1")
-                            .publish(nil, data: "foo") { error in
-                                expect(error).to(beNil())
-                                guard let connection = client.internal.transport as? TestProxyTransport else {
-                                    fail("No connection found")
-                                    return
-                                }
-                                expect(connection.lastUrl!.query).to(haveParam("clientId", withValue: options.clientId))
-                                done()
-                            }
-                    }
-                }
-
-                // RSA7e2
-                func test__013__publish__ClientOptions_clientId__should_include_an_X_Ably_ClientId_header_with_value_set_to_the_clientId_as_Base64_encoded_string_in_REST_connection_requests() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "john-doe"
-                    let client = ARTRest(options: options)
-                    testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                    client.internal.httpExecutor = testHTTPExecutor
-                    waitUntil(timeout: testTimeout) { done in
-                        client.channels.get("RSA7e1")
-                            .publish(nil, data: "foo") { error in
-                                expect(error).to(beNil())
-                                guard let request = testHTTPExecutor.requests.first else {
-                                    fail("No request found")
-                                    return
-                                }
-                                let clientIdBase64Encoded = options.clientId?
-                                    .data(using: .utf8)?
-                                    .base64EncodedString()
-                                expect(request.allHTTPHeaderFields?["X-Ably-ClientId"]).to(equal(clientIdBase64Encoded))
-                                done()
-                            }
-                    }
-                }
-
-            // RSL1m
-            
-
-                // RSL1m1
-                func test__014__publish__Message_clientId__publishing_with_no_clientId_when_the_clientId_is_set_to_some_value_in_the_client_options_should_result_in_a_message_received_with_the_clientId_property_set_to_that_value() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "client-rest"
-                    let expectedClientId = options.clientId
-                    let rest = ARTRest(options: options)
-                    options.clientId = "client-realtime"
-                    let realtime = ARTRealtime(options: options)
-
-                    let subscriber = realtime.channels.get("ch1")
-                    waitUntil(timeout: testTimeout) { done in
-                        subscriber.once(.attached) { _ in
-                            done()
-                        }
-                    }
-
-                    let publisher = rest.channels.get("ch1")
-                    waitUntil(timeout: testTimeout) { done in
-                        subscriber.subscribe { message in
-                            expect(message.clientId).to(equal(expectedClientId))
-                            subscriber.unsubscribe()
-                            done()
-                        }
-                        publisher.publish("check clientId", data: nil) { error in
-                            expect(error).to(beNil())
-                        }
-                    }
-                }
-
-                // RSL1m2
-                func test__015__publish__Message_clientId__publishing_with_a_clientId_set_to_the_same_value_as_the_clientId_in_the_client_options_should_result_in_a_message_received_with_the_clientId_property_set_to_that_value() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "client-rest"
-                    let expectedClientId = options.clientId!
-                    let rest = ARTRest(options: options)
-                    options.clientId = "client-realtime"
-                    let realtime = ARTRealtime(options: options)
-
-                    let subscriber = realtime.channels.get("ch1")
-                    waitUntil(timeout: testTimeout) { done in
-                        subscriber.once(.attached) { _ in
-                            done()
-                        }
-                    }
-
-                    let publisher = rest.channels.get("ch1")
-                    waitUntil(timeout: testTimeout) { done in
-                        subscriber.subscribe { message in
-                            expect(message.clientId).to(equal(expectedClientId))
-                            subscriber.unsubscribe()
-                            done()
-                        }
-                        publisher.publish("check clientId", data: nil, clientId: expectedClientId) { error in
-                            expect(error).to(beNil())
-                        }
-                    }
-                }
-
-                // RSL1m3
-                func test__016__publish__Message_clientId__publishing_with_a_clientId_set_to_a_value_from_an_unidentified_client_should_result_in_a_message_received_with_the_clientId_property_set_to_that_value() {
-                    let expectedClientId = "client-rest"
-                    let options = AblyTests.commonAppSetup()
-                    let rest = ARTRest(options: options)
-                    let realtime = ARTRealtime(options: options)
-
-                    let subscriber = realtime.channels.get("ch1")
-                    waitUntil(timeout: testTimeout) { done in
-                        subscriber.once(.attached) { _ in
-                            done()
-                        }
-                    }
-
-                    let publisher = rest.channels.get("ch1")
-                    waitUntil(timeout: testTimeout) { done in
-                        subscriber.subscribe { message in
-                            expect(message.clientId).to(equal(expectedClientId))
-                            subscriber.unsubscribe()
-                            done()
-                        }
-                        publisher.publish("check clientId", data: nil, clientId: expectedClientId) { error in
-                            expect(error).to(beNil())
-                        }
-                    }
-                }
-
-                // RSL1m4
-                func test__017__publish__Message_clientId__publishing_with_a_clientId_set_to_a_different_value_from_the_clientId_in_the_client_options_should_result_in_a_message_being_rejected_by_the_server() {
-                    let options = AblyTests.commonAppSetup()
-                    options.clientId = "client-rest"
-                    let rest = ARTRest(options: options)
-                    options.clientId = "client-realtime"
-                    let realtime = ARTRealtime(options: options)
-
-                    let subscriber = realtime.channels.get("ch1")
-                    waitUntil(timeout: testTimeout) { done in
-                        subscriber.once(.attached) { _ in
-                            done()
-                        }
-                    }
-
-                    let publisher = rest.channels.get("ch1")
-                    waitUntil(timeout: testTimeout) { done in
-                        subscriber.subscribe { message in
-                            fail("Should not receive the message")
-                        }
-                        publisher.publish("check clientId", data: nil, clientId: "foo") { error in
-                            expect(error?.code).to(equal(Int(ARTState.mismatchedClientId.rawValue)))
-                            done()
-                        }
-                    }
-                }
-
-            // https://github.com/ably/ably-cocoa/issues/1074 and related with RSL1m
-            func test__001__publish__should_not_fail_sending_a_message_with_no_clientId_in_the_client_options_and_credentials_that_can_assume_any_clientId() {
-                let options = AblyTests.clientOptions()
-                options.authCallback = { _, callback in
-                    getTestTokenDetails(clientId: "*") { token, error in
-                        callback(token, error)
-                    }
-                }
-
-                let rest = ARTRest(options: options)
-                let channel = rest.channels.get("#1074")
-
-                waitUntil(timeout: testTimeout) { done in
-                    // The first attempt encodes the message before requesting auth credentials so there's no clientId
-                    channel.publish("first message", data: nil) { error in
-                        expect(error).to(beNil())
-                        done()
-                    }
-                }
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.publish("second message", data: nil) { error in
-                        expect(error).to(beNil())
-                        done()
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: nil) { error in
+                publishError = error
+                channel.history { result, _ in
+                    publishedMessage = result?.items.first
+                    done()
                 }
             }
+        }
 
-            // RSL1h
-            func test__002__publish__should_provide_an_optional_argument_that_allows_the_clientId_value_to_be_specified() {
-                let options = AblyTests.commonAppSetup()
-                options.clientId = "john"
-                let client = ARTRest(options: options)
-                let channel = client.channels.get("test")
-                waitUntil(timeout: testTimeout) { done in
-                    channel.publish("name", data: "some data", clientId: "tester") { error in
-                        expect(error!.message).to(contain("invalid clientId"))
-                        done()
-                    }
+        expect(publishError).to(beNil())
+        expect(publishedMessage?.name).to(beNil())
+        expect(publishedMessage?.data).to(beNil())
+    }
+
+    func test__009__publish__with_a_Message_object__publishes_the_message_and_invokes_callback_with_success() {
+        var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
+        var publishedMessage: ARTMessage?
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish([ARTMessage(name: PublishArgs.name, data: PublishArgs.data)]) { error in
+                publishError = error
+                channel.history { result, _ in
+                    publishedMessage = result?.items.first
+                    done()
                 }
             }
+        }
 
-            // RSL1h, RSL6a2
-            func test__003__publish__should_provide_an_optional_argument_that_allows_the_extras_value_to_be_specified() {
-                let options = AblyTests.commonAppSetup()
-                // Prevent channel name to be prefixed by test-*
-                options.channelNamePrefix = nil
-                let client = ARTRest(options: options)
-                let channel = client.channels.get("pushenabled:test")
-                let extras = ["notification": ["title": "Hello from Ably!"]] as ARTJsonCompatible
+        expect(publishError).to(beNil())
+        expect(publishedMessage?.name).to(equal(PublishArgs.name))
+        expect(publishedMessage?.data as? String).to(equal(PublishArgs.data))
+    }
 
-                expect((client.internal.encoders["application/json"] as! ARTJsonLikeEncoder).message(from: [
-                    "data": "foo",
-                    "extras": ["notification": ["title": "Hello from Ably!"]]
-                ])?.extras == extras).to(beTrue())
+    // RSL1c
 
-                waitUntil(timeout: testTimeout) { done in
-                    channel.publish("name", data: "some data", extras: extras) { error in
-                        if let error = error {
-                            fail("unexpected error \(error)")
-                            done(); return
-                        }
+    func test__010__publish__with_an_array_of_Message_objects__publishes_the_messages_in_a_single_request_and_invokes_callback_with_success() {
+        let oldExecutor = client.internal.httpExecutor
+        defer { client.internal.httpExecutor = oldExecutor }
+        client.internal.httpExecutor = testHTTPExecutor
 
-                        let query = ARTDataQuery()
-                        query.limit = 1
+        var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
+        var publishedMessages: [ARTMessage] = []
 
-                        try! channel.history(query) { messages, error in
-                            if let error = error {
-                                fail("unexpected error \(error)")
-                                done(); return
-                            }
-                            guard let message = messages?.items.first else {
-                                fail("expected published message in history")
-                                done(); return
-                            }
-                            expect(message.extras == extras).to(beTrue())
-                            done()
-                        }
-                    }
+        let messages = [
+            ARTMessage(name: "bar", data: "foo"),
+            ARTMessage(name: "bat", data: "baz"),
+        ]
+        channel.publish(messages) { error in
+            publishError = error
+            client.internal.httpExecutor = oldExecutor
+            channel.history { result, _ in
+                if let items = result?.items {
+                    publishedMessages.append(contentsOf: items)
                 }
             }
+        }
 
-            // RSL1i
-            
+        expect(publishError).toEventually(beNil(), timeout: testTimeout)
+        expect(publishedMessages.count).toEventually(equal(messages.count), timeout: testTimeout)
+        for (i, publishedMessage) in publishedMessages.reversed().enumerated() {
+            expect(publishedMessage.data as? NSObject).to(equal(messages[i].data as? NSObject))
+            expect(publishedMessage.name).to(equal(messages[i].name))
+        }
+        expect(testHTTPExecutor.requests.count).to(equal(1))
+    }
 
-                func test__018__publish__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_the_publish_and_indicate_an_error() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRest(options: options)
-                    let channel = client.channels.get(channelName)
-                    let messages = buildMessagesThatExceedMaxMessageSize()
+    // RSL1f
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(messages) { error in
-                            expect(error?.code).to(equal(ARTErrorCode.maxMessageLengthExceeded.intValue))
-                            done()
-                        }
+    // RSL1f1
+    func test__011__publish__Unidentified_clients_using_Basic_Auth__should_publish_message_with_the_provided_clientId() {
+        let client = ARTRest(options: AblyTests.commonAppSetup())
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish([ARTMessage(name: nil, data: "message", clientId: "tester")]) { error in
+                expect(error).to(beNil())
+                expect(client.auth.internal.method).to(equal(ARTAuthMethod.basic))
+                channel.history { page, error in
+                    expect(error).to(beNil())
+                    guard let page = page else {
+                        fail("Page is empty"); done(); return
                     }
+                    guard let item = page.items.first else {
+                        fail("First item does not exist"); done(); return
+                    }
+                    expect(item.clientId).to(equal("tester"))
+                    done()
                 }
-
-                func test__019__publish__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__also_when_using_publish_data_clientId_extras() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRest(options: options)
-                    let channel = client.channels.get(channelName)
-                    let name = buildStringThatExceedMaxMessageSize()
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(name, data: nil, extras: nil) { error in
-                            expect(error?.code).to(equal(ARTErrorCode.maxMessageLengthExceeded.intValue))
-                            done()
-                        }
-                    }
-                }
-
-            // RSL1k
-            
-
-                // TO3n
-                func test__020__publish__idempotent_publishing__idempotentRestPublishing_option() {
-                    expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "2")) == true
-                    expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "2.0.0")) == true
-                    expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "1.1")) == false
-                    expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "1.1.2")) == false
-                    expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "1.2")) == true
-                    expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "1.2.2")) == true
-                    expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "1.0")) == false
-                    expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "1.0.5")) == false
-                    expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "0.9")) == false
-                    expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "0.9.1")) == false
-
-                    // Current version
-                    let options = AblyTests.clientOptions()
-                    expect(options.idempotentRestPublishing) == true
-                }
-
-                // RSL1k1
-                
-
-                    func test__027__publish__idempotent_publishing__random_idempotent_publish_id__should_generate_for_one_message_with_empty_id() {
-                        let message = ARTMessage(name: nil, data: "foo")
-                        expect(message.id).to(beNil())
-
-                        let rest = ARTRest(key: "xxxx:xxxx")
-                        rest.internal.options.idempotentRestPublishing = true
-                        let mockHTTPExecutor = MockHTTPExecutor()
-                        rest.internal.httpExecutor = mockHTTPExecutor
-                        let channel = rest.channels.get("idempotent")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish([message]) { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        guard let encodedBody = mockHTTPExecutor.requests.last?.httpBody else {
-                            fail("Body from the last request is empty"); return
-                        }
-
-                        let json = AblyTests.msgpackToJSON(encodedBody)
-                        assertMessagePayloadId(id: json.arrayValue.first?["id"].string, expectedSerial: "0")
-                        expect(message.id).to(beNil())
-                    }
-
-                    func test__028__publish__idempotent_publishing__random_idempotent_publish_id__should_generate_for_multiple_messages_with_empty_id() {
-                        let message1 = ARTMessage(name: nil, data: "foo1")
-                        expect(message1.id).to(beNil())
-                        let message2 = ARTMessage(name: "john", data: "foo2")
-                        expect(message2.id).to(beNil())
-
-                        let rest = ARTRest(key: "xxxx:xxxx")
-                        rest.internal.options.idempotentRestPublishing = true
-                        let mockHTTPExecutor = MockHTTPExecutor()
-                        rest.internal.httpExecutor = mockHTTPExecutor
-                        let channel = rest.channels.get("idempotent")
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish([message1, message2]) { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-
-                        guard let encodedBody = mockHTTPExecutor.requests.last?.httpBody else {
-                            fail("Body from the last request is empty"); return
-                        }
-
-                        let json = AblyTests.msgpackToJSON(encodedBody)
-                        let id1 = json.arrayValue.first?["id"].string
-                        assertMessagePayloadId(id: id1, expectedSerial: "0")
-                        let id2 = json.arrayValue.last?["id"].string
-                        assertMessagePayloadId(id: id2, expectedSerial: "1")
-
-                        // Same Base ID
-                        expect(id1?.split(separator: ":").first).to(equal(id2?.split(separator: ":").first))
-                    }
-
-                // RSL1k2
-                func test__021__publish__idempotent_publishing__should_not_generate_for_message_with_a_non_empty_id() {
-                    let message = ARTMessage(name: nil, data: "foo")
-                    message.id = "123"
-
-                    let rest = ARTRest(key: "xxxx:xxxx")
-                    rest.internal.options.idempotentRestPublishing = true
-                    let mockHTTPExecutor = MockHTTPExecutor()
-                    rest.internal.httpExecutor = mockHTTPExecutor
-                    let channel = rest.channels.get("idempotent")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish([message]) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    guard let encodedBody = mockHTTPExecutor.requests.last?.httpBody else {
-                        fail("Body from the last request is empty"); return
-                    }
-
-                    let json = AblyTests.msgpackToJSON(encodedBody)
-                    expect(json.arrayValue.first?["id"].string).to(equal("123"))
-                }
-
-                func test__022__publish__idempotent_publishing__should_generate_for_internal_message_that_is_created_in_publish_name_data___method() {
-                    let rest = ARTRest(key: "xxxx:xxxx")
-                    rest.internal.options.idempotentRestPublishing = true
-                    let mockHTTPExecutor = MockHTTPExecutor()
-                    rest.internal.httpExecutor = mockHTTPExecutor
-                    let channel = rest.channels.get("idempotent")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish("john", data: "foo") { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    guard let encodedBody = mockHTTPExecutor.requests.last?.httpBody else {
-                        fail("Body from the last request is empty"); return
-                    }
-
-                    let json = AblyTests.msgpackToJSON(encodedBody)
-                    assertMessagePayloadId(id: json["id"].string, expectedSerial: "0")
-                }
-
-                // RSL1k3
-                func test__023__publish__idempotent_publishing__should_not_generate_for_multiple_messages_with_a_non_empty_id() {
-                    let message1 = ARTMessage(name: nil, data: "foo1")
-                    expect(message1.id).to(beNil())
-                    let message2 = ARTMessage(name: "john", data: "foo2")
-                    message2.id = "123"
-
-                    let rest = ARTRest(key: "xxxx:xxxx")
-                    rest.internal.options.idempotentRestPublishing = true
-                    let mockHTTPExecutor = MockHTTPExecutor()
-                    rest.internal.httpExecutor = mockHTTPExecutor
-                    let channel = rest.channels.get("idempotent")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish([message1, message2]) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    guard let encodedBody = mockHTTPExecutor.requests.last?.httpBody else {
-                        fail("Body from the last request is empty"); return
-                    }
-
-                    let json = AblyTests.msgpackToJSON(encodedBody)
-                    expect(json.arrayValue.first?["id"].string).to(beNil())
-                    expect(json.arrayValue.last?["id"].string).to(equal("123"))
-                }
-
-                func test__024__publish__idempotent_publishing__should_not_generate_when_idempotentRestPublishing_flag_is_off() {
-                    let options = ARTClientOptions(key: "xxxx:xxxx")
-                    options.idempotentRestPublishing = false
-
-                    let message1 = ARTMessage(name: nil, data: "foo1")
-                    expect(message1.id).to(beNil())
-                    let message2 = ARTMessage(name: "john", data: "foo2")
-                    expect(message2.id).to(beNil())
-
-                    let rest = ARTRest(options: options)
-                    let mockHTTPExecutor = MockHTTPExecutor()
-                    rest.internal.httpExecutor = mockHTTPExecutor
-                    let channel = rest.channels.get("idempotent")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish([message1, message2]) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-
-                    guard let encodedBody = mockHTTPExecutor.requests.last?.httpBody else {
-                        fail("Body from the last request is empty"); return
-                    }
-
-                    let json = AblyTests.msgpackToJSON(encodedBody)
-                    expect(json.arrayValue.first?["id"].string).to(beNil())
-                    expect(json.arrayValue.last?["id"].string).to(beNil())
-                }
-
-                // RSL1k4
-                func test__025__publish__idempotent_publishing__should_have_only_one_published_message() {
-                    client.internal.options.idempotentRestPublishing = true
-                    client.internal.httpExecutor = testHTTPExecutor
-                    client.internal.options.fallbackHostsUseDefault = true
-
-                    let forceRetryError = ErrorSimulator(
-                        value: ARTErrorCode.internalError.intValue,
-                        description: "force retry",
-                        statusCode: 500,
-                        shouldPerformRequest: true,
-                        stubData: nil
-                    )
-
-                    testHTTPExecutor.simulateIncomingServerErrorOnNextRequest(forceRetryError)
-
-                    let messages = [
-                        ARTMessage(name: nil, data: "test1"),
-                        ARTMessage(name: nil, data: "test2"),
-                        ARTMessage(name: nil, data: "test3"),
-                    ]
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(messages) { error in
-                            expect(error).toNot(beNil())
-                            done()
-                        }
-                    }
-
-                    expect(testHTTPExecutor.requests.count) == 2
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.history { result, error in
-                            expect(error).to(beNil())
-                            guard let result = result else {
-                                fail("No result"); done(); return
-                            }
-                            expect(result.items.count) == 3
-                            done()
-                        }
-                    }
-                }
-
-                // RSL1k5
-                func test__026__publish__idempotent_publishing__should_publish_a_message_with_implicit_Id_only_once() {
-                    let options = AblyTests.commonAppSetup()
-                    let rest = ARTRest(options: options)
-                    rest.internal.options.idempotentRestPublishing = true
-                    let channel = rest.channels.get("idempotent")
-
-                    let message = ARTMessage(name: "unique", data: "foo")
-                    message.id = "123"
-
-                    for _ in 1...4 {
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish([message]) { error in
-                                expect(error).to(beNil())
-                                done()
-                            }
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.history { result, error in
-                            expect(error).to(beNil())
-                            guard let result = result else {
-                                fail("No result"); done(); return
-                            }
-                            expect(result.items.count) == 1
-                            expect(result.items.first?.id).to(equal("123"))
-                            done()
-                        }
-                    }
-                }
-          
-            // RSL1j
-            func test__004__publish__should_include_attributes_supplied_by_the_caller_in_the_encoded_message() {
-                let options = AblyTests.commonAppSetup()
-                let client = ARTRest(options: options)
-                let proxyHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                client.internal.httpExecutor = proxyHTTPExecutor
-
-                let channel = client.channels.get("foo")
-                let message = ARTMessage(name: nil, data: "")
-                message.id = "123"
-                message.name = "tester"
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.publish([message]) { error in
-                        expect(error).to(beNil())
-                        done()
-                    }
-                }
-
-                guard let encodedBody = proxyHTTPExecutor.requests.last?.httpBody else {
-                    fail("Body from the last request is empty"); return
-                }
-
-                guard let jsonMessage = AblyTests.msgpackToJSON(encodedBody).array?.first else {
-                    fail("Body from the last request is invalid"); return
-                }
-                expect(jsonMessage["name"].string).to(equal("tester"))
-                expect(jsonMessage["data"].string).to(equal(""))
-                expect(jsonMessage["id"].string).to(equal(message.id))
             }
+        }
+    }
 
-        // RSL2
-        
+    // RSA7e
 
-            // RSL2a
-            func test__029__history__should_return_a_PaginatedResult_page_containing_the_first_page_of_messages() {
-                let client = ARTRest(options: AblyTests.commonAppSetup())
-                let channel = client.channels.get("foo")
+    // RSA7e1
+    func test__012__publish__ClientOptions_clientId__should_include_the_clientId_as_a_querystring_parameter_in_realtime_connection_requests() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john-doe"
+        let client = AblyTests.newRealtime(options)
+        defer { client.dispose(); client.close() }
+        waitUntil(timeout: testTimeout) { done in
+            client.channels.get("RSA7e1")
+                .publish(nil, data: "foo") { error in
+                    expect(error).to(beNil())
+                    guard let connection = client.internal.transport as? TestProxyTransport else {
+                        fail("No connection found")
+                        return
+                    }
+                    expect(connection.lastUrl!.query).to(haveParam("clientId", withValue: options.clientId))
+                    done()
+                }
+        }
+    }
 
-                waitUntil(timeout: testTimeout) { done in
-                    channel.publish([
-                        .init(name: nil, data: "m1"),
-                        .init(name: nil, data: "m2"),
-                        .init(name: nil, data: "m3"),
-                        .init(name: nil, data: "m4"),
-                        .init(name: nil, data: "m5"),
-                    ],
-                    callback: { error in
-                        expect(error).to(beNil())
-                        done()
-                    })
+    // RSA7e2
+    func test__013__publish__ClientOptions_clientId__should_include_an_X_Ably_ClientId_header_with_value_set_to_the_clientId_as_Base64_encoded_string_in_REST_connection_requests() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john-doe"
+        let client = ARTRest(options: options)
+        testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = testHTTPExecutor
+        waitUntil(timeout: testTimeout) { done in
+            client.channels.get("RSA7e1")
+                .publish(nil, data: "foo") { error in
+                    expect(error).to(beNil())
+                    guard let request = testHTTPExecutor.requests.first else {
+                        fail("No request found")
+                        return
+                    }
+                    let clientIdBase64Encoded = options.clientId?
+                        .data(using: .utf8)?
+                        .base64EncodedString()
+                    expect(request.allHTTPHeaderFields?["X-Ably-ClientId"]).to(equal(clientIdBase64Encoded))
+                    done()
+                }
+        }
+    }
+
+    // RSL1m
+
+    // RSL1m1
+    func test__014__publish__Message_clientId__publishing_with_no_clientId_when_the_clientId_is_set_to_some_value_in_the_client_options_should_result_in_a_message_received_with_the_clientId_property_set_to_that_value() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "client-rest"
+        let expectedClientId = options.clientId
+        let rest = ARTRest(options: options)
+        options.clientId = "client-realtime"
+        let realtime = ARTRealtime(options: options)
+
+        let subscriber = realtime.channels.get("ch1")
+        waitUntil(timeout: testTimeout) { done in
+            subscriber.once(.attached) { _ in
+                done()
+            }
+        }
+
+        let publisher = rest.channels.get("ch1")
+        waitUntil(timeout: testTimeout) { done in
+            subscriber.subscribe { message in
+                expect(message.clientId).to(equal(expectedClientId))
+                subscriber.unsubscribe()
+                done()
+            }
+            publisher.publish("check clientId", data: nil) { error in
+                expect(error).to(beNil())
+            }
+        }
+    }
+
+    // RSL1m2
+    func test__015__publish__Message_clientId__publishing_with_a_clientId_set_to_the_same_value_as_the_clientId_in_the_client_options_should_result_in_a_message_received_with_the_clientId_property_set_to_that_value() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "client-rest"
+        let expectedClientId = options.clientId!
+        let rest = ARTRest(options: options)
+        options.clientId = "client-realtime"
+        let realtime = ARTRealtime(options: options)
+
+        let subscriber = realtime.channels.get("ch1")
+        waitUntil(timeout: testTimeout) { done in
+            subscriber.once(.attached) { _ in
+                done()
+            }
+        }
+
+        let publisher = rest.channels.get("ch1")
+        waitUntil(timeout: testTimeout) { done in
+            subscriber.subscribe { message in
+                expect(message.clientId).to(equal(expectedClientId))
+                subscriber.unsubscribe()
+                done()
+            }
+            publisher.publish("check clientId", data: nil, clientId: expectedClientId) { error in
+                expect(error).to(beNil())
+            }
+        }
+    }
+
+    // RSL1m3
+    func test__016__publish__Message_clientId__publishing_with_a_clientId_set_to_a_value_from_an_unidentified_client_should_result_in_a_message_received_with_the_clientId_property_set_to_that_value() {
+        let expectedClientId = "client-rest"
+        let options = AblyTests.commonAppSetup()
+        let rest = ARTRest(options: options)
+        let realtime = ARTRealtime(options: options)
+
+        let subscriber = realtime.channels.get("ch1")
+        waitUntil(timeout: testTimeout) { done in
+            subscriber.once(.attached) { _ in
+                done()
+            }
+        }
+
+        let publisher = rest.channels.get("ch1")
+        waitUntil(timeout: testTimeout) { done in
+            subscriber.subscribe { message in
+                expect(message.clientId).to(equal(expectedClientId))
+                subscriber.unsubscribe()
+                done()
+            }
+            publisher.publish("check clientId", data: nil, clientId: expectedClientId) { error in
+                expect(error).to(beNil())
+            }
+        }
+    }
+
+    // RSL1m4
+    func test__017__publish__Message_clientId__publishing_with_a_clientId_set_to_a_different_value_from_the_clientId_in_the_client_options_should_result_in_a_message_being_rejected_by_the_server() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "client-rest"
+        let rest = ARTRest(options: options)
+        options.clientId = "client-realtime"
+        let realtime = ARTRealtime(options: options)
+
+        let subscriber = realtime.channels.get("ch1")
+        waitUntil(timeout: testTimeout) { done in
+            subscriber.once(.attached) { _ in
+                done()
+            }
+        }
+
+        let publisher = rest.channels.get("ch1")
+        waitUntil(timeout: testTimeout) { done in
+            subscriber.subscribe { _ in
+                fail("Should not receive the message")
+            }
+            publisher.publish("check clientId", data: nil, clientId: "foo") { error in
+                expect(error?.code).to(equal(Int(ARTState.mismatchedClientId.rawValue)))
+                done()
+            }
+        }
+    }
+
+    // https://github.com/ably/ably-cocoa/issues/1074 and related with RSL1m
+    func test__001__publish__should_not_fail_sending_a_message_with_no_clientId_in_the_client_options_and_credentials_that_can_assume_any_clientId() {
+        let options = AblyTests.clientOptions()
+        options.authCallback = { _, callback in
+            getTestTokenDetails(clientId: "*") { token, error in
+                callback(token, error)
+            }
+        }
+
+        let rest = ARTRest(options: options)
+        let channel = rest.channels.get("#1074")
+
+        waitUntil(timeout: testTimeout) { done in
+            // The first attempt encodes the message before requesting auth credentials so there's no clientId
+            channel.publish("first message", data: nil) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish("second message", data: nil) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RSL1h
+    func test__002__publish__should_provide_an_optional_argument_that_allows_the_clientId_value_to_be_specified() {
+        let options = AblyTests.commonAppSetup()
+        options.clientId = "john"
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("test")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish("name", data: "some data", clientId: "tester") { error in
+                expect(error!.message).to(contain("invalid clientId"))
+                done()
+            }
+        }
+    }
+
+    // RSL1h, RSL6a2
+    func test__003__publish__should_provide_an_optional_argument_that_allows_the_extras_value_to_be_specified() {
+        let options = AblyTests.commonAppSetup()
+        // Prevent channel name to be prefixed by test-*
+        options.channelNamePrefix = nil
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("pushenabled:test")
+        let extras = ["notification": ["title": "Hello from Ably!"]] as ARTJsonCompatible
+
+        expect((client.internal.encoders["application/json"] as! ARTJsonLikeEncoder).message(from: [
+            "data": "foo",
+            "extras": ["notification": ["title": "Hello from Ably!"]],
+        ])?.extras == extras).to(beTrue())
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish("name", data: "some data", extras: extras) { error in
+                if let error = error {
+                    fail("unexpected error \(error)")
+                    done(); return
                 }
 
                 let query = ARTDataQuery()
-                query.direction = .forwards
-                query.limit = 2
+                query.limit = 1
 
-                try! channel.history(query) { result, error in
+                try! channel.history(query) { messages, error in
+                    if let error = error {
+                        fail("unexpected error \(error)")
+                        done(); return
+                    }
+                    guard let message = messages?.items.first else {
+                        fail("expected published message in history")
+                        done(); return
+                    }
+                    expect(message.extras == extras).to(beTrue())
+                    done()
+                }
+            }
+        }
+    }
+
+    // RSL1i
+
+    func test__018__publish__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_the_publish_and_indicate_an_error() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRest(options: options)
+        let channel = client.channels.get(channelName)
+        let messages = buildMessagesThatExceedMaxMessageSize()
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(messages) { error in
+                expect(error?.code).to(equal(ARTErrorCode.maxMessageLengthExceeded.intValue))
+                done()
+            }
+        }
+    }
+
+    func test__019__publish__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__also_when_using_publish_data_clientId_extras() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRest(options: options)
+        let channel = client.channels.get(channelName)
+        let name = buildStringThatExceedMaxMessageSize()
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(name, data: nil, extras: nil) { error in
+                expect(error?.code).to(equal(ARTErrorCode.maxMessageLengthExceeded.intValue))
+                done()
+            }
+        }
+    }
+
+    // RSL1k
+
+    // TO3n
+    func test__020__publish__idempotent_publishing__idempotentRestPublishing_option() {
+        expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "2")) == true
+        expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "2.0.0")) == true
+        expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "1.1")) == false
+        expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "1.1.2")) == false
+        expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "1.2")) == true
+        expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "1.2.2")) == true
+        expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "1.0")) == false
+        expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "1.0.5")) == false
+        expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "0.9")) == false
+        expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "0.9.1")) == false
+
+        // Current version
+        let options = AblyTests.clientOptions()
+        expect(options.idempotentRestPublishing) == true
+    }
+
+    // RSL1k1
+
+    func test__027__publish__idempotent_publishing__random_idempotent_publish_id__should_generate_for_one_message_with_empty_id() {
+        let message = ARTMessage(name: nil, data: "foo")
+        expect(message.id).to(beNil())
+
+        let rest = ARTRest(key: "xxxx:xxxx")
+        rest.internal.options.idempotentRestPublishing = true
+        let mockHTTPExecutor = MockHTTPExecutor()
+        rest.internal.httpExecutor = mockHTTPExecutor
+        let channel = rest.channels.get("idempotent")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish([message]) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let encodedBody = mockHTTPExecutor.requests.last?.httpBody else {
+            fail("Body from the last request is empty"); return
+        }
+
+        let json = AblyTests.msgpackToJSON(encodedBody)
+        assertMessagePayloadId(id: json.arrayValue.first?["id"].string, expectedSerial: "0")
+        expect(message.id).to(beNil())
+    }
+
+    func test__028__publish__idempotent_publishing__random_idempotent_publish_id__should_generate_for_multiple_messages_with_empty_id() {
+        let message1 = ARTMessage(name: nil, data: "foo1")
+        expect(message1.id).to(beNil())
+        let message2 = ARTMessage(name: "john", data: "foo2")
+        expect(message2.id).to(beNil())
+
+        let rest = ARTRest(key: "xxxx:xxxx")
+        rest.internal.options.idempotentRestPublishing = true
+        let mockHTTPExecutor = MockHTTPExecutor()
+        rest.internal.httpExecutor = mockHTTPExecutor
+        let channel = rest.channels.get("idempotent")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish([message1, message2]) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let encodedBody = mockHTTPExecutor.requests.last?.httpBody else {
+            fail("Body from the last request is empty"); return
+        }
+
+        let json = AblyTests.msgpackToJSON(encodedBody)
+        let id1 = json.arrayValue.first?["id"].string
+        assertMessagePayloadId(id: id1, expectedSerial: "0")
+        let id2 = json.arrayValue.last?["id"].string
+        assertMessagePayloadId(id: id2, expectedSerial: "1")
+
+        // Same Base ID
+        expect(id1?.split(separator: ":").first).to(equal(id2?.split(separator: ":").first))
+    }
+
+    // RSL1k2
+    func test__021__publish__idempotent_publishing__should_not_generate_for_message_with_a_non_empty_id() {
+        let message = ARTMessage(name: nil, data: "foo")
+        message.id = "123"
+
+        let rest = ARTRest(key: "xxxx:xxxx")
+        rest.internal.options.idempotentRestPublishing = true
+        let mockHTTPExecutor = MockHTTPExecutor()
+        rest.internal.httpExecutor = mockHTTPExecutor
+        let channel = rest.channels.get("idempotent")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish([message]) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let encodedBody = mockHTTPExecutor.requests.last?.httpBody else {
+            fail("Body from the last request is empty"); return
+        }
+
+        let json = AblyTests.msgpackToJSON(encodedBody)
+        expect(json.arrayValue.first?["id"].string).to(equal("123"))
+    }
+
+    func test__022__publish__idempotent_publishing__should_generate_for_internal_message_that_is_created_in_publish_name_data___method() {
+        let rest = ARTRest(key: "xxxx:xxxx")
+        rest.internal.options.idempotentRestPublishing = true
+        let mockHTTPExecutor = MockHTTPExecutor()
+        rest.internal.httpExecutor = mockHTTPExecutor
+        let channel = rest.channels.get("idempotent")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish("john", data: "foo") { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let encodedBody = mockHTTPExecutor.requests.last?.httpBody else {
+            fail("Body from the last request is empty"); return
+        }
+
+        let json = AblyTests.msgpackToJSON(encodedBody)
+        assertMessagePayloadId(id: json["id"].string, expectedSerial: "0")
+    }
+
+    // RSL1k3
+    func test__023__publish__idempotent_publishing__should_not_generate_for_multiple_messages_with_a_non_empty_id() {
+        let message1 = ARTMessage(name: nil, data: "foo1")
+        expect(message1.id).to(beNil())
+        let message2 = ARTMessage(name: "john", data: "foo2")
+        message2.id = "123"
+
+        let rest = ARTRest(key: "xxxx:xxxx")
+        rest.internal.options.idempotentRestPublishing = true
+        let mockHTTPExecutor = MockHTTPExecutor()
+        rest.internal.httpExecutor = mockHTTPExecutor
+        let channel = rest.channels.get("idempotent")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish([message1, message2]) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let encodedBody = mockHTTPExecutor.requests.last?.httpBody else {
+            fail("Body from the last request is empty"); return
+        }
+
+        let json = AblyTests.msgpackToJSON(encodedBody)
+        expect(json.arrayValue.first?["id"].string).to(beNil())
+        expect(json.arrayValue.last?["id"].string).to(equal("123"))
+    }
+
+    func test__024__publish__idempotent_publishing__should_not_generate_when_idempotentRestPublishing_flag_is_off() {
+        let options = ARTClientOptions(key: "xxxx:xxxx")
+        options.idempotentRestPublishing = false
+
+        let message1 = ARTMessage(name: nil, data: "foo1")
+        expect(message1.id).to(beNil())
+        let message2 = ARTMessage(name: "john", data: "foo2")
+        expect(message2.id).to(beNil())
+
+        let rest = ARTRest(options: options)
+        let mockHTTPExecutor = MockHTTPExecutor()
+        rest.internal.httpExecutor = mockHTTPExecutor
+        let channel = rest.channels.get("idempotent")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish([message1, message2]) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let encodedBody = mockHTTPExecutor.requests.last?.httpBody else {
+            fail("Body from the last request is empty"); return
+        }
+
+        let json = AblyTests.msgpackToJSON(encodedBody)
+        expect(json.arrayValue.first?["id"].string).to(beNil())
+        expect(json.arrayValue.last?["id"].string).to(beNil())
+    }
+
+    // RSL1k4
+    func test__025__publish__idempotent_publishing__should_have_only_one_published_message() {
+        client.internal.options.idempotentRestPublishing = true
+        client.internal.httpExecutor = testHTTPExecutor
+        client.internal.options.fallbackHostsUseDefault = true
+
+        let forceRetryError = ErrorSimulator(
+            value: ARTErrorCode.internalError.intValue,
+            description: "force retry",
+            statusCode: 500,
+            shouldPerformRequest: true,
+            stubData: nil
+        )
+
+        testHTTPExecutor.simulateIncomingServerErrorOnNextRequest(forceRetryError)
+
+        let messages = [
+            ARTMessage(name: nil, data: "test1"),
+            ARTMessage(name: nil, data: "test2"),
+            ARTMessage(name: nil, data: "test3"),
+        ]
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(messages) { error in
+                expect(error).toNot(beNil())
+                done()
+            }
+        }
+
+        expect(testHTTPExecutor.requests.count) == 2
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.history { result, error in
+                expect(error).to(beNil())
+                guard let result = result else {
+                    fail("No result"); done(); return
+                }
+                expect(result.items.count) == 3
+                done()
+            }
+        }
+    }
+
+    // RSL1k5
+    func test__026__publish__idempotent_publishing__should_publish_a_message_with_implicit_Id_only_once() {
+        let options = AblyTests.commonAppSetup()
+        let rest = ARTRest(options: options)
+        rest.internal.options.idempotentRestPublishing = true
+        let channel = rest.channels.get("idempotent")
+
+        let message = ARTMessage(name: "unique", data: "foo")
+        message.id = "123"
+
+        for _ in 1 ... 4 {
+            waitUntil(timeout: testTimeout) { done in
+                channel.publish([message]) { error in
+                    expect(error).to(beNil())
+                    done()
+                }
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.history { result, error in
+                expect(error).to(beNil())
+                guard let result = result else {
+                    fail("No result"); done(); return
+                }
+                expect(result.items.count) == 1
+                expect(result.items.first?.id).to(equal("123"))
+                done()
+            }
+        }
+    }
+
+    // RSL1j
+    func test__004__publish__should_include_attributes_supplied_by_the_caller_in_the_encoded_message() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRest(options: options)
+        let proxyHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        client.internal.httpExecutor = proxyHTTPExecutor
+
+        let channel = client.channels.get("foo")
+        let message = ARTMessage(name: nil, data: "")
+        message.id = "123"
+        message.name = "tester"
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish([message]) { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        guard let encodedBody = proxyHTTPExecutor.requests.last?.httpBody else {
+            fail("Body from the last request is empty"); return
+        }
+
+        guard let jsonMessage = AblyTests.msgpackToJSON(encodedBody).array?.first else {
+            fail("Body from the last request is invalid"); return
+        }
+        expect(jsonMessage["name"].string).to(equal("tester"))
+        expect(jsonMessage["data"].string).to(equal(""))
+        expect(jsonMessage["id"].string).to(equal(message.id))
+    }
+
+    // RSL2
+
+    // RSL2a
+    func test__029__history__should_return_a_PaginatedResult_page_containing_the_first_page_of_messages() {
+        let client = ARTRest(options: AblyTests.commonAppSetup())
+        let channel = client.channels.get("foo")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish([
+                .init(name: nil, data: "m1"),
+                .init(name: nil, data: "m2"),
+                .init(name: nil, data: "m3"),
+                .init(name: nil, data: "m4"),
+                .init(name: nil, data: "m5"),
+            ],
+            callback: { error in
+                expect(error).to(beNil())
+                done()
+            })
+        }
+
+        let query = ARTDataQuery()
+        query.direction = .forwards
+        query.limit = 2
+
+        try! channel.history(query) { result, error in
+            guard let result = result else {
+                fail("Result is empty"); return
+            }
+            expect(error).to(beNil())
+            expect(result.hasNext).to(beTrue())
+            expect(result.isLast).to(beFalse())
+            expect(result.items).to(haveCount(2))
+            let items = result.items.compactMap { $0.data as? String }
+            expect(items.first).to(equal("m1"))
+            expect(items.last).to(equal("m2"))
+
+            result.next { result, error in
+                guard let result = result else {
+                    fail("Result is empty"); return
+                }
+                expect(error).to(beNil())
+                expect(result.hasNext).to(beTrue())
+                expect(result.isLast).to(beFalse())
+                expect(result.items).to(haveCount(2))
+                let items = result.items.compactMap { $0.data as? String }
+                expect(items.first).to(equal("m3"))
+                expect(items.last).to(equal("m4"))
+
+                result.next { result, error in
                     guard let result = result else {
                         fail("Result is empty"); return
                     }
                     expect(error).to(beNil())
-                    expect(result.hasNext).to(beTrue())
-                    expect(result.isLast).to(beFalse())
-                    expect(result.items).to(haveCount(2))
-                    let items = result.items.compactMap({ $0.data as? String })
-                    expect(items.first).to(equal("m1"))
-                    expect(items.last).to(equal("m2"))
+                    expect(result.hasNext).to(beFalse())
+                    expect(result.isLast).to(beTrue())
+                    expect(result.items).to(haveCount(1))
+                    let items = result.items.compactMap { $0.data as? String }
+                    expect(items.first).to(equal("m5"))
 
-                    result.next { result, error in
+                    result.first { result, error in
                         guard let result = result else {
                             fail("Result is empty"); return
                         }
@@ -903,577 +917,537 @@ super.setUp()
                         expect(result.hasNext).to(beTrue())
                         expect(result.isLast).to(beFalse())
                         expect(result.items).to(haveCount(2))
-                        let items = result.items.compactMap({ $0.data as? String })
-                        expect(items.first).to(equal("m3"))
-                        expect(items.last).to(equal("m4"))
-
-                        result.next { result, error in
-                            guard let result = result else {
-                                fail("Result is empty"); return
-                            }
-                            expect(error).to(beNil())
-                            expect(result.hasNext).to(beFalse())
-                            expect(result.isLast).to(beTrue())
-                            expect(result.items).to(haveCount(1))
-                            let items = result.items.compactMap({ $0.data as? String })
-                            expect(items.first).to(equal("m5"))
-
-                            result.first { result, error in
-                                guard let result = result else {
-                                    fail("Result is empty"); return
-                                }
-                                expect(error).to(beNil())
-                                expect(result.hasNext).to(beTrue())
-                                expect(result.isLast).to(beFalse())
-                                expect(result.items).to(haveCount(2))
-                                let items = result.items.compactMap({ $0.data as? String })
-                                expect(items.first).to(equal("m1"))
-                                expect(items.last).to(equal("m2"))
-                            }
-                        }
+                        let items = result.items.compactMap { $0.data as? String }
+                        expect(items.first).to(equal("m1"))
+                        expect(items.last).to(equal("m2"))
                     }
                 }
             }
+        }
+    }
 
-            // RSL2b
-            
+    // RSL2b
 
-                // RSL2b1
-                func test__030__history__query_arguments__start_and_end_should_filter_messages_between_those_two_times() {
-                    let client = ARTRest(options: AblyTests.commonAppSetup())
-                    let channel = client.channels.get("test")
+    // RSL2b1
+    func test__030__history__query_arguments__start_and_end_should_filter_messages_between_those_two_times() {
+        let client = ARTRest(options: AblyTests.commonAppSetup())
+        let channel = client.channels.get("test")
 
-                    let query = ARTDataQuery()
-                    expect(query.direction) == ARTQueryDirection.backwards
-                    expect(query.limit) == 100
+        let query = ARTDataQuery()
+        expect(query.direction) == ARTQueryDirection.backwards
+        expect(query.limit) == 100
 
-                    waitUntil(timeout: testTimeout) { done in
-                        client.time { time, _ in
-                            query.start = time
-                            done()
-                        }
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            client.time { time, _ in
+                query.start = time
+                done()
+            }
+        }
 
-                    let messages = [
-                        ARTMessage(name: nil, data: "message1"),
-                        ARTMessage(name: nil, data: "message2")
-                    ]
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(messages) { _ in
-                            client.time { time, _ in
-                                query.end = time
-                                done()
-                            }
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        delay(0.2) {
-                            channel.publish(nil, data: "message3") { _ in
-                                done()
-                            }
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        try! channel.history(query) { result, error in
-                            expect(error).to(beNil())
-                            guard let result = result else {
-                                fail("PaginatedResult is empty"); done()
-                                return
-                            }
-                            expect(result.hasNext).to(beFalse())
-                            expect(result.isLast).to(beTrue())
-                            let items = result.items
-                            if items.count != 2 {
-                                fail("PaginatedResult has no items"); done()
-                                return
-                            }
-                            let messageItems = items.compactMap({ $0.data as? String })
-                            expect(messageItems.first).to(equal("message2"))
-                            expect(messageItems.last).to(equal("message1"))
-                            done()
-                        }
-                    }
-                }
-
-                // RSL2b1
-                func test__031__history__query_arguments__start_must_be_equal_to_or_less_than_end_and_is_unaffected_by_the_request_direction() {
-                    let client = ARTRest(options: AblyTests.commonAppSetup())
-                    let channel = client.channels.get("test")
-
-                    let query = ARTDataQuery()
-                    query.direction = .backwards
-                    query.end = NSDate() as Date
-                    query.start = query.end!.addingTimeInterval(10.0)
-
-                    expect { try channel.history(query) { _, _ in } }.to(throwError { (error: Error) in
-                        expect(error._code).to(equal(ARTDataQueryError.timestampRange.rawValue))
-                    })
-
-                    query.direction = .forwards
-
-                    expect { try channel.history(query) { _, _ in } }.to(throwError { (error: Error) in
-                        expect(error._code).to(equal(ARTDataQueryError.timestampRange.rawValue))
-                    })
-                }
-
-                // RSL2b2
-                func test__032__history__query_arguments__direction_backwards_or_forwards() {
-                    let client = ARTRest(options: AblyTests.commonAppSetup())
-                    let channel = client.channels.get("test")
-
-                    let query = ARTDataQuery()
-                    expect(query.direction) == ARTQueryDirection.backwards
-                    query.direction = .forwards
-
-                    let messages = [
-                        ARTMessage(name: nil, data: "message1"),
-                        ARTMessage(name: nil, data: "message2")
-                    ]
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(messages) { _ in
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        try! channel.history(query) { result, error in
-                            expect(error).to(beNil())
-                            guard let result = result else {
-                                fail("PaginatedResult is empty"); done()
-                                return
-                            }
-                            expect(result.hasNext).to(beFalse())
-                            expect(result.isLast).to(beTrue())
-                            let items = result.items
-                            if items.count != 2 {
-                                fail("PaginatedResult has no items"); done()
-                                return
-                            }
-                            let messageItems = items.compactMap({ $0.data as? String })
-                            expect(messageItems.first).to(equal("message1"))
-                            expect(messageItems.last).to(equal("message2"))
-                            done()
-                        }
-                    }
-                }
-
-                // RSL2b3
-                func test__033__history__query_arguments__limit_items_result() {
-                    let client = ARTRest(options: AblyTests.commonAppSetup())
-                    let channel = client.channels.get("test")
-
-                    let query = ARTDataQuery()
-                    expect(query.limit) == 100
-                    query.limit = 2
-
-                    let messages = (1...10).compactMap{ ARTMessage(name: nil, data: "message\($0)") }
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(messages) { _ in
-                            done()
-                        }
-                    }
-
-                    waitUntil(timeout: testTimeout) { done in
-                        try! channel.history(query) { result, error in
-                            expect(error).to(beNil())
-                            guard let result = result else {
-                                fail("PaginatedResult is empty"); done()
-                                return
-                            }
-                            expect(result.hasNext).to(beTrue())
-                            expect(result.isLast).to(beFalse())
-                            let items = result.items
-                            if items.count != 2 {
-                                fail("PaginatedResult has no items"); done()
-                                return
-                            }
-                            let messageItems = items.compactMap({ $0.data as? String })
-                            expect(messageItems.first).to(equal("message10"))
-                            expect(messageItems.last).to(equal("message9"))
-                            done()
-                        }
-                    }
-                }
-
-                // RSL2b3
-                func test__034__history__query_arguments__limit_supports_up_to_1000_items() {
-                    let client = ARTRest(options: AblyTests.commonAppSetup())
-                    let channel = client.channels.get("test")
-
-                    let query = ARTDataQuery()
-                    expect(query.limit) == 100
-
-                    query.limit = 1001
-                  expect{ try channel.history(query, callback: { _ , _  in }) }.to(throwError())
-
-                    query.limit = 1000
-                  expect{ try channel.history(query, callback: { _ , _  in }) }.toNot(throwError())
-                }
-
-        // RSL3, RSP1
-        
-
-            // RSP3
-            
-                func skipped__test__035__presence__get__should_return_presence_fixture_data() {
-                    let options = AblyTests.commonAppSetup()
-                    options.channelNamePrefix = nil
-                    client = ARTRest(options: options)
-                    let key = appSetupJson["cipher"]["key"].string!
-                    let cipherParams = ARTCipherParams.init(
-                        algorithm: appSetupJson["cipher"]["algorithm"].string!,
-                        key: key as ARTCipherKeyCompatible,
-                        iv: Data(base64Encoded: appSetupJson["cipher"]["iv"].string!, options: Data.Base64DecodingOptions.init(rawValue: 0))!
-                    )
-                    let channel = client.channels.get("persisted:presence_fixtures", options: ARTChannelOptions(cipher: cipherParams))
-                    var presenceMessages: [ARTPresenceMessage] = []
-
-                    channel.presence.get() { result, _ in
-                        if let items = result?.items {
-                            presenceMessages.append(contentsOf:items)
-                        }
-                        else {
-                            fail("expected items to not be empty")
-                        }
-                    }
-
-                    expect(presenceMessages.count).toEventually(equal(presenceFixtures.count), timeout: testTimeout)
-                    for message in presenceMessages {
-                        let fixtureMessage = presenceFixtures.filter({ (key, value) -> Bool in
-                            return message.clientId == value["clientId"].stringValue
-                        }).first!.1
-
-                        expect(message.data).toNot(beNil())
-                        expect(message.action).to(equal(ARTPresenceAction.present))
-
-                        let encodedFixture = channel.internal.dataEncoder.decode(
-                            fixtureMessage["data"].object,
-                            encoding:fixtureMessage.asDictionary!["encoding"] as? String
-                        )
-                        expect(message.data as? NSObject).to(equal(encodedFixture.data as? NSObject));
-                    }
-                }
-
-        // RSL4
-        
-
-            // RSL4a
-            func test__036__message_encoding__payloads_should_be_binary__strings__or_objects_capable_of_JSON_representation() {
-                let validCases: [TestCase]
-                if #available(iOS 11.0, *) {
-                    validCases = [
-                        TestCase(value: nil, expected: JSON([:])),
-                        TestCase(value: text, expected: JSON(["data": text])),
-                        TestCase(value: integer, expected: JSON(["data": integer])),
-                        TestCase(value: decimal, expected: JSON(["data": decimal])),
-                        TestCase(value: dictionary, expected: ["data": JSON(dictionary).rawString(options: [.sortedKeys])!, "encoding": "json"] as JSON),
-                        TestCase(value: array, expected: JSON(["data": JSON(array).rawString(options: [.sortedKeys])!, "encoding": "json"])),
-                        TestCase(value: binaryData, expected: JSON(["data": binaryData.toBase64, "encoding": "base64"])),
-                    ]
-                } else {
-                    validCases = [
-                        TestCase(value: nil, expected: JSON([:])),
-                        TestCase(value: text, expected: JSON(["data": text])),
-                        TestCase(value: integer, expected: JSON(["data": integer])),
-                        TestCase(value: decimal, expected: JSON(["data": decimal])),
-                        TestCase(value: dictionary, expected: ["data": JSON(dictionary).rawString()!, "encoding": "json"] as JSON),
-                        TestCase(value: array, expected: JSON(["data": JSON(array).rawString()!, "encoding": "json"])),
-                        TestCase(value: binaryData, expected: JSON(["data": binaryData.toBase64, "encoding": "base64"])),
-                    ]
-                }
-
-                client.internal.options.idempotentRestPublishing = false
-                client.internal.httpExecutor = testHTTPExecutor
-
-                validCases.forEach { caseTest in
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: caseTest.value) { error in
-                            expect(error).to(beNil())
-                            guard let httpBody = testHTTPExecutor.requests.last!.httpBody else {
-                                XCTFail("HTTPBody is nil");
-                                done(); return
-                            }
-                            var json = AblyTests.msgpackToJSON(httpBody)
-                            if let s = json["data"].string, let data = try? JSONSerialization.jsonObject(with: s.data(using: .utf8)!) {
-                                // Make sure the formatting is the same by parsing
-                                // and reformatting in the same way as the test case.
-                                if #available(iOS 11.0, *) {
-                                    json["data"] = JSON(JSON(data).rawString(options: [.sortedKeys])!)
-                                } else {
-                                    json["data"] = JSON(JSON(data).rawString()!)
-                                }
-                            }
-                            let mergedWithExpectedJSON = try! json.merged(with: caseTest.expected)
-                            expect(json).to(equal(mergedWithExpectedJSON))
-                            done()
-                        }
-                    }
-                }
-
-                let invalidCases = [5, 56.33, NSDate()] as [Any]
-
-                invalidCases.forEach { caseItem in
-                    waitUntil(timeout: testTimeout) { done in
-                        expect { channel.publish(nil, data: caseItem, callback: nil) }.toNot(raiseException())
-                        done()
-                    }
+        let messages = [
+            ARTMessage(name: nil, data: "message1"),
+            ARTMessage(name: nil, data: "message2"),
+        ]
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(messages) { _ in
+                client.time { time, _ in
+                    query.end = time
+                    done()
                 }
             }
+        }
 
-            // RSL4b
-            func test__037__message_encoding__encoding_attribute_should_represent_the_encoding_s__applied_in_right_to_left() {
-                let encodingCases = [
-                    TestCase(value: text, expected: JSON.null),
-                    TestCase(value: dictionary, expected: "json"),
-                    TestCase(value: array, expected: "json"),
-                    TestCase(value: binaryData, expected: "base64"),
-                ]
-
-                client.internal.httpExecutor = testHTTPExecutor
-
-                encodingCases.forEach { caseItem in
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: caseItem.value, callback: { error in
-                            expect(error).to(beNil())
-                            guard let httpBody = testHTTPExecutor.requests.last!.httpBody else {
-                                XCTFail("HTTPBody is nil");
-                                done(); return
-                            }
-                            expect(AblyTests.msgpackToJSON(httpBody)["encoding"]).to(equal(caseItem.expected))
-                            done()
-                        })
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            delay(0.2) {
+                channel.publish(nil, data: "message3") { _ in
+                    done()
                 }
             }
+        }
 
-            
-                // RSL4d1
-                func test__038__message_encoding__json__binary_payload_should_be_encoded_as_Base64_and_represented_as_a_JSON_string() {
-                    client.internal.httpExecutor = testHTTPExecutor
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: binaryData, callback: { error in
-                            expect(error).to(beNil())
-                            guard let httpBody = testHTTPExecutor.requests.last!.httpBody else {
-                                XCTFail("HTTPBody is nil");
-                                done(); return
-                            }
-                            // Binary
-                            let json = AblyTests.msgpackToJSON(httpBody)
-                            expect(json["data"].string).to(equal(binaryData.toBase64))
-                            expect(json["encoding"]).to(equal("base64"))
-                            done()
-                        })
-                    }
+        waitUntil(timeout: testTimeout) { done in
+            try! channel.history(query) { result, error in
+                expect(error).to(beNil())
+                guard let result = result else {
+                    fail("PaginatedResult is empty"); done()
+                    return
                 }
-
-                // RSL4d
-                func test__039__message_encoding__json__string_payload_should_be_represented_as_a_JSON_string() {
-                    client.internal.httpExecutor = testHTTPExecutor
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: text, callback: { error in
-                            expect(error).to(beNil())
-
-                            if let request = testHTTPExecutor.requests.last, let http = request.httpBody {
-                                // String (UTF-8)
-                                let json = AblyTests.msgpackToJSON(http)
-                                expect(json["data"].string).to(equal(text))
-                                expect(json["encoding"].string).to(beNil())
-                            }
-                            else {
-                                XCTFail("No request or HTTP body found")
-                            }
-                            done()
-                        })
-                    }
+                expect(result.hasNext).to(beFalse())
+                expect(result.isLast).to(beTrue())
+                let items = result.items
+                if items.count != 2 {
+                    fail("PaginatedResult has no items"); done()
+                    return
                 }
+                let messageItems = items.compactMap { $0.data as? String }
+                expect(messageItems.first).to(equal("message2"))
+                expect(messageItems.last).to(equal("message1"))
+                done()
+            }
+        }
+    }
 
-                // RSL4d3
-                
+    // RSL2b1
+    func test__031__history__query_arguments__start_must_be_equal_to_or_less_than_end_and_is_unaffected_by_the_request_direction() {
+        let client = ARTRest(options: AblyTests.commonAppSetup())
+        let channel = client.channels.get("test")
 
-                    func test__041__message_encoding__json__json_payload_should_be_stringified_either__as_a_JSON_Array() {
-                        client.internal.httpExecutor = testHTTPExecutor
-                        // JSON Array
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: array, callback: { error in
-                                expect(error).to(beNil())
+        let query = ARTDataQuery()
+        query.direction = .backwards
+        query.end = NSDate() as Date
+        query.start = query.end!.addingTimeInterval(10.0)
 
-                                if let request = testHTTPExecutor.requests.last, let http = request.httpBody {
-                                    // Array
-                                    let json = AblyTests.msgpackToJSON(http)
-                                    expect(try! JSON(data: json["data"].stringValue.data(using: .utf8)!).asArray).to(equal(array as NSArray?))
-                                    expect(json["encoding"].string).to(equal("json"))
-                                }
-                                else {
-                                    XCTFail("No request or HTTP body found")
-                                }
-                                done()
-                            })
-                        }
-                    }
+        expect { try channel.history(query) { _, _ in } }.to(throwError { (error: Error) in
+            expect(error._code).to(equal(ARTDataQueryError.timestampRange.rawValue))
+        })
 
-                    func test__042__message_encoding__json__json_payload_should_be_stringified_either__as_a_JSON_Object() {
-                        client.internal.httpExecutor = testHTTPExecutor
-                        // JSON Object
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: dictionary, callback: { error in
-                                expect(error).to(beNil())
+        query.direction = .forwards
 
-                                if let request = testHTTPExecutor.requests.last, let http = request.httpBody {
-                                    // Dictionary
-                                    let json = AblyTests.msgpackToJSON(http)
-                                    expect(try! JSON(data: json["data"].stringValue.data(using: .utf8)!).asDictionary).to(equal(dictionary as NSDictionary?))
-                                    expect(json["encoding"].string).to(equal("json"))
-                                }
-                                else {
-                                    XCTFail("No request or HTTP body found")
-                                }
-                                done()
-                            })
-                        }
-                    }
+        expect { try channel.history(query) { _, _ in } }.to(throwError { (error: Error) in
+            expect(error._code).to(equal(ARTDataQueryError.timestampRange.rawValue))
+        })
+    }
 
-                // RSL4d4
-                func test__040__message_encoding__json__messages_received_should_be_decoded_based_on_the_encoding_field() {
-                    let cases = [text, integer, decimal, dictionary, array, binaryData] as [Any]
+    // RSL2b2
+    func test__032__history__query_arguments__direction_backwards_or_forwards() {
+        let client = ARTRest(options: AblyTests.commonAppSetup())
+        let channel = client.channels.get("test")
 
-                    cases.forEach { caseTest in
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: caseTest, callback: { error in
-                                expect(error).to(beNil())
-                                done()
-                            })
-                        }
-                    }
+        let query = ARTDataQuery()
+        expect(query.direction) == ARTQueryDirection.backwards
+        query.direction = .forwards
 
-                    var totalReceived = 0
-                    channel.history { result, error in
-                        expect(error).to(beNil())
-                        guard let result = result else {
-                            XCTFail("Result is nil")
-                            return
-                        }
-                        expect(result.hasNext).to(beFalse())
+        let messages = [
+            ARTMessage(name: nil, data: "message1"),
+            ARTMessage(name: nil, data: "message2"),
+        ]
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(messages) { _ in
+                done()
+            }
+        }
 
-                        for (index, item) in (result.items.reversed().enumerated()) {
-                            totalReceived += 1
-
-                            switch item.data {
-                            case let value as NSDictionary:
-                                expect(value).to(equal(cases[index] as? NSDictionary))
-                                break
-                            case let value as NSArray:
-                                expect(value).to(equal(cases[index] as? NSArray))
-                                break
-                            case let value as NSData:
-                                expect(value).to(equal(cases[index] as? NSData))
-                                break
-                            case let value as NSString:
-                                expect(value).to(equal(cases[index] as? NSString))
-                                break
-                            default:
-                                XCTFail("Payload with unknown format")
-                                break
-                            }
-                        }
-                    }
-                    expect(totalReceived).toEventually(equal(cases.count), timeout: testTimeout)
+        waitUntil(timeout: testTimeout) { done in
+            try! channel.history(query) { result, error in
+                expect(error).to(beNil())
+                guard let result = result else {
+                    fail("PaginatedResult is empty"); done()
+                    return
                 }
-
-        // RSL5
-        
-
-            // RSL5b
-            
-                
-                func test__043__message_payload_encryption__should_support_AES_encryption__128_CBC_mode() {
-                    testSupportsAESEncryptionWithKeyLength(128)
+                expect(result.hasNext).to(beFalse())
+                expect(result.isLast).to(beTrue())
+                let items = result.items
+                if items.count != 2 {
+                    fail("PaginatedResult has no items"); done()
+                    return
                 }
-                
-                func test__044__message_payload_encryption__should_support_AES_encryption__256_CBC_mode() {
-                    testSupportsAESEncryptionWithKeyLength(256)
+                let messageItems = items.compactMap { $0.data as? String }
+                expect(messageItems.first).to(equal("message1"))
+                expect(messageItems.last).to(equal("message2"))
+                done()
+            }
+        }
+    }
+
+    // RSL2b3
+    func test__033__history__query_arguments__limit_items_result() {
+        let client = ARTRest(options: AblyTests.commonAppSetup())
+        let channel = client.channels.get("test")
+
+        let query = ARTDataQuery()
+        expect(query.limit) == 100
+        query.limit = 2
+
+        let messages = (1 ... 10).compactMap { ARTMessage(name: nil, data: "message\($0)") }
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(messages) { _ in
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            try! channel.history(query) { result, error in
+                expect(error).to(beNil())
+                guard let result = result else {
+                    fail("PaginatedResult is empty"); done()
+                    return
                 }
+                expect(result.hasNext).to(beTrue())
+                expect(result.isLast).to(beFalse())
+                let items = result.items
+                if items.count != 2 {
+                    fail("PaginatedResult has no items"); done()
+                    return
+                }
+                let messageItems = items.compactMap { $0.data as? String }
+                expect(messageItems.first).to(equal("message10"))
+                expect(messageItems.last).to(equal("message9"))
+                done()
+            }
+        }
+    }
 
-        // RSL6
-        
+    // RSL2b3
+    func test__034__history__query_arguments__limit_supports_up_to_1000_items() {
+        let client = ARTRest(options: AblyTests.commonAppSetup())
+        let channel = client.channels.get("test")
 
-            // RSL6b
-            func test__045__message_decoding__should_deliver_with_a_binary_payload_when_the_payload_was_successfully_decoded_but_it_could_not_be_decrypted() {
-                let options = AblyTests.commonAppSetup()
-                let clientEncrypted = ARTRest(options: options)
+        let query = ARTDataQuery()
+        expect(query.limit) == 100
 
-                let channelOptions = ARTChannelOptions(cipher: ["key":ARTCrypto.generateRandomKey()] as ARTCipherParamsCompatible)
-                let channelEncrypted = clientEncrypted.channels.get("test", options: channelOptions)
+        query.limit = 1001
+        expect { try channel.history(query, callback: { _, _ in }) }.to(throwError())
 
-                let expectedMessage = ["something":1]
+        query.limit = 1000
+        expect { try channel.history(query, callback: { _, _ in }) }.toNot(throwError())
+    }
 
-                waitUntil(timeout: testTimeout) { done in
-                    channelEncrypted.publish(nil, data: expectedMessage) { error in
-                        done()
+    // RSL3, RSP1
+
+    // RSP3
+
+    func skipped__test__035__presence__get__should_return_presence_fixture_data() {
+        let options = AblyTests.commonAppSetup()
+        options.channelNamePrefix = nil
+        client = ARTRest(options: options)
+        let key = appSetupJson["cipher"]["key"].string!
+        let cipherParams = ARTCipherParams(
+            algorithm: appSetupJson["cipher"]["algorithm"].string!,
+            key: key as ARTCipherKeyCompatible,
+            iv: Data(base64Encoded: appSetupJson["cipher"]["iv"].string!, options: Data.Base64DecodingOptions(rawValue: 0))!
+        )
+        let channel = client.channels.get("persisted:presence_fixtures", options: ARTChannelOptions(cipher: cipherParams))
+        var presenceMessages: [ARTPresenceMessage] = []
+
+        channel.presence.get { result, _ in
+            if let items = result?.items {
+                presenceMessages.append(contentsOf: items)
+            } else {
+                fail("expected items to not be empty")
+            }
+        }
+
+        expect(presenceMessages.count).toEventually(equal(presenceFixtures.count), timeout: testTimeout)
+        for message in presenceMessages {
+            let fixtureMessage = presenceFixtures.filter { _, value -> Bool in
+                message.clientId == value["clientId"].stringValue
+            }.first!.1
+
+            expect(message.data).toNot(beNil())
+            expect(message.action).to(equal(ARTPresenceAction.present))
+
+            let encodedFixture = channel.internal.dataEncoder.decode(
+                fixtureMessage["data"].object,
+                encoding: fixtureMessage.asDictionary!["encoding"] as? String
+            )
+            expect(message.data as? NSObject).to(equal(encodedFixture.data as? NSObject))
+        }
+    }
+
+    // RSL4
+
+    // RSL4a
+    func test__036__message_encoding__payloads_should_be_binary__strings__or_objects_capable_of_JSON_representation() {
+        let validCases: [TestCase]
+        if #available(iOS 11.0, *) {
+            validCases = [
+                TestCase(value: nil, expected: JSON([:])),
+                TestCase(value: text, expected: JSON(["data": text])),
+                TestCase(value: integer, expected: JSON(["data": integer])),
+                TestCase(value: decimal, expected: JSON(["data": decimal])),
+                TestCase(value: dictionary, expected: ["data": JSON(dictionary).rawString(options: [.sortedKeys])!, "encoding": "json"] as JSON),
+                TestCase(value: array, expected: JSON(["data": JSON(array).rawString(options: [.sortedKeys])!, "encoding": "json"])),
+                TestCase(value: binaryData, expected: JSON(["data": binaryData.toBase64, "encoding": "base64"])),
+            ]
+        } else {
+            validCases = [
+                TestCase(value: nil, expected: JSON([:])),
+                TestCase(value: text, expected: JSON(["data": text])),
+                TestCase(value: integer, expected: JSON(["data": integer])),
+                TestCase(value: decimal, expected: JSON(["data": decimal])),
+                TestCase(value: dictionary, expected: ["data": JSON(dictionary).rawString()!, "encoding": "json"] as JSON),
+                TestCase(value: array, expected: JSON(["data": JSON(array).rawString()!, "encoding": "json"])),
+                TestCase(value: binaryData, expected: JSON(["data": binaryData.toBase64, "encoding": "base64"])),
+            ]
+        }
+
+        client.internal.options.idempotentRestPublishing = false
+        client.internal.httpExecutor = testHTTPExecutor
+
+        validCases.forEach { caseTest in
+            waitUntil(timeout: testTimeout) { done in
+                channel.publish(nil, data: caseTest.value) { error in
+                    expect(error).to(beNil())
+                    guard let httpBody = testHTTPExecutor.requests.last!.httpBody else {
+                        XCTFail("HTTPBody is nil")
+                        done(); return
                     }
-                }
-
-                let client = ARTRest(options: options)
-                let channel = client.channels.get("test")
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.history { result, error in
-                        expect(error).to(beNil())
-                        guard let result = result else {
-                            fail("Result is empty"); done(); return
+                    var json = AblyTests.msgpackToJSON(httpBody)
+                    if let s = json["data"].string, let data = try? JSONSerialization.jsonObject(with: s.data(using: .utf8)!) {
+                        // Make sure the formatting is the same by parsing
+                        // and reformatting in the same way as the test case.
+                        if #available(iOS 11.0, *) {
+                            json["data"] = JSON(JSON(data).rawString(options: [.sortedKeys])!)
+                        } else {
+                            json["data"] = JSON(JSON(data).rawString()!)
                         }
-                        guard let message = result.items.first else {
-                            fail("First item does not exist"); done(); return
-                        }
-                        expect(message.data is NSData).to(beTrue())
-                        expect(message.encoding).to(equal("json/utf-8/cipher+aes-256-cbc"))
-                        done()
                     }
+                    let mergedWithExpectedJSON = try! json.merged(with: caseTest.expected)
+                    expect(json).to(equal(mergedWithExpectedJSON))
+                    done()
                 }
             }
+        }
 
-            // RSL6b
-            func test__046__message_decoding__should_deliver_with_encoding_attribute_set_indicating_the_residual_encoding_and_error_should_be_emitted() {
-                let options = AblyTests.commonAppSetup()
-                options.useBinaryProtocol = false
-                options.logHandler = ARTLog(capturingOutput: true)
-                let client = ARTRest(options: options)
-                let channelOptions = ARTChannelOptions(cipher: ["key":ARTCrypto.generateRandomKey()] as ARTCipherParamsCompatible)
-                let channel = client.channels.get("test", options: channelOptions)
-                client.internal.httpExecutor = testHTTPExecutor
+        let invalidCases = [5, 56.33, NSDate()] as [Any]
 
-                let expectedMessage = ["something":1]
-                let expectedData = try! JSONSerialization.data(withJSONObject: expectedMessage, options: JSONSerialization.WritingOptions(rawValue: 0))
+        invalidCases.forEach { caseItem in
+            waitUntil(timeout: testTimeout) { done in
+                expect { channel.publish(nil, data: caseItem, callback: nil) }.toNot(raiseException())
+                done()
+            }
+        }
+    }
 
-                testHTTPExecutor.setListenerProcessingDataResponse({ data in
-                    let dataStr = String(data: data!, encoding: String.Encoding.utf8)!
-                    return dataStr.replace("json/utf-8", withString: "invalid").data(using: String.Encoding.utf8)!
+    // RSL4b
+    func test__037__message_encoding__encoding_attribute_should_represent_the_encoding_s__applied_in_right_to_left() {
+        let encodingCases = [
+            TestCase(value: text, expected: JSON.null),
+            TestCase(value: dictionary, expected: "json"),
+            TestCase(value: array, expected: "json"),
+            TestCase(value: binaryData, expected: "base64"),
+        ]
+
+        client.internal.httpExecutor = testHTTPExecutor
+
+        encodingCases.forEach { caseItem in
+            waitUntil(timeout: testTimeout) { done in
+                channel.publish(nil, data: caseItem.value, callback: { error in
+                    expect(error).to(beNil())
+                    guard let httpBody = testHTTPExecutor.requests.last!.httpBody else {
+                        XCTFail("HTTPBody is nil")
+                        done(); return
+                    }
+                    expect(AblyTests.msgpackToJSON(httpBody)["encoding"]).to(equal(caseItem.expected))
+                    done()
                 })
+            }
+        }
+    }
 
-                waitUntil(timeout: testTimeout) { done in
-                    channel.publish(nil, data: expectedMessage) { error in
-                        done()
-                    }
+    // RSL4d1
+    func test__038__message_encoding__json__binary_payload_should_be_encoded_as_Base64_and_represented_as_a_JSON_string() {
+        client.internal.httpExecutor = testHTTPExecutor
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: binaryData, callback: { error in
+                expect(error).to(beNil())
+                guard let httpBody = testHTTPExecutor.requests.last!.httpBody else {
+                    XCTFail("HTTPBody is nil")
+                    done(); return
                 }
+                // Binary
+                let json = AblyTests.msgpackToJSON(httpBody)
+                expect(json["data"].string).to(equal(binaryData.toBase64))
+                expect(json["encoding"]).to(equal("base64"))
+                done()
+            })
+        }
+    }
 
-                waitUntil(timeout: testTimeout) { done in
-                    channel.history { result, error in
-                        expect(error).to(beNil())
-                        guard let result = result else {
-                            fail("Result is empty"); done(); return
-                        }
-                        guard let message = result.items.first else {
-                            fail("First item does not exist"); done(); return
-                        }
-                        expect(message.data as? NSData).to(equal(expectedData as NSData?))
-                        expect(message.encoding).to(equal("invalid"))
+    // RSL4d
+    func test__039__message_encoding__json__string_payload_should_be_represented_as_a_JSON_string() {
+        client.internal.httpExecutor = testHTTPExecutor
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: text, callback: { error in
+                expect(error).to(beNil())
 
-                        let logs = options.logHandler.captured
-                        let line = logs.reduce("") { $0 + "; " + $1.toString() } //Reduce in one line
-                        expect(line).to(contain("Failed to decode data: unknown encoding: 'invalid'"))
-                        done()
-                    }
+                if let request = testHTTPExecutor.requests.last, let http = request.httpBody {
+                    // String (UTF-8)
+                    let json = AblyTests.msgpackToJSON(http)
+                    expect(json["data"].string).to(equal(text))
+                    expect(json["encoding"].string).to(beNil())
+                } else {
+                    XCTFail("No request or HTTP body found")
+                }
+                done()
+            })
+        }
+    }
+
+    // RSL4d3
+
+    func test__041__message_encoding__json__json_payload_should_be_stringified_either__as_a_JSON_Array() {
+        client.internal.httpExecutor = testHTTPExecutor
+        // JSON Array
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: array, callback: { error in
+                expect(error).to(beNil())
+
+                if let request = testHTTPExecutor.requests.last, let http = request.httpBody {
+                    // Array
+                    let json = AblyTests.msgpackToJSON(http)
+                    expect(try! JSON(data: json["data"].stringValue.data(using: .utf8)!).asArray).to(equal(array as NSArray?))
+                    expect(json["encoding"].string).to(equal("json"))
+                } else {
+                    XCTFail("No request or HTTP body found")
+                }
+                done()
+            })
+        }
+    }
+
+    func test__042__message_encoding__json__json_payload_should_be_stringified_either__as_a_JSON_Object() {
+        client.internal.httpExecutor = testHTTPExecutor
+        // JSON Object
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: dictionary, callback: { error in
+                expect(error).to(beNil())
+
+                if let request = testHTTPExecutor.requests.last, let http = request.httpBody {
+                    // Dictionary
+                    let json = AblyTests.msgpackToJSON(http)
+                    expect(try! JSON(data: json["data"].stringValue.data(using: .utf8)!).asDictionary).to(equal(dictionary as NSDictionary?))
+                    expect(json["encoding"].string).to(equal("json"))
+                } else {
+                    XCTFail("No request or HTTP body found")
+                }
+                done()
+            })
+        }
+    }
+
+    // RSL4d4
+    func test__040__message_encoding__json__messages_received_should_be_decoded_based_on_the_encoding_field() {
+        let cases = [text, integer, decimal, dictionary, array, binaryData] as [Any]
+
+        cases.forEach { caseTest in
+            waitUntil(timeout: testTimeout) { done in
+                channel.publish(nil, data: caseTest, callback: { error in
+                    expect(error).to(beNil())
+                    done()
+                })
+            }
+        }
+
+        var totalReceived = 0
+        channel.history { result, error in
+            expect(error).to(beNil())
+            guard let result = result else {
+                XCTFail("Result is nil")
+                return
+            }
+            expect(result.hasNext).to(beFalse())
+
+            for (index, item) in result.items.reversed().enumerated() {
+                totalReceived += 1
+
+                switch item.data {
+                case let value as NSDictionary:
+                    expect(value).to(equal(cases[index] as? NSDictionary))
+                case let value as NSArray:
+                    expect(value).to(equal(cases[index] as? NSArray))
+                case let value as NSData:
+                    expect(value).to(equal(cases[index] as? NSData))
+                case let value as NSString:
+                    expect(value).to(equal(cases[index] as? NSString))
+                default:
+                    XCTFail("Payload with unknown format")
                 }
             }
+        }
+        expect(totalReceived).toEventually(equal(cases.count), timeout: testTimeout)
+    }
+
+    // RSL5
+
+    // RSL5b
+
+    func test__043__message_payload_encryption__should_support_AES_encryption__128_CBC_mode() {
+        testSupportsAESEncryptionWithKeyLength(128)
+    }
+
+    func test__044__message_payload_encryption__should_support_AES_encryption__256_CBC_mode() {
+        testSupportsAESEncryptionWithKeyLength(256)
+    }
+
+    // RSL6
+
+    // RSL6b
+    func test__045__message_decoding__should_deliver_with_a_binary_payload_when_the_payload_was_successfully_decoded_but_it_could_not_be_decrypted() {
+        let options = AblyTests.commonAppSetup()
+        let clientEncrypted = ARTRest(options: options)
+
+        let channelOptions = ARTChannelOptions(cipher: ["key": ARTCrypto.generateRandomKey()] as ARTCipherParamsCompatible)
+        let channelEncrypted = clientEncrypted.channels.get("test", options: channelOptions)
+
+        let expectedMessage = ["something": 1]
+
+        waitUntil(timeout: testTimeout) { done in
+            channelEncrypted.publish(nil, data: expectedMessage) { _ in
+                done()
+            }
+        }
+
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("test")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.history { result, error in
+                expect(error).to(beNil())
+                guard let result = result else {
+                    fail("Result is empty"); done(); return
+                }
+                guard let message = result.items.first else {
+                    fail("First item does not exist"); done(); return
+                }
+                expect(message.data is NSData).to(beTrue())
+                expect(message.encoding).to(equal("json/utf-8/cipher+aes-256-cbc"))
+                done()
+            }
+        }
+    }
+
+    // RSL6b
+    func test__046__message_decoding__should_deliver_with_encoding_attribute_set_indicating_the_residual_encoding_and_error_should_be_emitted() {
+        let options = AblyTests.commonAppSetup()
+        options.useBinaryProtocol = false
+        options.logHandler = ARTLog(capturingOutput: true)
+        let client = ARTRest(options: options)
+        let channelOptions = ARTChannelOptions(cipher: ["key": ARTCrypto.generateRandomKey()] as ARTCipherParamsCompatible)
+        let channel = client.channels.get("test", options: channelOptions)
+        client.internal.httpExecutor = testHTTPExecutor
+
+        let expectedMessage = ["something": 1]
+        let expectedData = try! JSONSerialization.data(withJSONObject: expectedMessage, options: JSONSerialization.WritingOptions(rawValue: 0))
+
+        testHTTPExecutor.setListenerProcessingDataResponse { data in
+            let dataStr = String(data: data!, encoding: String.Encoding.utf8)!
+            return dataStr.replace("json/utf-8", withString: "invalid").data(using: String.Encoding.utf8)!
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: expectedMessage) { _ in
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.history { result, error in
+                expect(error).to(beNil())
+                guard let result = result else {
+                    fail("Result is empty"); done(); return
+                }
+                guard let message = result.items.first else {
+                    fail("First item does not exist"); done(); return
+                }
+                expect(message.data as? NSData).to(equal(expectedData as NSData?))
+                expect(message.encoding).to(equal("invalid"))
+
+                let logs = options.logHandler.captured
+                let line = logs.reduce("") { $0 + "; " + $1.toString() } // Reduce in one line
+                expect(line).to(contain("Failed to decode data: unknown encoding: 'invalid'"))
+                done()
+            }
+        }
+    }
 }

--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -1,7 +1,7 @@
 import Ably
 import Foundation
 import Nimble
-import Quick
+import XCTest
 import SwiftyJSON
 
 private var client: ARTRest!

--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -4,11 +4,122 @@ import Quick
 import Foundation
 import SwiftyJSON
 
+        private var client: ARTRest!
+        private var channel: ARTRestChannel!
+        private var testHTTPExecutor: TestProxyHTTPExecutor!
+                private let channelName = "test-message-size"
+
+                private func assertMessagePayloadId(id: String?, expectedSerial: String) {
+                    guard let id = id else {
+                        fail("Message.id from payload is nil"); return
+                    }
+
+                    let idParts = id.split(separator: ":")
+
+                    if idParts.count != 2 {
+                        fail("Message.id from payload should have baseId and serial separated by a colon"); return
+                    }
+
+                    let baseId = String(idParts[0])
+                    let serial = String(idParts[1])
+
+                    guard let baseIdData = Data(base64Encoded: baseId) else {
+                        fail("BaseId should be a base64 encoded string"); return
+                    }
+
+                    expect(baseIdData.bytes.count) == 9
+                    expect(serial).to(equal(expectedSerial))
+                }
+            private let presenceFixtures = appSetupJson["post_apps"]["channels"][0]["presence"]
+
+            private let text = "John"
+            private let integer = "5"
+            private let decimal = "65.33"
+            private let dictionary = ["number": 3, "name": "John"] as [String : Any]
+            private let array = ["John", "Mary"]
+            private let binaryData = "123456".data(using: .utf8)!
+
+                private func testSupportsAESEncryptionWithKeyLength(_ encryptionKeyLength: UInt) {
+                    let options = AblyTests.commonAppSetup()
+                    let client = ARTRest(options: options)
+                    client.internal.httpExecutor = testHTTPExecutor
+                    
+                    let params: ARTCipherParams = ARTCrypto.getDefaultParams([
+                        "key": ARTCrypto.generateRandomKey(encryptionKeyLength)
+                    ])
+                    expect(params.algorithm).to(equal("AES"))
+                    expect(params.keyLength).to(equal(encryptionKeyLength))
+                    expect(params.mode).to(equal("CBC"))
+                    
+                    let channelOptions = ARTChannelOptions(cipher: params)
+                    let channel = client.channels.get("test", options: channelOptions)
+                    
+                    waitUntil(timeout: testTimeout) { done in
+                        channel.publish("test", data: "message1") { error in
+                            expect(error).to(beNil())
+                            done()
+                        }
+                    }
+                    
+                    guard let httpBody = testHTTPExecutor.requests.last?.httpBody else {
+                        fail("HTTPBody is empty")
+                        return
+                    }
+                    let httpBodyAsJSON = AblyTests.msgpackToJSON(httpBody)
+                    expect(httpBodyAsJSON["encoding"].string).to(equal("utf-8/cipher+aes-\(encryptionKeyLength)-cbc/base64"))
+                    expect(httpBodyAsJSON["name"].string).to(equal("test"))
+                    expect(httpBodyAsJSON["data"].string).toNot(equal("message1"))
+                    
+                    waitUntil(timeout: testTimeout) { done in
+                        channel.history { result, error in
+                            expect(error).to(beNil())
+                            guard let result = result else {
+                                fail("PaginatedResult is empty"); done()
+                                return
+                            }
+                            expect(result.hasNext).to(beFalse())
+                            expect(result.isLast).to(beTrue())
+                            let items = result.items
+                            if result.items.isEmpty {
+                                fail("PaginatedResult has no items"); done()
+                                return
+                            }
+                            expect(items[0].name).to(equal("test"))
+                            expect(items[0].data as? String).to(equal("message1"))
+                            done()
+                        }
+                    }
+                }
+
 class RestClientChannel: QuickSpec {
+
+// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+override class var defaultTestSuite : XCTestSuite {
+    let _ = client
+    let _ = channel
+    let _ = testHTTPExecutor
+    let _ = channelName
+    let _ = presenceFixtures
+    let _ = text
+    let _ = integer
+    let _ = decimal
+    let _ = dictionary
+    let _ = array
+    let _ = binaryData
+
+    return super.defaultTestSuite
+}
+
+            struct PublishArgs {
+                static let name = "foo"
+                static let data = "bar"
+            }
+
+            struct TestCase {
+                let value: Any?
+                let expected: JSON
+            }
     override func spec() {
-        var client: ARTRest!
-        var channel: ARTRestChannel!
-        var testHTTPExecutor: TestProxyHTTPExecutor!
 
         beforeEach {
             let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
@@ -19,10 +130,6 @@ class RestClientChannel: QuickSpec {
 
         // RSL1
         describe("publish") {
-            struct PublishArgs {
-                static let name = "foo"
-                static let data = "bar"
-            }
 
             // RSL1b
             context("with name and data arguments") {
@@ -434,7 +541,6 @@ class RestClientChannel: QuickSpec {
 
             // RSL1i
             context("If the total size of message(s) exceeds the maxMessageSize") {
-                let channelName = "test-message-size"
 
                 it("the client library should reject the publish and indicate an error") {
                     let options = AblyTests.commonAppSetup()
@@ -484,28 +590,6 @@ class RestClientChannel: QuickSpec {
                     // Current version
                     let options = AblyTests.clientOptions()
                     expect(options.idempotentRestPublishing) == true
-                }
-
-                func assertMessagePayloadId(id: String?, expectedSerial: String) {
-                    guard let id = id else {
-                        fail("Message.id from payload is nil"); return
-                    }
-
-                    let idParts = id.split(separator: ":")
-
-                    if idParts.count != 2 {
-                        fail("Message.id from payload should have baseId and serial separated by a colon"); return
-                    }
-
-                    let baseId = String(idParts[0])
-                    let serial = String(idParts[1])
-
-                    guard let baseIdData = Data(base64Encoded: baseId) else {
-                        fail("BaseId should be a base64 encoded string"); return
-                    }
-
-                    expect(baseIdData.bytes.count) == 9
-                    expect(serial).to(equal(expectedSerial))
                 }
 
                 // RSL1k1
@@ -1047,7 +1131,6 @@ class RestClientChannel: QuickSpec {
 
         // RSL3, RSP1
         xdescribe("presence") {
-            let presenceFixtures = appSetupJson["post_apps"]["channels"][0]["presence"]
 
             // RSP3
             context("get") {
@@ -1094,18 +1177,6 @@ class RestClientChannel: QuickSpec {
 
         // RSL4
         describe("message encoding") {
-
-            struct TestCase {
-                let value: Any?
-                let expected: JSON
-            }
-
-            let text = "John"
-            let integer = "5"
-            let decimal = "65.33"
-            let dictionary = ["number": 3, "name": "John"] as [String : Any]
-            let array = ["John", "Mary"]
-            let binaryData = "123456".data(using: .utf8)!
 
             // RSL4a
             it("payloads should be binary, strings, or objects capable of JSON representation") {
@@ -1338,58 +1409,6 @@ class RestClientChannel: QuickSpec {
 
             // RSL5b
             context("should support AES encryption") {
-
-                func testSupportsAESEncryptionWithKeyLength(_ encryptionKeyLength: UInt) {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRest(options: options)
-                    client.internal.httpExecutor = testHTTPExecutor
-                    
-                    let params: ARTCipherParams = ARTCrypto.getDefaultParams([
-                        "key": ARTCrypto.generateRandomKey(encryptionKeyLength)
-                    ])
-                    expect(params.algorithm).to(equal("AES"))
-                    expect(params.keyLength).to(equal(encryptionKeyLength))
-                    expect(params.mode).to(equal("CBC"))
-                    
-                    let channelOptions = ARTChannelOptions(cipher: params)
-                    let channel = client.channels.get("test", options: channelOptions)
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish("test", data: "message1") { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                    
-                    guard let httpBody = testHTTPExecutor.requests.last?.httpBody else {
-                        fail("HTTPBody is empty")
-                        return
-                    }
-                    let httpBodyAsJSON = AblyTests.msgpackToJSON(httpBody)
-                    expect(httpBodyAsJSON["encoding"].string).to(equal("utf-8/cipher+aes-\(encryptionKeyLength)-cbc/base64"))
-                    expect(httpBodyAsJSON["name"].string).to(equal("test"))
-                    expect(httpBodyAsJSON["data"].string).toNot(equal("message1"))
-                    
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.history { result, error in
-                            expect(error).to(beNil())
-                            guard let result = result else {
-                                fail("PaginatedResult is empty"); done()
-                                return
-                            }
-                            expect(result.hasNext).to(beFalse())
-                            expect(result.isLast).to(beTrue())
-                            let items = result.items
-                            if result.items.isEmpty {
-                                fail("PaginatedResult has no items"); done()
-                                return
-                            }
-                            expect(items[0].name).to(equal("test"))
-                            expect(items[0].data as? String).to(equal("message1"))
-                            done()
-                        }
-                    }
-                }
                 
                 it("128 CBC mode") {
                     testSupportsAESEncryptionWithKeyLength(128)

--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -91,7 +91,7 @@ import SwiftyJSON
                     }
                 }
 
-class RestClientChannel: QuickSpec {
+class RestClientChannel: XCTestCase {
 
 // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
 override class var defaultTestSuite : XCTestSuite {
@@ -119,9 +119,11 @@ override class var defaultTestSuite : XCTestSuite {
                 let value: Any?
                 let expected: JSON
             }
-    override func spec() {
 
-        beforeEach {
+        override func setUp() {
+super.setUp()
+
+
             let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
             client = ARTRest(options: options)
             channel = client.channels.get(ProcessInfo.processInfo.globallyUniqueString)
@@ -129,11 +131,11 @@ override class var defaultTestSuite : XCTestSuite {
         }
 
         // RSL1
-        describe("publish") {
+        
 
             // RSL1b
-            context("with name and data arguments") {
-                it("publishes the message and invokes callback with success") {
+            
+                func test__005__publish__with_name_and_data_arguments__publishes_the_message_and_invokes_callback_with_success() {
                     var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
                     var publishedMessage: ARTMessage?
 
@@ -148,11 +150,10 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(publishedMessage?.name).toEventually(equal(PublishArgs.name), timeout: testTimeout)
                     expect(publishedMessage?.data as? String).toEventually(equal(PublishArgs.data), timeout: testTimeout)
                 }
-            }
 
             // RSL1b, RSL1e
-            context("with name only") {
-                it("publishes the message and invokes callback with success") {
+            
+                func test__006__publish__with_name_only__publishes_the_message_and_invokes_callback_with_success() {
                     var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "io.ably.XCTest", code: -1, userInfo: nil))
                     var publishedMessage: ARTMessage?
 
@@ -167,11 +168,10 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(publishedMessage?.name).toEventually(equal(PublishArgs.name), timeout: testTimeout)
                     expect(publishedMessage?.data).toEventually(beNil(), timeout: testTimeout)
                 }
-            }
 
             // RSL1b, RSL1e
-            context("with data only") {
-                it("publishes the message and invokes callback with success") {
+            
+                func test__007__publish__with_data_only__publishes_the_message_and_invokes_callback_with_success() {
                     var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
                     var publishedMessage: ARTMessage?
 
@@ -186,11 +186,10 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(publishedMessage?.name).toEventually(beNil(), timeout: testTimeout)
                     expect(publishedMessage?.data as? String).toEventually(equal(PublishArgs.data), timeout: testTimeout)
                 }
-            }
 
             // RSL1b, RSL1e
-            context("with neither name nor data") {
-                it("publishes the message and invokes callback with success") {
+            
+                func test__008__publish__with_neither_name_nor_data__publishes_the_message_and_invokes_callback_with_success() {
                     var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
                     var publishedMessage: ARTMessage?
 
@@ -208,10 +207,9 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(publishedMessage?.name).to(beNil())
                     expect(publishedMessage?.data).to(beNil())
                 }
-            }
 
-            context("with a Message object") {
-                it("publishes the message and invokes callback with success") {
+            
+                func test__009__publish__with_a_Message_object__publishes_the_message_and_invokes_callback_with_success() {
                     var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
                     var publishedMessage: ARTMessage?
 
@@ -229,11 +227,10 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(publishedMessage?.name).to(equal(PublishArgs.name))
                     expect(publishedMessage?.data as? String).to(equal(PublishArgs.data))
                 }
-            }
 
             // RSL1c
-            context("with an array of Message objects") {
-                it("publishes the messages in a single request and invokes callback with success") {
+            
+                func test__010__publish__with_an_array_of_Message_objects__publishes_the_messages_in_a_single_request_and_invokes_callback_with_success() {
                     let oldExecutor = client.internal.httpExecutor
                     defer { client.internal.httpExecutor = oldExecutor}
                     client.internal.httpExecutor = testHTTPExecutor
@@ -263,12 +260,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                     expect(testHTTPExecutor.requests.count).to(equal(1))
                 }
-            }
 
             // RSL1f
-            context("Unidentified clients using Basic Auth") {
+            
                 // RSL1f1
-                it("should publish message with the provided clientId") {
+                func test__011__publish__Unidentified_clients_using_Basic_Auth__should_publish_message_with_the_provided_clientId() {
                     let client = ARTRest(options: AblyTests.commonAppSetup())
                     let channel = client.channels.get("test")
                     waitUntil(timeout: testTimeout) { done in
@@ -289,13 +285,12 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
             // RSA7e
-            context("ClientOptions clientId") {
+            
 
                 // RSA7e1
-                it("should include the clientId as a querystring parameter in realtime connection requests") {
+                func test__012__publish__ClientOptions_clientId__should_include_the_clientId_as_a_querystring_parameter_in_realtime_connection_requests() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john-doe"
                     let client = AblyTests.newRealtime(options)
@@ -315,7 +310,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSA7e2
-                it("should include an X-Ably-ClientId header with value set to the clientId as Base64 encoded string in REST connection requests") {
+                func test__013__publish__ClientOptions_clientId__should_include_an_X_Ably_ClientId_header_with_value_set_to_the_clientId_as_Base64_encoded_string_in_REST_connection_requests() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "john-doe"
                     let client = ARTRest(options: options)
@@ -338,13 +333,11 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // RSL1m
-            context("Message clientId") {
+            
 
                 // RSL1m1
-                it("publishing with no clientId when the clientId is set to some value in the client options should result in a message received with the clientId property set to that value") {
+                func test__014__publish__Message_clientId__publishing_with_no_clientId_when_the_clientId_is_set_to_some_value_in_the_client_options_should_result_in_a_message_received_with_the_clientId_property_set_to_that_value() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "client-rest"
                     let expectedClientId = options.clientId
@@ -373,7 +366,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSL1m2
-                it("publishing with a clientId set to the same value as the clientId in the client options should result in a message received with the clientId property set to that value") {
+                func test__015__publish__Message_clientId__publishing_with_a_clientId_set_to_the_same_value_as_the_clientId_in_the_client_options_should_result_in_a_message_received_with_the_clientId_property_set_to_that_value() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "client-rest"
                     let expectedClientId = options.clientId!
@@ -402,7 +395,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSL1m3
-                it("publishing with a clientId set to a value from an unidentified client should result in a message received with the clientId property set to that value") {
+                func test__016__publish__Message_clientId__publishing_with_a_clientId_set_to_a_value_from_an_unidentified_client_should_result_in_a_message_received_with_the_clientId_property_set_to_that_value() {
                     let expectedClientId = "client-rest"
                     let options = AblyTests.commonAppSetup()
                     let rest = ARTRest(options: options)
@@ -429,7 +422,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSL1m4
-                it("publishing with a clientId set to a different value from the clientId in the client options should result in a message being rejected by the server") {
+                func test__017__publish__Message_clientId__publishing_with_a_clientId_set_to_a_different_value_from_the_clientId_in_the_client_options_should_result_in_a_message_being_rejected_by_the_server() {
                     let options = AblyTests.commonAppSetup()
                     options.clientId = "client-rest"
                     let rest = ARTRest(options: options)
@@ -455,10 +448,8 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-            }
-
             // https://github.com/ably/ably-cocoa/issues/1074 and related with RSL1m
-            it("should not fail sending a message with no clientId in the client options and credentials that can assume any clientId") {
+            func test__001__publish__should_not_fail_sending_a_message_with_no_clientId_in_the_client_options_and_credentials_that_can_assume_any_clientId() {
                 let options = AblyTests.clientOptions()
                 options.authCallback = { _, callback in
                     getTestTokenDetails(clientId: "*") { token, error in
@@ -486,7 +477,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSL1h
-            it("should provide an optional argument that allows the clientId value to be specified") {
+            func test__002__publish__should_provide_an_optional_argument_that_allows_the_clientId_value_to_be_specified() {
                 let options = AblyTests.commonAppSetup()
                 options.clientId = "john"
                 let client = ARTRest(options: options)
@@ -500,7 +491,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSL1h, RSL6a2
-            it("should provide an optional argument that allows the extras value to be specified") {
+            func test__003__publish__should_provide_an_optional_argument_that_allows_the_extras_value_to_be_specified() {
                 let options = AblyTests.commonAppSetup()
                 // Prevent channel name to be prefixed by test-*
                 options.channelNamePrefix = nil
@@ -540,9 +531,9 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSL1i
-            context("If the total size of message(s) exceeds the maxMessageSize") {
+            
 
-                it("the client library should reject the publish and indicate an error") {
+                func test__018__publish__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__the_client_library_should_reject_the_publish_and_indicate_an_error() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRest(options: options)
                     let channel = client.channels.get(channelName)
@@ -556,7 +547,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
 
-                it("also when using publish:data:clientId:extras") {
+                func test__019__publish__If_the_total_size_of_message_s__exceeds_the_maxMessageSize__also_when_using_publish_data_clientId_extras() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRest(options: options)
                     let channel = client.channels.get(channelName)
@@ -569,13 +560,12 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
 
             // RSL1k
-            context("idempotent publishing") {
+            
 
                 // TO3n
-                it("idempotentRestPublishing option") {
+                func test__020__publish__idempotent_publishing__idempotentRestPublishing_option() {
                     expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "2")) == true
                     expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "2.0.0")) == true
                     expect(ARTClientOptions.getDefaultIdempotentRestPublishing(forVersion: "1.1")) == false
@@ -593,9 +583,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSL1k1
-                context("random idempotent publish id") {
+                
 
-                    it("should generate for one message with empty id") {
+                    func test__027__publish__idempotent_publishing__random_idempotent_publish_id__should_generate_for_one_message_with_empty_id() {
                         let message = ARTMessage(name: nil, data: "foo")
                         expect(message.id).to(beNil())
 
@@ -621,7 +611,7 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(message.id).to(beNil())
                     }
 
-                    it("should generate for multiple messages with empty id") {
+                    func test__028__publish__idempotent_publishing__random_idempotent_publish_id__should_generate_for_multiple_messages_with_empty_id() {
                         let message1 = ARTMessage(name: nil, data: "foo1")
                         expect(message1.id).to(beNil())
                         let message2 = ARTMessage(name: "john", data: "foo2")
@@ -653,10 +643,9 @@ override class var defaultTestSuite : XCTestSuite {
                         // Same Base ID
                         expect(id1?.split(separator: ":").first).to(equal(id2?.split(separator: ":").first))
                     }
-                }
 
                 // RSL1k2
-                it("should not generate for message with a non empty id") {
+                func test__021__publish__idempotent_publishing__should_not_generate_for_message_with_a_non_empty_id() {
                     let message = ARTMessage(name: nil, data: "foo")
                     message.id = "123"
 
@@ -681,7 +670,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(json.arrayValue.first?["id"].string).to(equal("123"))
                 }
 
-                it("should generate for internal message that is created in publish(name:data:) method") {
+                func test__022__publish__idempotent_publishing__should_generate_for_internal_message_that_is_created_in_publish_name_data___method() {
                     let rest = ARTRest(key: "xxxx:xxxx")
                     rest.internal.options.idempotentRestPublishing = true
                     let mockHTTPExecutor = MockHTTPExecutor()
@@ -704,7 +693,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSL1k3
-                it("should not generate for multiple messages with a non empty id") {
+                func test__023__publish__idempotent_publishing__should_not_generate_for_multiple_messages_with_a_non_empty_id() {
                     let message1 = ARTMessage(name: nil, data: "foo1")
                     expect(message1.id).to(beNil())
                     let message2 = ARTMessage(name: "john", data: "foo2")
@@ -732,7 +721,7 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(json.arrayValue.last?["id"].string).to(equal("123"))
                 }
 
-                it("should not generate when idempotentRestPublishing flag is off") {
+                func test__024__publish__idempotent_publishing__should_not_generate_when_idempotentRestPublishing_flag_is_off() {
                     let options = ARTClientOptions(key: "xxxx:xxxx")
                     options.idempotentRestPublishing = false
 
@@ -763,7 +752,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSL1k4
-                it("should have only one published message") {
+                func test__025__publish__idempotent_publishing__should_have_only_one_published_message() {
                     client.internal.options.idempotentRestPublishing = true
                     client.internal.httpExecutor = testHTTPExecutor
                     client.internal.options.fallbackHostsUseDefault = true
@@ -806,7 +795,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSL1k5
-                it("should publish a message with implicit Id only once") {
+                func test__026__publish__idempotent_publishing__should_publish_a_message_with_implicit_Id_only_once() {
                     let options = AblyTests.commonAppSetup()
                     let rest = ARTRest(options: options)
                     rest.internal.options.idempotentRestPublishing = true
@@ -836,10 +825,9 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
                 }
-            }
           
             // RSL1j
-            it("should include attributes supplied by the caller in the encoded message") {
+            func test__004__publish__should_include_attributes_supplied_by_the_caller_in_the_encoded_message() {
                 let options = AblyTests.commonAppSetup()
                 let client = ARTRest(options: options)
                 let proxyHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
@@ -868,13 +856,12 @@ override class var defaultTestSuite : XCTestSuite {
                 expect(jsonMessage["data"].string).to(equal(""))
                 expect(jsonMessage["id"].string).to(equal(message.id))
             }
-        }
 
         // RSL2
-        describe("history") {
+        
 
             // RSL2a
-            it("should return a PaginatedResult page containing the first page of messages") {
+            func test__029__history__should_return_a_PaginatedResult_page_containing_the_first_page_of_messages() {
                 let client = ARTRest(options: AblyTests.commonAppSetup())
                 let channel = client.channels.get("foo")
 
@@ -949,10 +936,10 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSL2b
-            context("query arguments") {
+            
 
                 // RSL2b1
-                it("start and end should filter messages between those two times") {
+                func test__030__history__query_arguments__start_and_end_should_filter_messages_between_those_two_times() {
                     let client = ARTRest(options: AblyTests.commonAppSetup())
                     let channel = client.channels.get("test")
 
@@ -1011,7 +998,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSL2b1
-                it("start must be equal to or less than end and is unaffected by the request direction") {
+                func test__031__history__query_arguments__start_must_be_equal_to_or_less_than_end_and_is_unaffected_by_the_request_direction() {
                     let client = ARTRest(options: AblyTests.commonAppSetup())
                     let channel = client.channels.get("test")
 
@@ -1032,7 +1019,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSL2b2
-                it("direction backwards or forwards") {
+                func test__032__history__query_arguments__direction_backwards_or_forwards() {
                     let client = ARTRest(options: AblyTests.commonAppSetup())
                     let channel = client.channels.get("test")
 
@@ -1073,7 +1060,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSL2b3
-                it("limit items result") {
+                func test__033__history__query_arguments__limit_items_result() {
                     let client = ARTRest(options: AblyTests.commonAppSetup())
                     let channel = client.channels.get("test")
 
@@ -1111,7 +1098,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSL2b3
-                it("limit supports up to 1000 items") {
+                func test__034__history__query_arguments__limit_supports_up_to_1000_items() {
                     let client = ARTRest(options: AblyTests.commonAppSetup())
                     let channel = client.channels.get("test")
 
@@ -1125,16 +1112,12 @@ override class var defaultTestSuite : XCTestSuite {
                   expect{ try channel.history(query, callback: { _ , _  in }) }.toNot(throwError())
                 }
 
-            }
-
-        }
-
         // RSL3, RSP1
-        xdescribe("presence") {
+        
 
             // RSP3
-            context("get") {
-                it("should return presence fixture data") {
+            
+                func skipped__test__035__presence__get__should_return_presence_fixture_data() {
                     let options = AblyTests.commonAppSetup()
                     options.channelNamePrefix = nil
                     client = ARTRest(options: options)
@@ -1172,14 +1155,12 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(message.data as? NSObject).to(equal(encodedFixture.data as? NSObject));
                     }
                 }
-            }
-        }
 
         // RSL4
-        describe("message encoding") {
+        
 
             // RSL4a
-            it("payloads should be binary, strings, or objects capable of JSON representation") {
+            func test__036__message_encoding__payloads_should_be_binary__strings__or_objects_capable_of_JSON_representation() {
                 let validCases: [TestCase]
                 if #available(iOS 11.0, *) {
                     validCases = [
@@ -1242,7 +1223,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSL4b
-            it("encoding attribute should represent the encoding(s) applied in right to left") {
+            func test__037__message_encoding__encoding_attribute_should_represent_the_encoding_s__applied_in_right_to_left() {
                 let encodingCases = [
                     TestCase(value: text, expected: JSON.null),
                     TestCase(value: dictionary, expected: "json"),
@@ -1267,9 +1248,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
             }
 
-            context("json") {
+            
                 // RSL4d1
-                it("binary payload should be encoded as Base64 and represented as a JSON string") {
+                func test__038__message_encoding__json__binary_payload_should_be_encoded_as_Base64_and_represented_as_a_JSON_string() {
                     client.internal.httpExecutor = testHTTPExecutor
                     waitUntil(timeout: testTimeout) { done in
                         channel.publish(nil, data: binaryData, callback: { error in
@@ -1288,7 +1269,7 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSL4d
-                it("string payload should be represented as a JSON string") {
+                func test__039__message_encoding__json__string_payload_should_be_represented_as_a_JSON_string() {
                     client.internal.httpExecutor = testHTTPExecutor
                     waitUntil(timeout: testTimeout) { done in
                         channel.publish(nil, data: text, callback: { error in
@@ -1309,9 +1290,9 @@ override class var defaultTestSuite : XCTestSuite {
                 }
 
                 // RSL4d3
-                context("json payload should be stringified either") {
+                
 
-                    it("as a JSON Array") {
+                    func test__041__message_encoding__json__json_payload_should_be_stringified_either__as_a_JSON_Array() {
                         client.internal.httpExecutor = testHTTPExecutor
                         // JSON Array
                         waitUntil(timeout: testTimeout) { done in
@@ -1332,7 +1313,7 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("as a JSON Object") {
+                    func test__042__message_encoding__json__json_payload_should_be_stringified_either__as_a_JSON_Object() {
                         client.internal.httpExecutor = testHTTPExecutor
                         // JSON Object
                         waitUntil(timeout: testTimeout) { done in
@@ -1353,10 +1334,8 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                }
-
                 // RSL4d4
-                it("messages received should be decoded based on the encoding field") {
+                func test__040__message_encoding__json__messages_received_should_be_decoded_based_on_the_encoding_field() {
                     let cases = [text, integer, decimal, dictionary, array, binaryData] as [Any]
 
                     cases.forEach { caseTest in
@@ -1401,31 +1380,26 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                     expect(totalReceived).toEventually(equal(cases.count), timeout: testTimeout)
                 }
-            }
-        }
 
         // RSL5
-        describe("message payload encryption") {
+        
 
             // RSL5b
-            context("should support AES encryption") {
+            
                 
-                it("128 CBC mode") {
+                func test__043__message_payload_encryption__should_support_AES_encryption__128_CBC_mode() {
                     testSupportsAESEncryptionWithKeyLength(128)
                 }
                 
-                it("256 CBC mode") {
+                func test__044__message_payload_encryption__should_support_AES_encryption__256_CBC_mode() {
                     testSupportsAESEncryptionWithKeyLength(256)
                 }
-            }
-
-        }
 
         // RSL6
-        describe("message decoding") {
+        
 
             // RSL6b
-            it("should deliver with a binary payload when the payload was successfully decoded but it could not be decrypted") {
+            func test__045__message_decoding__should_deliver_with_a_binary_payload_when_the_payload_was_successfully_decoded_but_it_could_not_be_decrypted() {
                 let options = AblyTests.commonAppSetup()
                 let clientEncrypted = ARTRest(options: options)
 
@@ -1460,7 +1434,7 @@ override class var defaultTestSuite : XCTestSuite {
             }
 
             // RSL6b
-            it("should deliver with encoding attribute set indicating the residual encoding and error should be emitted") {
+            func test__046__message_decoding__should_deliver_with_encoding_attribute_set_indicating_the_residual_encoding_and_error_should_be_emitted() {
                 let options = AblyTests.commonAppSetup()
                 options.useBinaryProtocol = false
                 options.logHandler = ARTLog(capturingOutput: true)
@@ -1502,8 +1476,4 @@ override class var defaultTestSuite : XCTestSuite {
                     }
                 }
             }
-
-        }
-
-    }
 }

--- a/Spec/RestClientChannels.swift
+++ b/Spec/RestClientChannels.swift
@@ -1,7 +1,7 @@
 import Ably
 import Aspects
 import Nimble
-import Quick
+import XCTest
 
 // Swift isn't yet smart enough to do this automatically when bridging Objective-C APIs
 extension ARTRestChannels: Sequence {

--- a/Spec/RestClientChannels.swift
+++ b/Spec/RestClientChannels.swift
@@ -18,17 +18,28 @@ private func beAChannel(named expectedValue: String) -> Predicate<ARTChannel> {
     }
 }
 
+        private var client: ARTRest!
+        private var channelName: String!
+
+        private let cipherParams: ARTCipherParams? = nil
+
 class RestClientChannels: QuickSpec {
+
+// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+override class var defaultTestSuite : XCTestSuite {
+    let _ = client
+    let _ = channelName
+    let _ = cipherParams
+
+    return super.defaultTestSuite
+}
+
     override func spec() {
-        var client: ARTRest!
-        var channelName: String!
 
         beforeEach {
             client = ARTRest(key: "fake:key")
             channelName = ProcessInfo.processInfo.globallyUniqueString
         }
-
-        let cipherParams: ARTCipherParams? = nil
 
         describe("RestClient") {
             context("channels") {

--- a/Spec/RestClientChannels.swift
+++ b/Spec/RestClientChannels.swift
@@ -23,7 +23,7 @@ private func beAChannel(named expectedValue: String) -> Predicate<ARTChannel> {
 
         private let cipherParams: ARTCipherParams? = nil
 
-class RestClientChannels: QuickSpec {
+class RestClientChannels: XCTestCase {
 
 // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
 override class var defaultTestSuite : XCTestSuite {
@@ -34,24 +34,25 @@ override class var defaultTestSuite : XCTestSuite {
     return super.defaultTestSuite
 }
 
-    override func spec() {
+        override func setUp() {
+super.setUp()
 
-        beforeEach {
+
             client = ARTRest(key: "fake:key")
             channelName = ProcessInfo.processInfo.globallyUniqueString
         }
 
-        describe("RestClient") {
-            context("channels") {
+        
+            
                 // RSN1
-                it("should return collection of channels") {
+                func test__001__RestClient__channels__should_return_collection_of_channels() {
                     let _: ARTRestChannels = client.channels
                 }
 
                 // RSN3
-                context("get") {
+                
                     // RSN3a
-                    it("should return a channel") {
+                    func test__003__RestClient__channels__get__should_return_a_channel() {
                         let channel = client.channels.get(channelName).internal
                         expect(channel).to(beAChannel(named: channelName))
 
@@ -60,7 +61,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSN3b
-                    it("should return a channel with the provided options") {
+                    func test__004__RestClient__channels__get__should_return_a_channel_with_the_provided_options() {
                         let options = ARTChannelOptions(cipher: cipherParams)
                         let channel = client.channels.get(channelName, options: options)
 
@@ -69,7 +70,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSN3b
-                    it("should not replace the options on an existing channel when none are provided") {
+                    func test__005__RestClient__channels__get__should_not_replace_the_options_on_an_existing_channel_when_none_are_provided() {
                         let options = ARTChannelOptions(cipher: cipherParams)
                         let channel = client.channels.get(channelName, options: options).internal
 
@@ -80,7 +81,7 @@ override class var defaultTestSuite : XCTestSuite {
                     }
 
                     // RSN3c
-                    it("should replace the options on an existing channel when new ones are provided") {
+                    func test__006__RestClient__channels__get__should_replace_the_options_on_an_existing_channel_when_new_ones_are_provided() {
                         let channel = client.channels.get(channelName).internal
                         let oldOptions = channel.options
 
@@ -91,22 +92,20 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(newButSameChannel.options).to(beIdenticalTo(newOptions))
                         expect(newButSameChannel.options).notTo(beIdenticalTo(oldOptions))
                     }
-                }
 
                 // RSN2
-                context("channelExists") {
-                    it("should check if a channel exists") {
+                
+                    func test__007__RestClient__channels__channelExists__should_check_if_a_channel_exists() {
                         expect(client.channels.exists(channelName)).to(beFalse())
 
                         client.channels.get(channelName)
 
                         expect(client.channels.exists(channelName)).to(beTrue())
                     }
-                }
 
                 // RSN4
-                context("releaseChannel") {
-                    it("should release a channel") {
+                
+                    func test__008__RestClient__channels__releaseChannel__should_release_a_channel() {
                         weak var channel: ARTRestChannelInternal!
 
                         autoreleasepool {
@@ -118,10 +117,9 @@ override class var defaultTestSuite : XCTestSuite {
 
                         expect(channel).to(beNil())
                     }
-                }
 
                 // RSN2
-                it("should be enumerable") {
+                func test__002__RestClient__channels__should_be_enumerable() {
                     let channels = [
                         client.channels.get(channelName).internal,
                         client.channels.get(String(channelName.reversed())).internal
@@ -131,7 +129,4 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(channels).to(contain((channel as! ARTRestChannel).internal))
                     }
                 }
-            }
-        }
-    }
 }

--- a/Spec/RestClientChannels.swift
+++ b/Spec/RestClientChannels.swift
@@ -1,12 +1,12 @@
 import Ably
+import Aspects
 import Nimble
 import Quick
-import Aspects
 
 // Swift isn't yet smart enough to do this automatically when bridging Objective-C APIs
 extension ARTRestChannels: Sequence {
     public func makeIterator() -> NSFastEnumerationIterator {
-        return NSFastEnumerationIterator(self.iterate())
+        return NSFastEnumerationIterator(iterate())
     }
 }
 
@@ -18,115 +18,111 @@ private func beAChannel(named expectedValue: String) -> Predicate<ARTChannel> {
     }
 }
 
-        private var client: ARTRest!
-        private var channelName: String!
+private var client: ARTRest!
+private var channelName: String!
 
-        private let cipherParams: ARTCipherParams? = nil
+private let cipherParams: ARTCipherParams? = nil
 
 class RestClientChannels: XCTestCase {
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = client
+        _ = channelName
+        _ = cipherParams
 
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = client
-    let _ = channelName
-    let _ = cipherParams
+        return super.defaultTestSuite
+    }
 
-    return super.defaultTestSuite
-}
+    override func setUp() {
+        super.setUp()
 
-        override func setUp() {
-super.setUp()
+        client = ARTRest(key: "fake:key")
+        channelName = ProcessInfo.processInfo.globallyUniqueString
+    }
 
+    // RSN1
+    func test__001__RestClient__channels__should_return_collection_of_channels() {
+        let _: ARTRestChannels = client.channels
+    }
 
-            client = ARTRest(key: "fake:key")
-            channelName = ProcessInfo.processInfo.globallyUniqueString
+    // RSN3
+
+    // RSN3a
+    func test__003__RestClient__channels__get__should_return_a_channel() {
+        let channel = client.channels.get(channelName).internal
+        expect(channel).to(beAChannel(named: channelName))
+
+        let sameChannel = client.channels.get(channelName).internal
+        expect(sameChannel).to(beIdenticalTo(channel))
+    }
+
+    // RSN3b
+    func test__004__RestClient__channels__get__should_return_a_channel_with_the_provided_options() {
+        let options = ARTChannelOptions(cipher: cipherParams)
+        let channel = client.channels.get(channelName, options: options)
+
+        expect(channel.internal).to(beAChannel(named: channelName))
+        expect(channel.internal.options).to(beIdenticalTo(options))
+    }
+
+    // RSN3b
+    func test__005__RestClient__channels__get__should_not_replace_the_options_on_an_existing_channel_when_none_are_provided() {
+        let options = ARTChannelOptions(cipher: cipherParams)
+        let channel = client.channels.get(channelName, options: options).internal
+
+        let newButSameChannel = client.channels.get(channelName).internal
+
+        expect(newButSameChannel).to(beIdenticalTo(channel))
+        expect(newButSameChannel.options).to(beIdenticalTo(options))
+    }
+
+    // RSN3c
+    func test__006__RestClient__channels__get__should_replace_the_options_on_an_existing_channel_when_new_ones_are_provided() {
+        let channel = client.channels.get(channelName).internal
+        let oldOptions = channel.options
+
+        let newOptions = ARTChannelOptions(cipher: cipherParams)
+        let newButSameChannel = client.channels.get(channelName, options: newOptions).internal
+
+        expect(newButSameChannel).to(beIdenticalTo(channel))
+        expect(newButSameChannel.options).to(beIdenticalTo(newOptions))
+        expect(newButSameChannel.options).notTo(beIdenticalTo(oldOptions))
+    }
+
+    // RSN2
+
+    func test__007__RestClient__channels__channelExists__should_check_if_a_channel_exists() {
+        expect(client.channels.exists(channelName)).to(beFalse())
+
+        client.channels.get(channelName)
+
+        expect(client.channels.exists(channelName)).to(beTrue())
+    }
+
+    // RSN4
+
+    func test__008__RestClient__channels__releaseChannel__should_release_a_channel() {
+        weak var channel: ARTRestChannelInternal!
+
+        autoreleasepool {
+            channel = client.channels.get(channelName).internal
+
+            expect(channel).to(beAChannel(named: channelName))
+            client.channels.release(channel.name)
         }
 
-        
-            
-                // RSN1
-                func test__001__RestClient__channels__should_return_collection_of_channels() {
-                    let _: ARTRestChannels = client.channels
-                }
+        expect(channel).to(beNil())
+    }
 
-                // RSN3
-                
-                    // RSN3a
-                    func test__003__RestClient__channels__get__should_return_a_channel() {
-                        let channel = client.channels.get(channelName).internal
-                        expect(channel).to(beAChannel(named: channelName))
+    // RSN2
+    func test__002__RestClient__channels__should_be_enumerable() {
+        let channels = [
+            client.channels.get(channelName).internal,
+            client.channels.get(String(channelName.reversed())).internal,
+        ]
 
-                        let sameChannel = client.channels.get(channelName).internal
-                        expect(sameChannel).to(beIdenticalTo(channel))
-                    }
-
-                    // RSN3b
-                    func test__004__RestClient__channels__get__should_return_a_channel_with_the_provided_options() {
-                        let options = ARTChannelOptions(cipher: cipherParams)
-                        let channel = client.channels.get(channelName, options: options)
-
-                        expect(channel.internal).to(beAChannel(named: channelName))
-                        expect(channel.internal.options).to(beIdenticalTo(options))
-                    }
-
-                    // RSN3b
-                    func test__005__RestClient__channels__get__should_not_replace_the_options_on_an_existing_channel_when_none_are_provided() {
-                        let options = ARTChannelOptions(cipher: cipherParams)
-                        let channel = client.channels.get(channelName, options: options).internal
-
-                        let newButSameChannel = client.channels.get(channelName).internal
-
-                        expect(newButSameChannel).to(beIdenticalTo(channel))
-                        expect(newButSameChannel.options).to(beIdenticalTo(options))
-                    }
-
-                    // RSN3c
-                    func test__006__RestClient__channels__get__should_replace_the_options_on_an_existing_channel_when_new_ones_are_provided() {
-                        let channel = client.channels.get(channelName).internal
-                        let oldOptions = channel.options
-
-                        let newOptions = ARTChannelOptions(cipher: cipherParams)
-                        let newButSameChannel = client.channels.get(channelName, options: newOptions).internal
-
-                        expect(newButSameChannel).to(beIdenticalTo(channel))
-                        expect(newButSameChannel.options).to(beIdenticalTo(newOptions))
-                        expect(newButSameChannel.options).notTo(beIdenticalTo(oldOptions))
-                    }
-
-                // RSN2
-                
-                    func test__007__RestClient__channels__channelExists__should_check_if_a_channel_exists() {
-                        expect(client.channels.exists(channelName)).to(beFalse())
-
-                        client.channels.get(channelName)
-
-                        expect(client.channels.exists(channelName)).to(beTrue())
-                    }
-
-                // RSN4
-                
-                    func test__008__RestClient__channels__releaseChannel__should_release_a_channel() {
-                        weak var channel: ARTRestChannelInternal!
-
-                        autoreleasepool {
-                            channel = client.channels.get(channelName).internal
-
-                            expect(channel).to(beAChannel(named: channelName))
-                            client.channels.release(channel.name)
-                        }
-
-                        expect(channel).to(beNil())
-                    }
-
-                // RSN2
-                func test__002__RestClient__channels__should_be_enumerable() {
-                    let channels = [
-                        client.channels.get(channelName).internal,
-                        client.channels.get(String(channelName.reversed())).internal
-                    ]
-
-                    for channel in client.channels {
-                        expect(channels).to(contain((channel as! ARTRestChannel).internal))
-                    }
-                }
+        for channel in client.channels {
+            expect(channels).to(contain((channel as! ARTRestChannel).internal))
+        }
+    }
 }

--- a/Spec/RestClientPresence.swift
+++ b/Spec/RestClientPresence.swift
@@ -2,15 +2,14 @@ import Ably
 import Quick
 import Nimble
 
-class RestClientPresence: QuickSpec {
-    override func spec() {
-        describe("Presence") {
+class RestClientPresence: XCTestCase {
+        
 
             // RSP3
-            context("get") {
+            
 
                 // RSP3a
-                xit("should return a PaginatedResult page containing the first page of members") {
+                func skipped__test__002__Presence__get__should_return_a_PaginatedResult_page_containing_the_first_page_of_members() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRest(options: options)
                     let channel = client.channels.get("test")
@@ -67,7 +66,7 @@ class RestClientPresence: QuickSpec {
                 }
 
                 // RSP3a1
-                it("limit should support up to 1000 items") {
+                func test__003__Presence__get__limit_should_support_up_to_1000_items() {
                     let client = ARTRest(options: AblyTests.commonAppSetup())
                     let channel = client.channels.get("test")
 
@@ -82,7 +81,7 @@ class RestClientPresence: QuickSpec {
                 }
 
                 // RSP3a2
-                it("clientId should filter members by the provided clientId") {
+                func test__004__Presence__get__clientId_should_filter_members_by_the_provided_clientId() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRest(options: options)
                     let channel = client.channels.get("test")
@@ -115,7 +114,7 @@ class RestClientPresence: QuickSpec {
                 }
 
                 // RSP3a3
-                it("connectionId should filter members by the provided connectionId") {
+                func test__005__Presence__get__connectionId_should_filter_members_by_the_provided_connectionId() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRest(options: options)
                     let channel = client.channels.get("test")
@@ -155,13 +154,11 @@ class RestClientPresence: QuickSpec {
                     }
                 }
 
-            }
-
             // RSP4
-            context("history") {
+            
 
                 // RSP4a
-                it("should return a PaginatedResult page containing the first page of members") {
+                func test__006__Presence__history__should_return_a_PaginatedResult_page_containing_the_first_page_of_members() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRest(options: options)
                     let channel = client.channels.get("test")
@@ -213,18 +210,16 @@ class RestClientPresence: QuickSpec {
                     }
                 }
 
-            }
-
             // RSP4
-            context("history") {
+            
 
                 // RSP4b
-                context("query argument") {
+                
 
                     // RSP4b2
                     // Disabled because there's something wrong in the Sandbox.
                     // More info at https://ably-real-time.slack.com/archives/C030C5YLY/p1614269570000400
-                    xit("direction should change the order of the members") {
+                    func skipped__test__007__Presence__history__query_argument__direction_should_change_the_order_of_the_members() {
                         let options = AblyTests.commonAppSetup()
                         let client = ARTRest(options: options)
                         let channel = client.channels.get("test")
@@ -271,18 +266,14 @@ class RestClientPresence: QuickSpec {
                         }
                     }
 
-                }
-
-            }
-
             // RSP4
-            context("history") {
+            
 
                 // RSP4b
-                context("query argument") {
+                
 
                     // RSP4b3
-                    it("limit supports up to 1000 members") {
+                    func test__009__Presence__history__query_argument__limit_supports_up_to_1000_members() {
                         let options = AblyTests.commonAppSetup()
                         let client = ARTRest(options: options)
                         let channel = client.channels.get("test")
@@ -313,10 +304,9 @@ class RestClientPresence: QuickSpec {
                             expect(error._code).to(equal(ARTDataQueryError.limit.rawValue))
                         })
                     }
-                }
 
                 // RSP3a3
-                it("connectionId should filter members by the provided connectionId") {
+                func test__008__Presence__history__connectionId_should_filter_members_by_the_provided_connectionId() {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRest(options: options)
                     let channel = client.channels.get("test")
@@ -356,16 +346,14 @@ class RestClientPresence: QuickSpec {
                     }
                 }
 
-            }
-
             // RSP4
-            context("history") {
+            
 
                 // RSP4b
-                context("query argument") {
+                
 
                     // RSP4b1
-                    it("start and end should filter members between those two times") {
+                    func test__010__Presence__history__query_argument__start_and_end_should_filter_members_between_those_two_times() {
                         let options = AblyTests.commonAppSetup()
                         let client = ARTRest(options: options)
                         let channel = client.channels.get("test")
@@ -418,7 +406,7 @@ class RestClientPresence: QuickSpec {
                     }
 
                     // RSP4b1
-                    it("start must be equal to or less than end and is unaffected by the request direction") {
+                    func test__011__Presence__history__query_argument__start_must_be_equal_to_or_less_than_end_and_is_unaffected_by_the_request_direction() {
                         let client = ARTRest(options: AblyTests.commonAppSetup())
                         let channel = client.channels.get("test")
 
@@ -438,12 +426,8 @@ class RestClientPresence: QuickSpec {
                         })
                     }
 
-                }
-
-            }
-
             // RSP5
-            it("presence messages retrieved are decoded in the same way that messages are decoded") {
+            func test__001__Presence__presence_messages_retrieved_are_decoded_in_the_same_way_that_messages_are_decoded() {
                 let options = AblyTests.commonAppSetup()
                 let client = ARTRest(options: options)
                 let channel = client.channels.get("test")
@@ -494,7 +478,4 @@ class RestClientPresence: QuickSpec {
 
                 expect(decodeNumberOfCalls).to(equal(2))
             }
-
-        }
-    }
 }

--- a/Spec/RestClientPresence.swift
+++ b/Spec/RestClientPresence.swift
@@ -1,6 +1,6 @@
 import Ably
 import Nimble
-import Quick
+import XCTest
 
 class RestClientPresence: XCTestCase {
     // RSP3

--- a/Spec/RestClientPresence.swift
+++ b/Spec/RestClientPresence.swift
@@ -1,481 +1,471 @@
 import Ably
-import Quick
 import Nimble
+import Quick
 
 class RestClientPresence: XCTestCase {
-        
-
-            // RSP3
-            
-
-                // RSP3a
-                func skipped__test__002__Presence__get__should_return_a_PaginatedResult_page_containing_the_first_page_of_members() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRest(options: options)
-                    let channel = client.channels.get("test")
-
-                    var disposable = [ARTRealtime]()
-                    defer {
-                        for clientItem in disposable {
-                            clientItem.dispose()
-                            clientItem.close()
-                        }
-                    }
-
-                    let expectedData = "online"
-                    let expectedPattern = "^user(\\d+)$"
-
-                    // Load 150 members (2 pages)
-                    disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 150, data:expectedData as AnyObject?, options: options)]
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.get { membersPage, error in
-                            expect(error).to(beNil())
-
-                            let membersPage = membersPage!
-                            expect(membersPage).to(beAnInstanceOf(ARTPaginatedResult<ARTPresenceMessage>.self))
-                            expect(membersPage.items).to(haveCount(100))
-
-                            let members = membersPage.items 
-                            expect(members).to(allPass({ member in
-                                return NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                                    && (member!.data as? String) == expectedData
-                            }))
-
-                            expect(membersPage.hasNext).to(beTrue())
-                            expect(membersPage.isLast).to(beFalse())
-
-                            membersPage.next { nextPage, error in
-                                expect(error).to(beNil())
-                                let nextPage = nextPage!
-                                expect(nextPage).to(beAnInstanceOf(ARTPaginatedResult<ARTPresenceMessage>.self))
-                                expect(nextPage.items).to(haveCount(50))
-
-                                let members = nextPage.items 
-                                expect(members).to(allPass({ member in
-                                    return NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                                        && (member!.data as? String) == expectedData
-                                }))
-
-                                expect(nextPage.hasNext).to(beFalse())
-                                expect(nextPage.isLast).to(beTrue())
-                                done()
-                            }
-                        }
-                    }
-                }
-
-                // RSP3a1
-                func test__003__Presence__get__limit_should_support_up_to_1000_items() {
-                    let client = ARTRest(options: AblyTests.commonAppSetup())
-                    let channel = client.channels.get("test")
-
-                    let query = ARTPresenceQuery()
-                    expect(query.limit).to(equal(100))
-
-                    query.limit = 1001
-                    expect{ try channel.presence.get(query, callback: { _, _ in }) }.to(throwError())
-
-                    query.limit = 1000
-                    expect{ try channel.presence.get(query, callback: { _, _ in }) }.toNot(throwError())
-                }
-
-                // RSP3a2
-                func test__004__Presence__get__clientId_should_filter_members_by_the_provided_clientId() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRest(options: options)
-                    let channel = client.channels.get("test")
-
-                    let realtime = ARTRealtime(options: options)
-                    defer { realtime.close() }
-                    let realtimeChannel = realtime.channels.get("test")
-
-                    realtimeChannel.presence.enterClient("ana", data: "mobile")
-                    realtimeChannel.presence.enterClient("john", data: "web")
-                    realtimeChannel.presence.enterClient("casey", data: "mobile")
-
-                    expect(realtimeChannel.internal.presenceMap.members).toEventually(haveCount(3), timeout: testTimeout)
-
-                    let query = ARTPresenceQuery()
-                    query.clientId = "john"
-
-                    waitUntil(timeout: testTimeout) { done in
-                        expect {
-                            try channel.presence.get(query) { membersPage, error in
-                                expect(error).to(beNil())
-                                expect(membersPage!.items).to(haveCount(1))
-                                let member = membersPage!.items[0]
-                                expect(member.clientId).to(equal("john"))
-                                expect(member.data as? NSObject).to(equal("web" as NSObject?))
-                                done()
-                            }
-                        }.toNot(throwError())
-                    }
-                }
-
-                // RSP3a3
-                func test__005__Presence__get__connectionId_should_filter_members_by_the_provided_connectionId() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRest(options: options)
-                    let channel = client.channels.get("test")
-
-                    var disposable = [ARTRealtime]()
-                    defer {
-                        for clientItem in disposable {
-                            clientItem.dispose()
-                            clientItem.close()
-                        }
-                    }
-
-                    // One connection
-                    disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 6, options: options)]
-
-                    // Another connection
-                    disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 3, startFrom: 7, options: options)]
-
-                    let query = ARTRealtimePresenceQuery()
-                    // Return all members from last connection (connectionId from the last connection)
-                    query.connectionId = disposable.last!.connection.id!
-
-                    waitUntil(timeout: testTimeout) { done in
-                        expect {
-                            try channel.presence.get(query) { membersPage, error in
-                                expect(error).to(beNil())
-                                expect(membersPage!.items).to(haveCount(3))
-                                expect(membersPage!.hasNext).to(beFalse())
-                                expect(membersPage!.isLast).to(beTrue())
-                                expect(membersPage!.items).to(allPass({ member in
-                                    let member = member!
-                                    return NSRegularExpression.match(member.clientId, pattern: "^user(7|8|9)")
-                                }))
-                                done()
-                            }
-                        }.toNot(throwError())
-                    }
-                }
-
-            // RSP4
-            
-
-                // RSP4a
-                func test__006__Presence__history__should_return_a_PaginatedResult_page_containing_the_first_page_of_members() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRest(options: options)
-                    let channel = client.channels.get("test")
-
-                    var realtime: ARTRealtime!
-                    defer { realtime.dispose(); realtime.close() }
-
-                    let expectedData = "online"
-                    let expectedPattern = "^user(\\d+)$"
-                    realtime = AblyTests.addMembersSequentiallyToChannel("test", members: 150, data: expectedData as AnyObject?, options: options)
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.presence.history { membersPage, error in
-                            expect(error).to(beNil())
-                            guard let membersPage = membersPage else {
-                                fail("Page is empty"); done(); return
-                            }
-                            expect(membersPage).to(beAnInstanceOf(ARTPaginatedResult<ARTPresenceMessage>.self))
-                            expect(membersPage.items).to(haveCount(100))
-
-                            let members = membersPage.items 
-                            expect(members).to(allPass({ member in
-                                return NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                                    && (member!.data as? String) == expectedData
-                            }))
-
-                            expect(membersPage.hasNext).to(beTrue())
-                            expect(membersPage.isLast).to(beFalse())
-
-                            membersPage.next { nextPage, error in
-                                expect(error).to(beNil())
-                                guard let nextPage = nextPage else {
-                                    fail("nextPage is empty"); done(); return
-                                }
-                                expect(nextPage).to(beAnInstanceOf(ARTPaginatedResult<ARTPresenceMessage>.self))
-                                expect(nextPage.items).to(haveCount(50))
-
-                                let members = nextPage.items 
-                                expect(members).to(allPass({ member in
-                                    return NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                                        && (member!.data as? String) == expectedData
-                                }))
-
-                                expect(nextPage.hasNext).to(beFalse())
-                                expect(nextPage.isLast).to(beTrue())
-                                done()
-                            }
-                        }
-                    }
-                }
-
-            // RSP4
-            
-
-                // RSP4b
-                
-
-                    // RSP4b2
-                    // Disabled because there's something wrong in the Sandbox.
-                    // More info at https://ably-real-time.slack.com/archives/C030C5YLY/p1614269570000400
-                    func skipped__test__007__Presence__history__query_argument__direction_should_change_the_order_of_the_members() {
-                        let options = AblyTests.commonAppSetup()
-                        let client = ARTRest(options: options)
-                        let channel = client.channels.get("test")
-
-                        var disposable = [ARTRealtime]()
-                        defer {
-                            for clientItem in disposable {
-                                clientItem.dispose()
-                                clientItem.close()
-                            }
-                        }
-
-                        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 10, data:nil, options: options)]
-
-                        let query = ARTDataQuery()
-                        expect(query.direction).to(equal(ARTQueryDirection.backwards))
-
-                        waitUntil(timeout: testTimeout) { done in
-                            expect {
-                                try channel.presence.history(query) { membersPage, error in
-                                    expect(error).to(beNil())
-                                    let firstMember = membersPage!.items.first!
-                                    expect(firstMember.clientId).to(equal("user10"))
-                                    let lastMember = membersPage!.items.last!
-                                    expect(lastMember.clientId).to(equal("user1"))
-                                    done()
-                                }
-                            }.toNot(throwError())
-                        }
-
-                        query.direction = .forwards
-
-                        waitUntil(timeout: testTimeout) { done in
-                            expect {
-                                try channel.presence.history(query) { membersPage, error in
-                                    expect(error).to(beNil())
-                                    let firstMember = membersPage!.items.first!
-                                    expect(firstMember.clientId).to(equal("user1"))
-                                    let lastMember = membersPage!.items.last!
-                                    expect(lastMember.clientId).to(equal("user10"))
-                                    done()
-                                }
-                            }.toNot(throwError())
-                        }
-                    }
-
-            // RSP4
-            
-
-                // RSP4b
-                
-
-                    // RSP4b3
-                    func test__009__Presence__history__query_argument__limit_supports_up_to_1000_members() {
-                        let options = AblyTests.commonAppSetup()
-                        let client = ARTRest(options: options)
-                        let channel = client.channels.get("test")
-
-                        var realtime: ARTRealtime!
-                        defer { realtime.dispose(); realtime.close() }
-                        realtime = AblyTests.addMembersSequentiallyToChannel("test", members: 1, options: options)
-
-                        let query = ARTDataQuery()
-                        expect(query.limit).to(equal(100))
-                        query.limit = 1
-
-                        waitUntil(timeout: testTimeout) { done in
-                            expect {
-                                try channel.presence.history(query) { membersPage, error in
-                                    expect(error).to(beNil())
-                                    expect(membersPage!.items).to(haveCount(1))
-                                    expect(membersPage!.hasNext).to(beFalse())
-                                    expect(membersPage!.isLast).to(beTrue())
-                                    done()
-                                }
-                            }.toNot(throwError())
-                        }
-
-                        query.limit = 1001
-
-                        expect { try channel.presence.history(query) { _, _ in } }.to(throwError { (error: Error) in
-                            expect(error._code).to(equal(ARTDataQueryError.limit.rawValue))
-                        })
-                    }
-
-                // RSP3a3
-                func test__008__Presence__history__connectionId_should_filter_members_by_the_provided_connectionId() {
-                    let options = AblyTests.commonAppSetup()
-                    let client = ARTRest(options: options)
-                    let channel = client.channels.get("test")
-
-                    var disposable = [ARTRealtime]()
-                    defer {
-                        for clientItem in disposable {
-                            clientItem.dispose()
-                            clientItem.close()
-                        }
-                    }
-
-                    // One connection
-                    disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 6, options: options)]
-
-                    // Another connection
-                    disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 3, startFrom: 7, options: options)]
-
-                    let query = ARTRealtimePresenceQuery()
-                    // Return all members from last connection (connectionId from the last connection)
-                    query.connectionId = disposable.last!.connection.id!
-
-                    waitUntil(timeout: testTimeout) { done in
-                        expect {
-                            try channel.presence.get(query) { membersPage, error in
-                                expect(error).to(beNil())
-                                expect(membersPage!.items).to(haveCount(3))
-                                expect(membersPage!.hasNext).to(beFalse())
-                                expect(membersPage!.isLast).to(beTrue())
-                                expect(membersPage!.items).to(allPass({ member in
-                                    let member = member 
-                                    return NSRegularExpression.match(member!.clientId, pattern: "^user(7|8|9)")
-                                }))
-                                done()
-                            }
-                        }.toNot(throwError())
-                    }
-                }
-
-            // RSP4
-            
-
-                // RSP4b
-                
-
-                    // RSP4b1
-                    func test__010__Presence__history__query_argument__start_and_end_should_filter_members_between_those_two_times() {
-                        let options = AblyTests.commonAppSetup()
-                        let client = ARTRest(options: options)
-                        let channel = client.channels.get("test")
-
-                        var disposable = [ARTRealtime]()
-                        defer {
-                            for clientItem in disposable {
-                                clientItem.dispose()
-                                clientItem.close()
-                            }
-                        }
-
-                        let query = ARTDataQuery()
-
-                        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 25, options: options)]
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.time { time, error in
-                                expect(error).to(beNil())
-                                query.start = time
-                                done()
-                            }
-                        }
-
-                        waitUntil(timeout: testTimeout) { done in
-                            delay(1.5) { done() }
-                        }
-
-                        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 3, options: options)]
-
-                        waitUntil(timeout: testTimeout) { done in
-                            client.time { time, error in
-                                expect(error).to(beNil())
-                                query.end = time
-                                done()
-                            }
-                        }
-
-                        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 10, options: options)]
-
-                        waitUntil(timeout: testTimeout) { done in
-                            expect {
-                                try channel.presence.history(query) { membersPage, error in
-                                    expect(error).to(beNil())
-                                    expect(membersPage!.items).to(haveCount(3))
-                                    done()
-                                }
-                            }.toNot(throwError())
-                        }
-                    }
-
-                    // RSP4b1
-                    func test__011__Presence__history__query_argument__start_must_be_equal_to_or_less_than_end_and_is_unaffected_by_the_request_direction() {
-                        let client = ARTRest(options: AblyTests.commonAppSetup())
-                        let channel = client.channels.get("test")
-
-                        let query = ARTDataQuery()
-                        query.direction = .backwards
-                        query.end = NSDate() as Date
-                        query.start = query.end!.addingTimeInterval(10.0)
-
-                        expect { try channel.presence.history(query) { _, _ in } }.to(throwError { (error: Error) in
-                            expect(error._code).to(equal(ARTDataQueryError.timestampRange.rawValue))
-                        })
-
-                        query.direction = .forwards
-
-                        expect { try channel.presence.history(query) { _, _ in } }.to(throwError { (error: Error) in
-                            expect(error._code).to(equal(ARTDataQueryError.timestampRange.rawValue))
-                        })
-                    }
-
-            // RSP5
-            func test__001__Presence__presence_messages_retrieved_are_decoded_in_the_same_way_that_messages_are_decoded() {
-                let options = AblyTests.commonAppSetup()
-                let client = ARTRest(options: options)
-                let channel = client.channels.get("test")
-
-                let expectedData = ["test":1]
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.publish(nil, data: expectedData) { _ in done() }
-                }
-
-                let realtime = ARTRealtime(options: options)
-                defer { realtime.dispose(); realtime.close() }
-                waitUntil(timeout: testTimeout) { done in
-                    let partialDone = AblyTests.splitDone(2, done: done)
-                    let channel = realtime.channels.get("test")
-                    channel.presence.enterClient("john", data: expectedData) { _ in
-                        partialDone()
-                    }
-                    channel.presence.subscribe { _ in
-                        channel.presence.unsubscribe()
-                        partialDone()
-                    }
-                }
-
-                typealias Done = () -> Void
-                func checkReceivedMessage<T: ARTBaseMessage>(_ done: @escaping Done) -> (ARTPaginatedResult<T>?, ARTErrorInfo?) -> Void {
-                    return { membersPage, error in
-                        expect(error).to(beNil())
-                        let member = membersPage!.items[0]
-                        expect(member.data as? NSDictionary).to(equal(expectedData as NSDictionary?))
-                        done()
-                    }
-                }
-
-                var decodeNumberOfCalls = 0
-                let hook = channel.internal.dataEncoder.testSuite_injectIntoMethod(after: #selector(ARTDataEncoder.decode(_:encoding:))) {
-                    decodeNumberOfCalls += 1
-                }
-                defer { hook.remove() }
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.history(checkReceivedMessage(done))
-                }
-
-                waitUntil(timeout: testTimeout) { done in
-                    channel.presence.history(checkReceivedMessage(done))
-                }
-
-                expect(decodeNumberOfCalls).to(equal(2))
+    // RSP3
+
+    // RSP3a
+    func skipped__test__002__Presence__get__should_return_a_PaginatedResult_page_containing_the_first_page_of_members() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("test")
+
+        var disposable = [ARTRealtime]()
+        defer {
+            for clientItem in disposable {
+                clientItem.dispose()
+                clientItem.close()
             }
+        }
+
+        let expectedData = "online"
+        let expectedPattern = "^user(\\d+)$"
+
+        // Load 150 members (2 pages)
+        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 150, data: expectedData as AnyObject?, options: options)]
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.get { membersPage, error in
+                expect(error).to(beNil())
+
+                let membersPage = membersPage!
+                expect(membersPage).to(beAnInstanceOf(ARTPaginatedResult<ARTPresenceMessage>.self))
+                expect(membersPage.items).to(haveCount(100))
+
+                let members = membersPage.items
+                expect(members).to(allPass { member in
+                    NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
+                        && (member!.data as? String) == expectedData
+                })
+
+                expect(membersPage.hasNext).to(beTrue())
+                expect(membersPage.isLast).to(beFalse())
+
+                membersPage.next { nextPage, error in
+                    expect(error).to(beNil())
+                    let nextPage = nextPage!
+                    expect(nextPage).to(beAnInstanceOf(ARTPaginatedResult<ARTPresenceMessage>.self))
+                    expect(nextPage.items).to(haveCount(50))
+
+                    let members = nextPage.items
+                    expect(members).to(allPass { member in
+                        NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
+                            && (member!.data as? String) == expectedData
+                    })
+
+                    expect(nextPage.hasNext).to(beFalse())
+                    expect(nextPage.isLast).to(beTrue())
+                    done()
+                }
+            }
+        }
+    }
+
+    // RSP3a1
+    func test__003__Presence__get__limit_should_support_up_to_1000_items() {
+        let client = ARTRest(options: AblyTests.commonAppSetup())
+        let channel = client.channels.get("test")
+
+        let query = ARTPresenceQuery()
+        expect(query.limit).to(equal(100))
+
+        query.limit = 1001
+        expect { try channel.presence.get(query, callback: { _, _ in }) }.to(throwError())
+
+        query.limit = 1000
+        expect { try channel.presence.get(query, callback: { _, _ in }) }.toNot(throwError())
+    }
+
+    // RSP3a2
+    func test__004__Presence__get__clientId_should_filter_members_by_the_provided_clientId() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("test")
+
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.close() }
+        let realtimeChannel = realtime.channels.get("test")
+
+        realtimeChannel.presence.enterClient("ana", data: "mobile")
+        realtimeChannel.presence.enterClient("john", data: "web")
+        realtimeChannel.presence.enterClient("casey", data: "mobile")
+
+        expect(realtimeChannel.internal.presenceMap.members).toEventually(haveCount(3), timeout: testTimeout)
+
+        let query = ARTPresenceQuery()
+        query.clientId = "john"
+
+        waitUntil(timeout: testTimeout) { done in
+            expect {
+                try channel.presence.get(query) { membersPage, error in
+                    expect(error).to(beNil())
+                    expect(membersPage!.items).to(haveCount(1))
+                    let member = membersPage!.items[0]
+                    expect(member.clientId).to(equal("john"))
+                    expect(member.data as? NSObject).to(equal("web" as NSObject?))
+                    done()
+                }
+            }.toNot(throwError())
+        }
+    }
+
+    // RSP3a3
+    func test__005__Presence__get__connectionId_should_filter_members_by_the_provided_connectionId() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("test")
+
+        var disposable = [ARTRealtime]()
+        defer {
+            for clientItem in disposable {
+                clientItem.dispose()
+                clientItem.close()
+            }
+        }
+
+        // One connection
+        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 6, options: options)]
+
+        // Another connection
+        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 3, startFrom: 7, options: options)]
+
+        let query = ARTRealtimePresenceQuery()
+        // Return all members from last connection (connectionId from the last connection)
+        query.connectionId = disposable.last!.connection.id!
+
+        waitUntil(timeout: testTimeout) { done in
+            expect {
+                try channel.presence.get(query) { membersPage, error in
+                    expect(error).to(beNil())
+                    expect(membersPage!.items).to(haveCount(3))
+                    expect(membersPage!.hasNext).to(beFalse())
+                    expect(membersPage!.isLast).to(beTrue())
+                    expect(membersPage!.items).to(allPass { member in
+                        let member = member!
+                        return NSRegularExpression.match(member.clientId, pattern: "^user(7|8|9)")
+                    })
+                    done()
+                }
+            }.toNot(throwError())
+        }
+    }
+
+    // RSP4
+
+    // RSP4a
+    func test__006__Presence__history__should_return_a_PaginatedResult_page_containing_the_first_page_of_members() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("test")
+
+        var realtime: ARTRealtime!
+        defer { realtime.dispose(); realtime.close() }
+
+        let expectedData = "online"
+        let expectedPattern = "^user(\\d+)$"
+        realtime = AblyTests.addMembersSequentiallyToChannel("test", members: 150, data: expectedData as AnyObject?, options: options)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.history { membersPage, error in
+                expect(error).to(beNil())
+                guard let membersPage = membersPage else {
+                    fail("Page is empty"); done(); return
+                }
+                expect(membersPage).to(beAnInstanceOf(ARTPaginatedResult<ARTPresenceMessage>.self))
+                expect(membersPage.items).to(haveCount(100))
+
+                let members = membersPage.items
+                expect(members).to(allPass { member in
+                    NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
+                        && (member!.data as? String) == expectedData
+                })
+
+                expect(membersPage.hasNext).to(beTrue())
+                expect(membersPage.isLast).to(beFalse())
+
+                membersPage.next { nextPage, error in
+                    expect(error).to(beNil())
+                    guard let nextPage = nextPage else {
+                        fail("nextPage is empty"); done(); return
+                    }
+                    expect(nextPage).to(beAnInstanceOf(ARTPaginatedResult<ARTPresenceMessage>.self))
+                    expect(nextPage.items).to(haveCount(50))
+
+                    let members = nextPage.items
+                    expect(members).to(allPass { member in
+                        NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
+                            && (member!.data as? String) == expectedData
+                    })
+
+                    expect(nextPage.hasNext).to(beFalse())
+                    expect(nextPage.isLast).to(beTrue())
+                    done()
+                }
+            }
+        }
+    }
+
+    // RSP4
+
+    // RSP4b
+
+    // RSP4b2
+    // Disabled because there's something wrong in the Sandbox.
+    // More info at https://ably-real-time.slack.com/archives/C030C5YLY/p1614269570000400
+    func skipped__test__007__Presence__history__query_argument__direction_should_change_the_order_of_the_members() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("test")
+
+        var disposable = [ARTRealtime]()
+        defer {
+            for clientItem in disposable {
+                clientItem.dispose()
+                clientItem.close()
+            }
+        }
+
+        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 10, data: nil, options: options)]
+
+        let query = ARTDataQuery()
+        expect(query.direction).to(equal(ARTQueryDirection.backwards))
+
+        waitUntil(timeout: testTimeout) { done in
+            expect {
+                try channel.presence.history(query) { membersPage, error in
+                    expect(error).to(beNil())
+                    let firstMember = membersPage!.items.first!
+                    expect(firstMember.clientId).to(equal("user10"))
+                    let lastMember = membersPage!.items.last!
+                    expect(lastMember.clientId).to(equal("user1"))
+                    done()
+                }
+            }.toNot(throwError())
+        }
+
+        query.direction = .forwards
+
+        waitUntil(timeout: testTimeout) { done in
+            expect {
+                try channel.presence.history(query) { membersPage, error in
+                    expect(error).to(beNil())
+                    let firstMember = membersPage!.items.first!
+                    expect(firstMember.clientId).to(equal("user1"))
+                    let lastMember = membersPage!.items.last!
+                    expect(lastMember.clientId).to(equal("user10"))
+                    done()
+                }
+            }.toNot(throwError())
+        }
+    }
+
+    // RSP4
+
+    // RSP4b
+
+    // RSP4b3
+    func test__009__Presence__history__query_argument__limit_supports_up_to_1000_members() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("test")
+
+        var realtime: ARTRealtime!
+        defer { realtime.dispose(); realtime.close() }
+        realtime = AblyTests.addMembersSequentiallyToChannel("test", members: 1, options: options)
+
+        let query = ARTDataQuery()
+        expect(query.limit).to(equal(100))
+        query.limit = 1
+
+        waitUntil(timeout: testTimeout) { done in
+            expect {
+                try channel.presence.history(query) { membersPage, error in
+                    expect(error).to(beNil())
+                    expect(membersPage!.items).to(haveCount(1))
+                    expect(membersPage!.hasNext).to(beFalse())
+                    expect(membersPage!.isLast).to(beTrue())
+                    done()
+                }
+            }.toNot(throwError())
+        }
+
+        query.limit = 1001
+
+        expect { try channel.presence.history(query) { _, _ in } }.to(throwError { (error: Error) in
+            expect(error._code).to(equal(ARTDataQueryError.limit.rawValue))
+        })
+    }
+
+    // RSP3a3
+    func test__008__Presence__history__connectionId_should_filter_members_by_the_provided_connectionId() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("test")
+
+        var disposable = [ARTRealtime]()
+        defer {
+            for clientItem in disposable {
+                clientItem.dispose()
+                clientItem.close()
+            }
+        }
+
+        // One connection
+        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 6, options: options)]
+
+        // Another connection
+        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 3, startFrom: 7, options: options)]
+
+        let query = ARTRealtimePresenceQuery()
+        // Return all members from last connection (connectionId from the last connection)
+        query.connectionId = disposable.last!.connection.id!
+
+        waitUntil(timeout: testTimeout) { done in
+            expect {
+                try channel.presence.get(query) { membersPage, error in
+                    expect(error).to(beNil())
+                    expect(membersPage!.items).to(haveCount(3))
+                    expect(membersPage!.hasNext).to(beFalse())
+                    expect(membersPage!.isLast).to(beTrue())
+                    expect(membersPage!.items).to(allPass { member in
+                        let member = member
+                        return NSRegularExpression.match(member!.clientId, pattern: "^user(7|8|9)")
+                    })
+                    done()
+                }
+            }.toNot(throwError())
+        }
+    }
+
+    // RSP4
+
+    // RSP4b
+
+    // RSP4b1
+    func test__010__Presence__history__query_argument__start_and_end_should_filter_members_between_those_two_times() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("test")
+
+        var disposable = [ARTRealtime]()
+        defer {
+            for clientItem in disposable {
+                clientItem.dispose()
+                clientItem.close()
+            }
+        }
+
+        let query = ARTDataQuery()
+
+        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 25, options: options)]
+
+        waitUntil(timeout: testTimeout) { done in
+            client.time { time, error in
+                expect(error).to(beNil())
+                query.start = time
+                done()
+            }
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            delay(1.5) { done() }
+        }
+
+        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 3, options: options)]
+
+        waitUntil(timeout: testTimeout) { done in
+            client.time { time, error in
+                expect(error).to(beNil())
+                query.end = time
+                done()
+            }
+        }
+
+        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 10, options: options)]
+
+        waitUntil(timeout: testTimeout) { done in
+            expect {
+                try channel.presence.history(query) { membersPage, error in
+                    expect(error).to(beNil())
+                    expect(membersPage!.items).to(haveCount(3))
+                    done()
+                }
+            }.toNot(throwError())
+        }
+    }
+
+    // RSP4b1
+    func test__011__Presence__history__query_argument__start_must_be_equal_to_or_less_than_end_and_is_unaffected_by_the_request_direction() {
+        let client = ARTRest(options: AblyTests.commonAppSetup())
+        let channel = client.channels.get("test")
+
+        let query = ARTDataQuery()
+        query.direction = .backwards
+        query.end = NSDate() as Date
+        query.start = query.end!.addingTimeInterval(10.0)
+
+        expect { try channel.presence.history(query) { _, _ in } }.to(throwError { (error: Error) in
+            expect(error._code).to(equal(ARTDataQueryError.timestampRange.rawValue))
+        })
+
+        query.direction = .forwards
+
+        expect { try channel.presence.history(query) { _, _ in } }.to(throwError { (error: Error) in
+            expect(error._code).to(equal(ARTDataQueryError.timestampRange.rawValue))
+        })
+    }
+
+    // RSP5
+    func test__001__Presence__presence_messages_retrieved_are_decoded_in_the_same_way_that_messages_are_decoded() {
+        let options = AblyTests.commonAppSetup()
+        let client = ARTRest(options: options)
+        let channel = client.channels.get("test")
+
+        let expectedData = ["test": 1]
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: expectedData) { _ in done() }
+        }
+
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.dispose(); realtime.close() }
+        waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            let channel = realtime.channels.get("test")
+            channel.presence.enterClient("john", data: expectedData) { _ in
+                partialDone()
+            }
+            channel.presence.subscribe { _ in
+                channel.presence.unsubscribe()
+                partialDone()
+            }
+        }
+
+        typealias Done = () -> Void
+        func checkReceivedMessage<T: ARTBaseMessage>(_ done: @escaping Done) -> (ARTPaginatedResult<T>?, ARTErrorInfo?) -> Void {
+            return { membersPage, error in
+                expect(error).to(beNil())
+                let member = membersPage!.items[0]
+                expect(member.data as? NSDictionary).to(equal(expectedData as NSDictionary?))
+                done()
+            }
+        }
+
+        var decodeNumberOfCalls = 0
+        let hook = channel.internal.dataEncoder.testSuite_injectIntoMethod(after: #selector(ARTDataEncoder.decode(_:encoding:))) {
+            decodeNumberOfCalls += 1
+        }
+        defer { hook.remove() }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.history(checkReceivedMessage(done))
+        }
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.presence.history(checkReceivedMessage(done))
+        }
+
+        expect(decodeNumberOfCalls).to(equal(2))
+    }
 }

--- a/Spec/RestClientStats.swift
+++ b/Spec/RestClientStats.swift
@@ -1,7 +1,7 @@
 import Ably
 import Foundation
 import Nimble
-import Quick
+import XCTest
 import SwiftyJSON
 
 private func postTestStats(_ stats: JSON) -> ARTClientOptions {

--- a/Spec/RestClientStats.swift
+++ b/Spec/RestClientStats.swift
@@ -43,15 +43,8 @@ private func queryStats(_ client: ARTRest, _ query: ARTStatsQuery, file: FileStr
     return stats!
 }
 
-class RestClientStats: QuickSpec {
-    override func spec() {
-        describe("RestClient") {
-            // RSC6
-            context("stats") {
-                // RSC6a
-                context("result") {
-                    let calendar = NSCalendar(identifier: NSCalendar.Identifier.gregorian)!
-                    let dateComponents: NSDateComponents = {
+                    private let calendar = NSCalendar(identifier: NSCalendar.Identifier.gregorian)!
+                    private let dateComponents: NSDateComponents = {
                         let dateComponents = NSDateComponents()
                         dateComponents.year = calendar.component(NSCalendar.Unit.year, from: NSDate() as Date) - 1
                         dateComponents.month = 2
@@ -60,15 +53,15 @@ class RestClientStats: QuickSpec {
                         dateComponents.minute = 3
                         return dateComponents
                     }()
-                    let date = calendar.date(from: dateComponents as DateComponents)!
-                    let dateFormatter: DateFormatter = {
+                    private let date = calendar.date(from: dateComponents as DateComponents)!
+                    private let dateFormatter: DateFormatter = {
                         let dateFormatter = DateFormatter()
                         dateFormatter.timeZone = NSTimeZone(name: "UTC") as TimeZone?
                         dateFormatter.dateFormat = "YYYY-MM-dd:HH:mm"
                         return dateFormatter
                     }()
                     
-                    let statsFixtures: JSON = [
+                    private let statsFixtures: JSON = [
                         [
                             "intervalId": dateFormatter.string(from: date), // 20XX-02-03:16:03
                             "inbound": [ "realtime": [ "messages": [ "count": 50, "data": 5000 ] ] ],
@@ -91,7 +84,28 @@ class RestClientStats: QuickSpec {
                         ]
                     ]
                     
-                    var statsOptions = ARTClientOptions()
+                    private var statsOptions = ARTClientOptions()
+
+class RestClientStats: QuickSpec {
+
+// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+override class var defaultTestSuite : XCTestSuite {
+    let _ = calendar
+    let _ = dateComponents
+    let _ = date
+    let _ = dateFormatter
+    let _ = statsFixtures
+    let _ = statsOptions
+
+    return super.defaultTestSuite
+}
+
+    override func spec() {
+        describe("RestClient") {
+            // RSC6
+            context("stats") {
+                // RSC6a
+                context("result") {
 
                     beforeEach {
                         statsOptions = postTestStats(statsFixtures)

--- a/Spec/RestClientStats.swift
+++ b/Spec/RestClientStats.swift
@@ -1,21 +1,21 @@
 import Ably
+import Foundation
 import Nimble
 import Quick
 import SwiftyJSON
-import Foundation
 
 private func postTestStats(_ stats: JSON) -> ARTClientOptions {
-    let options = AblyTests.setupOptions(AblyTests.jsonRestOptions, forceNewApp: true);
-    
+    let options = AblyTests.setupOptions(AblyTests.jsonRestOptions, forceNewApp: true)
+
     let keyBase64 = encodeBase64(options.key ?? "")
 
     let request = NSMutableURLRequest(url: URL(string: "\(AblyTests.clientOptions().restUrl().absoluteString)/stats")!)
-    
+
     request.httpMethod = "POST"
     request.httpBody = try? stats.rawData()
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.setValue("Basic \(keyBase64)", forHTTPHeaderField: "Authorization")
-    
+
     let (_, responseError, httpResponse) = NSURLSessionServerTrustSync().get(request)
 
     if let error = responseError {
@@ -25,7 +25,7 @@ private func postTestStats(_ stats: JSON) -> ARTClientOptions {
             XCTFail("Posting stats fixtures failed: code response \(response.statusCode)")
         }
     }
-    
+
     return options
 }
 
@@ -35,7 +35,7 @@ private func queryStats(_ client: ARTRest, _ query: ARTStatsQuery, file: FileStr
             try client.stats(query, callback: { result, err in
                 value((result, err))
             })
-        }.toNot(throwError() { _ in value(nil) })
+        }.toNot(throwError { _ in value(nil) })
     })!
     if let error = error {
         fail(error.message, file: file, line: line)
@@ -43,340 +43,339 @@ private func queryStats(_ client: ARTRest, _ query: ARTStatsQuery, file: FileStr
     return stats!
 }
 
-                    private let calendar = NSCalendar(identifier: NSCalendar.Identifier.gregorian)!
-                    private let dateComponents: NSDateComponents = {
-                        let dateComponents = NSDateComponents()
-                        dateComponents.year = calendar.component(NSCalendar.Unit.year, from: NSDate() as Date) - 1
-                        dateComponents.month = 2
-                        dateComponents.day = 3
-                        dateComponents.hour = 16
-                        dateComponents.minute = 3
-                        return dateComponents
-                    }()
-                    private let date = calendar.date(from: dateComponents as DateComponents)!
-                    private let dateFormatter: DateFormatter = {
-                        let dateFormatter = DateFormatter()
-                        dateFormatter.timeZone = NSTimeZone(name: "UTC") as TimeZone?
-                        dateFormatter.dateFormat = "YYYY-MM-dd:HH:mm"
-                        return dateFormatter
-                    }()
-                    
-                    private let statsFixtures: JSON = [
-                        [
-                            "intervalId": dateFormatter.string(from: date), // 20XX-02-03:16:03
-                            "inbound": [ "realtime": [ "messages": [ "count": 50, "data": 5000 ] ] ],
-                            "outbound": [ "realtime": [ "messages": [ "count": 20, "data": 2000 ] ] ]
-                        ],
-                        [
-                            "intervalId": dateFormatter.string(from: date.addingTimeInterval(60)), // 20XX-02-03:16:04
-                            "inbound": [ "realtime": [ "messages": [ "count": 60, "data": 6000 ] ] ],
-                            "outbound": [ "realtime": [ "messages": [ "count": 10, "data": 1000 ] ] ]
-                        ],
-                        [
-                            "intervalId": dateFormatter.string(from: date.addingTimeInterval(120)), // 20XX-02-03:16:05
-                            "inbound": [ "realtime": [ "messages": [ "count": 70, "data": 7000 ] ] ],
-                            "outbound": [ "realtime": [ "messages": [ "count": 40, "data": 4000 ] ] ],
-                            "persisted": [ "presence": [ "count": 20, "data": 2000 ] ],
-                            "connections": [ "tls": [ "peak": 20,  "opened": 10 ] ],
-                            "channels": [ "peak": 50, "opened": 30 ],
-                            "apiRequests": [ "succeeded": 50, "failed": 10 ],
-                            "tokenRequests": [ "succeeded": 60, "failed": 20 ]
-                        ]
-                    ]
-                    
-                    private var statsOptions = ARTClientOptions()
+private let calendar = NSCalendar(identifier: NSCalendar.Identifier.gregorian)!
+private let dateComponents: NSDateComponents = {
+    let dateComponents = NSDateComponents()
+    dateComponents.year = calendar.component(NSCalendar.Unit.year, from: NSDate() as Date) - 1
+    dateComponents.month = 2
+    dateComponents.day = 3
+    dateComponents.hour = 16
+    dateComponents.minute = 3
+    return dateComponents
+}()
+
+private let date = calendar.date(from: dateComponents as DateComponents)!
+private let dateFormatter: DateFormatter = {
+    let dateFormatter = DateFormatter()
+    dateFormatter.timeZone = NSTimeZone(name: "UTC") as TimeZone?
+    dateFormatter.dateFormat = "YYYY-MM-dd:HH:mm"
+    return dateFormatter
+}()
+
+private let statsFixtures: JSON = [
+    [
+        "intervalId": dateFormatter.string(from: date), // 20XX-02-03:16:03
+        "inbound": ["realtime": ["messages": ["count": 50, "data": 5000]]],
+        "outbound": ["realtime": ["messages": ["count": 20, "data": 2000]]],
+    ],
+    [
+        "intervalId": dateFormatter.string(from: date.addingTimeInterval(60)), // 20XX-02-03:16:04
+        "inbound": ["realtime": ["messages": ["count": 60, "data": 6000]]],
+        "outbound": ["realtime": ["messages": ["count": 10, "data": 1000]]],
+    ],
+    [
+        "intervalId": dateFormatter.string(from: date.addingTimeInterval(120)), // 20XX-02-03:16:05
+        "inbound": ["realtime": ["messages": ["count": 70, "data": 7000]]],
+        "outbound": ["realtime": ["messages": ["count": 40, "data": 4000]]],
+        "persisted": ["presence": ["count": 20, "data": 2000]],
+        "connections": ["tls": ["peak": 20, "opened": 10]],
+        "channels": ["peak": 50, "opened": 30],
+        "apiRequests": ["succeeded": 50, "failed": 10],
+        "tokenRequests": ["succeeded": 60, "failed": 20],
+    ],
+]
+
+private var statsOptions = ARTClientOptions()
 
 class RestClientStats: XCTestCase {
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = calendar
+        _ = dateComponents
+        _ = date
+        _ = dateFormatter
+        _ = statsFixtures
+        _ = statsOptions
 
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = calendar
-    let _ = dateComponents
-    let _ = date
-    let _ = dateFormatter
-    let _ = statsFixtures
-    let _ = statsOptions
+        return super.defaultTestSuite
+    }
 
-    return super.defaultTestSuite
-}
-        
-            // RSC6
-            
-                // RSC6a
-                
+    // RSC6
 
-                    func beforeEach__RestClient__stats__result() {
-                        statsOptions = postTestStats(statsFixtures)
-                    }
-                    
-                    func skipped__test__001__RestClient__stats__result__should_match_minute_level_inbound_and_outbound_fixture_data__forwards_() {
-beforeEach__RestClient__stats__result()
+    // RSC6a
 
-                        let client = ARTRest(options: statsOptions)
-                        let query = ARTStatsQuery()
-                        query.start = date
-                        query.direction = .forwards
-                        
-                        let result = queryStats(client, query)
-                        expect(result.items.count).to(equal(3))
-                        
-                        let totalInbound = result.items.reduce(0 as UInt, {
-                            return $0 + $1.inbound.all.messages.count
-                        })
-                        expect(totalInbound).to(equal(50 + 60 + 70))
-                        
-                        let totalOutbound = result.items.reduce(0 as UInt, {
-                            return $0 + $1.outbound.all.messages.count
-                        })
-                        expect(totalOutbound).to(equal(20 + 10 + 40))
-                    }
-                    
-                    func test__002__RestClient__stats__result__should_match_hour_level_inbound_and_outbound_fixture_data__forwards_() {
-beforeEach__RestClient__stats__result()
+    func beforeEach__RestClient__stats__result() {
+        statsOptions = postTestStats(statsFixtures)
+    }
 
-                        let client = ARTRest(options: statsOptions)
-                        let query = ARTStatsQuery()
-                        query.start = date
-                        query.direction = .forwards
-                        query.unit = .hour
-                        
-                        let result = queryStats(client, query)
-                        let totalInbound = result.items.reduce(0 as UInt, {
-                            return $0 + $1.inbound.all.messages.count
-                        })
-                        let totalOutbound = result.items.reduce(0 as UInt, {
-                            return $0 + $1.outbound.all.messages.count
-                        })
-                        
-                        expect(result.items.count).to(equal(1))
-                        expect(totalInbound).to(equal(50 + 60 + 70))
-                        expect(totalOutbound).to(equal(20 + 10 + 40))
-                    }
-                    
-                    func test__003__RestClient__stats__result__should_match_day_level_inbound_and_outbound_fixture_data__forwards_() {
-beforeEach__RestClient__stats__result()
+    func skipped__test__001__RestClient__stats__result__should_match_minute_level_inbound_and_outbound_fixture_data__forwards_() {
+        beforeEach__RestClient__stats__result()
 
-                        let client = ARTRest(options: statsOptions)
-                        let query = ARTStatsQuery()
-                        query.end = calendar.date(byAdding: .day, value: 1, to: date, options: NSCalendar.Options(rawValue: 0))
-                        query.direction = .forwards
-                        query.unit = .month
-                        
-                        let result = queryStats(client, query)
-                        let totalInbound = (result.items).reduce(0, { $0 + $1.inbound.all.messages.count })
-                        let totalOutbound = (result.items).reduce(0, { $0 + $1.outbound.all.messages.count })
-                        
-                        expect(result.items.count).to(equal(1))
-                        expect(totalInbound).to(equal(50 + 60 + 70))
-                        expect(totalOutbound).to(equal(20 + 10 + 40))
-                    }
-                    
-                    func skipped__test__004__RestClient__stats__result__should_match_month_level_inbound_and_outbound_fixture_data__forwards_() {
-beforeEach__RestClient__stats__result()
+        let client = ARTRest(options: statsOptions)
+        let query = ARTStatsQuery()
+        query.start = date
+        query.direction = .forwards
 
-                        let client = ARTRest(options: statsOptions)
-                        let query = ARTStatsQuery()
-                        query.end = calendar.date(byAdding: .month, value: 1, to: date, options: NSCalendar.Options(rawValue: 0))
-                        query.direction = .forwards
-                        query.unit = .month
-                        
-                        let result = queryStats(client, query)
-                        let totalInbound = (result.items).reduce(0, { $0 + $1.inbound.all.messages.count })
-                        let totalOutbound = (result.items).reduce(0, { $0 + $1.outbound.all.messages.count })
-                        
-                        expect(result.items.count).to(equal(1))
-                        expect(totalInbound).to(equal(50 + 60 + 70))
-                        expect(totalOutbound).to(equal(20 + 10 + 40))
-                    }
-                    
-                    func skipped__test__005__RestClient__stats__result__should_contain_only_one_item_when_limit_is_1__backwards() {
-beforeEach__RestClient__stats__result()
+        let result = queryStats(client, query)
+        expect(result.items.count).to(equal(3))
 
-                        let client = ARTRest(options: statsOptions)
-                        let query = ARTStatsQuery()
-                        query.end = date.addingTimeInterval(60) // 20XX-02-03:16:04
-                        query.limit = 1
-                        
-                        let result = queryStats(client, query)
-                        let totalInbound = (result.items).reduce(0, { $0 + $1.inbound.all.messages.count })
-                        let totalOutbound = (result.items).reduce(0, { $0 + $1.outbound.all.messages.count })
-                        
-                        expect(result.items.count).to(equal(1))
-                        expect(totalInbound).to(equal(60))
-                        expect(totalOutbound).to(equal(10))
-                    }
-                    
-                    func test__006__RestClient__stats__result__should_contain_only_one_item_when_limit_is_1__forwards() {
-beforeEach__RestClient__stats__result()
+        let totalInbound = result.items.reduce(0 as UInt) {
+            $0 + $1.inbound.all.messages.count
+        }
+        expect(totalInbound).to(equal(50 + 60 + 70))
 
-                        let client = ARTRest(options: statsOptions)
-                        let query = ARTStatsQuery()
-                        query.end = date.addingTimeInterval(60) // 20XX-02-03:16:04
-                        query.limit = 1
-                        query.direction = .forwards
-                        
-                        let result = queryStats(client, query)
-                        let totalInbound = (result.items).reduce(0, { $0 + $1.inbound.all.messages.count })
-                        let totalOutbound = (result.items).reduce(0, { $0 + $1.outbound.all.messages.count })
-                        
-                        expect(result.items.count).to(equal(1))
-                        expect(totalInbound).to(equal(50))
-                        expect(totalOutbound).to(equal(20))
-                    }
-                    
-                    func test__007__RestClient__stats__result__should_be_paginated_according_to_the_limit__backwards() {
-beforeEach__RestClient__stats__result()
+        let totalOutbound = result.items.reduce(0 as UInt) {
+            $0 + $1.outbound.all.messages.count
+        }
+        expect(totalOutbound).to(equal(20 + 10 + 40))
+    }
 
-                        let client = ARTRest(options: statsOptions)
-                        let query = ARTStatsQuery()
-                        query.end = date.addingTimeInterval(120) // 20XX-02-03:16:05
-                        query.limit = 1
+    func test__002__RestClient__stats__result__should_match_hour_level_inbound_and_outbound_fixture_data__forwards_() {
+        beforeEach__RestClient__stats__result()
 
-                        let firstPage = queryStats(client, query)
-                        expect(firstPage.items.count).to(equal(1))
-                        expect((firstPage.items)[0].inbound.all.messages.data).to(equal(7000))
-                        expect(firstPage.hasNext).to(beTrue())
-                        expect(firstPage.isLast).to(beFalse())
-                        
-                        guard let secondPage: ARTPaginatedResult<ARTStats> = (AblyTests.waitFor(timeout: testTimeout) { value in
-                            firstPage.next { page, err in
-                                expect(err).to(beNil())
-                                value(page)
-                            }
-                        }) else {
-                            return
-                        }
+        let client = ARTRest(options: statsOptions)
+        let query = ARTStatsQuery()
+        query.start = date
+        query.direction = .forwards
+        query.unit = .hour
 
-                        expect(secondPage.items.count).to(equal(1))
-                        expect((secondPage.items)[0].inbound.all.messages.data).to(equal(6000))
-                        expect(secondPage.hasNext).to(beTrue())
-                        expect(secondPage.isLast).to(beFalse())
-                        
-                        guard let thirdPage: ARTPaginatedResult<ARTStats> = (AblyTests.waitFor(timeout: testTimeout) { value in
-                            secondPage.next { page, err in
-                                expect(err).to(beNil())
-                                value(page)
-                            }
-                        }) else {
-                            return
-                        }
+        let result = queryStats(client, query)
+        let totalInbound = result.items.reduce(0 as UInt) {
+            $0 + $1.inbound.all.messages.count
+        }
+        let totalOutbound = result.items.reduce(0 as UInt) {
+            $0 + $1.outbound.all.messages.count
+        }
 
-                        expect(thirdPage.items.count).to(equal(1))
-                        expect((thirdPage.items)[0].inbound.all.messages.data).to(equal(5000))
-                        expect(thirdPage.isLast).to(beTrue())
-                        
-                        guard let firstPageAgain: ARTPaginatedResult<ARTStats> = (AblyTests.waitFor(timeout: testTimeout) { value in
-                            thirdPage.first { page, err in
-                                expect(err).to(beNil())
-                                value(page)
-                            }
-                        }) else {
-                            return
-                        }
+        expect(result.items.count).to(equal(1))
+        expect(totalInbound).to(equal(50 + 60 + 70))
+        expect(totalOutbound).to(equal(20 + 10 + 40))
+    }
 
-                        expect(firstPageAgain.items.count).to(equal(1))
-                        expect((firstPageAgain.items)[0].inbound.all.messages.data).to(equal(7000))
-                    }
-                    
-                    func skipped__test__008__RestClient__stats__result__should_be_paginated_according_to_the_limit__fowards_() {
-beforeEach__RestClient__stats__result()
+    func test__003__RestClient__stats__result__should_match_day_level_inbound_and_outbound_fixture_data__forwards_() {
+        beforeEach__RestClient__stats__result()
 
-                        let client = ARTRest(options: statsOptions)
-                        let query = ARTStatsQuery()
-                        query.end = date.addingTimeInterval(120) // 20XX-02-03:16:05
-                        query.limit = 1
-                        query.direction = .forwards
-                        
-                        let firstPage = queryStats(client, query)
-                        expect(firstPage.items.count).to(equal(1))
-                        expect((firstPage.items)[0].inbound.all.messages.data).to(equal(5000))
-                        expect(firstPage.hasNext).to(beTrue())
-                        expect(firstPage.isLast).to(beFalse())
-                        
-                        guard let secondPage: ARTPaginatedResult<ARTStats> = (AblyTests.waitFor(timeout: testTimeout) { value in
-                            firstPage.next { page, err in
-                                expect(err).to(beNil())
-                                value(page)
-                            }
-                        }) else {
-                            return
-                        }
+        let client = ARTRest(options: statsOptions)
+        let query = ARTStatsQuery()
+        query.end = calendar.date(byAdding: .day, value: 1, to: date, options: NSCalendar.Options(rawValue: 0))
+        query.direction = .forwards
+        query.unit = .month
 
-                        expect(secondPage.items.count).to(equal(1))
-                        expect((secondPage.items)[0].inbound.all.messages.data).to(equal(6000))
-                        expect(secondPage.hasNext).to(beTrue())
-                        expect(secondPage.isLast).to(beFalse())
-                        
-                        guard let thirdPage: ARTPaginatedResult<ARTStats> = (AblyTests.waitFor(timeout: testTimeout) { value in
-                            secondPage.next { page, err in
-                                expect(err).to(beNil())
-                                value(page)
-                            }
-                        }) else {
-                            return
-                        }
+        let result = queryStats(client, query)
+        let totalInbound = (result.items).reduce(0) { $0 + $1.inbound.all.messages.count }
+        let totalOutbound = (result.items).reduce(0) { $0 + $1.outbound.all.messages.count }
 
-                        expect(thirdPage.items.count).to(equal(1))
-                        expect((thirdPage.items)[0].inbound.all.messages.data).to(equal(7000))
-                        expect(thirdPage.isLast).to(beTrue())
-                        
-                        guard let firstPageAgain: ARTPaginatedResult<ARTStats> = (AblyTests.waitFor(timeout: testTimeout) { value in
-                            thirdPage.first { page, err in
-                                expect(err).to(beNil())
-                                value(page)
-                            }
-                        }) else {
-                            return
-                        }
+        expect(result.items.count).to(equal(1))
+        expect(totalInbound).to(equal(50 + 60 + 70))
+        expect(totalOutbound).to(equal(20 + 10 + 40))
+    }
 
-                        expect(firstPageAgain.items.count).to(equal(1))
-                        expect((firstPageAgain.items)[0].inbound.all.messages.data).to(equal(5000))
-                    }
-                
-                // RSC6b
-                
-                    // RSC6b1
-                    
-                        func test__009__RestClient__stats__query__start__should_return_an_error_when_later_than_end() {
-                            let client = ARTRest(key: "fake:key")
-                            let query = ARTStatsQuery()
-                            
-                            query.start = NSDate.distantFuture
-                            query.end = NSDate.distantPast
+    func skipped__test__004__RestClient__stats__result__should_match_month_level_inbound_and_outbound_fixture_data__forwards_() {
+        beforeEach__RestClient__stats__result()
 
-                            expect{try client.stats(query, callback:{ status, result in })}.to(throwError())
-                        }
-                    
-                    // RSC6b2
-                    
-                        func test__010__RestClient__stats__query__direction__should_be_backwards_by_default() {
-                            let query = ARTStatsQuery()
-                            
-                            expect(query.direction).to(equal(ARTQueryDirection.backwards));
-                        }
-                    
-                    // RSC6b3
-                    
-                        func test__011__RestClient__stats__query__limit__should_have_a_default_value_of_100() {
-                            let query = ARTStatsQuery()
-                            
-                            expect(query.limit).to(equal(100));
-                        }
-                        
-                        func test__012__RestClient__stats__query__limit__should_return_an_error_when_greater_than_1000() {
-                            let client = ARTRest(key: "fake:key")
-                            let query = ARTStatsQuery()
-                            
-                            query.limit = 1001;
+        let client = ARTRest(options: statsOptions)
+        let query = ARTStatsQuery()
+        query.end = calendar.date(byAdding: .month, value: 1, to: date, options: NSCalendar.Options(rawValue: 0))
+        query.direction = .forwards
+        query.unit = .month
 
-                            expect{try client.stats(query, callback:{ status, result in })}.to(throwError())
-                        }
-                    
-                    // RSC6b4
-                    
-                        func test__013__RestClient__stats__query__unit__should_default_to_minute() {
-                            let query = ARTStatsQuery()
-                            
-                            expect(query.unit).to(equal(ARTStatsGranularity.minute))
-                        }
+        let result = queryStats(client, query)
+        let totalInbound = (result.items).reduce(0) { $0 + $1.inbound.all.messages.count }
+        let totalOutbound = (result.items).reduce(0) { $0 + $1.outbound.all.messages.count }
+
+        expect(result.items.count).to(equal(1))
+        expect(totalInbound).to(equal(50 + 60 + 70))
+        expect(totalOutbound).to(equal(20 + 10 + 40))
+    }
+
+    func skipped__test__005__RestClient__stats__result__should_contain_only_one_item_when_limit_is_1__backwards() {
+        beforeEach__RestClient__stats__result()
+
+        let client = ARTRest(options: statsOptions)
+        let query = ARTStatsQuery()
+        query.end = date.addingTimeInterval(60) // 20XX-02-03:16:04
+        query.limit = 1
+
+        let result = queryStats(client, query)
+        let totalInbound = (result.items).reduce(0) { $0 + $1.inbound.all.messages.count }
+        let totalOutbound = (result.items).reduce(0) { $0 + $1.outbound.all.messages.count }
+
+        expect(result.items.count).to(equal(1))
+        expect(totalInbound).to(equal(60))
+        expect(totalOutbound).to(equal(10))
+    }
+
+    func test__006__RestClient__stats__result__should_contain_only_one_item_when_limit_is_1__forwards() {
+        beforeEach__RestClient__stats__result()
+
+        let client = ARTRest(options: statsOptions)
+        let query = ARTStatsQuery()
+        query.end = date.addingTimeInterval(60) // 20XX-02-03:16:04
+        query.limit = 1
+        query.direction = .forwards
+
+        let result = queryStats(client, query)
+        let totalInbound = (result.items).reduce(0) { $0 + $1.inbound.all.messages.count }
+        let totalOutbound = (result.items).reduce(0) { $0 + $1.outbound.all.messages.count }
+
+        expect(result.items.count).to(equal(1))
+        expect(totalInbound).to(equal(50))
+        expect(totalOutbound).to(equal(20))
+    }
+
+    func test__007__RestClient__stats__result__should_be_paginated_according_to_the_limit__backwards() {
+        beforeEach__RestClient__stats__result()
+
+        let client = ARTRest(options: statsOptions)
+        let query = ARTStatsQuery()
+        query.end = date.addingTimeInterval(120) // 20XX-02-03:16:05
+        query.limit = 1
+
+        let firstPage = queryStats(client, query)
+        expect(firstPage.items.count).to(equal(1))
+        expect((firstPage.items)[0].inbound.all.messages.data).to(equal(7000))
+        expect(firstPage.hasNext).to(beTrue())
+        expect(firstPage.isLast).to(beFalse())
+
+        guard let secondPage: ARTPaginatedResult<ARTStats> = (AblyTests.waitFor(timeout: testTimeout) { value in
+            firstPage.next { page, err in
+                expect(err).to(beNil())
+                value(page)
+            }
+        }) else {
+            return
+        }
+
+        expect(secondPage.items.count).to(equal(1))
+        expect((secondPage.items)[0].inbound.all.messages.data).to(equal(6000))
+        expect(secondPage.hasNext).to(beTrue())
+        expect(secondPage.isLast).to(beFalse())
+
+        guard let thirdPage: ARTPaginatedResult<ARTStats> = (AblyTests.waitFor(timeout: testTimeout) { value in
+            secondPage.next { page, err in
+                expect(err).to(beNil())
+                value(page)
+            }
+        }) else {
+            return
+        }
+
+        expect(thirdPage.items.count).to(equal(1))
+        expect((thirdPage.items)[0].inbound.all.messages.data).to(equal(5000))
+        expect(thirdPage.isLast).to(beTrue())
+
+        guard let firstPageAgain: ARTPaginatedResult<ARTStats> = (AblyTests.waitFor(timeout: testTimeout) { value in
+            thirdPage.first { page, err in
+                expect(err).to(beNil())
+                value(page)
+            }
+        }) else {
+            return
+        }
+
+        expect(firstPageAgain.items.count).to(equal(1))
+        expect((firstPageAgain.items)[0].inbound.all.messages.data).to(equal(7000))
+    }
+
+    func skipped__test__008__RestClient__stats__result__should_be_paginated_according_to_the_limit__fowards_() {
+        beforeEach__RestClient__stats__result()
+
+        let client = ARTRest(options: statsOptions)
+        let query = ARTStatsQuery()
+        query.end = date.addingTimeInterval(120) // 20XX-02-03:16:05
+        query.limit = 1
+        query.direction = .forwards
+
+        let firstPage = queryStats(client, query)
+        expect(firstPage.items.count).to(equal(1))
+        expect((firstPage.items)[0].inbound.all.messages.data).to(equal(5000))
+        expect(firstPage.hasNext).to(beTrue())
+        expect(firstPage.isLast).to(beFalse())
+
+        guard let secondPage: ARTPaginatedResult<ARTStats> = (AblyTests.waitFor(timeout: testTimeout) { value in
+            firstPage.next { page, err in
+                expect(err).to(beNil())
+                value(page)
+            }
+        }) else {
+            return
+        }
+
+        expect(secondPage.items.count).to(equal(1))
+        expect((secondPage.items)[0].inbound.all.messages.data).to(equal(6000))
+        expect(secondPage.hasNext).to(beTrue())
+        expect(secondPage.isLast).to(beFalse())
+
+        guard let thirdPage: ARTPaginatedResult<ARTStats> = (AblyTests.waitFor(timeout: testTimeout) { value in
+            secondPage.next { page, err in
+                expect(err).to(beNil())
+                value(page)
+            }
+        }) else {
+            return
+        }
+
+        expect(thirdPage.items.count).to(equal(1))
+        expect((thirdPage.items)[0].inbound.all.messages.data).to(equal(7000))
+        expect(thirdPage.isLast).to(beTrue())
+
+        guard let firstPageAgain: ARTPaginatedResult<ARTStats> = (AblyTests.waitFor(timeout: testTimeout) { value in
+            thirdPage.first { page, err in
+                expect(err).to(beNil())
+                value(page)
+            }
+        }) else {
+            return
+        }
+
+        expect(firstPageAgain.items.count).to(equal(1))
+        expect((firstPageAgain.items)[0].inbound.all.messages.data).to(equal(5000))
+    }
+
+    // RSC6b
+
+    // RSC6b1
+
+    func test__009__RestClient__stats__query__start__should_return_an_error_when_later_than_end() {
+        let client = ARTRest(key: "fake:key")
+        let query = ARTStatsQuery()
+
+        query.start = NSDate.distantFuture
+        query.end = NSDate.distantPast
+
+        expect { try client.stats(query, callback: { _, _ in }) }.to(throwError())
+    }
+
+    // RSC6b2
+
+    func test__010__RestClient__stats__query__direction__should_be_backwards_by_default() {
+        let query = ARTStatsQuery()
+
+        expect(query.direction).to(equal(ARTQueryDirection.backwards))
+    }
+
+    // RSC6b3
+
+    func test__011__RestClient__stats__query__limit__should_have_a_default_value_of_100() {
+        let query = ARTStatsQuery()
+
+        expect(query.limit).to(equal(100))
+    }
+
+    func test__012__RestClient__stats__query__limit__should_return_an_error_when_greater_than_1000() {
+        let client = ARTRest(key: "fake:key")
+        let query = ARTStatsQuery()
+
+        query.limit = 1001
+
+        expect { try client.stats(query, callback: { _, _ in }) }.to(throwError())
+    }
+
+    // RSC6b4
+
+    func test__013__RestClient__stats__query__unit__should_default_to_minute() {
+        let query = ARTStatsQuery()
+
+        expect(query.unit).to(equal(ARTStatsGranularity.minute))
+    }
 }

--- a/Spec/RestClientStats.swift
+++ b/Spec/RestClientStats.swift
@@ -86,7 +86,7 @@ private func queryStats(_ client: ARTRest, _ query: ARTStatsQuery, file: FileStr
                     
                     private var statsOptions = ARTClientOptions()
 
-class RestClientStats: QuickSpec {
+class RestClientStats: XCTestCase {
 
 // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
 override class var defaultTestSuite : XCTestSuite {
@@ -99,19 +99,19 @@ override class var defaultTestSuite : XCTestSuite {
 
     return super.defaultTestSuite
 }
-
-    override func spec() {
-        describe("RestClient") {
+        
             // RSC6
-            context("stats") {
+            
                 // RSC6a
-                context("result") {
+                
 
-                    beforeEach {
+                    func beforeEach__RestClient__stats__result() {
                         statsOptions = postTestStats(statsFixtures)
                     }
                     
-                    xit("should match minute-level inbound and outbound fixture data (forwards)") {
+                    func skipped__test__001__RestClient__stats__result__should_match_minute_level_inbound_and_outbound_fixture_data__forwards_() {
+beforeEach__RestClient__stats__result()
+
                         let client = ARTRest(options: statsOptions)
                         let query = ARTStatsQuery()
                         query.start = date
@@ -131,7 +131,9 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(totalOutbound).to(equal(20 + 10 + 40))
                     }
                     
-                    it("should match hour-level inbound and outbound fixture data (forwards)") {
+                    func test__002__RestClient__stats__result__should_match_hour_level_inbound_and_outbound_fixture_data__forwards_() {
+beforeEach__RestClient__stats__result()
+
                         let client = ARTRest(options: statsOptions)
                         let query = ARTStatsQuery()
                         query.start = date
@@ -151,7 +153,9 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(totalOutbound).to(equal(20 + 10 + 40))
                     }
                     
-                    it("should match day-level inbound and outbound fixture data (forwards)") {
+                    func test__003__RestClient__stats__result__should_match_day_level_inbound_and_outbound_fixture_data__forwards_() {
+beforeEach__RestClient__stats__result()
+
                         let client = ARTRest(options: statsOptions)
                         let query = ARTStatsQuery()
                         query.end = calendar.date(byAdding: .day, value: 1, to: date, options: NSCalendar.Options(rawValue: 0))
@@ -167,7 +171,9 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(totalOutbound).to(equal(20 + 10 + 40))
                     }
                     
-                    xit("should match month-level inbound and outbound fixture data (forwards)") {
+                    func skipped__test__004__RestClient__stats__result__should_match_month_level_inbound_and_outbound_fixture_data__forwards_() {
+beforeEach__RestClient__stats__result()
+
                         let client = ARTRest(options: statsOptions)
                         let query = ARTStatsQuery()
                         query.end = calendar.date(byAdding: .month, value: 1, to: date, options: NSCalendar.Options(rawValue: 0))
@@ -183,7 +189,9 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(totalOutbound).to(equal(20 + 10 + 40))
                     }
                     
-                    xit("should contain only one item when limit is 1 (backwards") {
+                    func skipped__test__005__RestClient__stats__result__should_contain_only_one_item_when_limit_is_1__backwards() {
+beforeEach__RestClient__stats__result()
+
                         let client = ARTRest(options: statsOptions)
                         let query = ARTStatsQuery()
                         query.end = date.addingTimeInterval(60) // 20XX-02-03:16:04
@@ -198,7 +206,9 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(totalOutbound).to(equal(10))
                     }
                     
-                    it("should contain only one item when limit is 1 (forwards") {
+                    func test__006__RestClient__stats__result__should_contain_only_one_item_when_limit_is_1__forwards() {
+beforeEach__RestClient__stats__result()
+
                         let client = ARTRest(options: statsOptions)
                         let query = ARTStatsQuery()
                         query.end = date.addingTimeInterval(60) // 20XX-02-03:16:04
@@ -214,7 +224,9 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(totalOutbound).to(equal(20))
                     }
                     
-                    it("should be paginated according to the limit (backwards") {
+                    func test__007__RestClient__stats__result__should_be_paginated_according_to_the_limit__backwards() {
+beforeEach__RestClient__stats__result()
+
                         let client = ARTRest(options: statsOptions)
                         let query = ARTStatsQuery()
                         query.end = date.addingTimeInterval(120) // 20XX-02-03:16:05
@@ -266,7 +278,9 @@ override class var defaultTestSuite : XCTestSuite {
                         expect((firstPageAgain.items)[0].inbound.all.messages.data).to(equal(7000))
                     }
                     
-                    xit("should be paginated according to the limit (fowards)") {
+                    func skipped__test__008__RestClient__stats__result__should_be_paginated_according_to_the_limit__fowards_() {
+beforeEach__RestClient__stats__result()
+
                         let client = ARTRest(options: statsOptions)
                         let query = ARTStatsQuery()
                         query.end = date.addingTimeInterval(120) // 20XX-02-03:16:05
@@ -318,13 +332,12 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(firstPageAgain.items.count).to(equal(1))
                         expect((firstPageAgain.items)[0].inbound.all.messages.data).to(equal(5000))
                     }
-                }
                 
                 // RSC6b
-                context("query") {
+                
                     // RSC6b1
-                    context("start") {
-                        it("should return an error when later than end") {
+                    
+                        func test__009__RestClient__stats__query__start__should_return_an_error_when_later_than_end() {
                             let client = ARTRest(key: "fake:key")
                             let query = ARTStatsQuery()
                             
@@ -333,26 +346,24 @@ override class var defaultTestSuite : XCTestSuite {
 
                             expect{try client.stats(query, callback:{ status, result in })}.to(throwError())
                         }
-                    }
                     
                     // RSC6b2
-                    context("direction") {
-                        it("should be backwards by default") {
+                    
+                        func test__010__RestClient__stats__query__direction__should_be_backwards_by_default() {
                             let query = ARTStatsQuery()
                             
                             expect(query.direction).to(equal(ARTQueryDirection.backwards));
                         }
-                    }
                     
                     // RSC6b3
-                    context("limit") {
-                        it("should have a default value of 100") {
+                    
+                        func test__011__RestClient__stats__query__limit__should_have_a_default_value_of_100() {
                             let query = ARTStatsQuery()
                             
                             expect(query.limit).to(equal(100));
                         }
                         
-                        it("should return an error when greater than 1000") {
+                        func test__012__RestClient__stats__query__limit__should_return_an_error_when_greater_than_1000() {
                             let client = ARTRest(key: "fake:key")
                             let query = ARTStatsQuery()
                             
@@ -360,18 +371,12 @@ override class var defaultTestSuite : XCTestSuite {
 
                             expect{try client.stats(query, callback:{ status, result in })}.to(throwError())
                         }
-                    }
                     
                     // RSC6b4
-                    context("unit") {
-                        it("should default to minute") {
+                    
+                        func test__013__RestClient__stats__query__unit__should_default_to_minute() {
                             let query = ARTStatsQuery()
                             
                             expect(query.unit).to(equal(ARTStatsGranularity.minute))
                         }
-                    }
-                }
-            }
-        }
-    }
 }

--- a/Spec/RestPaginated.swift
+++ b/Spec/RestPaginated.swift
@@ -3,13 +3,23 @@ import Nimble
 import Quick
 import SwiftyJSON
 
+
+            private let links = "<./messages?start=0&end=1535035746063&limit=100&direction=backwards&format=msgpack&firstEnd=1535035746063&fromDate=1535035746063&mode=all>; rel=\"first\", <./messages?start=0&end=1535035746063&limit=100&direction=backwards&format=msgpack&firstEnd=1535035746063&fromDate=1535035746063&mode=all>; rel=\"current\""
+
+            private let url = URL(string: "https://sandbox-rest.ably.io:443/channels/foo/messages?limit=100&direction=backwards")!
+
 class RestPaginated : QuickSpec {
+
+// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+override class var defaultTestSuite : XCTestSuite {
+    let _ = links
+    let _ = url
+
+    return super.defaultTestSuite
+}
+
     override func spec() {
         describe("RestPaginated") {
-
-            let links = "<./messages?start=0&end=1535035746063&limit=100&direction=backwards&format=msgpack&firstEnd=1535035746063&fromDate=1535035746063&mode=all>; rel=\"first\", <./messages?start=0&end=1535035746063&limit=100&direction=backwards&format=msgpack&firstEnd=1535035746063&fromDate=1535035746063&mode=all>; rel=\"current\""
-
-            let url = URL(string: "https://sandbox-rest.ably.io:443/channels/foo/messages?limit=100&direction=backwards")!
 
             it("should extract links from the response") {
                 guard let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: ["Link": links]) else {

--- a/Spec/RestPaginated.swift
+++ b/Spec/RestPaginated.swift
@@ -1,6 +1,6 @@
 import Ably
 import Nimble
-import Quick
+import XCTest
 import SwiftyJSON
 
 private let links = "<./messages?start=0&end=1535035746063&limit=100&direction=backwards&format=msgpack&firstEnd=1535035746063&fromDate=1535035746063&mode=all>; rel=\"first\", <./messages?start=0&end=1535035746063&limit=100&direction=backwards&format=msgpack&firstEnd=1535035746063&fromDate=1535035746063&mode=all>; rel=\"current\""

--- a/Spec/RestPaginated.swift
+++ b/Spec/RestPaginated.swift
@@ -8,7 +8,7 @@ import SwiftyJSON
 
             private let url = URL(string: "https://sandbox-rest.ably.io:443/channels/foo/messages?limit=100&direction=backwards")!
 
-class RestPaginated : QuickSpec {
+class RestPaginated : XCTestCase {
 
 // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
 override class var defaultTestSuite : XCTestSuite {
@@ -17,11 +17,9 @@ override class var defaultTestSuite : XCTestSuite {
 
     return super.defaultTestSuite
 }
+        
 
-    override func spec() {
-        describe("RestPaginated") {
-
-            it("should extract links from the response") {
+            func test__001__RestPaginated__should_extract_links_from_the_response() {
                 guard let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: ["Link": links]) else {
                     fail("Invalid HTTPURLResponse"); return
                 }
@@ -31,7 +29,7 @@ override class var defaultTestSuite : XCTestSuite {
                 expect(extractedLinks.keys).to(contain("first" ,"current"))
             }
 
-            it("should create next/first/last request from extracted link path") {
+            func test__002__RestPaginated__should_create_next_first_last_request_from_extracted_link_path() {
                 let request = URLRequest(url: url)
 
                 guard let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: ["Link": links]) else {
@@ -52,6 +50,4 @@ override class var defaultTestSuite : XCTestSuite {
 
                 expect(firstRequest.url?.absoluteString).to(equal("https://sandbox-rest.ably.io:443/channels/foo/messages?start=0&end=1535035746063&limit=100&direction=backwards&format=msgpack&firstEnd=1535035746063&fromDate=1535035746063&mode=all"))
             }
-        }
-    }
 }

--- a/Spec/RestPaginated.swift
+++ b/Spec/RestPaginated.swift
@@ -3,51 +3,48 @@ import Nimble
 import Quick
 import SwiftyJSON
 
+private let links = "<./messages?start=0&end=1535035746063&limit=100&direction=backwards&format=msgpack&firstEnd=1535035746063&fromDate=1535035746063&mode=all>; rel=\"first\", <./messages?start=0&end=1535035746063&limit=100&direction=backwards&format=msgpack&firstEnd=1535035746063&fromDate=1535035746063&mode=all>; rel=\"current\""
 
-            private let links = "<./messages?start=0&end=1535035746063&limit=100&direction=backwards&format=msgpack&firstEnd=1535035746063&fromDate=1535035746063&mode=all>; rel=\"first\", <./messages?start=0&end=1535035746063&limit=100&direction=backwards&format=msgpack&firstEnd=1535035746063&fromDate=1535035746063&mode=all>; rel=\"current\""
+private let url = URL(string: "https://sandbox-rest.ably.io:443/channels/foo/messages?limit=100&direction=backwards")!
 
-            private let url = URL(string: "https://sandbox-rest.ably.io:443/channels/foo/messages?limit=100&direction=backwards")!
+class RestPaginated: XCTestCase {
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = links
+        _ = url
 
-class RestPaginated : XCTestCase {
+        return super.defaultTestSuite
+    }
 
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = links
-    let _ = url
+    func test__001__RestPaginated__should_extract_links_from_the_response() {
+        guard let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: ["Link": links]) else {
+            fail("Invalid HTTPURLResponse"); return
+        }
+        guard let extractedLinks = response.extractLinks() else {
+            fail("Couldn't extract links from response"); return
+        }
+        expect(extractedLinks.keys).to(contain("first", "current"))
+    }
 
-    return super.defaultTestSuite
-}
-        
+    func test__002__RestPaginated__should_create_next_first_last_request_from_extracted_link_path() {
+        let request = URLRequest(url: url)
 
-            func test__001__RestPaginated__should_extract_links_from_the_response() {
-                guard let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: ["Link": links]) else {
-                    fail("Invalid HTTPURLResponse"); return
-                }
-                guard let extractedLinks = response.extractLinks() else {
-                    fail("Couldn't extract links from response"); return
-                }
-                expect(extractedLinks.keys).to(contain("first" ,"current"))
-            }
+        guard let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: ["Link": links]) else {
+            fail("Invalid HTTPURLResponse"); return
+        }
+        guard let extractedLinks = response.extractLinks() else {
+            fail("Couldn't extract links from response"); return
+        }
+        expect(extractedLinks.keys).to(contain("first", "current"))
 
-            func test__002__RestPaginated__should_create_next_first_last_request_from_extracted_link_path() {
-                let request = URLRequest(url: url)
+        guard let firstLink = extractedLinks["first"] as? String else {
+            fail("First link is missing from extracted links"); return
+        }
 
-                guard let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: ["Link": links]) else {
-                    fail("Invalid HTTPURLResponse"); return
-                }
-                guard let extractedLinks = response.extractLinks() else {
-                    fail("Couldn't extract links from response"); return
-                }
-                expect(extractedLinks.keys).to(contain("first" ,"current"))
+        guard let firstRequest = NSMutableURLRequest(path: firstLink, relativeTo: request) else {
+            fail("First link isn't a valid URL"); return
+        }
 
-                guard let firstLink = extractedLinks["first"] as? String else {
-                    fail("First link is missing from extracted links"); return
-                }
-
-                guard let firstRequest = NSMutableURLRequest(path: firstLink, relativeTo: request) else {
-                    fail("First link isn't a valid URL"); return
-                }
-
-                expect(firstRequest.url?.absoluteString).to(equal("https://sandbox-rest.ably.io:443/channels/foo/messages?start=0&end=1535035746063&limit=100&direction=backwards&format=msgpack&firstEnd=1535035746063&fromDate=1535035746063&mode=all"))
-            }
+        expect(firstRequest.url?.absoluteString).to(equal("https://sandbox-rest.ably.io:443/channels/foo/messages?start=0&end=1535035746063&limit=100&direction=backwards&format=msgpack&firstEnd=1535035746063&fromDate=1535035746063&mode=all"))
+    }
 }

--- a/Spec/Stats.swift
+++ b/Spec/Stats.swift
@@ -1,468 +1,447 @@
 import Ably
+import Foundation
 import Nimble
 import Quick
 import SwiftyJSON
-import Foundation
 
-            private let encoder = ARTJsonLikeEncoder()
-                private let subject: ARTStatsConnectionTypes? = {
-                    let data: JSON = [
-                        [ "connections": [ "tls": [ "opened": 5], "all": [ "peak": 10 ] ] ]
-                    ]
-                    let rawData = try! data.rawData()
-                    let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
-                    return stats?.connections
-                }()
-                private let channelsTestsSubject: ARTStatsResourceCount? = {
-                    let data: JSON = [
-                        [ "channels": [ "opened": 5, "peak": 10 ] ]
-                    ]
-                    let rawData = try! data.rawData()
-                    let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
-                    return stats?.channels
-                }()
-                private let pushTestsSubject: ARTStatsPushCount? = {
-                    let data: JSON = [
-                        [ "push":
-                            [
-                                "messages": 10,
-                                "notifications": [
-                                    "invalid": 1,
-                                    "attempted": 2,
-                                    "successful": 3,
-                                    "failed": 4
-                                ],
-                                "directPublishes": 5
-                            ]
-                        ]
-                    ]
-                    let rawData = try! data.rawData()
-                    let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
-                    return stats?.pushes
-                }()
-                private let inProgressTestsStats: ARTStats? = {
-                    let data: JSON = [
-                        [ "inProgress": "2004-02-01:05:06" ]
-                    ]
-                    let rawData = try! data.rawData()
-                    return try! encoder.decodeStats(rawData)[0] as? ARTStats
-                }()
-                private let countTestStats: ARTStats? = {
-                    let data: JSON = [
-                        [ "count": 55 ]
-                    ]
-                    let rawData = try! data.rawData()
-                    return try! encoder.decodeStats(rawData)[0] as? ARTStats
-                }()
+private let encoder = ARTJsonLikeEncoder()
+private let subject: ARTStatsConnectionTypes? = {
+    let data: JSON = [
+        ["connections": ["tls": ["opened": 5], "all": ["peak": 10]]],
+    ]
+    let rawData = try! data.rawData()
+    let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
+    return stats?.connections
+}()
+
+private let channelsTestsSubject: ARTStatsResourceCount? = {
+    let data: JSON = [
+        ["channels": ["opened": 5, "peak": 10]],
+    ]
+    let rawData = try! data.rawData()
+    let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
+    return stats?.channels
+}()
+
+private let pushTestsSubject: ARTStatsPushCount? = {
+    let data: JSON = [
+        ["push":
+            [
+                "messages": 10,
+                "notifications": [
+                    "invalid": 1,
+                    "attempted": 2,
+                    "successful": 3,
+                    "failed": 4,
+                ],
+                "directPublishes": 5,
+            ]],
+    ]
+    let rawData = try! data.rawData()
+    let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
+    return stats?.pushes
+}()
+
+private let inProgressTestsStats: ARTStats? = {
+    let data: JSON = [
+        ["inProgress": "2004-02-01:05:06"],
+    ]
+    let rawData = try! data.rawData()
+    return try! encoder.decodeStats(rawData)[0] as? ARTStats
+}()
+
+private let countTestStats: ARTStats? = {
+    let data: JSON = [
+        ["count": 55],
+    ]
+    let rawData = try! data.rawData()
+    return try! encoder.decodeStats(rawData)[0] as? ARTStats
+}()
 
 class Stats: XCTestCase {
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = encoder
+        _ = subject
+        _ = channelsTestsSubject
+        _ = pushTestsSubject
+        _ = inProgressTestsStats
+        _ = countTestStats
+
+        return super.defaultTestSuite
+    }
+
+    enum TestCase_ReusableTestsTestAttribute {
+        case should_return_a_MessagesTypes_object
+        case should_return_value_for_message_counts
+        case should_return_value_for_all_data_transferred
+        case should_return_zero_for_empty_values
+    }
+
+    // TS6
+    func reusableTestsTestAttribute(_ attribute: String, testCase: TestCase_ReusableTestsTestAttribute, beforeEach contextBeforeEach: (() -> Void)? = nil, afterEach contextAfterEach: (() -> Void)? = nil) {
+        let data: JSON = [
+            [attribute: ["messages": ["count": 5], "all": ["data": 10]]],
+        ]
+        let rawData = try! data.rawData()
+        let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
+        let subject = stats?.value(forKey: attribute) as? ARTStatsMessageTypes
+
+        func test__should_return_a_MessagesTypes_object() {
+            contextBeforeEach?()
+
+            expect(subject).to(beAnInstanceOf(ARTStatsMessageTypes.self))
+
+            contextAfterEach?()
+        }
+
+        // TS5
+        func test__should_return_value_for_message_counts() {
+            contextBeforeEach?()
+
+            expect(subject?.messages.count).to(equal(5))
+
+            contextAfterEach?()
+        }
+
+        // TS5
+        func test__should_return_value_for_all_data_transferred() {
+            contextBeforeEach?()
+
+            expect(subject?.all.data).to(equal(10))
+
+            contextAfterEach?()
+        }
+
+        // TS2
+        func test__should_return_zero_for_empty_values() {
+            contextBeforeEach?()
+
+            expect(subject?.presence.count).to(equal(0))
+
+            contextAfterEach?()
+        }
+
+        switch testCase {
+        case .should_return_a_MessagesTypes_object:
+            test__should_return_a_MessagesTypes_object()
+        case .should_return_value_for_message_counts:
+            test__should_return_value_for_message_counts()
+        case .should_return_value_for_all_data_transferred:
+            test__should_return_value_for_all_data_transferred()
+        case .should_return_zero_for_empty_values:
+            test__should_return_zero_for_empty_values()
+        }
+    }
+
+    func reusableTestsWrapper__Stats__all__reusableTestsTestAttribute(testCase: TestCase_ReusableTestsTestAttribute) {
+        reusableTestsTestAttribute("all", testCase: testCase)
+    }
+
+    func test__001__Stats__all__should_return_a_MessagesTypes_object() {
+        reusableTestsWrapper__Stats__all__reusableTestsTestAttribute(testCase: .should_return_a_MessagesTypes_object)
+    }
+
+    func test__002__Stats__all__should_return_value_for_message_counts() {
+        reusableTestsWrapper__Stats__all__reusableTestsTestAttribute(testCase: .should_return_value_for_message_counts)
+    }
+
+    func test__003__Stats__all__should_return_value_for_all_data_transferred() {
+        reusableTestsWrapper__Stats__all__reusableTestsTestAttribute(testCase: .should_return_value_for_all_data_transferred)
+    }
+
+    func test__004__Stats__all__should_return_zero_for_empty_values() {
+        reusableTestsWrapper__Stats__all__reusableTestsTestAttribute(testCase: .should_return_zero_for_empty_values)
+    }
+
+    func reusableTestsWrapper__Stats__persisted__reusableTestsTestAttribute(testCase: TestCase_ReusableTestsTestAttribute) {
+        reusableTestsTestAttribute("persisted", testCase: testCase)
+    }
+
+    func test__005__Stats__persisted__should_return_a_MessagesTypes_object() {
+        reusableTestsWrapper__Stats__persisted__reusableTestsTestAttribute(testCase: .should_return_a_MessagesTypes_object)
+    }
+
+    func test__006__Stats__persisted__should_return_value_for_message_counts() {
+        reusableTestsWrapper__Stats__persisted__reusableTestsTestAttribute(testCase: .should_return_value_for_message_counts)
+    }
+
+    func test__007__Stats__persisted__should_return_value_for_all_data_transferred() {
+        reusableTestsWrapper__Stats__persisted__reusableTestsTestAttribute(testCase: .should_return_value_for_all_data_transferred)
+    }
+
+    func test__008__Stats__persisted__should_return_zero_for_empty_values() {
+        reusableTestsWrapper__Stats__persisted__reusableTestsTestAttribute(testCase: .should_return_zero_for_empty_values)
+    }
+
+    enum TestCase_ReusableTestsTestDirection {
+        case should_return_a_MessageTraffic_object
+        case should_return_value_for_realtime_message_counts
+        case should_return_value_for_all_presence_data
+    }
+
+    // TS7
+    func reusableTestsTestDirection(_ direction: String, testCase: TestCase_ReusableTestsTestDirection, beforeEach contextBeforeEach: (() -> Void)? = nil, afterEach contextAfterEach: (() -> Void)? = nil) {
+        let data: JSON = [
+            [direction: [
+                "realtime": ["messages": ["count": 5]],
+                "all": ["messages": ["count": 25], "presence": ["data": 210]],
+            ]],
+        ]
+        let rawData = try! data.rawData()
+        let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
+        let subject = stats?.value(forKey: direction) as? ARTStatsMessageTraffic
+
+        func test__should_return_a_MessageTraffic_object() {
+            contextBeforeEach?()
+
+            expect(subject).to(beAnInstanceOf(ARTStatsMessageTraffic.self))
+
+            contextAfterEach?()
+        }
+
+        // TS5
+        func test__should_return_value_for_realtime_message_counts() {
+            contextBeforeEach?()
+
+            expect(subject?.realtime.messages.count).to(equal(5))
+
+            contextAfterEach?()
+        }
+
+        // TS5
+        func test__should_return_value_for_all_presence_data() {
+            contextBeforeEach?()
+
+            expect(subject?.all.presence.data).to(equal(210))
+
+            contextAfterEach?()
+        }
+
+        switch testCase {
+        case .should_return_a_MessageTraffic_object:
+            test__should_return_a_MessageTraffic_object()
+        case .should_return_value_for_realtime_message_counts:
+            test__should_return_value_for_realtime_message_counts()
+        case .should_return_value_for_all_presence_data:
+            test__should_return_value_for_all_presence_data()
+        }
+    }
+
+    func reusableTestsWrapper__Stats__inbound__reusableTestsTestDirection(testCase: TestCase_ReusableTestsTestDirection) {
+        reusableTestsTestDirection("inbound", testCase: testCase)
+    }
+
+    func test__009__Stats__inbound__should_return_a_MessageTraffic_object() {
+        reusableTestsWrapper__Stats__inbound__reusableTestsTestDirection(testCase: .should_return_a_MessageTraffic_object)
+    }
 
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = encoder
-    let _ = subject
-    let _ = channelsTestsSubject
-    let _ = pushTestsSubject
-    let _ = inProgressTestsStats
-    let _ = countTestStats
-
-    return super.defaultTestSuite
-}
-        
-enum TestCase_ReusableTestsTestAttribute {
-case should_return_a_MessagesTypes_object
-case should_return_value_for_message_counts
-case should_return_value_for_all_data_transferred
-case should_return_zero_for_empty_values
-}
-
-
-            // TS6
-            func reusableTestsTestAttribute(_ attribute: String, testCase: TestCase_ReusableTestsTestAttribute, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil) {
-                let data: JSON = [
-                    [ attribute: [ "messages": [ "count": 5], "all": [ "data": 10 ] ] ]
-                ]
-                let rawData = try! data.rawData()
-                let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
-                let subject = stats?.value(forKey: attribute) as? ARTStatsMessageTypes
-
-                func test__should_return_a_MessagesTypes_object() {
-contextBeforeEach?()
-
-                    expect(subject).to(beAnInstanceOf(ARTStatsMessageTypes.self))
-
-contextAfterEach?()
-
-                }
-
-                // TS5
-                func test__should_return_value_for_message_counts() {
-contextBeforeEach?()
-
-                    expect(subject?.messages.count).to(equal(5))
-
-contextAfterEach?()
-
-                }
-
-                // TS5
-                func test__should_return_value_for_all_data_transferred() {
-contextBeforeEach?()
-
-                    expect(subject?.all.data).to(equal(10))
-
-contextAfterEach?()
+    func test__010__Stats__inbound__should_return_value_for_realtime_message_counts() {
+        reusableTestsWrapper__Stats__inbound__reusableTestsTestDirection(testCase: .should_return_value_for_realtime_message_counts)
+    }
 
-                }
-
-                // TS2
-                func test__should_return_zero_for_empty_values() {
-contextBeforeEach?()
-
-                    expect(subject?.presence.count).to(equal(0))
-
-contextAfterEach?()
-
-                }
-
-switch testCase  {
-case .should_return_a_MessagesTypes_object:
-    test__should_return_a_MessagesTypes_object()
-case .should_return_value_for_message_counts:
-    test__should_return_value_for_message_counts()
-case .should_return_value_for_all_data_transferred:
-    test__should_return_value_for_all_data_transferred()
-case .should_return_zero_for_empty_values:
-    test__should_return_zero_for_empty_values()
-}
-
-            }
-            
-            
-                func reusableTestsWrapper__Stats__all__reusableTestsTestAttribute(testCase: TestCase_ReusableTestsTestAttribute) {
-                reusableTestsTestAttribute("all", testCase: testCase)}
-func test__001__Stats__all__should_return_a_MessagesTypes_object() {
-reusableTestsWrapper__Stats__all__reusableTestsTestAttribute(testCase: .should_return_a_MessagesTypes_object)
-}
-
-func test__002__Stats__all__should_return_value_for_message_counts() {
-reusableTestsWrapper__Stats__all__reusableTestsTestAttribute(testCase: .should_return_value_for_message_counts)
-}
-
-func test__003__Stats__all__should_return_value_for_all_data_transferred() {
-reusableTestsWrapper__Stats__all__reusableTestsTestAttribute(testCase: .should_return_value_for_all_data_transferred)
-}
-
-func test__004__Stats__all__should_return_zero_for_empty_values() {
-reusableTestsWrapper__Stats__all__reusableTestsTestAttribute(testCase: .should_return_zero_for_empty_values)
-}
-
-            
-            
-                func reusableTestsWrapper__Stats__persisted__reusableTestsTestAttribute(testCase: TestCase_ReusableTestsTestAttribute) {
-                reusableTestsTestAttribute("persisted", testCase: testCase)}
-func test__005__Stats__persisted__should_return_a_MessagesTypes_object() {
-reusableTestsWrapper__Stats__persisted__reusableTestsTestAttribute(testCase: .should_return_a_MessagesTypes_object)
-}
-
-func test__006__Stats__persisted__should_return_value_for_message_counts() {
-reusableTestsWrapper__Stats__persisted__reusableTestsTestAttribute(testCase: .should_return_value_for_message_counts)
-}
-
-func test__007__Stats__persisted__should_return_value_for_all_data_transferred() {
-reusableTestsWrapper__Stats__persisted__reusableTestsTestAttribute(testCase: .should_return_value_for_all_data_transferred)
-}
-
-func test__008__Stats__persisted__should_return_zero_for_empty_values() {
-reusableTestsWrapper__Stats__persisted__reusableTestsTestAttribute(testCase: .should_return_zero_for_empty_values)
-}
-
-enum TestCase_ReusableTestsTestDirection {
-case should_return_a_MessageTraffic_object
-case should_return_value_for_realtime_message_counts
-case should_return_value_for_all_presence_data
-}
-
-
-            // TS7
-            func reusableTestsTestDirection(_ direction: String, testCase: TestCase_ReusableTestsTestDirection, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil) {
-                let data: JSON = [
-                    [ direction: [
-                        "realtime": [ "messages": [ "count": 5] ],
-                        "all": [ "messages": [ "count": 25 ], "presence": [ "data": 210 ] ]
-                    ] ]
-                ]
-                let rawData = try! data.rawData()
-                let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
-                let subject = stats?.value(forKey: direction) as? ARTStatsMessageTraffic
-
-                func test__should_return_a_MessageTraffic_object() {
-contextBeforeEach?()
-
-                    expect(subject).to(beAnInstanceOf(ARTStatsMessageTraffic.self))
-
-contextAfterEach?()
-
-                }
-
-                // TS5
-                func test__should_return_value_for_realtime_message_counts() {
-contextBeforeEach?()
-
-                    expect(subject?.realtime.messages.count).to(equal(5))
-
-contextAfterEach?()
-
-                }
-
-                // TS5
-                func test__should_return_value_for_all_presence_data() {
-contextBeforeEach?()
-
-                    expect(subject?.all.presence.data).to(equal(210))
-
-contextAfterEach?()
-
-                }
-
-switch testCase  {
-case .should_return_a_MessageTraffic_object:
-    test__should_return_a_MessageTraffic_object()
-case .should_return_value_for_realtime_message_counts:
-    test__should_return_value_for_realtime_message_counts()
-case .should_return_value_for_all_presence_data:
-    test__should_return_value_for_all_presence_data()
-}
-
-            }
-        
-            
-                func reusableTestsWrapper__Stats__inbound__reusableTestsTestDirection(testCase: TestCase_ReusableTestsTestDirection) {
-                reusableTestsTestDirection("inbound", testCase: testCase)}
-func test__009__Stats__inbound__should_return_a_MessageTraffic_object() {
-reusableTestsWrapper__Stats__inbound__reusableTestsTestDirection(testCase: .should_return_a_MessageTraffic_object)
-}
-
-func test__010__Stats__inbound__should_return_value_for_realtime_message_counts() {
-reusableTestsWrapper__Stats__inbound__reusableTestsTestDirection(testCase: .should_return_value_for_realtime_message_counts)
-}
-
-func test__011__Stats__inbound__should_return_value_for_all_presence_data() {
-reusableTestsWrapper__Stats__inbound__reusableTestsTestDirection(testCase: .should_return_value_for_all_presence_data)
-}
-
-            
-            
-                func reusableTestsWrapper__Stats__outbound__reusableTestsTestDirection(testCase: TestCase_ReusableTestsTestDirection) {
-                reusableTestsTestDirection("outbound", testCase: testCase)}
-func test__012__Stats__outbound__should_return_a_MessageTraffic_object() {
-reusableTestsWrapper__Stats__outbound__reusableTestsTestDirection(testCase: .should_return_a_MessageTraffic_object)
-}
-
-func test__013__Stats__outbound__should_return_value_for_realtime_message_counts() {
-reusableTestsWrapper__Stats__outbound__reusableTestsTestDirection(testCase: .should_return_value_for_realtime_message_counts)
-}
-
-func test__014__Stats__outbound__should_return_value_for_all_presence_data() {
-reusableTestsWrapper__Stats__outbound__reusableTestsTestDirection(testCase: .should_return_value_for_all_presence_data)
-}
-
-
-            // TS4
-            
-
-                func test__015__Stats__connections__should_return_a_ConnectionTypes_object() {
-                    expect(subject).to(beAnInstanceOf(ARTStatsConnectionTypes.self))
-                }
-
-                func test__016__Stats__connections__should_return_value_for_tls_opened_counts() {
-                    expect(subject?.tls.opened).to(equal(5))
-                }
-
-                func test__017__Stats__connections__should_return_value_for_all_peak_connections() {
-                    expect(subject?.all.peak).to(equal(10))
-                }
-
-                // TS2
-                func test__018__Stats__connections__should_return_zero_for_empty_values() {
-                    expect(subject?.all.refused).to(equal(0))
-                }
-
-            // TS9
-            
-
-                func test__019__Stats__channels__should_return_a_ResourceCount_object() {
-                    expect(channelsTestsSubject).to(beAnInstanceOf(ARTStatsResourceCount.self))
-                }
-
-                func test__020__Stats__channels__should_return_value_for_opened_counts() {
-                    expect(channelsTestsSubject?.opened).to(equal(5))
-                }
-
-                func test__021__Stats__channels__should_return_value_for_peak_channels() {
-                    expect(channelsTestsSubject?.peak).to(equal(10))
-                }
-
-                // TS2
-                func test__022__Stats__channels__should_return_zero_for_empty_values() {
-                    expect(channelsTestsSubject?.refused).to(equal(0))
-                }
-enum TestCase_ReusableTestsTestRequestType {
-case should_return_a_RequestCount_object
-case should_return_value_for_succeeded
-case should_return_value_for_failed
-}
-
-
-            // TS8
-            func reusableTestsTestRequestType(_ requestType: String, testCase: TestCase_ReusableTestsTestRequestType, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil) {
-                let data: JSON = [
-                    [ requestType: [ "succeeded": 5, "failed": 10 ] ]
-                ]
-                let rawData = try! data.rawData()
-                let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
-                let subject = stats?.value(forKey: requestType) as? ARTStatsRequestCount
-                
-                func test__should_return_a_RequestCount_object() {
-contextBeforeEach?()
-
-                    expect(subject).to(beAnInstanceOf(ARTStatsRequestCount.self))
-
-contextAfterEach?()
-
-                }
-
-                func test__should_return_value_for_succeeded() {
-contextBeforeEach?()
-
-                    expect(subject?.succeeded).to(equal(5))
-
-contextAfterEach?()
-
-                }
-
-                func test__should_return_value_for_failed() {
-contextBeforeEach?()
-
-                    expect(subject?.failed).to(equal(10))
-
-contextAfterEach?()
-
-                }
-
-switch testCase  {
-case .should_return_a_RequestCount_object:
-    test__should_return_a_RequestCount_object()
-case .should_return_value_for_succeeded:
-    test__should_return_value_for_succeeded()
-case .should_return_value_for_failed:
-    test__should_return_value_for_failed()
-}
-
-            }
-            
-            
-                func reusableTestsWrapper__Stats__apiRequests__reusableTestsTestRequestType(testCase: TestCase_ReusableTestsTestRequestType) {
-                reusableTestsTestRequestType("apiRequests", testCase: testCase)}
-func test__023__Stats__apiRequests__should_return_a_RequestCount_object() {
-reusableTestsWrapper__Stats__apiRequests__reusableTestsTestRequestType(testCase: .should_return_a_RequestCount_object)
-}
-
-func test__024__Stats__apiRequests__should_return_value_for_succeeded() {
-reusableTestsWrapper__Stats__apiRequests__reusableTestsTestRequestType(testCase: .should_return_value_for_succeeded)
-}
-
-func test__025__Stats__apiRequests__should_return_value_for_failed() {
-reusableTestsWrapper__Stats__apiRequests__reusableTestsTestRequestType(testCase: .should_return_value_for_failed)
-}
-
-            
-            
-                func reusableTestsWrapper__Stats__tokenRequests__reusableTestsTestRequestType(testCase: TestCase_ReusableTestsTestRequestType) {
-                reusableTestsTestRequestType("tokenRequests", testCase: testCase)}
-func test__026__Stats__tokenRequests__should_return_a_RequestCount_object() {
-reusableTestsWrapper__Stats__tokenRequests__reusableTestsTestRequestType(testCase: .should_return_a_RequestCount_object)
-}
-
-func test__027__Stats__tokenRequests__should_return_value_for_succeeded() {
-reusableTestsWrapper__Stats__tokenRequests__reusableTestsTestRequestType(testCase: .should_return_value_for_succeeded)
-}
-
-func test__028__Stats__tokenRequests__should_return_value_for_failed() {
-reusableTestsWrapper__Stats__tokenRequests__reusableTestsTestRequestType(testCase: .should_return_value_for_failed)
-}
-
-            
-            
-                func test__029__Stats__interval__should_return_a_Date_object_representing_the_start_of_the_interval() {
-                    let data: JSON = [
-                        [ "intervalId": "2004-02-01:05:06" ]
-                    ]
-                    let rawData = try! data.rawData()
-                    let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
-                    
-                    let dateComponents = NSDateComponents()
-                    dateComponents.year = 2004
-                    dateComponents.month = 2
-                    dateComponents.day = 1
-                    dateComponents.hour = 5
-                    dateComponents.minute = 6
-                    dateComponents.timeZone = NSTimeZone(name: "UTC") as TimeZone?
-
-                    let expected = NSCalendar(identifier: NSCalendar.Identifier.gregorian)?.date(from: dateComponents as DateComponents)
-
-                    expect(stats?.intervalTime()).to(equal(expected))
-                }
-            
-            
-
-                func test__030__Stats__push__should_return_a_ARTStatsPushCount_object() {
-                    expect(pushTestsSubject).to(beAnInstanceOf(ARTStatsPushCount.self))
-                }
-
-                func test__031__Stats__push__should_return_value_for_messages_count() {
-                    expect(pushTestsSubject?.messages).to(equal(10))
-                }
-
-                func test__032__Stats__push__should_return_value_for_invalid_notifications() {
-                    expect(pushTestsSubject?.invalid).to(equal(1))
-                }
-
-                func test__033__Stats__push__should_return_value_for_attempted_notifications() {
-                    expect(pushTestsSubject?.attempted).to(equal(2))
-                }
-
-                func test__034__Stats__push__should_return_value_for_successful_notifications() {
-                    expect(pushTestsSubject?.succeeded).to(equal(3))
-                }
-
-                func test__035__Stats__push__should_return_value_for_failed_notifications() {
-                    expect(pushTestsSubject?.failed).to(equal(4))
-                }
-
-                func test__036__Stats__push__should_return_value_for_directPublishes() {
-                    expect(pushTestsSubject?.direct).to(equal(5))
-                }
-
-            
-
-                func test__037__Stats__inProgress__should_return_a_Date_object_representing_the_last_sub_interval_included_in_this_statistic() {
-                    let dateComponents = NSDateComponents()
-                    dateComponents.year = 2004
-                    dateComponents.month = 2
-                    dateComponents.day = 1
-                    dateComponents.hour = 5
-                    dateComponents.minute = 6
-                    dateComponents.timeZone = NSTimeZone(name: "UTC") as TimeZone?
-
-                    let expected = NSCalendar(identifier: NSCalendar.Identifier.gregorian)?.date(from: dateComponents as DateComponents)
-
-                    expect(inProgressTestsStats?.dateFromInProgress()).to(equal(expected))
-                }
-            
-            
-
-                func test__038__Stats__count__should_return_value_for_number_of_lower_level_stats() {
-                    expect(countTestStats?.count).to(equal(55))
-                }
+    func test__011__Stats__inbound__should_return_value_for_all_presence_data() {
+        reusableTestsWrapper__Stats__inbound__reusableTestsTestDirection(testCase: .should_return_value_for_all_presence_data)
+    }
+
+    func reusableTestsWrapper__Stats__outbound__reusableTestsTestDirection(testCase: TestCase_ReusableTestsTestDirection) {
+        reusableTestsTestDirection("outbound", testCase: testCase)
+    }
+
+    func test__012__Stats__outbound__should_return_a_MessageTraffic_object() {
+        reusableTestsWrapper__Stats__outbound__reusableTestsTestDirection(testCase: .should_return_a_MessageTraffic_object)
+    }
+
+    func test__013__Stats__outbound__should_return_value_for_realtime_message_counts() {
+        reusableTestsWrapper__Stats__outbound__reusableTestsTestDirection(testCase: .should_return_value_for_realtime_message_counts)
+    }
+
+    func test__014__Stats__outbound__should_return_value_for_all_presence_data() {
+        reusableTestsWrapper__Stats__outbound__reusableTestsTestDirection(testCase: .should_return_value_for_all_presence_data)
+    }
+
+    // TS4
+
+    func test__015__Stats__connections__should_return_a_ConnectionTypes_object() {
+        expect(subject).to(beAnInstanceOf(ARTStatsConnectionTypes.self))
+    }
+
+    func test__016__Stats__connections__should_return_value_for_tls_opened_counts() {
+        expect(subject?.tls.opened).to(equal(5))
+    }
+
+    func test__017__Stats__connections__should_return_value_for_all_peak_connections() {
+        expect(subject?.all.peak).to(equal(10))
+    }
+
+    // TS2
+    func test__018__Stats__connections__should_return_zero_for_empty_values() {
+        expect(subject?.all.refused).to(equal(0))
+    }
+
+    // TS9
+
+    func test__019__Stats__channels__should_return_a_ResourceCount_object() {
+        expect(channelsTestsSubject).to(beAnInstanceOf(ARTStatsResourceCount.self))
+    }
+
+    func test__020__Stats__channels__should_return_value_for_opened_counts() {
+        expect(channelsTestsSubject?.opened).to(equal(5))
+    }
+
+    func test__021__Stats__channels__should_return_value_for_peak_channels() {
+        expect(channelsTestsSubject?.peak).to(equal(10))
+    }
+
+    // TS2
+    func test__022__Stats__channels__should_return_zero_for_empty_values() {
+        expect(channelsTestsSubject?.refused).to(equal(0))
+    }
+
+    enum TestCase_ReusableTestsTestRequestType {
+        case should_return_a_RequestCount_object
+        case should_return_value_for_succeeded
+        case should_return_value_for_failed
+    }
+
+    // TS8
+    func reusableTestsTestRequestType(_ requestType: String, testCase: TestCase_ReusableTestsTestRequestType, beforeEach contextBeforeEach: (() -> Void)? = nil, afterEach contextAfterEach: (() -> Void)? = nil) {
+        let data: JSON = [
+            [requestType: ["succeeded": 5, "failed": 10]],
+        ]
+        let rawData = try! data.rawData()
+        let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
+        let subject = stats?.value(forKey: requestType) as? ARTStatsRequestCount
+
+        func test__should_return_a_RequestCount_object() {
+            contextBeforeEach?()
+
+            expect(subject).to(beAnInstanceOf(ARTStatsRequestCount.self))
+
+            contextAfterEach?()
+        }
+
+        func test__should_return_value_for_succeeded() {
+            contextBeforeEach?()
+
+            expect(subject?.succeeded).to(equal(5))
+
+            contextAfterEach?()
+        }
+
+        func test__should_return_value_for_failed() {
+            contextBeforeEach?()
+
+            expect(subject?.failed).to(equal(10))
+
+            contextAfterEach?()
+        }
+
+        switch testCase {
+        case .should_return_a_RequestCount_object:
+            test__should_return_a_RequestCount_object()
+        case .should_return_value_for_succeeded:
+            test__should_return_value_for_succeeded()
+        case .should_return_value_for_failed:
+            test__should_return_value_for_failed()
+        }
+    }
+
+    func reusableTestsWrapper__Stats__apiRequests__reusableTestsTestRequestType(testCase: TestCase_ReusableTestsTestRequestType) {
+        reusableTestsTestRequestType("apiRequests", testCase: testCase)
+    }
+
+    func test__023__Stats__apiRequests__should_return_a_RequestCount_object() {
+        reusableTestsWrapper__Stats__apiRequests__reusableTestsTestRequestType(testCase: .should_return_a_RequestCount_object)
+    }
+
+    func test__024__Stats__apiRequests__should_return_value_for_succeeded() {
+        reusableTestsWrapper__Stats__apiRequests__reusableTestsTestRequestType(testCase: .should_return_value_for_succeeded)
+    }
+
+    func test__025__Stats__apiRequests__should_return_value_for_failed() {
+        reusableTestsWrapper__Stats__apiRequests__reusableTestsTestRequestType(testCase: .should_return_value_for_failed)
+    }
+
+    func reusableTestsWrapper__Stats__tokenRequests__reusableTestsTestRequestType(testCase: TestCase_ReusableTestsTestRequestType) {
+        reusableTestsTestRequestType("tokenRequests", testCase: testCase)
+    }
+
+    func test__026__Stats__tokenRequests__should_return_a_RequestCount_object() {
+        reusableTestsWrapper__Stats__tokenRequests__reusableTestsTestRequestType(testCase: .should_return_a_RequestCount_object)
+    }
+
+    func test__027__Stats__tokenRequests__should_return_value_for_succeeded() {
+        reusableTestsWrapper__Stats__tokenRequests__reusableTestsTestRequestType(testCase: .should_return_value_for_succeeded)
+    }
+
+    func test__028__Stats__tokenRequests__should_return_value_for_failed() {
+        reusableTestsWrapper__Stats__tokenRequests__reusableTestsTestRequestType(testCase: .should_return_value_for_failed)
+    }
+
+    func test__029__Stats__interval__should_return_a_Date_object_representing_the_start_of_the_interval() {
+        let data: JSON = [
+            ["intervalId": "2004-02-01:05:06"],
+        ]
+        let rawData = try! data.rawData()
+        let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
+
+        let dateComponents = NSDateComponents()
+        dateComponents.year = 2004
+        dateComponents.month = 2
+        dateComponents.day = 1
+        dateComponents.hour = 5
+        dateComponents.minute = 6
+        dateComponents.timeZone = NSTimeZone(name: "UTC") as TimeZone?
+
+        let expected = NSCalendar(identifier: NSCalendar.Identifier.gregorian)?.date(from: dateComponents as DateComponents)
+
+        expect(stats?.intervalTime()).to(equal(expected))
+    }
+
+    func test__030__Stats__push__should_return_a_ARTStatsPushCount_object() {
+        expect(pushTestsSubject).to(beAnInstanceOf(ARTStatsPushCount.self))
+    }
+
+    func test__031__Stats__push__should_return_value_for_messages_count() {
+        expect(pushTestsSubject?.messages).to(equal(10))
+    }
+
+    func test__032__Stats__push__should_return_value_for_invalid_notifications() {
+        expect(pushTestsSubject?.invalid).to(equal(1))
+    }
+
+    func test__033__Stats__push__should_return_value_for_attempted_notifications() {
+        expect(pushTestsSubject?.attempted).to(equal(2))
+    }
+
+    func test__034__Stats__push__should_return_value_for_successful_notifications() {
+        expect(pushTestsSubject?.succeeded).to(equal(3))
+    }
+
+    func test__035__Stats__push__should_return_value_for_failed_notifications() {
+        expect(pushTestsSubject?.failed).to(equal(4))
+    }
+
+    func test__036__Stats__push__should_return_value_for_directPublishes() {
+        expect(pushTestsSubject?.direct).to(equal(5))
+    }
+
+    func test__037__Stats__inProgress__should_return_a_Date_object_representing_the_last_sub_interval_included_in_this_statistic() {
+        let dateComponents = NSDateComponents()
+        dateComponents.year = 2004
+        dateComponents.month = 2
+        dateComponents.day = 1
+        dateComponents.hour = 5
+        dateComponents.minute = 6
+        dateComponents.timeZone = NSTimeZone(name: "UTC") as TimeZone?
+
+        let expected = NSCalendar(identifier: NSCalendar.Identifier.gregorian)?.date(from: dateComponents as DateComponents)
+
+        expect(inProgressTestsStats?.dateFromInProgress()).to(equal(expected))
+    }
+
+    func test__038__Stats__count__should_return_value_for_number_of_lower_level_stats() {
+        expect(countTestStats?.count).to(equal(55))
+    }
 }

--- a/Spec/Stats.swift
+++ b/Spec/Stats.swift
@@ -1,7 +1,7 @@
 import Ably
 import Foundation
 import Nimble
-import Quick
+import XCTest
 import SwiftyJSON
 
 private let encoder = ARTJsonLikeEncoder()

--- a/Spec/Stats.swift
+++ b/Spec/Stats.swift
@@ -55,7 +55,7 @@ import Foundation
                     return try! encoder.decodeStats(rawData)[0] as? ARTStats
                 }()
 
-class Stats: QuickSpec {
+class Stats: XCTestCase {
 
 // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
 override class var defaultTestSuite : XCTestSuite {
@@ -68,12 +68,17 @@ override class var defaultTestSuite : XCTestSuite {
 
     return super.defaultTestSuite
 }
+        
+enum TestCase_ReusableTestsTestAttribute {
+case should_return_a_MessagesTypes_object
+case should_return_value_for_message_counts
+case should_return_value_for_all_data_transferred
+case should_return_zero_for_empty_values
+}
 
-    override func spec() {
-        describe("Stats") {
 
             // TS6
-            func reusableTestsTestAttribute(_ attribute: String) {
+            func reusableTestsTestAttribute(_ attribute: String, testCase: TestCase_ReusableTestsTestAttribute, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil) {
                 let data: JSON = [
                     [ attribute: [ "messages": [ "count": 5], "all": [ "data": 10 ] ] ]
                 ]
@@ -81,36 +86,106 @@ override class var defaultTestSuite : XCTestSuite {
                 let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
                 let subject = stats?.value(forKey: attribute) as? ARTStatsMessageTypes
 
-                it("should return a MessagesTypes object") {
+                func test__should_return_a_MessagesTypes_object() {
+contextBeforeEach?()
+
                     expect(subject).to(beAnInstanceOf(ARTStatsMessageTypes.self))
+
+contextAfterEach?()
+
                 }
 
                 // TS5
-                it("should return value for message counts") {
+                func test__should_return_value_for_message_counts() {
+contextBeforeEach?()
+
                     expect(subject?.messages.count).to(equal(5))
+
+contextAfterEach?()
+
                 }
 
                 // TS5
-                it("should return value for all data transferred") {
+                func test__should_return_value_for_all_data_transferred() {
+contextBeforeEach?()
+
                     expect(subject?.all.data).to(equal(10))
+
+contextAfterEach?()
+
                 }
 
                 // TS2
-                it("should return zero for empty values") {
+                func test__should_return_zero_for_empty_values() {
+contextBeforeEach?()
+
                     expect(subject?.presence.count).to(equal(0))
+
+contextAfterEach?()
+
                 }
+
+switch testCase  {
+case .should_return_a_MessagesTypes_object:
+    test__should_return_a_MessagesTypes_object()
+case .should_return_value_for_message_counts:
+    test__should_return_value_for_message_counts()
+case .should_return_value_for_all_data_transferred:
+    test__should_return_value_for_all_data_transferred()
+case .should_return_zero_for_empty_values:
+    test__should_return_zero_for_empty_values()
+}
+
             }
             
-            context("all") {
-                reusableTestsTestAttribute("all")
-            }
             
-            context("persisted") {
-                reusableTestsTestAttribute("persisted")
-            }
+                func reusableTestsWrapper__Stats__all__reusableTestsTestAttribute(testCase: TestCase_ReusableTestsTestAttribute) {
+                reusableTestsTestAttribute("all", testCase: testCase)}
+func test__001__Stats__all__should_return_a_MessagesTypes_object() {
+reusableTestsWrapper__Stats__all__reusableTestsTestAttribute(testCase: .should_return_a_MessagesTypes_object)
+}
+
+func test__002__Stats__all__should_return_value_for_message_counts() {
+reusableTestsWrapper__Stats__all__reusableTestsTestAttribute(testCase: .should_return_value_for_message_counts)
+}
+
+func test__003__Stats__all__should_return_value_for_all_data_transferred() {
+reusableTestsWrapper__Stats__all__reusableTestsTestAttribute(testCase: .should_return_value_for_all_data_transferred)
+}
+
+func test__004__Stats__all__should_return_zero_for_empty_values() {
+reusableTestsWrapper__Stats__all__reusableTestsTestAttribute(testCase: .should_return_zero_for_empty_values)
+}
+
+            
+            
+                func reusableTestsWrapper__Stats__persisted__reusableTestsTestAttribute(testCase: TestCase_ReusableTestsTestAttribute) {
+                reusableTestsTestAttribute("persisted", testCase: testCase)}
+func test__005__Stats__persisted__should_return_a_MessagesTypes_object() {
+reusableTestsWrapper__Stats__persisted__reusableTestsTestAttribute(testCase: .should_return_a_MessagesTypes_object)
+}
+
+func test__006__Stats__persisted__should_return_value_for_message_counts() {
+reusableTestsWrapper__Stats__persisted__reusableTestsTestAttribute(testCase: .should_return_value_for_message_counts)
+}
+
+func test__007__Stats__persisted__should_return_value_for_all_data_transferred() {
+reusableTestsWrapper__Stats__persisted__reusableTestsTestAttribute(testCase: .should_return_value_for_all_data_transferred)
+}
+
+func test__008__Stats__persisted__should_return_zero_for_empty_values() {
+reusableTestsWrapper__Stats__persisted__reusableTestsTestAttribute(testCase: .should_return_zero_for_empty_values)
+}
+
+enum TestCase_ReusableTestsTestDirection {
+case should_return_a_MessageTraffic_object
+case should_return_value_for_realtime_message_counts
+case should_return_value_for_all_presence_data
+}
+
 
             // TS7
-            func reusableTestsTestDirection(_ direction: String) {
+            func reusableTestsTestDirection(_ direction: String, testCase: TestCase_ReusableTestsTestDirection, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil) {
                 let data: JSON = [
                     [ direction: [
                         "realtime": [ "messages": [ "count": 5] ],
@@ -121,73 +196,126 @@ override class var defaultTestSuite : XCTestSuite {
                 let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
                 let subject = stats?.value(forKey: direction) as? ARTStatsMessageTraffic
 
-                it("should return a MessageTraffic object") {
+                func test__should_return_a_MessageTraffic_object() {
+contextBeforeEach?()
+
                     expect(subject).to(beAnInstanceOf(ARTStatsMessageTraffic.self))
+
+contextAfterEach?()
+
                 }
 
                 // TS5
-                it("should return value for realtime message counts") {
+                func test__should_return_value_for_realtime_message_counts() {
+contextBeforeEach?()
+
                     expect(subject?.realtime.messages.count).to(equal(5))
+
+contextAfterEach?()
+
                 }
 
                 // TS5
-                it("should return value for all presence data") {
+                func test__should_return_value_for_all_presence_data() {
+contextBeforeEach?()
+
                     expect(subject?.all.presence.data).to(equal(210))
+
+contextAfterEach?()
+
                 }
+
+switch testCase  {
+case .should_return_a_MessageTraffic_object:
+    test__should_return_a_MessageTraffic_object()
+case .should_return_value_for_realtime_message_counts:
+    test__should_return_value_for_realtime_message_counts()
+case .should_return_value_for_all_presence_data:
+    test__should_return_value_for_all_presence_data()
+}
+
             }
         
-            context("inbound") {
-                reusableTestsTestDirection("inbound")
-            }
             
-            context("outbound") {
-                reusableTestsTestDirection("outbound")
-            }
+                func reusableTestsWrapper__Stats__inbound__reusableTestsTestDirection(testCase: TestCase_ReusableTestsTestDirection) {
+                reusableTestsTestDirection("inbound", testCase: testCase)}
+func test__009__Stats__inbound__should_return_a_MessageTraffic_object() {
+reusableTestsWrapper__Stats__inbound__reusableTestsTestDirection(testCase: .should_return_a_MessageTraffic_object)
+}
+
+func test__010__Stats__inbound__should_return_value_for_realtime_message_counts() {
+reusableTestsWrapper__Stats__inbound__reusableTestsTestDirection(testCase: .should_return_value_for_realtime_message_counts)
+}
+
+func test__011__Stats__inbound__should_return_value_for_all_presence_data() {
+reusableTestsWrapper__Stats__inbound__reusableTestsTestDirection(testCase: .should_return_value_for_all_presence_data)
+}
+
+            
+            
+                func reusableTestsWrapper__Stats__outbound__reusableTestsTestDirection(testCase: TestCase_ReusableTestsTestDirection) {
+                reusableTestsTestDirection("outbound", testCase: testCase)}
+func test__012__Stats__outbound__should_return_a_MessageTraffic_object() {
+reusableTestsWrapper__Stats__outbound__reusableTestsTestDirection(testCase: .should_return_a_MessageTraffic_object)
+}
+
+func test__013__Stats__outbound__should_return_value_for_realtime_message_counts() {
+reusableTestsWrapper__Stats__outbound__reusableTestsTestDirection(testCase: .should_return_value_for_realtime_message_counts)
+}
+
+func test__014__Stats__outbound__should_return_value_for_all_presence_data() {
+reusableTestsWrapper__Stats__outbound__reusableTestsTestDirection(testCase: .should_return_value_for_all_presence_data)
+}
+
 
             // TS4
-            context("connections") {
+            
 
-                it("should return a ConnectionTypes object") {
+                func test__015__Stats__connections__should_return_a_ConnectionTypes_object() {
                     expect(subject).to(beAnInstanceOf(ARTStatsConnectionTypes.self))
                 }
 
-                it("should return value for tls opened counts") {
+                func test__016__Stats__connections__should_return_value_for_tls_opened_counts() {
                     expect(subject?.tls.opened).to(equal(5))
                 }
 
-                it("should return value for all peak connections") {
+                func test__017__Stats__connections__should_return_value_for_all_peak_connections() {
                     expect(subject?.all.peak).to(equal(10))
                 }
 
                 // TS2
-                it("should return zero for empty values") {
+                func test__018__Stats__connections__should_return_zero_for_empty_values() {
                     expect(subject?.all.refused).to(equal(0))
                 }
-            }
 
             // TS9
-            context("channels") {
+            
 
-                it("should return a ResourceCount object") {
+                func test__019__Stats__channels__should_return_a_ResourceCount_object() {
                     expect(channelsTestsSubject).to(beAnInstanceOf(ARTStatsResourceCount.self))
                 }
 
-                it("should return value for opened counts") {
+                func test__020__Stats__channels__should_return_value_for_opened_counts() {
                     expect(channelsTestsSubject?.opened).to(equal(5))
                 }
 
-                it("should return value for peak channels") {
+                func test__021__Stats__channels__should_return_value_for_peak_channels() {
                     expect(channelsTestsSubject?.peak).to(equal(10))
                 }
 
                 // TS2
-                it("should return zero for empty values") {
+                func test__022__Stats__channels__should_return_zero_for_empty_values() {
                     expect(channelsTestsSubject?.refused).to(equal(0))
                 }
-            }
+enum TestCase_ReusableTestsTestRequestType {
+case should_return_a_RequestCount_object
+case should_return_value_for_succeeded
+case should_return_value_for_failed
+}
+
 
             // TS8
-            func reusableTestsTestRequestType(_ requestType: String) {
+            func reusableTestsTestRequestType(_ requestType: String, testCase: TestCase_ReusableTestsTestRequestType, beforeEach contextBeforeEach: (() -> ())? = nil, afterEach contextAfterEach: (() -> ())? = nil) {
                 let data: JSON = [
                     [ requestType: [ "succeeded": 5, "failed": 10 ] ]
                 ]
@@ -195,29 +323,78 @@ override class var defaultTestSuite : XCTestSuite {
                 let stats = try! encoder.decodeStats(rawData)[0] as? ARTStats
                 let subject = stats?.value(forKey: requestType) as? ARTStatsRequestCount
                 
-                it("should return a RequestCount object") {
+                func test__should_return_a_RequestCount_object() {
+contextBeforeEach?()
+
                     expect(subject).to(beAnInstanceOf(ARTStatsRequestCount.self))
+
+contextAfterEach?()
+
                 }
 
-                it("should return value for succeeded") {
+                func test__should_return_value_for_succeeded() {
+contextBeforeEach?()
+
                     expect(subject?.succeeded).to(equal(5))
+
+contextAfterEach?()
+
                 }
 
-                it("should return value for failed") {
+                func test__should_return_value_for_failed() {
+contextBeforeEach?()
+
                     expect(subject?.failed).to(equal(10))
+
+contextAfterEach?()
+
                 }
+
+switch testCase  {
+case .should_return_a_RequestCount_object:
+    test__should_return_a_RequestCount_object()
+case .should_return_value_for_succeeded:
+    test__should_return_value_for_succeeded()
+case .should_return_value_for_failed:
+    test__should_return_value_for_failed()
+}
+
             }
             
-            context("apiRequests") {
-                reusableTestsTestRequestType("apiRequests")
-            }
             
-            context("tokenRequests") {
-                reusableTestsTestRequestType("tokenRequests")
-            }
+                func reusableTestsWrapper__Stats__apiRequests__reusableTestsTestRequestType(testCase: TestCase_ReusableTestsTestRequestType) {
+                reusableTestsTestRequestType("apiRequests", testCase: testCase)}
+func test__023__Stats__apiRequests__should_return_a_RequestCount_object() {
+reusableTestsWrapper__Stats__apiRequests__reusableTestsTestRequestType(testCase: .should_return_a_RequestCount_object)
+}
+
+func test__024__Stats__apiRequests__should_return_value_for_succeeded() {
+reusableTestsWrapper__Stats__apiRequests__reusableTestsTestRequestType(testCase: .should_return_value_for_succeeded)
+}
+
+func test__025__Stats__apiRequests__should_return_value_for_failed() {
+reusableTestsWrapper__Stats__apiRequests__reusableTestsTestRequestType(testCase: .should_return_value_for_failed)
+}
+
             
-            context("interval") {
-                it("should return a Date object representing the start of the interval") {
+            
+                func reusableTestsWrapper__Stats__tokenRequests__reusableTestsTestRequestType(testCase: TestCase_ReusableTestsTestRequestType) {
+                reusableTestsTestRequestType("tokenRequests", testCase: testCase)}
+func test__026__Stats__tokenRequests__should_return_a_RequestCount_object() {
+reusableTestsWrapper__Stats__tokenRequests__reusableTestsTestRequestType(testCase: .should_return_a_RequestCount_object)
+}
+
+func test__027__Stats__tokenRequests__should_return_value_for_succeeded() {
+reusableTestsWrapper__Stats__tokenRequests__reusableTestsTestRequestType(testCase: .should_return_value_for_succeeded)
+}
+
+func test__028__Stats__tokenRequests__should_return_value_for_failed() {
+reusableTestsWrapper__Stats__tokenRequests__reusableTestsTestRequestType(testCase: .should_return_value_for_failed)
+}
+
+            
+            
+                func test__029__Stats__interval__should_return_a_Date_object_representing_the_start_of_the_interval() {
                     let data: JSON = [
                         [ "intervalId": "2004-02-01:05:06" ]
                     ]
@@ -236,42 +413,40 @@ override class var defaultTestSuite : XCTestSuite {
 
                     expect(stats?.intervalTime()).to(equal(expected))
                 }
-            }
             
-            context("push") {
+            
 
-                it("should return a ARTStatsPushCount object") {
+                func test__030__Stats__push__should_return_a_ARTStatsPushCount_object() {
                     expect(pushTestsSubject).to(beAnInstanceOf(ARTStatsPushCount.self))
                 }
 
-                it("should return value for messages count") {
+                func test__031__Stats__push__should_return_value_for_messages_count() {
                     expect(pushTestsSubject?.messages).to(equal(10))
                 }
 
-                it("should return value for invalid notifications") {
+                func test__032__Stats__push__should_return_value_for_invalid_notifications() {
                     expect(pushTestsSubject?.invalid).to(equal(1))
                 }
 
-                it("should return value for attempted notifications") {
+                func test__033__Stats__push__should_return_value_for_attempted_notifications() {
                     expect(pushTestsSubject?.attempted).to(equal(2))
                 }
 
-                it("should return value for successful notifications") {
+                func test__034__Stats__push__should_return_value_for_successful_notifications() {
                     expect(pushTestsSubject?.succeeded).to(equal(3))
                 }
 
-                it("should return value for failed notifications") {
+                func test__035__Stats__push__should_return_value_for_failed_notifications() {
                     expect(pushTestsSubject?.failed).to(equal(4))
                 }
 
-                it("should return value for directPublishes") {
+                func test__036__Stats__push__should_return_value_for_directPublishes() {
                     expect(pushTestsSubject?.direct).to(equal(5))
                 }
-            }
 
-            context("inProgress") {
+            
 
-                it("should return a Date object representing the last sub-interval included in this statistic") {
+                func test__037__Stats__inProgress__should_return_a_Date_object_representing_the_last_sub_interval_included_in_this_statistic() {
                     let dateComponents = NSDateComponents()
                     dateComponents.year = 2004
                     dateComponents.month = 2
@@ -284,14 +459,10 @@ override class var defaultTestSuite : XCTestSuite {
 
                     expect(inProgressTestsStats?.dateFromInProgress()).to(equal(expected))
                 }
-            }
             
-            context("count") {
+            
 
-                it("should return value for number of lower-level stats") {
+                func test__038__Stats__count__should_return_value_for_number_of_lower_level_stats() {
                     expect(countTestStats?.count).to(equal(55))
                 }
-            }
-        }
-    }
 }

--- a/Spec/Stringifiable.swift
+++ b/Spec/Stringifiable.swift
@@ -2,11 +2,10 @@ import Ably
 import Quick
 import Nimble
 
-class Stringifiable: QuickSpec {
-    override func spec() {
-        describe("Stringifiable") {
-            context("type conversion") {
-                it("as string") {
+class Stringifiable: XCTestCase {
+        
+            
+                func test__001__Stringifiable__type_conversion__as_string() {
                     expect(
                         ARTStringifiable(string: "Lorem Ipsum").stringValue
                     )
@@ -15,7 +14,7 @@ class Stringifiable: QuickSpec {
                     )
                 }
                 
-                it("as bool [true]") {
+                func test__002__Stringifiable__type_conversion__as_bool__true_() {
                     expect {
                         ARTStringifiable(bool: true).stringValue
                     }
@@ -24,7 +23,7 @@ class Stringifiable: QuickSpec {
                     )
                 }
                 
-                it("as bool [false]") {
+                func test__003__Stringifiable__type_conversion__as_bool__false_() {
                     expect {
                         ARTStringifiable(bool: false).stringValue
                     }
@@ -33,7 +32,7 @@ class Stringifiable: QuickSpec {
                     )
                 }
                 
-                it("as integer that is not treated as bool [false]") {
+                func test__004__Stringifiable__type_conversion__as_integer_that_is_not_treated_as_bool__false_() {
                     expect {
                         ARTStringifiable(number: NSNumber(value: 0)).stringValue
                     }
@@ -42,7 +41,7 @@ class Stringifiable: QuickSpec {
                     )
                 }
                 
-                it("as integer that is not treated as bool [true]") {
+                func test__005__Stringifiable__type_conversion__as_integer_that_is_not_treated_as_bool__true_() {
                     expect {
                         ARTStringifiable(number: NSNumber(value: 1)).stringValue
                     }
@@ -51,7 +50,7 @@ class Stringifiable: QuickSpec {
                     )
                 }
                 
-                it("as number [Int]") {
+                func test__006__Stringifiable__type_conversion__as_number__Int_() {
                     expect {
                         ARTStringifiable(number: NSNumber(value: 12)).stringValue
                     }
@@ -60,7 +59,7 @@ class Stringifiable: QuickSpec {
                     )
                 }
                 
-                it("as number [Float 1 decimal digit]") {
+                func test__007__Stringifiable__type_conversion__as_number__Float_1_decimal_digit_() {
                     expect {
                         ARTStringifiable(number: NSNumber(value: 0.1)).stringValue
                     }
@@ -69,7 +68,7 @@ class Stringifiable: QuickSpec {
                     )
                 }
                 
-                it("as number [Float 2 decimal digits]") {
+                func test__008__Stringifiable__type_conversion__as_number__Float_2_decimal_digits_() {
                     expect {
                         ARTStringifiable(number: NSNumber(value: 0.12)).stringValue
                     }
@@ -78,7 +77,7 @@ class Stringifiable: QuickSpec {
                     )
                 }
                 
-                it("as number [Float 4 decimal digits]") {
+                func test__009__Stringifiable__type_conversion__as_number__Float_4_decimal_digits_() {
                     expect {
                         ARTStringifiable(number: NSNumber(value: 0.1234)).stringValue
                     }
@@ -86,7 +85,4 @@ class Stringifiable: QuickSpec {
                         equal("0.1234")
                     )
                 }
-            }
-        }
-    }
 }

--- a/Spec/Stringifiable.swift
+++ b/Spec/Stringifiable.swift
@@ -1,6 +1,6 @@
 import Ably
 import Nimble
-import Quick
+import XCTest
 
 class Stringifiable: XCTestCase {
     func test__001__Stringifiable__type_conversion__as_string() {

--- a/Spec/Stringifiable.swift
+++ b/Spec/Stringifiable.swift
@@ -1,88 +1,86 @@
 import Ably
-import Quick
 import Nimble
+import Quick
 
 class Stringifiable: XCTestCase {
-        
-            
-                func test__001__Stringifiable__type_conversion__as_string() {
-                    expect(
-                        ARTStringifiable(string: "Lorem Ipsum").stringValue
-                    )
-                    .to(
-                        equal("Lorem Ipsum")
-                    )
-                }
-                
-                func test__002__Stringifiable__type_conversion__as_bool__true_() {
-                    expect {
-                        ARTStringifiable(bool: true).stringValue
-                    }
-                    .to(
-                        equal("true")
-                    )
-                }
-                
-                func test__003__Stringifiable__type_conversion__as_bool__false_() {
-                    expect {
-                        ARTStringifiable(bool: false).stringValue
-                    }
-                    .to(
-                        equal("false")
-                    )
-                }
-                
-                func test__004__Stringifiable__type_conversion__as_integer_that_is_not_treated_as_bool__false_() {
-                    expect {
-                        ARTStringifiable(number: NSNumber(value: 0)).stringValue
-                    }
-                    .to(
-                        equal("0")
-                    )
-                }
-                
-                func test__005__Stringifiable__type_conversion__as_integer_that_is_not_treated_as_bool__true_() {
-                    expect {
-                        ARTStringifiable(number: NSNumber(value: 1)).stringValue
-                    }
-                    .to(
-                        equal("1")
-                    )
-                }
-                
-                func test__006__Stringifiable__type_conversion__as_number__Int_() {
-                    expect {
-                        ARTStringifiable(number: NSNumber(value: 12)).stringValue
-                    }
-                    .to(
-                        equal("12")
-                    )
-                }
-                
-                func test__007__Stringifiable__type_conversion__as_number__Float_1_decimal_digit_() {
-                    expect {
-                        ARTStringifiable(number: NSNumber(value: 0.1)).stringValue
-                    }
-                    .to(
-                        equal("0.1")
-                    )
-                }
-                
-                func test__008__Stringifiable__type_conversion__as_number__Float_2_decimal_digits_() {
-                    expect {
-                        ARTStringifiable(number: NSNumber(value: 0.12)).stringValue
-                    }
-                    .to(
-                        equal("0.12")
-                    )
-                }
-                
-                func test__009__Stringifiable__type_conversion__as_number__Float_4_decimal_digits_() {
-                    expect {
-                        ARTStringifiable(number: NSNumber(value: 0.1234)).stringValue
-                    }
-                    .to(
-                        equal("0.1234")
-                    )
-                }
+    func test__001__Stringifiable__type_conversion__as_string() {
+        expect(
+            ARTStringifiable(string: "Lorem Ipsum").stringValue
+        )
+        .to(
+            equal("Lorem Ipsum")
+        )
+    }
+
+    func test__002__Stringifiable__type_conversion__as_bool__true_() {
+        expect {
+            ARTStringifiable(bool: true).stringValue
+        }
+        .to(
+            equal("true")
+        )
+    }
+
+    func test__003__Stringifiable__type_conversion__as_bool__false_() {
+        expect {
+            ARTStringifiable(bool: false).stringValue
+        }
+        .to(
+            equal("false")
+        )
+    }
+
+    func test__004__Stringifiable__type_conversion__as_integer_that_is_not_treated_as_bool__false_() {
+        expect {
+            ARTStringifiable(number: NSNumber(value: 0)).stringValue
+        }
+        .to(
+            equal("0")
+        )
+    }
+
+    func test__005__Stringifiable__type_conversion__as_integer_that_is_not_treated_as_bool__true_() {
+        expect {
+            ARTStringifiable(number: NSNumber(value: 1)).stringValue
+        }
+        .to(
+            equal("1")
+        )
+    }
+
+    func test__006__Stringifiable__type_conversion__as_number__Int_() {
+        expect {
+            ARTStringifiable(number: NSNumber(value: 12)).stringValue
+        }
+        .to(
+            equal("12")
+        )
+    }
+
+    func test__007__Stringifiable__type_conversion__as_number__Float_1_decimal_digit_() {
+        expect {
+            ARTStringifiable(number: NSNumber(value: 0.1)).stringValue
+        }
+        .to(
+            equal("0.1")
+        )
+    }
+
+    func test__008__Stringifiable__type_conversion__as_number__Float_2_decimal_digits_() {
+        expect {
+            ARTStringifiable(number: NSNumber(value: 0.12)).stringValue
+        }
+        .to(
+            equal("0.12")
+        )
+    }
+
+    func test__009__Stringifiable__type_conversion__as_number__Float_4_decimal_digits_() {
+        expect {
+            ARTStringifiable(number: NSNumber(value: 0.1234)).stringValue
+        }
+        .to(
+            equal("0.1234")
+        )
+    }
 }

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -12,11 +12,27 @@ typealias HookToken = AspectToken
 
 let AblyTestsErrorDomain = "test.ably.io"
 
-class Configuration : QuickConfiguration {
-    override class func configure(_ configuration: Quick.Configuration!) {
-        configuration.beforeSuite {
-            AsyncDefaults.timeout = testTimeout
+class AblyTestsConfiguration: NSObject, XCTestObservation {
+    override init() {
+        super.init()
+        XCTestObservationCenter.shared.addTestObserver(self)
+    }
+    
+    private var performedPreFirstTestCaseSetup = false
+    
+    func testCaseWillStart(_ testCase: XCTestCase) {
+        if !performedPreFirstTestCaseSetup {
+            preFirstTestCaseSetup()
+            performedPreFirstTestCaseSetup = true
         }
+    }
+    
+    private func preFirstTestCaseSetup() {
+        // This is code that, when we were using the Quick testing
+        // framework, was inside a `configuration.beforeSuite` hook,
+        // which means it runs just before the execution of the first
+        // test case.
+        AsyncDefaults.timeout = testTimeout
     }
 }
 

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -1,7 +1,6 @@
 import Ably
 import Foundation
 import XCTest
-import Quick
 import Nimble
 import SwiftyJSON
 import Aspects

--- a/Spec/Utilities.swift
+++ b/Spec/Utilities.swift
@@ -18,7 +18,7 @@ import Foundation
                 private let extras = ["push": ["key": "value"]]
                 private let clientId = "clientId"
 
-class Utilities: QuickSpec {
+class Utilities: XCTestCase {
 
 // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
 override class var defaultTestSuite : XCTestSuite {
@@ -38,17 +38,17 @@ override class var defaultTestSuite : XCTestSuite {
 
     return super.defaultTestSuite
 }
+        
 
-    override func spec() {
-        describe("Utilities") {
-
-            context("JSON Encoder") {
-                beforeEach {
+            
+                func beforeEach__Utilities__JSON_Encoder() {
                     jsonEncoder = ARTJsonLikeEncoder()
                     jsonEncoder.delegate = ARTJsonEncoder()
                 }
 
-                it("should decode a protocol message that has an error without a message") {
+                func test__001__Utilities__JSON_Encoder__should_decode_a_protocol_message_that_has_an_error_without_a_message() {
+beforeEach__Utilities__JSON_Encoder()
+
                     let jsonObject: NSDictionary = [
                         "action": 9,
                         "error": [
@@ -66,7 +66,9 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(error.message).to(equal(""))
                 }
 
-                it("should encode a protocol message that has invalid data") {
+                func test__002__Utilities__JSON_Encoder__should_encode_a_protocol_message_that_has_invalid_data() {
+beforeEach__Utilities__JSON_Encoder()
+
                     let pm = ARTProtocolMessage()
                     pm.action = .message
                     pm.channel = "foo"
@@ -81,7 +83,9 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(result).to(beNil())
                 }
 
-                it("should decode data with malformed JSON") {
+                func test__003__Utilities__JSON_Encoder__should_decode_data_with_malformed_JSON() {
+beforeEach__Utilities__JSON_Encoder()
+
                     let malformedJSON = "{...}"
                     let data = malformedJSON.data(using: String.Encoding.utf8)!
                     var result: AnyObject?
@@ -92,7 +96,9 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(result).to(beNil())
                 }
 
-                it("should decode data with malformed MsgPack") {
+                func test__004__Utilities__JSON_Encoder__should_decode_data_with_malformed_MsgPack() {
+beforeEach__Utilities__JSON_Encoder()
+
                     let data = NSData()
                     var result: AnyObject?
                     expect{ result = try ARTMsgPackEncoder().decode(data as Data) as! (Data) as (Data) as AnyObject? }.to(throwError { error in
@@ -101,8 +107,10 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(result).to(beNil())
                 }
 
-                context("in Realtime") {
-                    it("should handle and emit the invalid data error") {
+                
+                    func test__005__Utilities__JSON_Encoder__in_Realtime__should_handle_and_emit_the_invalid_data_error() {
+beforeEach__Utilities__JSON_Encoder()
+
                         let options = AblyTests.commonAppSetup()
                         let realtime = ARTRealtime(options: options)
                         defer { realtime.close() }
@@ -129,7 +137,9 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("should ignore invalid transport message") {
+                    func test__006__Utilities__JSON_Encoder__in_Realtime__should_ignore_invalid_transport_message() {
+beforeEach__Utilities__JSON_Encoder()
+
                         let options = AblyTests.commonAppSetup()
                         let realtime = ARTRealtime(options: options)
                         defer { realtime.close() }
@@ -163,10 +173,11 @@ override class var defaultTestSuite : XCTestSuite {
                         channel.off()
                         channel.unsubscribe()
                     }
-                }
 
-                context("in Rest") {
-                    it("should handle and emit the invalid data error") {
+                
+                    func test__007__Utilities__JSON_Encoder__in_Rest__should_handle_and_emit_the_invalid_data_error() {
+beforeEach__Utilities__JSON_Encoder()
+
                         let options = AblyTests.commonAppSetup()
                         let rest = ARTRest(options: options)
                         let channel = rest.channels.get("foo")
@@ -192,7 +203,9 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("should ignore invalid response payload") {
+                    func test__008__Utilities__JSON_Encoder__in_Rest__should_ignore_invalid_response_payload() {
+beforeEach__Utilities__JSON_Encoder()
+
                         let options = AblyTests.commonAppSetup()
                         let rest = ARTRest(options: options)
                         let testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
@@ -223,12 +236,10 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                         }
                     }
-                }
-            }
 
-            context("EventEmitter") {
+            
 
-                beforeEach {
+                func beforeEach__Utilities__EventEmitter() {
                     eventEmitter = ARTInternalEventEmitter(queue: AblyTests.queue)
                     receivedFoo1 = nil
                     receivedFoo2 = nil
@@ -243,7 +254,9 @@ override class var defaultTestSuite : XCTestSuite {
                     eventEmitter.once { receivedAllOnce = $0 as? Int }
                 }
 
-                it("should emit events to all relevant listeners") {
+                func test__009__Utilities__EventEmitter__should_emit_events_to_all_relevant_listeners() {
+beforeEach__Utilities__EventEmitter()
+
                     eventEmitter.emit("foo", with: 123 as AnyObject?)
 
                     expect(receivedFoo1).to(equal(123))
@@ -263,7 +276,9 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(receivedAll).toEventually(equal(789), timeout: testTimeout)
                 }
                 
-                it("should only call once listeners once for its event") {
+                func test__010__Utilities__EventEmitter__should_only_call_once_listeners_once_for_its_event() {
+beforeEach__Utilities__EventEmitter()
+
                     eventEmitter.emit("foo", with: 123 as AnyObject?)
 
                     expect(receivedBarOnce).to(beNil())
@@ -280,8 +295,10 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(receivedAllOnce).to(equal(123))
                 }
                 
-                context("calling off with a single listener argument") {
-                    it("should stop receiving events when calling off with a single listener argument") {
+                
+                    func test__011__Utilities__EventEmitter__calling_off_with_a_single_listener_argument__should_stop_receiving_events_when_calling_off_with_a_single_listener_argument() {
+beforeEach__Utilities__EventEmitter()
+
                         eventEmitter.off(listenerFoo1!)
                         eventEmitter.emit("foo", with: 123 as AnyObject?)
                         
@@ -300,7 +317,9 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(receivedAll).to(equal(222))
                     }
 
-                    xit("should remove the timeout") {
+                    func skipped__test__012__Utilities__EventEmitter__calling_off_with_a_single_listener_argument__should_remove_the_timeout() {
+beforeEach__Utilities__EventEmitter()
+
                         listenerFoo1!.setTimer(0.1, onTimeout: {
                             fail("onTimeout callback shouldn't have been called")
                         }).startTimer()
@@ -311,10 +330,11 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                         }
                     }
-                }
                 
-                context("calling off with listener and event arguments") {
-                    it("should still receive events if off doesn't match the listener's criteria") {
+                
+                    func test__013__Utilities__EventEmitter__calling_off_with_listener_and_event_arguments__should_still_receive_events_if_off_doesn_t_match_the_listener_s_criteria() {
+beforeEach__Utilities__EventEmitter()
+
                         eventEmitter.off("foo", listener: listenerAll!)
                         eventEmitter.emit("foo", with: 111 as AnyObject?)
 
@@ -322,17 +342,20 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(receivedAll).to(equal(111))
                     }
 
-                    it("should stop receive events if off matches the listener's criteria") {
+                    func test__014__Utilities__EventEmitter__calling_off_with_listener_and_event_arguments__should_stop_receive_events_if_off_matches_the_listener_s_criteria() {
+beforeEach__Utilities__EventEmitter()
+
                         eventEmitter.off("foo", listener: listenerFoo1!)
                         eventEmitter.emit("foo", with: 111 as AnyObject?)
 
                         expect(receivedFoo1).to(beNil())
                         expect(receivedAll).to(equal(111))
                     }
-                }
                 
-                context("calling off with no arguments") {
-                    it("should remove all listeners") {
+                
+                    func test__015__Utilities__EventEmitter__calling_off_with_no_arguments__should_remove_all_listeners() {
+beforeEach__Utilities__EventEmitter()
+
                         eventEmitter.off()
                         eventEmitter.emit("foo", with: 111 as AnyObject?)
                         
@@ -347,14 +370,18 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(receivedAll).to(beNil())
                     }
                     
-                    it("should allow listening again") {
+                    func test__016__Utilities__EventEmitter__calling_off_with_no_arguments__should_allow_listening_again() {
+beforeEach__Utilities__EventEmitter()
+
                         eventEmitter.off()
                         eventEmitter.on("foo", callback: { receivedFoo1 = $0 as? Int })
                         eventEmitter.emit("foo", with: 111 as AnyObject?)
                         expect(receivedFoo1).to(equal(111))
                     }
 
-                    it("should remove all timeouts") {
+                    func test__017__Utilities__EventEmitter__calling_off_with_no_arguments__should_remove_all_timeouts() {
+beforeEach__Utilities__EventEmitter()
+
                         listenerFoo1!.setTimer(0.1, onTimeout: {
                             fail("onTimeout callback shouldn't have been called")
                         }).startTimer()
@@ -368,10 +395,11 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                         }
                     }
-                }
 
-                context("the timed method") {
-                    it("should not call onTimeout if the deadline isn't reached") {
+                
+                    func test__018__Utilities__EventEmitter__the_timed_method__should_not_call_onTimeout_if_the_deadline_isn_t_reached() {
+beforeEach__Utilities__EventEmitter()
+
                         weak var timer = listenerFoo1!.setTimer(0.2, onTimeout: {
                             fail("onTimeout callback shouldn't have been called")
                         })
@@ -385,7 +413,9 @@ override class var defaultTestSuite : XCTestSuite {
                         }
                     }
 
-                    it("should call onTimeout and off the listener if the deadline is reached") {
+                    func test__019__Utilities__EventEmitter__the_timed_method__should_call_onTimeout_and_off_the_listener_if_the_deadline_is_reached() {
+beforeEach__Utilities__EventEmitter()
+
                         var calledOnTimeout = false
                         let beforeEmitting = NSDate()
                         listenerFoo1!.setTimer(0.3, onTimeout: {
@@ -401,12 +431,13 @@ override class var defaultTestSuite : XCTestSuite {
                             }
                         }
                     }
-                }
                 
-                context("set of listeners") {
+                
                     
                     // RTE6a
-                    it("should not change over the course of the emit") {
+                    func test__020__Utilities__EventEmitter__set_of_listeners__should_not_change_over_the_course_of_the_emit() {
+beforeEach__Utilities__EventEmitter()
+
                         var firstCallbackCalled = false;
                         var secondCallbackCalled = false;
                         eventEmitter.on("a", callback: { _ in
@@ -419,12 +450,10 @@ override class var defaultTestSuite : XCTestSuite {
                         expect(firstCallbackCalled).to(beTrue())
                         expect(secondCallbackCalled).to(beFalse())
                     }
-                }
-            }
 
-            context("Logger") {
+            
 
-                it("should have a history of logs") {
+                func test__021__Utilities__Logger__should_have_a_history_of_logs() {
                     let options = AblyTests.commonAppSetup()
                     let realtime = ARTRealtime(options: options)
                     realtime.internal.logger.logLevel = .verbose
@@ -442,32 +471,27 @@ override class var defaultTestSuite : XCTestSuite {
                     expect(realtime.internal.logger.history.map{ $0.message }.first).to(contain("channel state transitions from 1 - Attaching to 2 - Attached"))
                     expect(realtime.internal.logger.history.filter{ $0.message.contains("realtime state transitions to 2 - Connected") }).to(haveCount(1))
                 }
-
-            }
             
-            context("maxMessageSize") {
+            
 
-                it("calculates maxMessageSize of a Message with name and data") {
+                func test__022__Utilities__maxMessageSize__calculates_maxMessageSize_of_a_Message_with_name_and_data() {
                     let message = ARTMessage(name: "this is name", data: data)
                     let expectedSize = "{\"test\":\"test\"}".count + message.name!.count
                     expect(message.messageSize()).to(equal(expectedSize))
                 }
 
-                it("calculates maxMessageSize of a Message with name, data and extras") {
+                func test__023__Utilities__maxMessageSize__calculates_maxMessageSize_of_a_Message_with_name__data_and_extras() {
                     let message = ARTMessage(name: "this is name", data: data)
                     message.extras = extras as ARTJsonCompatible
                     let expectedSize = "{\"test\":\"test\"}".count + "{\"push\":{\"key\":\"value\"}}".count + message.name!.count
                     expect(message.messageSize()).to(equal(expectedSize))
                 }
 
-                it("calculates maxMessageSize of a Message with name, data, clientId and extras") {
+                func test__024__Utilities__maxMessageSize__calculates_maxMessageSize_of_a_Message_with_name__data__clientId_and_extras() {
                     let message = ARTMessage(name: "this is name", data: data)
                     message.clientId = clientId
                     message.extras = extras as ARTJsonCompatible
                     let expectedSize = "{\"test\":\"test\"}".count + "{\"push\":{\"key\":\"value\"}}".count + clientId.count + message.name!.count
                     expect(message.messageSize()).to(equal(expectedSize))
                 }
-            }
-        }
-    }
 }

--- a/Spec/Utilities.swift
+++ b/Spec/Utilities.swift
@@ -1,497 +1,480 @@
 import Ably
+import Foundation
 import Nimble
 import Quick
-import Foundation
 
-                private var jsonEncoder: ARTJsonLikeEncoder!
+private var jsonEncoder: ARTJsonLikeEncoder!
 
-                private var eventEmitter = ARTInternalEventEmitter<NSString, AnyObject>(queue: AblyTests.queue)
-                private var receivedFoo1: Int?
-                private var receivedFoo2: Int?
-                private var receivedBar: Int?
-                private var receivedBarOnce: Int?
-                private var receivedAll: Int?
-                private var receivedAllOnce: Int?
-                private weak var listenerFoo1: ARTEventListener?
-                private weak var listenerAll: ARTEventListener?
-                private let data = ["test": "test"]
-                private let extras = ["push": ["key": "value"]]
-                private let clientId = "clientId"
+private var eventEmitter = ARTInternalEventEmitter<NSString, AnyObject>(queue: AblyTests.queue)
+private var receivedFoo1: Int?
+private var receivedFoo2: Int?
+private var receivedBar: Int?
+private var receivedBarOnce: Int?
+private var receivedAll: Int?
+private var receivedAllOnce: Int?
+private weak var listenerFoo1: ARTEventListener?
+private weak var listenerAll: ARTEventListener?
+private let data = ["test": "test"]
+private let extras = ["push": ["key": "value"]]
+private let clientId = "clientId"
 
 class Utilities: XCTestCase {
+    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+    override class var defaultTestSuite: XCTestSuite {
+        _ = jsonEncoder
+        _ = eventEmitter
+        _ = receivedFoo1
+        _ = receivedFoo2
+        _ = receivedBar
+        _ = receivedBarOnce
+        _ = receivedAll
+        _ = receivedAllOnce
+        _ = listenerFoo1
+        _ = listenerAll
+        _ = data
+        _ = extras
+        _ = clientId
 
-// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-override class var defaultTestSuite : XCTestSuite {
-    let _ = jsonEncoder
-    let _ = eventEmitter
-    let _ = receivedFoo1
-    let _ = receivedFoo2
-    let _ = receivedBar
-    let _ = receivedBarOnce
-    let _ = receivedAll
-    let _ = receivedAllOnce
-    let _ = listenerFoo1
-    let _ = listenerAll
-    let _ = data
-    let _ = extras
-    let _ = clientId
+        return super.defaultTestSuite
+    }
 
-    return super.defaultTestSuite
-}
-        
+    func beforeEach__Utilities__JSON_Encoder() {
+        jsonEncoder = ARTJsonLikeEncoder()
+        jsonEncoder.delegate = ARTJsonEncoder()
+    }
 
-            
-                func beforeEach__Utilities__JSON_Encoder() {
-                    jsonEncoder = ARTJsonLikeEncoder()
-                    jsonEncoder.delegate = ARTJsonEncoder()
+    func test__001__Utilities__JSON_Encoder__should_decode_a_protocol_message_that_has_an_error_without_a_message() {
+        beforeEach__Utilities__JSON_Encoder()
+
+        let jsonObject: NSDictionary = [
+            "action": 9,
+            "error": [
+                "code": 40142,
+                "statusCode": "401",
+            ],
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: jsonObject, options: [])
+        guard let protocolMessage = try? jsonEncoder.decodeProtocolMessage(data) else {
+            fail("Decoder has failed"); return
+        }
+        guard let error = protocolMessage.error else {
+            fail("Error is empty"); return
+        }
+        expect(error.message).to(equal(""))
+    }
+
+    func test__002__Utilities__JSON_Encoder__should_encode_a_protocol_message_that_has_invalid_data() {
+        beforeEach__Utilities__JSON_Encoder()
+
+        let pm = ARTProtocolMessage()
+        pm.action = .message
+        pm.channel = "foo"
+        pm.messages = [ARTMessage(name: "status", data: NSDate(), clientId: "user")]
+        var result: Data?
+        expect { result = try jsonEncoder.encode(pm) }.to(throwError { error in
+            let e = error as NSError
+            expect(e.domain).to(equal(ARTAblyErrorDomain))
+            expect(e.code).to(equal(Int(ARTClientCodeError.invalidType.rawValue)))
+            expect(e.localizedDescription).to(contain("Invalid type in JSON write"))
+        })
+        expect(result).to(beNil())
+    }
+
+    func test__003__Utilities__JSON_Encoder__should_decode_data_with_malformed_JSON() {
+        beforeEach__Utilities__JSON_Encoder()
+
+        let malformedJSON = "{...}"
+        let data = malformedJSON.data(using: String.Encoding.utf8)!
+        var result: AnyObject?
+        expect { result = try ARTJsonEncoder().decode(data) as AnyObject? }.to(throwError { error in
+            let e = error as NSError
+            expect(e.localizedDescription).to(contain("data couldn’t be read"))
+        })
+        expect(result).to(beNil())
+    }
+
+    func test__004__Utilities__JSON_Encoder__should_decode_data_with_malformed_MsgPack() {
+        beforeEach__Utilities__JSON_Encoder()
+
+        let data = NSData()
+        var result: AnyObject?
+        expect { result = try ARTMsgPackEncoder().decode(data as Data) as! (Data) as (Data) as AnyObject? }.to(throwError { error in
+            expect(error).toNot(beNil())
+        })
+        expect(result).to(beNil())
+    }
+
+    func test__005__Utilities__JSON_Encoder__in_Realtime__should_handle_and_emit_the_invalid_data_error() {
+        beforeEach__Utilities__JSON_Encoder()
+
+        let options = AblyTests.commonAppSetup()
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.close() }
+        let channel = realtime.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish("test", data: NSDate()) { error in
+                guard let error = error else {
+                    fail("Error shouldn't be nil"); done(); return
                 }
-
-                func test__001__Utilities__JSON_Encoder__should_decode_a_protocol_message_that_has_an_error_without_a_message() {
-beforeEach__Utilities__JSON_Encoder()
-
-                    let jsonObject: NSDictionary = [
-                        "action": 9,
-                        "error": [
-                            "code": 40142,
-                            "statusCode": "401",
-                        ]
-                    ]
-                    let data = try! JSONSerialization.data(withJSONObject: jsonObject, options: [])
-                    guard let protocolMessage = try? jsonEncoder.decodeProtocolMessage(data) else {
-                        fail("Decoder has failed"); return
-                    }
-                    guard let error = protocolMessage.error else {
-                        fail("Error is empty"); return
-                    }
-                    expect(error.message).to(equal(""))
+                expect(error.message).to(contain("encoding failed"))
+                expect(error.reason).to(contain("must be NSString, NSData, NSArray or NSDictionary"))
+                done()
+            }
+        }
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish([ARTMessage(name: nil, data: NSDate()), ARTMessage(name: nil, data: NSDate())]) { error in
+                guard let error = error else {
+                    fail("Error shouldn't be nil"); done(); return
                 }
+                expect(error.message).to(contain("encoding failed"))
+                expect(error.reason).to(contain("must be NSString, NSData, NSArray or NSDictionary"))
+                done()
+            }
+        }
+    }
 
-                func test__002__Utilities__JSON_Encoder__should_encode_a_protocol_message_that_has_invalid_data() {
-beforeEach__Utilities__JSON_Encoder()
+    func test__006__Utilities__JSON_Encoder__in_Realtime__should_ignore_invalid_transport_message() {
+        beforeEach__Utilities__JSON_Encoder()
 
-                    let pm = ARTProtocolMessage()
-                    pm.action = .message
-                    pm.channel = "foo"
-                    pm.messages = [ARTMessage(name: "status", data: NSDate(), clientId: "user")]
-                    var result: Data?
-                    expect{ result = try jsonEncoder.encode(pm) }.to(throwError { error in
-                        let e = error as NSError
-                        expect(e.domain).to(equal(ARTAblyErrorDomain))
-                        expect(e.code).to(equal(Int(ARTClientCodeError.invalidType.rawValue)))
-                        expect(e.localizedDescription).to(contain("Invalid type in JSON write"))
-                        })
-                    expect(result).to(beNil())
+        let options = AblyTests.commonAppSetup()
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.close() }
+        let channel = realtime.channels.get("foo")
+
+        // Garbage values (whatever is on the heap)
+        let bytes = UnsafeMutablePointer<Int>.allocate(capacity: 1)
+        defer { bytes.deallocate() }
+        let data = NSData(bytes: bytes, length: MemoryLayout<Int>.size)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                realtime.connection.once { _ in
+                    fail("Should not receive any connection change state")
                 }
-
-                func test__003__Utilities__JSON_Encoder__should_decode_data_with_malformed_JSON() {
-beforeEach__Utilities__JSON_Encoder()
-
-                    let malformedJSON = "{...}"
-                    let data = malformedJSON.data(using: String.Encoding.utf8)!
-                    var result: AnyObject?
-                    expect{ result = try ARTJsonEncoder().decode(data) as AnyObject? }.to(throwError { error in
-                        let e = error as NSError
-                        expect(e.localizedDescription).to(contain("data couldn’t be read"))
-                    })
-                    expect(result).to(beNil())
+                channel.once { _ in
+                    fail("Should not receive any channel change state")
                 }
-
-                func test__004__Utilities__JSON_Encoder__should_decode_data_with_malformed_MsgPack() {
-beforeEach__Utilities__JSON_Encoder()
-
-                    let data = NSData()
-                    var result: AnyObject?
-                    expect{ result = try ARTMsgPackEncoder().decode(data as Data) as! (Data) as (Data) as AnyObject? }.to(throwError { error in
-                        expect(error).toNot(beNil())
-                    })
-                    expect(result).to(beNil())
+                channel.subscribe { _ in
+                    fail("Should not receive any message")
                 }
+                var result: AnyObject?
+                expect { result = realtime.internal.transport?.receive(with: data as Data) }.toNot(raiseException())
+                expect(result).to(beNil())
+                done()
+            }
+        }
 
-                
-                    func test__005__Utilities__JSON_Encoder__in_Realtime__should_handle_and_emit_the_invalid_data_error() {
-beforeEach__Utilities__JSON_Encoder()
+        realtime.connection.off()
+        channel.off()
+        channel.unsubscribe()
+    }
 
-                        let options = AblyTests.commonAppSetup()
-                        let realtime = ARTRealtime(options: options)
-                        defer { realtime.close() }
-                        let channel = realtime.channels.get("foo")
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish("test", data: NSDate()) { error in
-                                guard let error = error else {
-                                    fail("Error shouldn't be nil"); done(); return
-                                }
-                                expect(error.message).to(contain("encoding failed"))
-                                expect(error.reason).to(contain("must be NSString, NSData, NSArray or NSDictionary"))
-                                done()
-                            }
-                        }
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish([ARTMessage(name: nil, data: NSDate()), ARTMessage(name: nil, data: NSDate())]) { error in
-                                guard let error = error else {
-                                    fail("Error shouldn't be nil"); done(); return
-                                }
-                                expect(error.message).to(contain("encoding failed"))
-                                expect(error.reason).to(contain("must be NSString, NSData, NSArray or NSDictionary"))
-                                done()
-                            }
-                        }
-                    }
+    func test__007__Utilities__JSON_Encoder__in_Rest__should_handle_and_emit_the_invalid_data_error() {
+        beforeEach__Utilities__JSON_Encoder()
 
-                    func test__006__Utilities__JSON_Encoder__in_Realtime__should_ignore_invalid_transport_message() {
-beforeEach__Utilities__JSON_Encoder()
-
-                        let options = AblyTests.commonAppSetup()
-                        let realtime = ARTRealtime(options: options)
-                        defer { realtime.close() }
-                        let channel = realtime.channels.get("foo")
-
-                        // Garbage values (whatever is on the heap)
-                        let bytes = UnsafeMutablePointer<Int>.allocate(capacity: 1)
-                        defer { bytes.deallocate() }
-                        let data = NSData(bytes: bytes, length: MemoryLayout<Int>.size)
-
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.attach { error in
-                                expect(error).to(beNil())
-                                realtime.connection.once { _ in
-                                    fail("Should not receive any connection change state")
-                                }
-                                channel.once { _ in
-                                    fail("Should not receive any channel change state")
-                                }
-                                channel.subscribe { _ in
-                                    fail("Should not receive any message")
-                                }
-                                var result: AnyObject?
-                                expect{ result = realtime.internal.transport?.receive(with: data as Data) }.toNot(raiseException())
-                                expect(result).to(beNil())
-                                done()
-                            }
-                        }
-
-                        realtime.connection.off()
-                        channel.off()
-                        channel.unsubscribe()
-                    }
-
-                
-                    func test__007__Utilities__JSON_Encoder__in_Rest__should_handle_and_emit_the_invalid_data_error() {
-beforeEach__Utilities__JSON_Encoder()
-
-                        let options = AblyTests.commonAppSetup()
-                        let rest = ARTRest(options: options)
-                        let channel = rest.channels.get("foo")
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish("test", data: NSDate()) { error in
-                                guard let error = error else {
-                                    fail("Error shouldn't be nil"); done(); return
-                                }
-                                expect(error.message).to(contain("encoding failed"))
-                                expect(error.reason).to(contain("must be NSString, NSData, NSArray or NSDictionary"))
-                                done()
-                            }
-                        }
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish([ARTMessage(name: nil, data: NSDate()), ARTMessage(name: nil, data: NSDate())]) { error in
-                                guard let error = error else {
-                                    fail("Error shouldn't be nil"); done(); return
-                                }
-                                expect(error.message).to(contain("encoding failed"))
-                                expect(error.reason).to(contain("must be NSString, NSData, NSArray or NSDictionary"))
-                                done()
-                            }
-                        }
-                    }
-
-                    func test__008__Utilities__JSON_Encoder__in_Rest__should_ignore_invalid_response_payload() {
-beforeEach__Utilities__JSON_Encoder()
-
-                        let options = AblyTests.commonAppSetup()
-                        let rest = ARTRest(options: options)
-                        let testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
-                        rest.internal.httpExecutor = testHTTPExecutor
-                        let channel = rest.channels.get("foo")
-
-                        // Garbage values (whatever is on the heap)
-                        let bytes = UnsafeMutablePointer<Int>.allocate(capacity: 1)
-                        defer { bytes.deallocate() }
-                        let data = NSData(bytes: bytes, length: MemoryLayout<Int>.size)
-
-                        testHTTPExecutor.simulateIncomingPayloadOnNextRequest(data as Data)
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: nil) { error in
-                                expect(error).to(beNil()) //ignored
-                                done()
-                            }
-                        }
-
-                        testHTTPExecutor.simulateIncomingPayloadOnNextRequest(data as Data)
-                        waitUntil(timeout: testTimeout) { done in
-                            channel.history { result, error in
-                                guard let error = error else {
-                                    fail("Error is nil"); done(); return
-                                }
-                                expect(error.reason).to(contain("JSON text did not start with array or object and option to allow fragments not set"))
-                                done()
-                            }
-                        }
-                    }
-
-            
-
-                func beforeEach__Utilities__EventEmitter() {
-                    eventEmitter = ARTInternalEventEmitter(queue: AblyTests.queue)
-                    receivedFoo1 = nil
-                    receivedFoo2 = nil
-                    receivedBar = nil
-                    receivedBarOnce = nil
-                    receivedAll = nil
-                    listenerFoo1 = eventEmitter.on("foo", callback: { receivedFoo1 = $0 as? Int })
-                    eventEmitter.on("foo", callback: { receivedFoo2 = $0 as? Int })
-                    eventEmitter.on("bar", callback: { receivedBar = $0 as? Int })
-                    eventEmitter.once("bar", callback: { receivedBarOnce = $0 as? Int })
-                    listenerAll = eventEmitter.on { receivedAll = $0 as? Int }
-                    eventEmitter.once { receivedAllOnce = $0 as? Int }
+        let options = AblyTests.commonAppSetup()
+        let rest = ARTRest(options: options)
+        let channel = rest.channels.get("foo")
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish("test", data: NSDate()) { error in
+                guard let error = error else {
+                    fail("Error shouldn't be nil"); done(); return
                 }
-
-                func test__009__Utilities__EventEmitter__should_emit_events_to_all_relevant_listeners() {
-beforeEach__Utilities__EventEmitter()
-
-                    eventEmitter.emit("foo", with: 123 as AnyObject?)
-
-                    expect(receivedFoo1).to(equal(123))
-                    expect(receivedFoo2).to(equal(123))
-                    expect(receivedBar).to(beNil())
-                    expect(receivedAll).to(equal(123))
-                    
-                    eventEmitter.emit("bar", with:456 as AnyObject?)
-                    
-                    expect(receivedFoo1).to(equal(123))
-                    expect(receivedFoo2).to(equal(123))
-                    expect(receivedBar).to(equal(456))
-                    expect(receivedAll).to(equal(456))
-                    
-                    eventEmitter.emit("qux", with:789 as AnyObject?)
-                    
-                    expect(receivedAll).toEventually(equal(789), timeout: testTimeout)
+                expect(error.message).to(contain("encoding failed"))
+                expect(error.reason).to(contain("must be NSString, NSData, NSArray or NSDictionary"))
+                done()
+            }
+        }
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish([ARTMessage(name: nil, data: NSDate()), ARTMessage(name: nil, data: NSDate())]) { error in
+                guard let error = error else {
+                    fail("Error shouldn't be nil"); done(); return
                 }
-                
-                func test__010__Utilities__EventEmitter__should_only_call_once_listeners_once_for_its_event() {
-beforeEach__Utilities__EventEmitter()
+                expect(error.message).to(contain("encoding failed"))
+                expect(error.reason).to(contain("must be NSString, NSData, NSArray or NSDictionary"))
+                done()
+            }
+        }
+    }
 
-                    eventEmitter.emit("foo", with: 123 as AnyObject?)
+    func test__008__Utilities__JSON_Encoder__in_Rest__should_ignore_invalid_response_payload() {
+        beforeEach__Utilities__JSON_Encoder()
 
-                    expect(receivedBarOnce).to(beNil())
-                    expect(receivedAllOnce).to(equal(123))
-                    
-                    eventEmitter.emit("bar", with: 456 as AnyObject?)
-                    
-                    expect(receivedBarOnce).to(equal(456))
-                    expect(receivedAllOnce).to(equal(123))
+        let options = AblyTests.commonAppSetup()
+        let rest = ARTRest(options: options)
+        let testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
+        rest.internal.httpExecutor = testHTTPExecutor
+        let channel = rest.channels.get("foo")
 
-                    eventEmitter.emit("bar", with: 789 as AnyObject?)
-                    
-                    expect(receivedBarOnce).to(equal(456))
-                    expect(receivedAllOnce).to(equal(123))
+        // Garbage values (whatever is on the heap)
+        let bytes = UnsafeMutablePointer<Int>.allocate(capacity: 1)
+        defer { bytes.deallocate() }
+        let data = NSData(bytes: bytes, length: MemoryLayout<Int>.size)
+
+        testHTTPExecutor.simulateIncomingPayloadOnNextRequest(data as Data)
+        waitUntil(timeout: testTimeout) { done in
+            channel.publish(nil, data: nil) { error in
+                expect(error).to(beNil()) // ignored
+                done()
+            }
+        }
+
+        testHTTPExecutor.simulateIncomingPayloadOnNextRequest(data as Data)
+        waitUntil(timeout: testTimeout) { done in
+            channel.history { _, error in
+                guard let error = error else {
+                    fail("Error is nil"); done(); return
                 }
-                
-                
-                    func test__011__Utilities__EventEmitter__calling_off_with_a_single_listener_argument__should_stop_receiving_events_when_calling_off_with_a_single_listener_argument() {
-beforeEach__Utilities__EventEmitter()
+                expect(error.reason).to(contain("JSON text did not start with array or object and option to allow fragments not set"))
+                done()
+            }
+        }
+    }
 
-                        eventEmitter.off(listenerFoo1!)
-                        eventEmitter.emit("foo", with: 123 as AnyObject?)
-                        
-                        expect(receivedFoo1).to(beNil())
-                        expect(receivedFoo2).to(equal(123))
-                        expect(receivedAll).to(equal(123))
-                        
-                        eventEmitter.emit("bar", with: 222 as AnyObject?)
-                        
-                        expect(receivedFoo2).to(equal(123))
-                        expect(receivedAll).to(equal(222))
-                        
-                        eventEmitter.off(listenerAll!)
-                        eventEmitter.emit("bar", with: 333 as AnyObject?)
-                        
-                        expect(receivedAll).to(equal(222))
-                    }
+    func beforeEach__Utilities__EventEmitter() {
+        eventEmitter = ARTInternalEventEmitter(queue: AblyTests.queue)
+        receivedFoo1 = nil
+        receivedFoo2 = nil
+        receivedBar = nil
+        receivedBarOnce = nil
+        receivedAll = nil
+        listenerFoo1 = eventEmitter.on("foo", callback: { receivedFoo1 = $0 as? Int })
+        eventEmitter.on("foo", callback: { receivedFoo2 = $0 as? Int })
+        eventEmitter.on("bar", callback: { receivedBar = $0 as? Int })
+        eventEmitter.once("bar", callback: { receivedBarOnce = $0 as? Int })
+        listenerAll = eventEmitter.on { receivedAll = $0 as? Int }
+        eventEmitter.once { receivedAllOnce = $0 as? Int }
+    }
 
-                    func skipped__test__012__Utilities__EventEmitter__calling_off_with_a_single_listener_argument__should_remove_the_timeout() {
-beforeEach__Utilities__EventEmitter()
+    func test__009__Utilities__EventEmitter__should_emit_events_to_all_relevant_listeners() {
+        beforeEach__Utilities__EventEmitter()
 
-                        listenerFoo1!.setTimer(0.1, onTimeout: {
-                            fail("onTimeout callback shouldn't have been called")
-                        }).startTimer()
-                        eventEmitter.off(listenerFoo1!)
-                        waitUntil(timeout: DispatchTimeInterval.milliseconds(300)) { done in
-                            AblyTests.queue.asyncAfter(deadline: DispatchTime.now() + 0.3) {
-                                done()
-                            }
-                        }
-                    }
-                
-                
-                    func test__013__Utilities__EventEmitter__calling_off_with_listener_and_event_arguments__should_still_receive_events_if_off_doesn_t_match_the_listener_s_criteria() {
-beforeEach__Utilities__EventEmitter()
+        eventEmitter.emit("foo", with: 123 as AnyObject?)
 
-                        eventEmitter.off("foo", listener: listenerAll!)
-                        eventEmitter.emit("foo", with: 111 as AnyObject?)
+        expect(receivedFoo1).to(equal(123))
+        expect(receivedFoo2).to(equal(123))
+        expect(receivedBar).to(beNil())
+        expect(receivedAll).to(equal(123))
 
-                        expect(receivedFoo1).to(equal(111))
-                        expect(receivedAll).to(equal(111))
-                    }
+        eventEmitter.emit("bar", with: 456 as AnyObject?)
 
-                    func test__014__Utilities__EventEmitter__calling_off_with_listener_and_event_arguments__should_stop_receive_events_if_off_matches_the_listener_s_criteria() {
-beforeEach__Utilities__EventEmitter()
+        expect(receivedFoo1).to(equal(123))
+        expect(receivedFoo2).to(equal(123))
+        expect(receivedBar).to(equal(456))
+        expect(receivedAll).to(equal(456))
 
-                        eventEmitter.off("foo", listener: listenerFoo1!)
-                        eventEmitter.emit("foo", with: 111 as AnyObject?)
+        eventEmitter.emit("qux", with: 789 as AnyObject?)
 
-                        expect(receivedFoo1).to(beNil())
-                        expect(receivedAll).to(equal(111))
-                    }
-                
-                
-                    func test__015__Utilities__EventEmitter__calling_off_with_no_arguments__should_remove_all_listeners() {
-beforeEach__Utilities__EventEmitter()
+        expect(receivedAll).toEventually(equal(789), timeout: testTimeout)
+    }
 
-                        eventEmitter.off()
-                        eventEmitter.emit("foo", with: 111 as AnyObject?)
-                        
-                        expect(receivedFoo1).to(beNil())
-                        expect(receivedFoo2).to(beNil())
-                        expect(receivedAll).to(beNil())
-                        
-                        eventEmitter.emit("bar", with: 111 as AnyObject?)
-                        
-                        expect(receivedBar).to(beNil())
-                        expect(receivedBarOnce).to(beNil())
-                        expect(receivedAll).to(beNil())
-                    }
-                    
-                    func test__016__Utilities__EventEmitter__calling_off_with_no_arguments__should_allow_listening_again() {
-beforeEach__Utilities__EventEmitter()
+    func test__010__Utilities__EventEmitter__should_only_call_once_listeners_once_for_its_event() {
+        beforeEach__Utilities__EventEmitter()
 
-                        eventEmitter.off()
-                        eventEmitter.on("foo", callback: { receivedFoo1 = $0 as? Int })
-                        eventEmitter.emit("foo", with: 111 as AnyObject?)
-                        expect(receivedFoo1).to(equal(111))
-                    }
+        eventEmitter.emit("foo", with: 123 as AnyObject?)
 
-                    func test__017__Utilities__EventEmitter__calling_off_with_no_arguments__should_remove_all_timeouts() {
-beforeEach__Utilities__EventEmitter()
+        expect(receivedBarOnce).to(beNil())
+        expect(receivedAllOnce).to(equal(123))
 
-                        listenerFoo1!.setTimer(0.1, onTimeout: {
-                            fail("onTimeout callback shouldn't have been called")
-                        }).startTimer()
-                        listenerAll!.setTimer(0.1, onTimeout: {
-                            fail("onTimeout callback shouldn't have been called")
-                        }).startTimer()
-                        eventEmitter.off()
-                        waitUntil(timeout: DispatchTimeInterval.milliseconds(300)) { done in
-                            AblyTests.queue.asyncAfter(deadline: .now() + 0.15) {
-                                done()
-                            }
-                        }
-                    }
+        eventEmitter.emit("bar", with: 456 as AnyObject?)
 
-                
-                    func test__018__Utilities__EventEmitter__the_timed_method__should_not_call_onTimeout_if_the_deadline_isn_t_reached() {
-beforeEach__Utilities__EventEmitter()
+        expect(receivedBarOnce).to(equal(456))
+        expect(receivedAllOnce).to(equal(123))
 
-                        weak var timer = listenerFoo1!.setTimer(0.2, onTimeout: {
-                            fail("onTimeout callback shouldn't have been called")
-                        })
-                        waitUntil(timeout: DispatchTimeInterval.seconds(1)) { done in
-                            timer?.startTimer()
-                            eventEmitter.emit("foo", with: 123 as AnyObject?)
-                            AblyTests.queue.asyncAfter(deadline: .now() + 0.3) {
-                                expect(receivedFoo1).toNot(beNil())
-                                done()
-                            }
-                        }
-                    }
+        eventEmitter.emit("bar", with: 789 as AnyObject?)
 
-                    func test__019__Utilities__EventEmitter__the_timed_method__should_call_onTimeout_and_off_the_listener_if_the_deadline_is_reached() {
-beforeEach__Utilities__EventEmitter()
+        expect(receivedBarOnce).to(equal(456))
+        expect(receivedAllOnce).to(equal(123))
+    }
 
-                        var calledOnTimeout = false
-                        let beforeEmitting = NSDate()
-                        listenerFoo1!.setTimer(0.3, onTimeout: {
-                            calledOnTimeout = true
-                            expect(NSDate()).to(beCloseTo(beforeEmitting.addingTimeInterval(0.3), within: 0.2))
-                        }).startTimer()
-                        waitUntil(timeout: DispatchTimeInterval.milliseconds(500)) { done in
-                            AblyTests.queue.asyncAfter(deadline: .now() + 0.35) {
-                                expect(calledOnTimeout).to(beTrue())
-                                eventEmitter.emit("foo", with: 123 as AnyObject?)
-                                expect(receivedFoo1).to(beNil())
-                                done()
-                            }
-                        }
-                    }
-                
-                
-                    
-                    // RTE6a
-                    func test__020__Utilities__EventEmitter__set_of_listeners__should_not_change_over_the_course_of_the_emit() {
-beforeEach__Utilities__EventEmitter()
+    func test__011__Utilities__EventEmitter__calling_off_with_a_single_listener_argument__should_stop_receiving_events_when_calling_off_with_a_single_listener_argument() {
+        beforeEach__Utilities__EventEmitter()
 
-                        var firstCallbackCalled = false;
-                        var secondCallbackCalled = false;
-                        eventEmitter.on("a", callback: { _ in
-                            firstCallbackCalled = true
-                            eventEmitter.on("b", callback: { _ in
-                                secondCallbackCalled = true
-                            })
-                        })
-                        eventEmitter.emit("a", with: "123" as AnyObject?)
-                        expect(firstCallbackCalled).to(beTrue())
-                        expect(secondCallbackCalled).to(beFalse())
-                    }
+        eventEmitter.off(listenerFoo1!)
+        eventEmitter.emit("foo", with: 123 as AnyObject?)
 
-            
+        expect(receivedFoo1).to(beNil())
+        expect(receivedFoo2).to(equal(123))
+        expect(receivedAll).to(equal(123))
 
-                func test__021__Utilities__Logger__should_have_a_history_of_logs() {
-                    let options = AblyTests.commonAppSetup()
-                    let realtime = ARTRealtime(options: options)
-                    realtime.internal.logger.logLevel = .verbose
-                    defer { realtime.close() }
-                    let channel = realtime.channels.get("foo")
+        eventEmitter.emit("bar", with: 222 as AnyObject?)
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
+        expect(receivedFoo2).to(equal(123))
+        expect(receivedAll).to(equal(222))
 
-                    expect(realtime.internal.logger.history.count).toNot(beGreaterThan(100))
-                    expect(realtime.internal.logger.history.map{ $0.message }.first).to(contain("channel state transitions from 1 - Attaching to 2 - Attached"))
-                    expect(realtime.internal.logger.history.filter{ $0.message.contains("realtime state transitions to 2 - Connected") }).to(haveCount(1))
-                }
-            
-            
+        eventEmitter.off(listenerAll!)
+        eventEmitter.emit("bar", with: 333 as AnyObject?)
 
-                func test__022__Utilities__maxMessageSize__calculates_maxMessageSize_of_a_Message_with_name_and_data() {
-                    let message = ARTMessage(name: "this is name", data: data)
-                    let expectedSize = "{\"test\":\"test\"}".count + message.name!.count
-                    expect(message.messageSize()).to(equal(expectedSize))
-                }
+        expect(receivedAll).to(equal(222))
+    }
 
-                func test__023__Utilities__maxMessageSize__calculates_maxMessageSize_of_a_Message_with_name__data_and_extras() {
-                    let message = ARTMessage(name: "this is name", data: data)
-                    message.extras = extras as ARTJsonCompatible
-                    let expectedSize = "{\"test\":\"test\"}".count + "{\"push\":{\"key\":\"value\"}}".count + message.name!.count
-                    expect(message.messageSize()).to(equal(expectedSize))
-                }
+    func skipped__test__012__Utilities__EventEmitter__calling_off_with_a_single_listener_argument__should_remove_the_timeout() {
+        beforeEach__Utilities__EventEmitter()
 
-                func test__024__Utilities__maxMessageSize__calculates_maxMessageSize_of_a_Message_with_name__data__clientId_and_extras() {
-                    let message = ARTMessage(name: "this is name", data: data)
-                    message.clientId = clientId
-                    message.extras = extras as ARTJsonCompatible
-                    let expectedSize = "{\"test\":\"test\"}".count + "{\"push\":{\"key\":\"value\"}}".count + clientId.count + message.name!.count
-                    expect(message.messageSize()).to(equal(expectedSize))
-                }
+        listenerFoo1!.setTimer(0.1, onTimeout: {
+            fail("onTimeout callback shouldn't have been called")
+        }).startTimer()
+        eventEmitter.off(listenerFoo1!)
+        waitUntil(timeout: DispatchTimeInterval.milliseconds(300)) { done in
+            AblyTests.queue.asyncAfter(deadline: DispatchTime.now() + 0.3) {
+                done()
+            }
+        }
+    }
+
+    func test__013__Utilities__EventEmitter__calling_off_with_listener_and_event_arguments__should_still_receive_events_if_off_doesn_t_match_the_listener_s_criteria() {
+        beforeEach__Utilities__EventEmitter()
+
+        eventEmitter.off("foo", listener: listenerAll!)
+        eventEmitter.emit("foo", with: 111 as AnyObject?)
+
+        expect(receivedFoo1).to(equal(111))
+        expect(receivedAll).to(equal(111))
+    }
+
+    func test__014__Utilities__EventEmitter__calling_off_with_listener_and_event_arguments__should_stop_receive_events_if_off_matches_the_listener_s_criteria() {
+        beforeEach__Utilities__EventEmitter()
+
+        eventEmitter.off("foo", listener: listenerFoo1!)
+        eventEmitter.emit("foo", with: 111 as AnyObject?)
+
+        expect(receivedFoo1).to(beNil())
+        expect(receivedAll).to(equal(111))
+    }
+
+    func test__015__Utilities__EventEmitter__calling_off_with_no_arguments__should_remove_all_listeners() {
+        beforeEach__Utilities__EventEmitter()
+
+        eventEmitter.off()
+        eventEmitter.emit("foo", with: 111 as AnyObject?)
+
+        expect(receivedFoo1).to(beNil())
+        expect(receivedFoo2).to(beNil())
+        expect(receivedAll).to(beNil())
+
+        eventEmitter.emit("bar", with: 111 as AnyObject?)
+
+        expect(receivedBar).to(beNil())
+        expect(receivedBarOnce).to(beNil())
+        expect(receivedAll).to(beNil())
+    }
+
+    func test__016__Utilities__EventEmitter__calling_off_with_no_arguments__should_allow_listening_again() {
+        beforeEach__Utilities__EventEmitter()
+
+        eventEmitter.off()
+        eventEmitter.on("foo", callback: { receivedFoo1 = $0 as? Int })
+        eventEmitter.emit("foo", with: 111 as AnyObject?)
+        expect(receivedFoo1).to(equal(111))
+    }
+
+    func test__017__Utilities__EventEmitter__calling_off_with_no_arguments__should_remove_all_timeouts() {
+        beforeEach__Utilities__EventEmitter()
+
+        listenerFoo1!.setTimer(0.1, onTimeout: {
+            fail("onTimeout callback shouldn't have been called")
+        }).startTimer()
+        listenerAll!.setTimer(0.1, onTimeout: {
+            fail("onTimeout callback shouldn't have been called")
+        }).startTimer()
+        eventEmitter.off()
+        waitUntil(timeout: DispatchTimeInterval.milliseconds(300)) { done in
+            AblyTests.queue.asyncAfter(deadline: .now() + 0.15) {
+                done()
+            }
+        }
+    }
+
+    func test__018__Utilities__EventEmitter__the_timed_method__should_not_call_onTimeout_if_the_deadline_isn_t_reached() {
+        beforeEach__Utilities__EventEmitter()
+
+        weak var timer = listenerFoo1!.setTimer(0.2, onTimeout: {
+            fail("onTimeout callback shouldn't have been called")
+        })
+        waitUntil(timeout: DispatchTimeInterval.seconds(1)) { done in
+            timer?.startTimer()
+            eventEmitter.emit("foo", with: 123 as AnyObject?)
+            AblyTests.queue.asyncAfter(deadline: .now() + 0.3) {
+                expect(receivedFoo1).toNot(beNil())
+                done()
+            }
+        }
+    }
+
+    func test__019__Utilities__EventEmitter__the_timed_method__should_call_onTimeout_and_off_the_listener_if_the_deadline_is_reached() {
+        beforeEach__Utilities__EventEmitter()
+
+        var calledOnTimeout = false
+        let beforeEmitting = NSDate()
+        listenerFoo1!.setTimer(0.3, onTimeout: {
+            calledOnTimeout = true
+            expect(NSDate()).to(beCloseTo(beforeEmitting.addingTimeInterval(0.3), within: 0.2))
+        }).startTimer()
+        waitUntil(timeout: DispatchTimeInterval.milliseconds(500)) { done in
+            AblyTests.queue.asyncAfter(deadline: .now() + 0.35) {
+                expect(calledOnTimeout).to(beTrue())
+                eventEmitter.emit("foo", with: 123 as AnyObject?)
+                expect(receivedFoo1).to(beNil())
+                done()
+            }
+        }
+    }
+
+    // RTE6a
+    func test__020__Utilities__EventEmitter__set_of_listeners__should_not_change_over_the_course_of_the_emit() {
+        beforeEach__Utilities__EventEmitter()
+
+        var firstCallbackCalled = false
+        var secondCallbackCalled = false
+        eventEmitter.on("a", callback: { _ in
+            firstCallbackCalled = true
+            eventEmitter.on("b", callback: { _ in
+                secondCallbackCalled = true
+            })
+        })
+        eventEmitter.emit("a", with: "123" as AnyObject?)
+        expect(firstCallbackCalled).to(beTrue())
+        expect(secondCallbackCalled).to(beFalse())
+    }
+
+    func test__021__Utilities__Logger__should_have_a_history_of_logs() {
+        let options = AblyTests.commonAppSetup()
+        let realtime = ARTRealtime(options: options)
+        realtime.internal.logger.logLevel = .verbose
+        defer { realtime.close() }
+        let channel = realtime.channels.get("foo")
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                expect(error).to(beNil())
+                done()
+            }
+        }
+
+        expect(realtime.internal.logger.history.count).toNot(beGreaterThan(100))
+        expect(realtime.internal.logger.history.map { $0.message }.first).to(contain("channel state transitions from 1 - Attaching to 2 - Attached"))
+        expect(realtime.internal.logger.history.filter { $0.message.contains("realtime state transitions to 2 - Connected") }).to(haveCount(1))
+    }
+
+    func test__022__Utilities__maxMessageSize__calculates_maxMessageSize_of_a_Message_with_name_and_data() {
+        let message = ARTMessage(name: "this is name", data: data)
+        let expectedSize = "{\"test\":\"test\"}".count + message.name!.count
+        expect(message.messageSize()).to(equal(expectedSize))
+    }
+
+    func test__023__Utilities__maxMessageSize__calculates_maxMessageSize_of_a_Message_with_name__data_and_extras() {
+        let message = ARTMessage(name: "this is name", data: data)
+        message.extras = extras as ARTJsonCompatible
+        let expectedSize = "{\"test\":\"test\"}".count + "{\"push\":{\"key\":\"value\"}}".count + message.name!.count
+        expect(message.messageSize()).to(equal(expectedSize))
+    }
+
+    func test__024__Utilities__maxMessageSize__calculates_maxMessageSize_of_a_Message_with_name__data__clientId_and_extras() {
+        let message = ARTMessage(name: "this is name", data: data)
+        message.clientId = clientId
+        message.extras = extras as ARTJsonCompatible
+        let expectedSize = "{\"test\":\"test\"}".count + "{\"push\":{\"key\":\"value\"}}".count + clientId.count + message.name!.count
+        expect(message.messageSize()).to(equal(expectedSize))
+    }
 }

--- a/Spec/Utilities.swift
+++ b/Spec/Utilities.swift
@@ -1,7 +1,7 @@
 import Ably
 import Foundation
 import Nimble
-import Quick
+import XCTest
 
 private var jsonEncoder: ARTJsonLikeEncoder!
 

--- a/Spec/Utilities.swift
+++ b/Spec/Utilities.swift
@@ -3,12 +3,46 @@ import Nimble
 import Quick
 import Foundation
 
+                private var jsonEncoder: ARTJsonLikeEncoder!
+
+                private var eventEmitter = ARTInternalEventEmitter<NSString, AnyObject>(queue: AblyTests.queue)
+                private var receivedFoo1: Int?
+                private var receivedFoo2: Int?
+                private var receivedBar: Int?
+                private var receivedBarOnce: Int?
+                private var receivedAll: Int?
+                private var receivedAllOnce: Int?
+                private weak var listenerFoo1: ARTEventListener?
+                private weak var listenerAll: ARTEventListener?
+                private let data = ["test": "test"]
+                private let extras = ["push": ["key": "value"]]
+                private let clientId = "clientId"
+
 class Utilities: QuickSpec {
+
+// XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
+override class var defaultTestSuite : XCTestSuite {
+    let _ = jsonEncoder
+    let _ = eventEmitter
+    let _ = receivedFoo1
+    let _ = receivedFoo2
+    let _ = receivedBar
+    let _ = receivedBarOnce
+    let _ = receivedAll
+    let _ = receivedAllOnce
+    let _ = listenerFoo1
+    let _ = listenerAll
+    let _ = data
+    let _ = extras
+    let _ = clientId
+
+    return super.defaultTestSuite
+}
+
     override func spec() {
         describe("Utilities") {
 
             context("JSON Encoder") {
-                var jsonEncoder: ARTJsonLikeEncoder!
                 beforeEach {
                     jsonEncoder = ARTJsonLikeEncoder()
                     jsonEncoder.delegate = ARTJsonEncoder()
@@ -193,16 +227,6 @@ class Utilities: QuickSpec {
             }
 
             context("EventEmitter") {
-
-                var eventEmitter = ARTInternalEventEmitter<NSString, AnyObject>(queue: AblyTests.queue)
-                var receivedFoo1: Int?
-                var receivedFoo2: Int?
-                var receivedBar: Int?
-                var receivedBarOnce: Int?
-                var receivedAll: Int?
-                var receivedAllOnce: Int?
-                weak var listenerFoo1: ARTEventListener?
-                weak var listenerAll: ARTEventListener?
 
                 beforeEach {
                     eventEmitter = ARTInternalEventEmitter(queue: AblyTests.queue)
@@ -422,9 +446,6 @@ class Utilities: QuickSpec {
             }
             
             context("maxMessageSize") {
-                let data = ["test": "test"]
-                let extras = ["push": ["key": "value"]]
-                let clientId = "clientId"
 
                 it("calculates maxMessageSize of a Message with name and data") {
                     let message = ARTMessage(name: "this is name", data: data)


### PR DESCRIPTION
## What does this pull request do?

Removes the [Quick testing framework](https://github.com/Quick/Quick).

## Why are we doing this?

See #1201 for details. The main two reasons are:

- to get the ability to run individual tests using Xcode’s UI;
- using the Apple native test framework instead of a third-party library that will be unfamiliar to many Swift developers.

## How do we do it?

I wrote an [automated migrator tool](https://github.com/ably/quick-to-xctest-migrator) to do the bulk of the work here. (The code for the migrator is still rather messy. We're thinking about tidying it up to make it publicly available, but it's not there yet.)

## How is this pull request structured?

Each of the steps below is a commit which I recommend reviewing individually (else you'll struggle to make _any_ sense of this PR, I think):

1. (Migrator tool) Move all of the `spec` / `describe` / `context` level local variable and function declarations into `private` variables at the top of the file.
2. (Migrator tool) Convert each `QuickSpec` subclass into a subclass of `XCTestCase`. We replace the `spec` method declaration with a set of reusable functions and `func test…` instance methods.
3. (Manual) Step 2 has left the code quite messy (see [my comment on this PR about indentation](https://github.com/ably/ably-cocoa/pull/1240#discussion_r759249368)) so we run [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) (a code formatting tool) on it to sort this out.
4. (Manual) We replace the use of Quick's `configuration.beforeSuite` hook.
5. (Manual) We remove Quick as a dependency of the project.

## Does this change the behaviour of the tests?

For the most part, no. One of my main aims was for the migrated tests to behave exactly the same as the originals running under Quick. This turned out to be important, because we have tests that are dependent upon things like order of variable initialization and order of test execution (see my diff-level comments on this PR, and https://github.com/ably/ably-cocoa/issues/1241).

The only difference is in the behaviour of local variables in the `reusableTests` functions. See [this comment](https://github.com/ably/ably-cocoa/pull/1240#discussion_r759360311).

### How did I verify that the behaviour is unchanged?

The migrator has a `--add-logging` option, which adds logging statements to all of the `before/afterEach` and `it` calls. I used the `ably-cocoa-tests-linter-log-comparison` tool in the migrator repo to compare the logs emitted by the pre and post migration tests, and confirmed that everything runs in the same order.

(The tool doesn't verify the order of variable initialization; that I did in a more ad-hoc way, adding a few logging statements selectively by hand.)

## Notes

I've left comments on the PR for things that I wanted to point out, or which I'd like opinions on. Please ignore the "Outdated" tag for now; nothing is outdated yet 🙂