### PR TITLE
[Groundwork for #1201] Rewrite test descriptions containing meaningful symbols

### DIFF
--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -2249,7 +2249,7 @@ class Auth : QuickSpec {
             }
 
             // RSA9c
-            it("should generate a unique 16+ character nonce if none is provided") {
+            it("should generate a unique 16 plus character nonce if none is provided") {
                 let rest = ARTRest(options: AblyTests.commonAppSetup())
 
                 waitUntil(timeout: testTimeout) { done in

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -1326,7 +1326,7 @@ class RealtimeClientConnection: QuickSpec {
             context("serial") {
 
                 // RTN10a
-                it("should be -1 once connected") {
+                it("should be minus 1 once connected") {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer {
                         client.dispose()
@@ -2814,7 +2814,7 @@ class RealtimeClientConnection: QuickSpec {
                 }
                 
                 // RTN15g RTN15g1
-                context("when connection (ttl + idle interval) period has passed since last activity") {
+                context("when connection (ttl plus idle interval) period has passed since last activity") {
                     var ttlAndIdleIntervalPassedTestsClient: ARTRealtime!
                     var ttlAndIdleIntervalPassedTestsConnectionId = ""
                     let customTtlInterval: TimeInterval = 0.1
@@ -2893,7 +2893,7 @@ class RealtimeClientConnection: QuickSpec {
                 }
                 
                 // RTN15g2
-                context("when connection (ttl + idle interval) period has NOT passed since last activity") {
+                context("when connection (ttl plus idle interval) period has NOT passed since last activity") {
                     var ttlAndIdleIntervalNotPassedTestsClient: ARTRealtime!
                     var ttlAndIdleIntervalNotPassedTestsConnectionId = ""
                     
@@ -4261,7 +4261,7 @@ class RealtimeClientConnection: QuickSpec {
                 }
 
                 // RTN22a
-                it("re-authenticate and resume the connection when the client is forcibly disconnected following a DISCONNECTED message containing an error code in the range 40140 <= code < 40150") {
+                it("re-authenticate and resume the connection when the client is forcibly disconnected following a DISCONNECTED message containing an error code greater than or equal to 40140 and less than 40150") {
                     let options = AblyTests.commonAppSetup()
                     options.token = getTestToken(key: options.key!, ttl: 5.0)
                     let client = ARTRealtime(options: options)


### PR DESCRIPTION
## What does this do?

Rewrites test descriptions so that they don't contain any symbols which, if removed, would change the meaning of the test description.

## Does it change the behaviour of the test suite?

No, it's just a refactor.

## Why are we doing this?

It’s groundwork for removing the Quick testing framework using an automated migrator tool (#1201).  The migrator that I’m writing will convert all symbols in test descriptions to underscores in the emitted method names. This is okay most of the time, but we have a few places where the symbols have meaning, and removing them will change the description of the test. The migrator emits a warning when it thinks this is the case, but it’s up to us to look at this output and decide which ones need changing.