### PR TITLE
Complete Xcode 13.1’s “Update to recommended settings” wizard

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -2467,7 +2467,7 @@
 				CLASSPREFIX = ART;
 				DefaultBuildSystemTypeForWorkspace = Original;
 				LastSwiftUpdateCheck = 1120;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1310;
 				ORGANIZATIONNAME = Ably;
 				TargetAttributes = {
 					856AAC891B6E304B00B07119 = {

--- a/Ably.xcodeproj/xcshareddata/xcschemes/Ably-SoakTest-App.xcscheme
+++ b/Ably.xcodeproj/xcshareddata/xcschemes/Ably-SoakTest-App.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Ably.xcodeproj/xcshareddata/xcschemes/Ably-iOS-Tests.xcscheme
+++ b/Ably.xcodeproj/xcshareddata/xcschemes/Ably-iOS-Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Ably.xcodeproj/xcshareddata/xcschemes/Ably-iOS.xcscheme
+++ b/Ably.xcodeproj/xcshareddata/xcschemes/Ably-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Ably.xcodeproj/xcshareddata/xcschemes/Ably-macOS-Tests.xcscheme
+++ b/Ably.xcodeproj/xcshareddata/xcschemes/Ably-macOS-Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Ably.xcodeproj/xcshareddata/xcschemes/Ably-macOS.xcscheme
+++ b/Ably.xcodeproj/xcshareddata/xcschemes/Ably-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Ably.xcodeproj/xcshareddata/xcschemes/Ably-tvOS-Tests.xcscheme
+++ b/Ably.xcodeproj/xcshareddata/xcschemes/Ably-tvOS-Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Ably.xcodeproj/xcshareddata/xcschemes/Ably-tvOS.xcscheme
+++ b/Ably.xcodeproj/xcshareddata/xcschemes/Ably-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This makes the slightly-annoying warning go away. The recommended changes were to increase our deployment target to iOS 12, which I refused.