### PR TITLE
XCTUnwrap instead of guard

### DIFF
--- a/Spec/Tests/AuthTests.swift
+++ b/Spec/Tests/AuthTests.swift
@@ -73,11 +73,11 @@ private func rsa8gTestsSetupDependencies() {
 private let authCallbackTestsOptions = AblyTests.clientOptions()
 private let jwtAndRestTestsOptions = AblyTests.clientOptions()
 private var client: ARTRest!
-private var jsonEncoder: ARTJsonLikeEncoder = {
+private func createJsonEncoder() -> ARTJsonLikeEncoder {
     let encoder = ARTJsonLikeEncoder()
     encoder.delegate = ARTJsonEncoder()
     return encoder
-}()
+}
 
 private func jwtContentTypeTestsSetupDependencies() {
     if client == nil {
@@ -1492,7 +1492,7 @@ class AuthTests: XCTestCase {
 
     func test__065__requestToken__authUrl__query_will_provide_a_TokenDetails() throws {
         let testTokenDetails = try XCTUnwrap(getTestTokenDetails(clientId: "tester"), "TokenDetails is empty")
-        let jsonTokenDetails = try XCTUnwrap(jsonEncoder.encode(testTokenDetails), "Invalid TokenDetails")
+        let jsonTokenDetails = try XCTUnwrap(createJsonEncoder().encode(testTokenDetails), "Invalid TokenDetails")
 
         let options = ARTClientOptions()
         options.authUrl = URL(string: "http://echo.ably.io")
@@ -1547,7 +1547,7 @@ class AuthTests: XCTestCase {
         }
         
         let testTokenRequest = try XCTUnwrap(tokenRequest, "TokenRequest is empty")
-        let jsonTokenRequest = try XCTUnwrap(try jsonEncoder.encode(testTokenRequest), "Invalid TokenRequest")
+        let jsonTokenRequest = try XCTUnwrap(createJsonEncoder().encode(testTokenRequest), "Invalid TokenRequest")
 
         // JSON with TokenRequest
         options.authParams = [URLQueryItem]()
@@ -2939,7 +2939,7 @@ class AuthTests: XCTestCase {
     func test__107__authorize__should_adhere_to_all_requirements_relating_to__authUrl_with_json() throws {
         
         let tokenDetails = try XCTUnwrap(getTestTokenDetails(), "TokenDetails is empty")
-        let tokenDetailsData = try XCTUnwrap(try jsonEncoder.encode(tokenDetails), "Couldn't encode token details")
+        let tokenDetailsData = try XCTUnwrap(createJsonEncoder().encode(tokenDetails), "Couldn't encode token details")
         let tokenDetailsJSON = try XCTUnwrap(String(data: tokenDetailsData, encoding: .utf8), "JSON TokenDetails is empty")
 
         let options = ARTClientOptions()
@@ -2992,7 +2992,7 @@ class AuthTests: XCTestCase {
             }
         }
 
-        let tokenRequestData = try XCTUnwrap(try jsonEncoder.encode(tokenRequest), "Encode failure")
+        let tokenRequestData = try XCTUnwrap(createJsonEncoder().encode(tokenRequest), "Encode failure")
         let tokenRequestJSON = try XCTUnwrap(String(data: tokenRequestData, encoding: .utf8), "JSON Token Request is empty")
 
         options.authUrl = URL(string: "http://echo.ably.io")!
@@ -3101,7 +3101,7 @@ class AuthTests: XCTestCase {
         let rest = ARTRest(options: AblyTests.commonAppSetup())
 
         let testTokenDetails = try XCTUnwrap(getTestTokenDetails(ttl: 0.1))
-        let tokenRequestData = try XCTUnwrap(try jsonEncoder.encode(testTokenDetails), "Encode failure")
+        let tokenRequestData = try XCTUnwrap(createJsonEncoder().encode(testTokenDetails), "Encode failure")
 
         let authOptions = ARTAuthOptions()
         authOptions.authUrl = URL(string: "http://echo.ably.io")!

--- a/Spec/Tests/AuthTests.swift
+++ b/Spec/Tests/AuthTests.swift
@@ -122,7 +122,7 @@ class AuthTests: XCTestCase {
     }
 
     // RSA11
-    func test__004__Basic__should_send_the_API_key_in_the_Authorization_header() {
+    func test__004__Basic__should_send_the_API_key_in_the_Authorization_header() throws {
         let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
         let client = ARTRest(options: options)
         testHTTPExecutor = TestProxyHTTPExecutor(options.logHandler)
@@ -140,10 +140,7 @@ class AuthTests: XCTestCase {
 
         let expectedAuthorization = "Basic \(key64)"
 
-        guard let request = testHTTPExecutor.requests.first else {
-            fail("No request found")
-            return
-        }
+        let request = try XCTUnwrap(testHTTPExecutor.requests.first, "No request found")
 
         let authorization = request.allHTTPHeaderFields?["Authorization"]
 
@@ -160,7 +157,7 @@ class AuthTests: XCTestCase {
     // RSA3
 
     // RSA3a
-    func test__010__Token__token_auth__should_work_over_HTTP() {
+    func test__010__Token__token_auth__should_work_over_HTTP() throws {
         let options = AblyTests.clientOptions(requestToken: true)
         options.tls = false
         let clientHTTP = ARTRest(options: options)
@@ -172,19 +169,13 @@ class AuthTests: XCTestCase {
                 done()
             }
         }
-
-        guard let request = testHTTPExecutor.requests.first else {
-            fail("No request found")
-            return
-        }
-        guard let url = request.url else {
-            fail("Request is invalid")
-            return
-        }
+        
+        let url = try XCTUnwrap(testHTTPExecutor.requests.first?.url, "No request url found")
+        
         expect(url.scheme).to(equal("http"), description: "No HTTP support")
     }
 
-    func test__011__Token__token_auth__should_work_over_HTTPS() {
+    func test__011__Token__token_auth__should_work_over_HTTPS() throws {
         let options = AblyTests.clientOptions(requestToken: true)
         options.tls = true
         let clientHTTPS = ARTRest(options: options)
@@ -197,20 +188,14 @@ class AuthTests: XCTestCase {
             }
         }
 
-        guard let request = testHTTPExecutor.requests.first else {
-            fail("No request found")
-            return
-        }
-        guard let url = request.url else {
-            fail("Request is invalid")
-            return
-        }
+        let url = try XCTUnwrap(testHTTPExecutor.requests.first?.url, "No request url found")
+        
         expect(url.scheme).to(equal("https"), description: "No HTTPS support")
     }
 
     // RSA3b
 
-    func test__012__Token__token_auth__for_REST_requests__should_send_the_token_in_the_Authorization_header() {
+    func test__012__Token__token_auth__for_REST_requests__should_send_the_token_in_the_Authorization_header() throws {
         let options = AblyTests.clientOptions()
         options.token = getTestToken()
 
@@ -231,10 +216,7 @@ class AuthTests: XCTestCase {
 
         let expectedAuthorization = "Bearer \(currentToken)"
 
-        guard let request = testHTTPExecutor.requests.first else {
-            fail("No request found")
-            return
-        }
+        let request = try XCTUnwrap(testHTTPExecutor.requests.first, "No request found")
 
         let authorization = request.allHTTPHeaderFields?["Authorization"]
 
@@ -916,7 +898,7 @@ class AuthTests: XCTestCase {
 
     // RSA15a
 
-    func test__041__Token__token_auth_and_clientId__should_check_clientId_consistency__on_rest() {
+    func test__041__Token__token_auth_and_clientId__should_check_clientId_consistency__on_rest() throws {
         let expectedClientId = "client_string"
         let options = AblyTests.commonAppSetup()
         options.useTokenAuth = true
@@ -938,8 +920,10 @@ class AuthTests: XCTestCase {
                 done()
             }
         }
-
-        switch extractBodyAsMsgPack(testHTTPExecutor.requests.first) {
+        
+        let request = try XCTUnwrap(testHTTPExecutor.requests.first, "No request found")
+        
+        switch extractBodyAsMsgPack(request) {
         case let .failure(error):
             XCTFail(error)
         case let .success(httpBody):
@@ -1091,7 +1075,7 @@ class AuthTests: XCTestCase {
     }
 
     // RSA6
-    func test__008__Token__should_omit_capability_field_if_it_is_not_specified() {
+    func test__008__Token__should_omit_capability_field_if_it_is_not_specified() throws {
         let tokenParams = ARTTokenParams()
         expect(tokenParams.capability).to(beNil())
 
@@ -1111,8 +1095,10 @@ class AuthTests: XCTestCase {
                 done()
             }
         }
-
-        switch extractBodyAsMsgPack(testHTTPExecutor.requests.first) {
+        
+        let request = try XCTUnwrap(testHTTPExecutor.requests.first, "No request found")
+        
+        switch extractBodyAsMsgPack(request) {
         case let .failure(error):
             fail(error)
         case let .success(httpBody):
@@ -1121,7 +1107,7 @@ class AuthTests: XCTestCase {
     }
 
     // RSA6
-    func test__009__Token__should_add_capability_field_if_the_user_specifies_it() {
+    func test__009__Token__should_add_capability_field_if_the_user_specifies_it() throws {
         let tokenParams = ARTTokenParams()
         tokenParams.capability = "{\"*\":[\"*\"]}"
 
@@ -1140,8 +1126,10 @@ class AuthTests: XCTestCase {
                 done()
             }
         }
-
-        switch extractBodyAsMsgPack(testHTTPExecutor.requests.first) {
+        
+        let request = try XCTUnwrap(testHTTPExecutor.requests.first, "No request found")
+        
+        switch extractBodyAsMsgPack(request) {
         case let .failure(error):
             fail(error)
         case let .success(httpBody):

--- a/Spec/Tests/PushActivationStateMachineTests.swift
+++ b/Spec/Tests/PushActivationStateMachineTests.swift
@@ -97,21 +97,21 @@ class PushActivationStateMachineTests: XCTestCase {
     // RSH3a2
 
     // RSH3a2a
-    func reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a) {
+    func reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a) throws {
         // RSH3a2a
-        reusableTestsRsh3a2a(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_NotActivated)
+        try reusableTestsRsh3a2a(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_NotActivated)
     }
 
-    func test__011__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() {
-        reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match)
+    func test__011__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match)
     }
 
-    func test__012__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() {
-        reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync)
+    func test__012__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync)
     }
 
-    func test__013__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() {
-        reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync)
+    func test__013__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync)
     }
 
     // RSH3a2b
@@ -123,15 +123,12 @@ class PushActivationStateMachineTests: XCTestCase {
         expect(rest.device.id.count) == 36
     }
 
-    func test__015__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__local_device__should_have_a_generated_secret() {
+    func test__015__Activation_state_machine__State_NotActivated__on_Event_CalledActivate__local_device__should_have_a_generated_secret() throws {
         beforeEach__Activation_state_machine__State_NotActivated()
 
-        guard let deviceSecret = rest.device.secret else {
-            fail("Device Secret should be available because it's loaded when the getter of the property is called"); return
-        }
-        guard let data = Data(base64Encoded: deviceSecret) else {
-            fail("Device Secret should be encoded with Base64"); return
-        }
+        let secret = try XCTUnwrap(rest.device.secret, "Device Secret should be available in storage")
+        let data = try XCTUnwrap(Data(base64Encoded: secret), "Device Secret should be encoded with Base64")
+        
         expect(data.count) == 32 // 32 bytes digest
     }
 
@@ -302,7 +299,7 @@ class PushActivationStateMachineTests: XCTestCase {
     }
 
     // RSH3b3b, RSH3b3c
-    func test__024__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_fire_GotDeviceRegistration_event() {
+    func test__024__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_fire_GotDeviceRegistration_event() throws {
         beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
 
         expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
@@ -335,24 +332,13 @@ class PushActivationStateMachineTests: XCTestCase {
         expect(httpExecutor.requests.count) == 1
         let requests = httpExecutor.requests.compactMap { $0.url?.path }.filter { $0 == "/push/deviceRegistrations" }
         expect(requests).to(haveCount(1))
-        guard let request = httpExecutor.requests.first else {
-            fail("should have a \"/push/deviceRegistrations\" request"); return
-        }
-        guard let url = request.url else {
-            fail("should have a \"/push/deviceRegistrations\" URL"); return
-        }
-        guard let rawBody = request.httpBody else {
-            fail("should have a body"); return
-        }
-        let decodedBody: Any
-        do {
-            decodedBody = try stateMachine.rest.defaultEncoder.decode(rawBody)
-        } catch {
-            fail("Decode failed: \(error)"); return
-        }
-        guard let body = decodedBody as? NSDictionary else {
-            fail("body is invalid"); return
-        }
+        
+        let request = try XCTUnwrap(httpExecutor.requests.first, "Should have a \"/push/deviceRegistrations\" request")
+        let url = try XCTUnwrap(request.url, "Request should have a \"/push/deviceRegistrations\" URL")
+        let rawBody = try XCTUnwrap(request.httpBody, "Request should have a body")
+        let decodedBody = try XCTUnwrap(try stateMachine.rest.defaultEncoder.decode(rawBody), "Decode request body failed")
+        let body = try XCTUnwrap(decodedBody as? NSDictionary, "Request body is invalid")
+        
         expect(url.host).to(equal(rest.internal.options.restUrl().host))
         expect(request.httpMethod) == "POST"
         expect(body.value(forKey: "id") as? String).to(equal(rest.device.id))
@@ -362,7 +348,7 @@ class PushActivationStateMachineTests: XCTestCase {
     }
 
     // RSH3b3c
-    func test__025__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_fire_GettingDeviceRegistrationFailed_event() {
+    func test__025__Activation_state_machine__State_WaitingForPushDeviceDetails__on_Event_GotPushDeviceDetails__should_fire_GettingDeviceRegistrationFailed_event() throws {
         beforeEach__Activation_state_machine__State_WaitingForPushDeviceDetails()
 
         expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForPushDeviceDetails.self))
@@ -393,24 +379,13 @@ class PushActivationStateMachineTests: XCTestCase {
         expect(httpExecutor.requests.count) == 1
         let requests = httpExecutor.requests.compactMap { $0.url?.path }.filter { $0 == "/push/deviceRegistrations" }
         expect(requests).to(haveCount(1))
-        guard let request = httpExecutor.requests.first else {
-            fail("should have a \"/push/deviceRegistrations\" request"); return
-        }
-        guard request.url != nil else {
-            fail("should have a \"/push/deviceRegistrations\" URL"); return
-        }
-        guard let rawBody = request.httpBody else {
-            fail("should have a body"); return
-        }
-        let decodedBody: Any
-        do {
-            decodedBody = try stateMachine.rest.defaultEncoder.decode(rawBody)
-        } catch {
-            fail("Decode failed: \(error)"); return
-        }
-        guard let body = decodedBody as? NSDictionary else {
-            fail("body is invalid"); return
-        }
+        
+        let request = try XCTUnwrap(httpExecutor.requests.first, "Should have a \"/push/deviceRegistrations\" request")
+        let _ = try XCTUnwrap(request.url, "Request should have a \"/push/deviceRegistrations\" URL")
+        let rawBody = try XCTUnwrap(request.httpBody, "Request should have a body")
+        let decodedBody = try XCTUnwrap(try stateMachine.rest.defaultEncoder.decode(rawBody), "Decode request body failed")
+        let body = try XCTUnwrap(decodedBody as? NSDictionary, "Request body is invalid")
+        
         expect(body.value(forKey: "id") as? String).to(equal(rest.device.id))
         expect(body.value(forKey: "push") as? [String: [String: String]]).to(equal(expectedPushRecipient))
         expect(body.value(forKey: "formFactor") as? String) == expectedFormFactor
@@ -585,28 +560,28 @@ class PushActivationStateMachineTests: XCTestCase {
 
     // RSH3d2
 
-    func reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: TestCase_ReusableTestsRsh3d2) {
-        reusableTestsRsh3d2(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_WaitingForNewPushDeviceDetails)
+    func reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: TestCase_ReusableTestsRsh3d2) throws {
+        try reusableTestsRsh3d2(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_WaitingForNewPushDeviceDetails)
     }
 
-    func test__031__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_Deregistered_event() {
-        reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_Deregistered_event)
+    func test__031__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_Deregistered_event() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_Deregistered_event)
     }
 
-    func test__032__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event() {
-        reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event)
+    func test__032__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event)
     }
 
-    func test__033__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header() {
-        reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header)
+    func test__033__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header)
     }
 
-    func test__034__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header() {
-        reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header)
+    func test__034__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header)
     }
 
-    func test__035__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_fire_DeregistrationFailed_event() {
-        reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_DeregistrationFailed_event)
+    func test__035__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__should_fire_DeregistrationFailed_event() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_DeregistrationFailed_event)
     }
 
     enum TestCase_ReusableTestsTestStateWaitingForRegistrationSyncThrough {
@@ -773,64 +748,64 @@ class PushActivationStateMachineTests: XCTestCase {
 
     // RSH3f1
 
-    func reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a) {
-        reusableTestsRsh3a2a(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed)
+    func reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a) throws {
+        try reusableTestsRsh3a2a(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed)
     }
 
-    func test__042__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() {
-        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match)
+    func test__042__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match)
     }
 
-    func test__043__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() {
-        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync)
+    func test__043__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync)
     }
 
-    func test__044__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() {
-        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync)
+    func test__044__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledActivate__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync)
     }
 
     // RSH3f1
 
-    func reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a) {
-        reusableTestsRsh3a2a(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed)
+    func reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a) throws {
+        try reusableTestsRsh3a2a(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed)
     }
 
-    func test__045__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() {
-        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match)
+    func test__045__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__emits_a_SyncRegistrationFailed_event_with_code_61002_if_client_IDs_don_t_match)
     }
 
-    func test__046__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() {
-        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync)
+    func test__046__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync)
     }
 
-    func test__047__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() {
-        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync)
+    func test__047__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_GotPushDeviceDetails__reusableTestsRsh3a2a(testCase: .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync)
     }
 
     // RSH3f2
 
-    func reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: TestCase_ReusableTestsRsh3d2) {
-        reusableTestsRsh3d2(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed)
+    func reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: TestCase_ReusableTestsRsh3d2) throws {
+        try reusableTestsRsh3d2(testCase: testCase, beforeEach: beforeEach__Activation_state_machine__State_AfterRegistrationSyncFailed)
     }
 
-    func test__048__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_Deregistered_event() {
-        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_Deregistered_event)
+    func test__048__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_Deregistered_event() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_Deregistered_event)
     }
 
-    func test__049__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event() {
-        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event)
+    func test__049__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event)
     }
 
-    func test__050__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header() {
-        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header)
+    func test__050__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header)
     }
 
-    func test__051__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header() {
-        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header)
+    func test__051__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header)
     }
 
-    func test__052__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_fire_DeregistrationFailed_event() {
-        reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_DeregistrationFailed_event)
+    func test__052__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__should_fire_DeregistrationFailed_event() throws {
+        try reusableTestsWrapper__Activation_state_machine__State_AfterRegistrationSyncFailed__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_DeregistrationFailed_event)
     }
 
     // RSH3g
@@ -895,7 +870,7 @@ class PushActivationStateMachineTests: XCTestCase {
     }
 
     // RSH4
-    func test__005__Activation_state_machine__should_queue_event_that_has_no_transition_defined_for_it() {
+    func test__005__Activation_state_machine__should_queue_event_that_has_no_transition_defined_for_it() throws {
         // Start with WaitingForDeregistration state
         let storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForDeregistration(machine: initialStateMachine))
         rest.internal.storage = storage
@@ -910,9 +885,7 @@ class PushActivationStateMachineTests: XCTestCase {
         expect(stateMachine.pendingEvents).toEventually(haveCount(1), timeout: testTimeout)
         stateMachine.transitions = nil
 
-        guard let pendingEvent = stateMachine.pendingEvents.firstObject else {
-            fail("Pending event is missing"); return
-        }
+        let pendingEvent = try XCTUnwrap(stateMachine.pendingEvents.firstObject, "Pending event is missing")
         expect(pendingEvent).to(beAKindOf(ARTPushActivationEventCalledActivate.self))
 
         waitUntil(timeout: testTimeout) { done in
@@ -962,7 +935,7 @@ class PushActivationStateMachineTests: XCTestCase {
         case the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync
     }
 
-    func reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a, beforeEach contextBeforeEach: (() -> Void)? = nil, afterEach contextAfterEach: (() -> Void)? = nil) {
+    func reusableTestsRsh3a2a(testCase: TestCase_ReusableTestsRsh3a2a, beforeEach contextBeforeEach: (() -> Void)? = nil, afterEach contextAfterEach: (() -> Void)? = nil) throws {
         let testDeviceId = "aaaa"
 
         // RSH3a2a1
@@ -1047,7 +1020,7 @@ class PushActivationStateMachineTests: XCTestCase {
         }
 
         // RSH3a2a3, RSH3a2a4, RSH3b3c
-        func test__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() {
+        func test__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync() throws {
             beforeEach__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID()
 
             let delegate = StateMachineDelegate()
@@ -1069,24 +1042,13 @@ class PushActivationStateMachineTests: XCTestCase {
 
             let requests = httpExecutor.requests.compactMap { $0.url?.path }.filter { $0 == "/push/deviceRegistrations/\(rest.device.id)" }
             expect(requests).to(haveCount(1))
-            guard let request = httpExecutor.requests.first else {
-                fail("should have a \"/push/deviceRegistrations/:deviceId\" request"); return
-            }
-            guard let url = request.url else {
-                fail("should have a URL"); return
-            }
-            guard let rawBody = request.httpBody else {
-                fail("should have a body"); return
-            }
-            let decodedBody: Any
-            do {
-                decodedBody = try stateMachine.rest.defaultEncoder.decode(rawBody)
-            } catch {
-                fail("Decode failed: \(error)"); return
-            }
-            guard let body = decodedBody as? NSDictionary else {
-                fail("body is invalid"); return
-            }
+            
+            let request = try XCTUnwrap(httpExecutor.requests.first, "Should have a \"/push/deviceRegistrations\" request")
+            let url = try XCTUnwrap(request.url, "Request should have a \"/push/deviceRegistrations\" URL")
+            let rawBody = try XCTUnwrap(request.httpBody, "Request should have a body")
+            let decodedBody = try XCTUnwrap(try stateMachine.rest.defaultEncoder.decode(rawBody), "Decode request body failed")
+            let body = try XCTUnwrap(decodedBody as? NSDictionary, "Request body is invalid")
+            
             expect(url.host).to(equal(rest.internal.options.restUrl().host))
             expect(request.httpMethod) == "PUT"
             expect(body.value(forKey: "id") as? String).to(equal(rest.device.id))
@@ -1103,7 +1065,7 @@ class PushActivationStateMachineTests: XCTestCase {
         case .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync:
             test__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__calls_registerCallback__transitions_to_WaitingForRegistrationSync()
         case .the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync:
-            test__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync()
+            try test__the_local_device_has_id_and_deviceIdentityToken__the_local_DeviceDetails_matches_the_instance_s_client_ID__PUTs_device_registration__transitions_to_WaitingForRegistrationSync()
         }
     }
 
@@ -1115,7 +1077,7 @@ class PushActivationStateMachineTests: XCTestCase {
         case should_fire_DeregistrationFailed_event
     }
 
-    func reusableTestsRsh3d2(testCase: TestCase_ReusableTestsRsh3d2, beforeEach contextBeforeEach: (() -> Void)? = nil, afterEach contextAfterEach: (() -> Void)? = nil) {
+    func reusableTestsRsh3d2(testCase: TestCase_ReusableTestsRsh3d2, beforeEach contextBeforeEach: (() -> Void)? = nil, afterEach contextAfterEach: (() -> Void)? = nil) throws {
         // RSH3d2a, RSH3d2c, RSH3d2d
         func test__should_use_custom_deregisterCallback_and_fire_Deregistered_event() {
             contextBeforeEach?()
@@ -1187,7 +1149,7 @@ class PushActivationStateMachineTests: XCTestCase {
         }
 
         // RSH3d2b, RSH3d2c, RSH3d2d
-        func test__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header() {
+        func test__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header() throws {
             contextBeforeEach?()
 
             let delegate = StateMachineDelegate()
@@ -1212,12 +1174,10 @@ class PushActivationStateMachineTests: XCTestCase {
             expect(httpExecutor.requests.count) == 1
             let requests = httpExecutor.requests.compactMap { $0.url?.path }.filter { $0 == "/push/deviceRegistrations/\(rest.device.id)" }
             expect(requests).to(haveCount(1))
-            guard let request = httpExecutor.requests.first else {
-                fail("should have a \"/push/deviceRegistrations\" request"); return
-            }
-            guard let url = request.url else {
-                fail("should have a \"/push/deviceRegistrations\" URL"); return
-            }
+            
+            let request = try XCTUnwrap(httpExecutor.requests.first, "Should have a \"/push/deviceRegistrations\" request")
+            let url = try XCTUnwrap(request.url, "Request should have a \"/push/deviceRegistrations\" URL")
+
             expect(url.host).to(equal(rest.internal.options.restUrl().host))
             expect(request.httpMethod) == "DELETE"
             expect(request.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
@@ -1228,7 +1188,7 @@ class PushActivationStateMachineTests: XCTestCase {
         }
 
         // RSH3d2b, RSH3d2c, RSH3d2d
-        func test__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header() {
+        func test__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header() throws {
             contextBeforeEach?()
 
             let delegate = StateMachineDelegate()
@@ -1266,12 +1226,10 @@ class PushActivationStateMachineTests: XCTestCase {
             expect(httpExecutor.requests.count) == 1
             let requests = httpExecutor.requests.compactMap { $0.url?.path }.filter { $0 == "/push/deviceRegistrations/\(rest.device.id)" }
             expect(requests).to(haveCount(1))
-            guard let request = httpExecutor.requests.first else {
-                fail("should have a \"/push/deviceRegistrations\" request"); return
-            }
-            guard let url = request.url else {
-                fail("should have a \"/push/deviceRegistrations\" URL"); return
-            }
+            
+            let request = try XCTUnwrap(httpExecutor.requests.first, "Should have a \"/push/deviceRegistrations\" request")
+            let url = try XCTUnwrap(request.url, "Request should have a \"/push/deviceRegistrations\" URL")
+
             expect(url.host).to(equal(rest.internal.options.restUrl().host))
             expect(request.httpMethod) == "DELETE"
             expect(rest.device.identityTokenDetails).to(beNil())
@@ -1283,7 +1241,7 @@ class PushActivationStateMachineTests: XCTestCase {
         }
 
         // RSH3d2c
-        func test__should_fire_DeregistrationFailed_event() {
+        func test__should_fire_DeregistrationFailed_event() throws {
             contextBeforeEach?()
 
             let delegate = StateMachineDelegate()
@@ -1312,12 +1270,10 @@ class PushActivationStateMachineTests: XCTestCase {
             expect(httpExecutor.requests.count) == 1
             let requests = httpExecutor.requests.compactMap { $0.url?.path }.filter { $0 == "/push/deviceRegistrations/\(rest.device.id)" }
             expect(requests).to(haveCount(1))
-            guard let request = httpExecutor.requests.first else {
-                fail("should have a \"/push/deviceRegistrations\" request"); return
-            }
-            guard let url = request.url else {
-                fail("should have a \"/push/deviceRegistrations\" URL"); return
-            }
+            
+            let request = try XCTUnwrap(httpExecutor.requests.first, "Should have a \"/push/deviceRegistrations\" request")
+            let url = try XCTUnwrap(request.url, "Request should have a \"/push/deviceRegistrations\" URL")
+
             expect(url.host).to(equal(rest.internal.options.restUrl().host))
             expect(request.httpMethod) == "DELETE"
 
@@ -1330,11 +1286,11 @@ class PushActivationStateMachineTests: XCTestCase {
         case .should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event:
             test__should_use_custom_deregisterCallback_and_fire_DeregistrationFailed_event()
         case .should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header:
-            test__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header()
+            try test__should_fire_Deregistered_event_and_include_DeviceSecret_HTTP_header()
         case .should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header:
-            test__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header()
+            try test__should_fire_Deregistered_event_and_include_DeviceIdentityToken_HTTP_header()
         case .should_fire_DeregistrationFailed_event:
-            test__should_fire_DeregistrationFailed_event()
+            try test__should_fire_DeregistrationFailed_event()
         }
     }
 }

--- a/Spec/Tests/PushAdminTests.swift
+++ b/Spec/Tests/PushAdminTests.swift
@@ -185,7 +185,7 @@ class PushAdminTests: XCTestCase {
 
     // RSH1a
 
-    func test__001__publish__should_perform_an_HTTP_request_to__push_publish() {
+    func test__001__publish__should_perform_an_HTTP_request_to__push_publish() throws {
         waitUntil(timeout: testTimeout) { done in
             rest.push.admin.publish(recipient, data: payload) { error in
                 expect(error).to(beNil())
@@ -193,12 +193,8 @@ class PushAdminTests: XCTestCase {
             }
         }
 
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("Request is missing"); return
-        }
-        guard let url = request.url else {
-            fail("URL is missing"); return
-        }
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
+        let url = try XCTUnwrap(request.url, "No request url found")
 
         expect(url.absoluteString).to(contain("/push/publish"))
 

--- a/Spec/Tests/PushAdminTests.swift
+++ b/Spec/Tests/PushAdminTests.swift
@@ -363,7 +363,7 @@ class PushAdminTests: XCTestCase {
         }
     }
 
-    func test__008__Device_Registrations__get__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() {
+    func test__008__Device_Registrations__get__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() throws {
         let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
         defer { realtime.dispose(); realtime.close() }
         realtime.internal.rest.httpExecutor = mockHttpExecutor
@@ -385,17 +385,14 @@ class PushAdminTests: XCTestCase {
                 done()
             }
         }
-
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("No requests found")
-            return
-        }
-
+        
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
+        
         expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
     }
 
-    func test__009__Device_Registrations__get__push_device_authentication__should_include_DeviceSecret_HTTP_header() {
+    func test__009__Device_Registrations__get__push_device_authentication__should_include_DeviceSecret_HTTP_header() throws {
         let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
         defer { realtime.dispose(); realtime.close() }
         realtime.internal.rest.httpExecutor = mockHttpExecutor
@@ -406,12 +403,9 @@ class PushAdminTests: XCTestCase {
             }
         }
 
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("No requests found")
-            return
-        }
-
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
+        
         expect(authorization).to(equal(localDevice.secret))
     }
 
@@ -479,7 +473,7 @@ class PushAdminTests: XCTestCase {
 
     // RSH1b4
 
-    func test__014__Device_Registrations__remove__should_unregister_a_device() {
+    func test__014__Device_Registrations__remove__should_unregister_a_device() throws {
         let options = AblyTests.commonAppSetup()
         options.pushFullWait = true
         let realtime = ARTRealtime(options: options)
@@ -492,10 +486,7 @@ class PushAdminTests: XCTestCase {
             }
         }
 
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("No requests found")
-            return
-        }
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
 
         expect(request.httpMethod) == "DELETE"
         expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
@@ -504,7 +495,7 @@ class PushAdminTests: XCTestCase {
 
     // RSH1b3
 
-    func test__015__Device_Registrations__save__should_register_a_device() {
+    func test__015__Device_Registrations__save__should_register_a_device() throws {
         let options = AblyTests.commonAppSetup()
         options.pushFullWait = true
         let realtime = ARTRealtime(options: options)
@@ -516,18 +507,15 @@ class PushAdminTests: XCTestCase {
                 done()
             }
         }
-
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("No requests found")
-            return
-        }
+        
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
 
         expect(request.httpMethod) == "PUT"
         expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
         expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
     }
 
-    func test__016__Device_Registrations__save__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() {
+    func test__016__Device_Registrations__save__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() throws {
         let options = AblyTests.commonAppSetup()
         options.pushFullWait = true
         let realtime = ARTRealtime(options: options)
@@ -552,18 +540,15 @@ class PushAdminTests: XCTestCase {
                 done()
             }
         }
-
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("No requests found")
-            return
-        }
-        expect(request.httpMethod).to(equal("PUT"))
-
+        
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
+        
+        expect(request.httpMethod).to(equal("PUT"))
         expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
     }
 
-    func test__017__Device_Registrations__save__push_device_authentication__should_include_DeviceSecret_HTTP_header() {
+    func test__017__Device_Registrations__save__push_device_authentication__should_include_DeviceSecret_HTTP_header() throws {
         let options = AblyTests.commonAppSetup()
         options.pushFullWait = true
         let realtime = ARTRealtime(options: options)
@@ -577,19 +562,16 @@ class PushAdminTests: XCTestCase {
             }
         }
 
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("No requests found")
-            return
-        }
-        expect(request.httpMethod).to(equal("PUT"))
-
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
+        
+        expect(request.httpMethod).to(equal("PUT"))
         expect(authorization).to(equal(localDevice.secret))
     }
 
     // RSH1b5
 
-    func test__018__Device_Registrations__removeWhere__should_unregister_a_device() {
+    func test__018__Device_Registrations__removeWhere__should_unregister_a_device() throws {
         let options = AblyTests.commonAppSetup()
         options.pushFullWait = true
         let realtime = ARTRealtime(options: options)
@@ -620,11 +602,8 @@ class PushAdminTests: XCTestCase {
                 done()
             }
         }
-
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("No requests found")
-            return
-        }
+        
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
 
         expect(request.httpMethod) == "DELETE"
         expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
@@ -668,7 +647,7 @@ class PushAdminTests: XCTestCase {
 
     // RSH1c3
 
-    func test__019__Channel_Subscriptions__save__should_add_a_subscription() {
+    func test__019__Channel_Subscriptions__save__should_add_a_subscription() throws {
         let options = AblyTests.commonAppSetup()
         let realtime = ARTRealtime(options: options)
         defer { realtime.dispose(); realtime.close() }
@@ -682,10 +661,7 @@ class PushAdminTests: XCTestCase {
             }
         }
 
-        guard let request = testProxyHTTPExecutor.requests.first else {
-            fail("No requests found")
-            return
-        }
+        let request = try XCTUnwrap(testProxyHTTPExecutor.requests.first, "No request found")
 
         expect(request.httpMethod).to(equal("POST"))
         expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
@@ -720,7 +696,7 @@ class PushAdminTests: XCTestCase {
         }
     }
 
-    func test__022__Channel_Subscriptions__save__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() {
+    func test__022__Channel_Subscriptions__save__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() throws {
         let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
         defer { realtime.dispose(); realtime.close() }
         realtime.internal.rest.httpExecutor = mockHttpExecutor
@@ -746,16 +722,13 @@ class PushAdminTests: XCTestCase {
             }
         }
 
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("No requests found")
-            return
-        }
-
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
+        
         expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
     }
 
-    func test__023__Channel_Subscriptions__save__push_device_authentication__should_include_DeviceSecret_HTTP_header() {
+    func test__023__Channel_Subscriptions__save__push_device_authentication__should_include_DeviceSecret_HTTP_header() throws {
         let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
         defer { realtime.dispose(); realtime.close() }
         realtime.internal.rest.httpExecutor = mockHttpExecutor
@@ -769,12 +742,9 @@ class PushAdminTests: XCTestCase {
             }
         }
 
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("No requests found")
-            return
-        }
-
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
+        
         expect(authorization).to(equal(localDevice.secret))
     }
 
@@ -817,7 +787,7 @@ class PushAdminTests: XCTestCase {
 
     // RSH1c4
 
-    func test__026__Channel_Subscriptions__remove__should_remove_a_subscription() {
+    func test__026__Channel_Subscriptions__remove__should_remove_a_subscription() throws {
         let options = AblyTests.commonAppSetup()
         let realtime = ARTRealtime(options: options)
         defer { realtime.dispose(); realtime.close() }
@@ -831,11 +801,8 @@ class PushAdminTests: XCTestCase {
             }
         }
 
-        guard let request = testProxyHTTPExecutor.requests.first else {
-            fail("No requests found")
-            return
-        }
-
+        let request = try XCTUnwrap(testProxyHTTPExecutor.requests.first, "No request found")
+        
         expect(request.httpMethod).to(equal("DELETE"))
         expect(request.allHTTPHeaderFields?["X-Ably-DeviceToken"]).to(beNil())
         expect(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]).to(beNil())
@@ -852,7 +819,7 @@ class PushAdminTests: XCTestCase {
         }
     }
 
-    func test__027__Channel_Subscriptions__remove__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() {
+    func test__027__Channel_Subscriptions__remove__push_device_authentication__should_include_DeviceIdentityToken_HTTP_header() throws {
         let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
         defer { realtime.dispose(); realtime.close() }
         realtime.internal.rest.httpExecutor = mockHttpExecutor
@@ -878,16 +845,13 @@ class PushAdminTests: XCTestCase {
             }
         }
 
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("No requests found")
-            return
-        }
-
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
+        
         expect(authorization).to(equal(testIdentityTokenDetails.token.base64Encoded()))
     }
 
-    func test__028__Channel_Subscriptions__remove__push_device_authentication__should_include_DeviceSecret_HTTP_header() {
+    func test__028__Channel_Subscriptions__remove__push_device_authentication__should_include_DeviceSecret_HTTP_header() throws {
         let realtime = ARTRealtime(options: AblyTests.commonAppSetup())
         defer { realtime.dispose(); realtime.close() }
         realtime.internal.rest.httpExecutor = mockHttpExecutor
@@ -901,12 +865,9 @@ class PushAdminTests: XCTestCase {
             }
         }
 
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("No requests found")
-            return
-        }
-
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
+        
         expect(authorization).to(equal(localDevice.secret))
     }
 

--- a/Spec/Tests/PushChannelTests.swift
+++ b/Spec/Tests/PushChannelTests.swift
@@ -46,7 +46,7 @@ class PushChannelTests: XCTestCase {
     }
 
     // RSH7a2, RSH7a3
-    func test__002__Push_Channel__subscribeDevice__should_do_a_POST_request_to__push_channelSubscriptions_and_include_device_authentication() {
+    func test__002__Push_Channel__subscribeDevice__should_do_a_POST_request_to__push_channelSubscriptions_and_include_device_authentication() throws {
         let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
         rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
         defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
@@ -59,26 +59,14 @@ class PushChannelTests: XCTestCase {
             }
         }
 
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("should have a \"/push/channelSubscriptions\" request"); return
-        }
-        guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
-            fail("should have a \"/push/channelSubscriptions\" URL"); return
-        }
-        guard let rawBody = request.httpBody else {
-            fail("should have a body"); return
-        }
-        let decodedBody: Any
-        do {
-            decodedBody = try rest.internal.defaultEncoder.decode(rawBody)
-        } catch {
-            fail("Decode failed: \(error)"); return
-        }
-        guard let body = decodedBody as? NSDictionary else {
-            fail("body is invalid"); return
-        }
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "should have a \"/push/channelSubscriptions\" request")
+        let url = try XCTUnwrap(request.url, "No request url found")
+        let rawBody = try XCTUnwrap(request.httpBody, "should have a body")
+        let decodedBody = try XCTUnwrap(try rest.internal.defaultEncoder.decode(rawBody), "Decode request body failed")
+        let body = try XCTUnwrap(decodedBody as? NSDictionary, "Request body is invalid")
 
         expect(request.httpMethod) == "POST"
+        expect(url.absoluteString).to(contain("/push/channelSubscriptions"))
         expect(body.value(forKey: "deviceId") as? String).to(equal(rest.device.id))
         expect(body.value(forKey: "channel") as? String).to(equal(channel.name))
 
@@ -112,7 +100,7 @@ class PushChannelTests: XCTestCase {
     }
 
     // RSH7b2
-    func test__004__Push_Channel__subscribeClient__should_do_a_POST_request_to__push_channelSubscriptions() {
+    func test__004__Push_Channel__subscribeClient__should_do_a_POST_request_to__push_channelSubscriptions() throws {
         let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
         rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
         defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
@@ -125,26 +113,14 @@ class PushChannelTests: XCTestCase {
             }
         }
 
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("should have a \"/push/channelSubscriptions\" request"); return
-        }
-        guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
-            fail("should have a \"/push/channelSubscriptions\" URL"); return
-        }
-        guard let rawBody = request.httpBody else {
-            fail("should have a body"); return
-        }
-        let decodedBody: Any
-        do {
-            decodedBody = try rest.internal.defaultEncoder.decode(rawBody)
-        } catch {
-            fail("Decode failed: \(error)"); return
-        }
-        guard let body = decodedBody as? NSDictionary else {
-            fail("body is invalid"); return
-        }
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "should have a \"/push/channelSubscriptions\" request")
+        let url = try XCTUnwrap(request.url, "No request url found")
+        let rawBody = try XCTUnwrap(request.httpBody, "should have a body")
+        let decodedBody = try XCTUnwrap(try rest.internal.defaultEncoder.decode(rawBody), "Decode request body failed")
+        let body = try XCTUnwrap(decodedBody as? NSDictionary, "Request body is invalid")
 
         expect(request.httpMethod) == "POST"
+        expect(url.absoluteString).to(contain("/push/channelSubscriptions"))
         expect(body.value(forKey: "clientId") as? String).to(equal(rest.device.clientId))
         expect(body.value(forKey: "channel") as? String).to(equal(channel.name))
 
@@ -169,7 +145,7 @@ class PushChannelTests: XCTestCase {
     }
 
     // RSH7c2, RSH7c3
-    func test__006__Push_Channel__unsubscribeDevice__should_do_a_DELETE_request_to__push_channelSubscriptions_and_include_device_authentication() {
+    func test__006__Push_Channel__unsubscribeDevice__should_do_a_DELETE_request_to__push_channelSubscriptions_and_include_device_authentication() throws {
         let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
         rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
         defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
@@ -182,17 +158,12 @@ class PushChannelTests: XCTestCase {
             }
         }
 
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("should have a \"/push/channelSubscriptions\" request"); return
-        }
-        guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
-            fail("should have a \"/push/channelSubscriptions\" URL"); return
-        }
-        guard let query = request.url?.query else {
-            fail("should have a body"); return
-        }
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "should have a \"/push/channelSubscriptions\" request")
+        let url = try XCTUnwrap(request.url, "No request url found")
+        let query = try XCTUnwrap(url.query, "should have a query")
 
         expect(request.httpMethod) == "DELETE"
+        expect(url.absoluteString).to(contain("/push/channelSubscriptions"))
         expect(query).to(haveParam("deviceId", withValue: rest.device.id))
         expect(query).to(haveParam("channel", withValue: channel.name))
 
@@ -226,7 +197,7 @@ class PushChannelTests: XCTestCase {
     }
 
     // RSH7d2
-    func test__008__Push_Channel__unsubscribeClient__should_do_a_DELETE_request_to__push_channelSubscriptions() {
+    func test__008__Push_Channel__unsubscribeClient__should_do_a_DELETE_request_to__push_channelSubscriptions() throws {
         let testIdentityTokenDetails = ARTDeviceIdentityTokenDetails(token: "xxxx-xxxx-xxx", issued: Date(), expires: Date.distantFuture, capability: "", clientId: "")
         rest.device.setAndPersistIdentityTokenDetails(testIdentityTokenDetails)
         defer { rest.device.setAndPersistIdentityTokenDetails(nil) }
@@ -239,17 +210,12 @@ class PushChannelTests: XCTestCase {
             }
         }
 
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("should have a \"/push/channelSubscriptions\" request"); return
-        }
-        guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
-            fail("should have a \"/push/channelSubscriptions\" URL"); return
-        }
-        guard let query = request.url?.query else {
-            fail("should have a body"); return
-        }
-
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "should have a \"/push/channelSubscriptions\" request")
+        let url = try XCTUnwrap(request.url, "No request url found")
+        let query = try XCTUnwrap(url.query, "should have a query")
+        
         expect(request.httpMethod) == "DELETE"
+        expect(url.absoluteString).to(contain("/push/channelSubscriptions"))
         expect(query).to(haveParam("clientId", withValue: rest.device.clientId!))
         expect(query).to(haveParam("channel", withValue: channel.name))
 
@@ -259,7 +225,7 @@ class PushChannelTests: XCTestCase {
 
     // RSH7e
 
-    func test__009__Push_Channel__listSubscriptions__should_return_a_paginated_result_with_PushChannelSubscription_filtered_by_channel_and_device() {
+    func test__009__Push_Channel__listSubscriptions__should_return_a_paginated_result_with_PushChannelSubscription_filtered_by_channel_and_device() throws {
         let params = [
             "deviceId": "111",
             "channel": "aaa",
@@ -273,23 +239,18 @@ class PushChannelTests: XCTestCase {
             }
         }
 
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("should have a \"/push/channelSubscriptions\" request"); return
-        }
-        guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
-            fail("should have a \"/push/channelSubscriptions\" URL"); return
-        }
-        guard let query = request.url?.query else {
-            fail("should have a body"); return
-        }
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "should have a \"/push/channelSubscriptions\" request")
+        let url = try XCTUnwrap(request.url, "No request url found")
+        let query = try XCTUnwrap(url.query, "should have a query")
 
+        expect(url.absoluteString).to(contain("/push/channelSubscriptions"))
         expect(query).to(haveParam("deviceId", withValue: params["deviceId"]))
         expect(query).toNot(haveParam("clientId", withValue: rest.device.clientId))
         expect(query).to(haveParam("channel", withValue: params["channel"]))
         expect(query).to(haveParam("concatFilters", withValue: "true"))
     }
 
-    func test__010__Push_Channel__listSubscriptions__should_return_a_paginated_result_with_PushChannelSubscription_filtered_by_channel_and_client() {
+    func test__010__Push_Channel__listSubscriptions__should_return_a_paginated_result_with_PushChannelSubscription_filtered_by_channel_and_client() throws {
         let params = [
             "clientId": "tester",
             "channel": "aaa",
@@ -303,16 +264,11 @@ class PushChannelTests: XCTestCase {
             }
         }
 
-        guard let request = mockHttpExecutor.requests.first else {
-            fail("should have a \"/push/channelSubscriptions\" request"); return
-        }
-        guard let url = request.url, url.absoluteString.contains("/push/channelSubscriptions") else {
-            fail("should have a \"/push/channelSubscriptions\" URL"); return
-        }
-        guard let query = request.url?.query else {
-            fail("should have a body"); return
-        }
+        let request = try XCTUnwrap(mockHttpExecutor.requests.first, "should have a \"/push/channelSubscriptions\" request")
+        let url = try XCTUnwrap(request.url, "No request url found")
+        let query = try XCTUnwrap(url.query, "should have a query")
 
+        expect(url.absoluteString).to(contain("/push/channelSubscriptions"))
         expect(query).to(haveParam("clientId", withValue: params["clientId"]))
         expect(query).toNot(haveParam("deviceId", withValue: rest.device.id))
         expect(query).to(haveParam("channel", withValue: params["channel"]))

--- a/Spec/Tests/RestClientTests.swift
+++ b/Spec/Tests/RestClientTests.swift
@@ -435,7 +435,7 @@ class RestClientTests: XCTestCase {
     }
 
     // RSC12
-    func test__003__RestClient__REST_endpoint_host_should_be_configurable_in_the_Client_constructor_with_the_option_restHost() {
+    func test__003__RestClient__REST_endpoint_host_should_be_configurable_in_the_Client_constructor_with_the_option_restHost() throws {
         let options = ARTClientOptions(key: "xxxx:xxxx")
         expect(options.restHost).to(equal("rest.ably.io"))
         options.restHost = "rest.ably.test"
@@ -449,7 +449,10 @@ class RestClientTests: XCTestCase {
                 done()
             }
         }
-        expect(testHTTPExecutor.requests.first!.url!.absoluteString).to(contain("//rest.ably.test"))
+        
+        let url = try XCTUnwrap(testHTTPExecutor.requests.first?.url, "No request url found")
+
+        expect(url.absoluteString).to(contain("//rest.ably.test"))
     }
 
     // RSC16
@@ -468,7 +471,7 @@ class RestClientTests: XCTestCase {
     }
 
     // RSC7, RSC18
-    func test__004__RestClient__should_send_requests_over_http_and_https() {
+    func test__004__RestClient__should_send_requests_over_http_and_https() throws {
         let options = AblyTests.commonAppSetup()
 
         let clientHttps = ARTRest(options: options)
@@ -481,7 +484,8 @@ class RestClientTests: XCTestCase {
             }
         }
 
-        let requestUrlA = testHTTPExecutor.requests.first!.url!
+        let requestUrlA = try XCTUnwrap(testHTTPExecutor.requests.first?.url, "No request url found")
+
         expect(requestUrlA.scheme).to(equal("https"))
 
         options.clientId = "client_http"
@@ -497,7 +501,7 @@ class RestClientTests: XCTestCase {
             }
         }
 
-        let requestUrlB = testHTTPExecutor.requests.last!.url!
+        let requestUrlB = try XCTUnwrap(testHTTPExecutor.requests.last?.url, "No request url found")
         expect(requestUrlB.scheme).to(equal("http"))
     }
 
@@ -1574,7 +1578,7 @@ class RestClientTests: XCTestCase {
     }
 
     // RSC8a
-    func test__008__RestClient__should_use_MsgPack_binary_protocol() {
+    func test__008__RestClient__should_use_MsgPack_binary_protocol() throws {
         let options = AblyTests.commonAppSetup()
         expect(options.useBinaryProtocol).to(beTrue())
 
@@ -1586,8 +1590,10 @@ class RestClientTests: XCTestCase {
                 done()
             }
         }
+        
+        let request = try XCTUnwrap(testHTTPExecutor.requests.first, "No request found")
 
-        switch extractBodyAsMsgPack(testHTTPExecutor.requests.first) {
+        switch extractBodyAsMsgPack(request) {
         case let .failure(error):
             fail(error)
         default: break
@@ -1608,7 +1614,7 @@ class RestClientTests: XCTestCase {
     }
 
     // RSC8b
-    func test__009__RestClient__should_use_JSON_text_protocol() {
+    func test__009__RestClient__should_use_JSON_text_protocol() throws {
         let options = AblyTests.commonAppSetup()
         options.useBinaryProtocol = false
 
@@ -1620,8 +1626,10 @@ class RestClientTests: XCTestCase {
                 done()
             }
         }
+        
+        let request = try XCTUnwrap(testHTTPExecutor.requests.first, "No request found")
 
-        switch extractBodyAsJSON(testHTTPExecutor.requests.first) {
+        switch extractBodyAsJSON(request) {
         case let .failure(error):
             fail(error)
         default: break


### PR DESCRIPTION
Since the purpose of this PR is to improve readability of the tests, I've only replaced places that were overwhelmed with `guard` statements followed one after another. Also standalone cases where clause were one of a bunch mentioned in previous sentence (in most cases).