### PR TITLE
Fix/1177 full reset device details (RSH3g2a only)

### DIFF
--- a/Source/ARTLocalDevice+Private.h
+++ b/Source/ARTLocalDevice+Private.h
@@ -22,6 +22,8 @@ extern NSString *const ARTAPNSDeviceTokenKey;
 + (NSString *)generateId;
 + (NSString *)generateSecret;
 
+- (void)reset;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/ARTLocalDevice.h
+++ b/Source/ARTLocalDevice.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
+- (void)reset;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/ARTLocalDevice.h
+++ b/Source/ARTLocalDevice.h
@@ -16,8 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (void)reset;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/ARTLocalDevice.m
+++ b/Source/ARTLocalDevice.m
@@ -110,4 +110,19 @@ NSString *const ARTDevicePushTransportType = @"apns";
     return _identityTokenDetails != nil;
 }
 
+- (void)clearStorage {
+    for (NSString *key in @[ ARTDeviceIdKey, ARTDeviceIdentityTokenKey ]) {
+        [self.storage setObject:nil forKey:key];
+    }
+}
+
+- (void)reset {
+    self.id = @"";
+    self.secret = nil;
+    self.clientId = nil;
+    _identityTokenDetails = nil;
+    [self.push.recipient removeAllObjects];
+    [self clearStorage];
+}
+
 @end

--- a/Source/ARTPushActivationState.m
+++ b/Source/ARTPushActivationState.m
@@ -259,8 +259,8 @@ ARTPushActivationState *validateAndSync(ARTPushActivationStateMachine *machine, 
     }
     else if ([event isKindOfClass:[ARTPushActivationEventDeregistered class]]) {
         #if TARGET_OS_IOS
-        ARTLocalDevice *local = self.machine.rest.device_nosync;
-        [local setAndPersistIdentityTokenDetails:nil];
+        ARTLocalDevice *device = self.machine.rest.device_nosync;
+        [device reset];
         #endif
         [self.machine callDeactivatedCallback:nil];
         return [ARTPushActivationStateNotActivated newWithMachine:self.machine];

--- a/Spec/Tests/PushActivationStateMachineTests.swift
+++ b/Spec/Tests/PushActivationStateMachineTests.swift
@@ -869,8 +869,15 @@ class PushActivationStateMachineTests: XCTestCase {
         expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
         expect(deactivatedCallbackCalled).to(beTrue())
         expect(resetDeviceCalled).to(beTrue())
+        
         // RSH3g2a
+        expect(stateMachine.rest.device.id).to(equal(""))
+        expect(stateMachine.rest.device.secret).to(beNil())
+        expect(stateMachine.rest.device.clientId).to(beNil())
+        expect(stateMachine.rest.device.push.recipient).to(beEmpty())
         expect(stateMachine.rest.device.identityTokenDetails).to(beNil())
+        expect(stateMachine.rest.device.storage.object(forKey: ARTDeviceIdKey)).to(beNil())
+        expect(stateMachine.rest.device.storage.object(forKey: ARTDeviceIdentityTokenKey)).to(beNil())
     }
 
     // RSH3g3


### PR DESCRIPTION
This PR goes instead of #1253, because that one was addressing two different issues (not respecting [RSH3g2a](https://docs.ably.io/client-lib-development-guide/features/#RSH3g2a) and [RSH8b](https://ably.com/documentation/client-lib-development-guide/features#RSH8b)).

This addresses RSH3g2a only (Issue #1177), For RSH8b there is another issue - https://github.com/ably/ably-cocoa/issues/1256

