### PR TITLE
When setting realtime channel options, pass through to REST channel

### DIFF
--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -1235,6 +1235,7 @@ dispatch_sync(_queue, ^{
 
 - (void)setOptions_nosync:(ARTRealtimeChannelOptions *_Nullable)options callback:(nullable ARTCallback)callback {
     [self setOptions_nosync:options];
+    [self.restChannel setOptions_nosync:options];
 
     if (!options.modes && !options.params) {
         if (callback)

--- a/Spec/Test Utilities/NSObject+TestSuite.m
+++ b/Spec/Test Utilities/NSObject+TestSuite.m
@@ -17,7 +17,7 @@
     return [self aspect_hookSelector:selector withOptions:AspectPositionAfter usingBlock:^(id<AspectInfo> info) {
         __autoreleasing id arg;
         [[info originalInvocation] getArgument:&arg atIndex:2+index];
-        callback([arg copy]);
+        callback(arg);
     } error:nil];
 }
 


### PR DESCRIPTION
When calling `-[ARTRealtimeChannel setOptions:callback:]`, the passed options are not used to update the options of this instance’s REST channel. This means that, for example, if we update the realtime channel’s cipher options, these options will not be used to decrypt messages subsequently fetched using the `-history:*` methods.

I think this is something we missed when fixing #1207.

This issue is causing ably/ably-flutter#296.

Closes #1265.