### PR TITLE
Don’t build Carthage libraries for unnecessary platforms

### DIFF
--- a/.github/workflows/integration-test-iOS11.yaml
+++ b/.github/workflows/integration-test-iOS11.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           make submodules
           bundle install
-          make update_carthage_dependencies
+          make update_carthage_dependencies_ios
           bundle exec fastlane test_iOS11
 
       - name: Check Static Analyzer Output

--- a/.github/workflows/integration-test-iOS12.yaml
+++ b/.github/workflows/integration-test-iOS12.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           make submodules
           bundle install
-          make update_carthage_dependencies
+          make update_carthage_dependencies_ios
           bundle exec fastlane test_iOS12
 
       - name: Check Static Analyzer Output

--- a/.github/workflows/integration-test-macOS.yaml
+++ b/.github/workflows/integration-test-macOS.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           make submodules
           bundle install
-          make update_carthage_dependencies
+          make update_carthage_dependencies_macos
           bundle exec fastlane test_macOS
 
       - name: Check Static Analyzer Output

--- a/.github/workflows/integration-test-tvOS.yaml
+++ b/.github/workflows/integration-test-tvOS.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           make submodules
           bundle install
-          make update_carthage_dependencies
+          make update_carthage_dependencies_tvos
           bundle exec fastlane test_tvOS12
 
       - name: Check Static Analyzer Output


### PR DESCRIPTION
Hopefully will speed CI jobs up a bit. We should probably have done this as part of #1274.