### PR TITLE
Make Git ignore `derived_data` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 build/
 .build
 DerivedData
+derived_data/
 
 ## Various settings
 *.pbxuser


### PR DESCRIPTION
It's where Fastlane-triggered builds put their derived data. Handy to have this ignored when running Fastlane locally.