### PR TITLE
Fix test observability server upload on `main`

### DIFF
--- a/Scripts/local_dev_upload_test_results.sh
+++ b/Scripts/local_dev_upload_test_results.sh
@@ -14,5 +14,6 @@ export GITHUB_RUN_ATTEMPT="1"
 export GITHUB_BASE_REF="main"
 export GITHUB_HEAD_REF="my-branch"
 export GITHUB_JOB="fake-job"
+export GITHUB_REPOSITORY="ably/ably-cocoa"
 
 ./Scripts/upload_test_results.sh --upload-server-base-url "http://localhost:3000"


### PR DESCRIPTION
I forgot that `GITHUB_BASE_REF` and `GITHUB_HEAD_REF` are only set for builds triggered by pull requests.