### PR TITLE
(#1309) A first attempt at fixing test case `114e01a8-8971-4c3a-9cb7-0bb128e2749e`

### DIFF
--- a/Spec/Tests/RealtimeClientPresenceTests.swift
+++ b/Spec/Tests/RealtimeClientPresenceTests.swift
@@ -1182,9 +1182,29 @@ class RealtimeClientPresenceTests: XCTestCase {
         let channel = client.channels.get(uniqueChannelName())
 
         waitUntil(timeout: testTimeout) { done in
+            var encounteredEnterOrPresent = false
+            
+            // We don't know which type of event will reflect our `enter`-ing the channel
+            // - usually it will be an `.enter` but sometimes, if we receive a SYNC ProtocolMessage
+            // before the PRESENCE one triggered by our `enter`-ing, then we’ll get a `.present`.
+            
+            // No idea if this is an appropriate fix but let's see if it makes the test pass.
+            
             channel.presence.subscribe(.enter) { member in
                 expect(member.data).to(beNil())
-                done()
+                if (!encounteredEnterOrPresent) {
+                    print("1279: done triggered by .enter")
+                    encounteredEnterOrPresent = true
+                    done()
+                }
+            }
+            channel.presence.subscribe(.present) { member in
+                expect(member.data).to(beNil())
+                if (!encounteredEnterOrPresent) {
+                    print("1279: done triggered by .present")
+                    encounteredEnterOrPresent = true
+                    done()
+                }
             }
             channel.presence.enter(nil)
         }


### PR DESCRIPTION
Closes #1309.