### PR TITLE
Removed call to `registerForRemoteNotifications` from basic APNS example

### DIFF
--- a/Examples/AblyPush/AblyPushExample/AblyHelper.swift
+++ b/Examples/AblyPush/AblyPushExample/AblyHelper.swift
@@ -85,7 +85,6 @@ extension AblyHelper: UNUserNotificationCenterDelegate {
     static func requestUserNotificationAuthorization() {
         UNUserNotificationCenter.current().requestAuthorization(options:[.badge, .alert, .sound]) { granted, error in
             DispatchQueue.main.async() {
-                UIApplication.shared.registerForRemoteNotifications()
                 print("Push auth: \(error?.localizedDescription ?? (granted ? "Granted" : "Not Granted"))")
             }
         }


### PR DESCRIPTION
Closes #1359 