### PR TITLE
(#1309, #1331) Speculative presence fixes with extra logging in test case `1e5beffd-b21f-4281-85c9-b1b6ab02471d` (run for longer)

### DIFF
--- a/Spec/Tests/RealtimeClientPresenceTests.swift
+++ b/Spec/Tests/RealtimeClientPresenceTests.swift
@@ -2471,7 +2471,7 @@ class RealtimeClientPresenceTests: XCTestCase {
             channel1.attach { error in
                 expect(error).to(beNil())
                 let partlyDone = AblyTests.splitDone(2, done: done)
-                channel1.presence.subscribe(.enter) { member in
+                waitForFirstPresenceEnterOrPresentEvent(on: channel1) { member in
                     expect(member.data as? NSObject).to(equal(expectedData as NSObject?))
                     partlyDone()
                 }

--- a/Spec/Tests/RealtimeClientPresenceTests.swift
+++ b/Spec/Tests/RealtimeClientPresenceTests.swift
@@ -2467,15 +2467,23 @@ class RealtimeClientPresenceTests: XCTestCase {
 
         let expectedData = ["data": 123]
 
+        NSLog("1e5beffd-b21f-4281-85c9-b1b6ab02471d: before waitUntil")
         waitUntil(timeout: testTimeout) { done in
+            NSLog("1e5beffd-b21f-4281-85c9-b1b6ab02471d: before channel1.attach")
             channel1.attach { error in
+                NSLog("1e5beffd-b21f-4281-85c9-b1b6ab02471d: inside channel1.attach callback")
                 expect(error).to(beNil())
                 let partlyDone = AblyTests.splitDone(2, done: done)
+                NSLog("1e5beffd-b21f-4281-85c9-b1b6ab02471d: before waitForFirstPresenceEnterOrPresentEvent")
                 waitForFirstPresenceEnterOrPresentEvent(on: channel1) { member in
+                    NSLog("1e5beffd-b21f-4281-85c9-b1b6ab02471d: inside waitForFirstPresenceEnterOrPresentEvent callback")
+                    NSLog("1e5beffd-b21f-4281-85c9-b1b6ab02471d: type(of: member.data): \(type(of: member.data))")
                     expect(member.data as? NSObject).to(equal(expectedData as NSObject?))
                     partlyDone()
                 }
+                NSLog("1e5beffd-b21f-4281-85c9-b1b6ab02471d: before channel2.presence.enter")
                 channel2.presence.enter(expectedData) { error in
+                    NSLog("1e5beffd-b21f-4281-85c9-b1b6ab02471d: inside channel2.presence.enter callback")
                     expect(error).to(beNil())
                     partlyDone()
                 }

--- a/Spec/Tests/RealtimeClientPresenceTests.swift
+++ b/Spec/Tests/RealtimeClientPresenceTests.swift
@@ -1182,9 +1182,29 @@ class RealtimeClientPresenceTests: XCTestCase {
         let channel = client.channels.get(uniqueChannelName())
 
         waitUntil(timeout: testTimeout) { done in
+            var encounteredEnterOrPresent = false
+            
+            // We don't know which type of event will reflect our `enter`-ing the channel
+            // - usually it will be an `.enter` but sometimes, if we receive a SYNC ProtocolMessage
+            // before the PRESENCE one triggered by our `enter`-ing, then we’ll get a `.present`.
+            
+            // No idea if this is an appropriate fix but let's see if it makes the test pass.
+            
             channel.presence.subscribe(.enter) { member in
                 expect(member.data).to(beNil())
-                done()
+                if (!encounteredEnterOrPresent) {
+                    print("1279: done triggered by .enter")
+                    encounteredEnterOrPresent = true
+                    done()
+                }
+            }
+            channel.presence.subscribe(.present) { member in
+                expect(member.data).to(beNil())
+                if (!encounteredEnterOrPresent) {
+                    print("1279: done triggered by .present")
+                    encounteredEnterOrPresent = true
+                    done()
+                }
             }
             channel.presence.enter(nil)
         }

--- a/Spec/Tests/RealtimeClientPresenceTests.swift
+++ b/Spec/Tests/RealtimeClientPresenceTests.swift
@@ -2451,7 +2451,7 @@ class RealtimeClientPresenceTests: XCTestCase {
 
     // RTP8e
     func test__078__Presence__enter__optional_data_can_be_included_when_entering_a_channel() {
-        let options = AblyTests.commonAppSetup()
+        let options = AblyTests.commonAppSetup(true)
 
         options.clientId = "john"
         let client1 = ARTRealtime(options: options)

--- a/Spec/Tests/RealtimeClientPresenceTests.swift
+++ b/Spec/Tests/RealtimeClientPresenceTests.swift
@@ -2477,7 +2477,7 @@ class RealtimeClientPresenceTests: XCTestCase {
                 NSLog("1e5beffd-b21f-4281-85c9-b1b6ab02471d: before waitForFirstPresenceEnterOrPresentEvent")
                 waitForFirstPresenceEnterOrPresentEvent(on: channel1) { member in
                     NSLog("1e5beffd-b21f-4281-85c9-b1b6ab02471d: inside waitForFirstPresenceEnterOrPresentEvent callback")
-                    NSLog("1e5beffd-b21f-4281-85c9-b1b6ab02471d: type(of: member.data): \(type(of: member.data))")
+                    NSLog("1e5beffd-b21f-4281-85c9-b1b6ab02471d: type(of: member.data!): \(type(of: member.data!))")
                     expect(member.data as? NSObject).to(equal(expectedData as NSObject?))
                     partlyDone()
                 }


### PR DESCRIPTION
A longer-running version of #1353.