### PR TITLE
(#1279) Upload crash reports to test observability server

### DIFF
--- a/.github/workflows/integration-test-iOS14_4.yaml
+++ b/.github/workflows/integration-test-iOS14_4.yaml
@@ -20,7 +20,27 @@ jobs:
       ABLY_ENV: sandbox
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out SDK repo
+        uses: actions/checkout@v2
+
+      - name: Check out xcparse repo
+        uses: actions/checkout@v3
+        with:
+          repository: ably-forks/xcparse
+          ref: emit-test-case-info
+          path: xcparse
+
+      - id: get-xcparse-commit-sha
+        name: Get xcparse commit SHA
+        run: |
+          cd xcparse
+          echo "::set-output name=sha::$(git rev-parse HEAD)"
+
+      - name: "actions/cache@v3 (xcparse binary)"
+        uses: actions/cache@v3
+        with:
+          path: xcparse/.build/debug/xcparse
+          key: ${{ runner.os }}-xcparse-${{ steps.get-xcparse-commit-sha.outputs.sha }}
 
       - name: Reset Simulators
         run: xcrun simctl erase all

--- a/.github/workflows/integration-test-macOS10_15.yaml
+++ b/.github/workflows/integration-test-macOS10_15.yaml
@@ -20,7 +20,27 @@ jobs:
       ABLY_ENV: sandbox
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out SDK repo
+        uses: actions/checkout@v2
+
+      - name: Check out xcparse repo
+        uses: actions/checkout@v3
+        with:
+          repository: ably-forks/xcparse
+          ref: emit-test-case-info
+          path: xcparse
+
+      - id: get-xcparse-commit-sha
+        name: Get xcparse commit SHA
+        run: |
+          cd xcparse
+          echo "::set-output name=sha::$(git rev-parse HEAD)"
+
+      - name: "actions/cache@v3 (xcparse binary)"
+        uses: actions/cache@v3
+        with:
+          path: xcparse/.build/debug/xcparse
+          key: ${{ runner.os }}-xcparse-${{ steps.get-xcparse-commit-sha.outputs.sha }}
 
       - name: Reset Simulators
         run: xcrun simctl erase all

--- a/.github/workflows/integration-test-tvOS14_3.yaml
+++ b/.github/workflows/integration-test-tvOS14_3.yaml
@@ -20,7 +20,27 @@ jobs:
       ABLY_ENV: sandbox
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out SDK repo
+        uses: actions/checkout@v2
+
+      - name: Check out xcparse repo
+        uses: actions/checkout@v3
+        with:
+          repository: ably-forks/xcparse
+          ref: emit-test-case-info
+          path: xcparse
+
+      - id: get-xcparse-commit-sha
+        name: Get xcparse commit SHA
+        run: |
+          cd xcparse
+          echo "::set-output name=sha::$(git rev-parse HEAD)"
+
+      - name: "actions/cache@v3 (xcparse binary)"
+        uses: actions/cache@v3
+        with:
+          path: xcparse/.build/debug/xcparse
+          key: ${{ runner.os }}-xcparse-${{ steps.get-xcparse-commit-sha.outputs.sha }}
 
       - name: Reset Simulators
         run: xcrun simctl erase all

--- a/fastlane/Scanfile
+++ b/fastlane/Scanfile
@@ -5,3 +5,4 @@ ensure_devices_found true
 output_types "junit"
 # I'm being explicit about this because I want to make sure it's being used, to make sure that trainer is used to generate the JUnit report
 xcodebuild_formatter "xcbeautify"
+result_bundle true


### PR DESCRIPTION
## What does this do?

After the tests have run in CI, it uses (our fork of) the `xcparse` tool to extract any crash reports from the `.xcresult` bundle generated by Xcode, and it uploads these to the test observability server.

## Why are we doing this?

So that we can find out the reason why a test has crashed (see commit messages for more details).

## Example

Here's an example of a failure with a crash report attached: https://test-observability.herokuapp.com/repos/ably/ably-cocoa/uploads/c31a9238-5b46-4799-ae1a-1d4c50a3cb53