### PR TITLE
Premature disconnect to test reconnect within 10 seconds

### DIFF
--- a/Spec/Tests/RealtimeClientConnectionTests.swift
+++ b/Spec/Tests/RealtimeClientConnectionTests.swift
@@ -2483,15 +2483,13 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__064__Connection__connection_failures_once_CONNECTED__if_a_Connection_transport_is_disconnected_unexpectedly_or_if_a_token_expires__then_the_Connection_manager_will_immediately_attempt_to_reconnect() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
-        let ttl = 3.0
-        options.tokenDetails = getTestTokenDetails(ttl: ttl)
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { _ in
-                // if realtime didn't disconnect after ttl, fire onDisconnected manually a second later
-                delay(ttl + 1.0) {
+                // Simulate interruption shortly
+                delay(1.0) {
                     client.internal.onDisconnected()
                 }
             }

--- a/Spec/Tests/RealtimeClientConnectionTests.swift
+++ b/Spec/Tests/RealtimeClientConnectionTests.swift
@@ -2483,11 +2483,18 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__064__Connection__connection_failures_once_CONNECTED__if_a_Connection_transport_is_disconnected_unexpectedly_or_if_a_token_expires__then_the_Connection_manager_will_immediately_attempt_to_reconnect() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
-        options.tokenDetails = getTestTokenDetails(ttl: 3.0)
+        let ttl = 3.0
+        options.tokenDetails = getTestTokenDetails(ttl: ttl)
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in
+            client.connection.once(.connected) { _ in
+                // if realtime didn't disconnect after ttl, fire onDisconnected manually a second later
+                delay(ttl + 1.0) {
+                    client.internal.onDisconnected()
+                }
+            }
             client.connection.on(.disconnected) { _ in
                 let disconnectedTime = Date()
                 client.connection.on(.connected) { _ in


### PR DESCRIPTION
Most failures for this test are related to the test timeout. One of the causes is disconnect message failed to be received in time. To eliminate this and simulate sudden `.disconnected` event I've added manual disconnection. This change will not help in case of timeout for `connected` event.