### PR TITLE
(#1309, #1321, #1331) Fixes for 3 presence tests

### DIFF
--- a/Spec/Tests/RealtimeClientPresenceTests.swift
+++ b/Spec/Tests/RealtimeClientPresenceTests.swift
@@ -535,11 +535,16 @@ class RealtimeClientPresenceTests: XCTestCase {
     func test__015__Presence__subscribe__with_no_arguments_should_subscribe_a_listener_to_all_presence_messages() {
         let options = AblyTests.commonAppSetup()
 
-        let client1 = ARTRealtime(options: options)
+        let client1 = AblyTests.newRealtime(options)
         defer { client1.close() }
         
         let channelName = uniqueChannelName()
         let channel1 = client1.channels.get(channelName)
+        // We want to make sure that the ENTER presence action that we publish
+        // gets sent by Realtime as a PRESENCE protocol message, and not in the
+        // channel’s initial post-attach SYNC. So, we wait for any initial SYNC
+        // to complete before publishing any presence actions.
+        attachAndWaitForInitialPresenceSyncToComplete(client: client1, channel: channel1)
 
         let client2 = ARTRealtime(options: options)
         defer { client2.close() }


### PR DESCRIPTION
## What does this do?

Fixes the tests described in 

- #1309
- #1321 
- #1331

See commit messages for more details.

## Why do I think it's fixed them?

Here's the evidence I have that makes me suspect they're now fixed.

- [These results](https://test-observability.herokuapp.com/repos/ably/ably-cocoa/uploads?branches%5B%5D=1309-new-speculative-fix-to-test-case-114e01a8-8971-4c3a-9cb7-0bb128e2749e&createdBefore=&createdAfter=&failureMessage=) just contain the fix for #1309. 82 uploads, no failures in that test.

- [These results](https://test-observability.herokuapp.com/repos/ably/ably-cocoa/uploads?branches%5B%5D=1309-new-speculative-fix-for-test-case-84c9fbc5-8882-4010-ba99-3e44d1793397&createdBefore=&createdAfter=&failureMessage=) just contain the fix for #1321. 74 test runs, no failures in that test.

- [These results](https://test-observability.herokuapp.com/repos/ably/ably-cocoa/uploads?branches%5B%5D=1331-new-speculative-fix-for-test-case-1e5beffd-b21f-4281-85c9-b1b6ab02471d&createdBefore=&createdAfter=&failureMessage=) just contain the fix for #1331. 63 test runs, no failures in that test.

- [These results](https://test-observability.herokuapp.com/repos/ably/ably-cocoa/uploads?branches%5B%5D=1309-1321-1331-presence-test-fixes-run-long&branches%5B%5D=1333-speculative-fix-for-test-case-ac44f09c-f521-4bfc-a3d7-58d4f7428c74&createdBefore=2022-05-05T12%3A24%3A00Z&createdAfter=&failureMessage=) contain all of the fixes from this branch. 318 test runs. Only one of these tests failed, just the once, [and that was due to an SSL handshake error](https://test-observability.herokuapp.com/repos/ably/ably-cocoa/test_cases/114e01a8-8971-4c3a-9cb7-0bb128e2749e?branches%5B%5D=1309-1321-1331-presence-test-fixes-run-long&branches%5B%5D=1333-speculative-fix-for-test-case-ac44f09c-f521-4bfc-a3d7-58d4f7428c74&createdBefore=2022-05-05T12%3A24%3A00.000Z).