### PR TITLE
(#1322) Fix crashes in test case `PushTests.test__008__LocalDevice__has_a_device_method_that_returns_a_LocalDevice` (`4f837671-6233-41f1-94e8-01174d1da7b8`)

### DIFF
--- a/Source/ARTDeviceStorage.h
+++ b/Source/ARTDeviceStorage.h
@@ -3,6 +3,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// Instances of ARTDeviceStorage should expect to have their methods called
+// from any thread.
 @protocol ARTDeviceStorage <NSObject>
 - (nullable id)objectForKey:(NSString *)key;
 - (void)setObject:(nullable id)value forKey:(NSString *)key;

--- a/Source/ARTRest+Private.h
+++ b/Source/ARTRest+Private.h
@@ -64,6 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSObject<ARTCancellable> *)internetIsUp:(void (^)(BOOL isUp))cb;
 
 #if TARGET_OS_IOS
+// This is only intended to be called from test code.
 - (void)resetDeviceSingleton;
 #endif
 

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -724,10 +724,28 @@ dispatch_async(_queue, ^{
     return ret;
 }
 
-// Store address of once_token to access it in debug function.
-static dispatch_once_t *device_once_token;
-
 - (ARTLocalDevice *)device_nosync {
+    __block ARTLocalDevice *ret;
+    dispatch_sync(ARTRestInternal.deviceAccessQueue, ^{
+        ret = [self deviceWithClientId_onlyCallOnDeviceAccessQueue:self.auth.clientId_nosync];
+    });
+    return ret;
+}
+
++ (dispatch_queue_t)deviceAccessQueue {
+    static dispatch_queue_t queue;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        queue = dispatch_queue_create("io.ably.deviceAccess", DISPATCH_QUEUE_SERIAL);
+    });
+    
+    return queue;
+}
+
+static BOOL sharedDeviceNeedsLoading_onlyAccessOnDeviceAccessQueue = YES;
+
+- (ARTLocalDevice *)deviceWithClientId_onlyCallOnDeviceAccessQueue:(NSString *)clientId {
     // The device is shared in a static variable because it's a reflection
     // of what's persisted. Having a device instance per ARTRest instance
     // could leave some instances in a stale state, if, through another
@@ -736,17 +754,18 @@ static dispatch_once_t *device_once_token;
     // As a side effect, the first instance "wins" at setting the device's
     // client ID.
 
-    static dispatch_once_t once;
-    device_once_token = &once;
     static id device;
-    dispatch_once(&once, ^{
-        device = [ARTLocalDevice load:self.auth.clientId_nosync storage:self.storage];
-    });
+    if (sharedDeviceNeedsLoading_onlyAccessOnDeviceAccessQueue) {
+        device = [ARTLocalDevice load:clientId storage:self.storage];
+        sharedDeviceNeedsLoading_onlyAccessOnDeviceAccessQueue = NO;
+    }
     return device;
 }
 
 - (void)resetDeviceSingleton {
-    if (device_once_token) *device_once_token = 0;
+    dispatch_sync([ARTRestInternal deviceAccessQueue], ^{
+        sharedDeviceNeedsLoading_onlyAccessOnDeviceAccessQueue = YES;
+    });
 }
 #endif
 


### PR DESCRIPTION
## What does this do?

Introduces various concurrency-related fixes related to the local device. Together, I believe these fix various crashes that we've observed in the test mentioned in the title (#1322). See commit messages for more details.

## How do I know it's fixed the test?

[These](https://test-observability.herokuapp.com/repos/ably/ably-cocoa/uploads/compare?alternative-branches%5B%5D=1322-fix-test-case-4f837671-6233-41f1-94e8-01174d1da7b8-take-3-run-longer&alternative-createdBefore=&alternative-createdAfter=&alternative-failureMessage=) are the results of the tests running continuously with these fixes applied. At time of writing, there are 97 test runs with no failures in this test, but I'll keep it running for a while more before merging.