### PR TITLE
(#1395) Fix failures in test case `RealtimeClientPresenceTests.test__111__Presence__get__Query__set_of_params___waitForSync_is_false__should_return_immediately_the_known_set_of_presence_members` (`ee46a8e6-e4ed-489c-83c7-648774930f92`)

### DIFF
--- a/Spec/Test Utilities/TestUtilities.swift
+++ b/Spec/Test Utilities/TestUtilities.swift
@@ -1166,12 +1166,12 @@ class TestProxyTransport: ARTWebSocketTransport {
         }
     }
 
-    /// The modifier will be used in the internal queue.
+    /// The modifier will be called on the internal queue.
     func setBeforeIncomingMessageModifier(_ callback: ((ARTProtocolMessage) -> ARTProtocolMessage)?) {
         self.callbackBeforeIncomingMessageModifier = callback
     }
 
-    /// The modifier will be used in the internal queue.
+    /// The modifier will be called on the internal queue.
     func setAfterIncomingMessageModifier(_ callback: ((ARTProtocolMessage) -> ARTProtocolMessage)?) {
         self.callbackAfterIncomingMessageModifier = callback
     }

--- a/Spec/Test Utilities/TestUtilities.swift
+++ b/Spec/Test Utilities/TestUtilities.swift
@@ -1145,8 +1145,8 @@ class TestProxyTransport: ARTWebSocketTransport {
     private var callbackBeforeProcessingIncomingMessage: ((ARTProtocolMessage) -> Void)?
     private var callbackAfterProcessingIncomingMessage: ((ARTProtocolMessage) -> Void)?
     private var callbackBeforeProcessingOutgoingMessage: ((ARTProtocolMessage) -> Void)?
-    private var callbackBeforeIncomingMessageModifier: ((ARTProtocolMessage) -> ARTProtocolMessage)?
-    private var callbackAfterIncomingMessageModifier: ((ARTProtocolMessage) -> ARTProtocolMessage)?
+    private var callbackBeforeIncomingMessageModifier: ((ARTProtocolMessage) -> ARTProtocolMessage?)?
+    private var callbackAfterIncomingMessageModifier: ((ARTProtocolMessage) -> ARTProtocolMessage?)?
 
     func setListenerBeforeProcessingIncomingMessage(_ callback: ((ARTProtocolMessage) -> Void)?) {
         queue.sync {
@@ -1167,12 +1167,16 @@ class TestProxyTransport: ARTWebSocketTransport {
     }
 
     /// The modifier will be called on the internal queue.
-    func setBeforeIncomingMessageModifier(_ callback: ((ARTProtocolMessage) -> ARTProtocolMessage)?) {
+    ///
+    /// If `callback` returns nil, the message will be ignored.
+    func setBeforeIncomingMessageModifier(_ callback: ((ARTProtocolMessage) -> ARTProtocolMessage?)?) {
         self.callbackBeforeIncomingMessageModifier = callback
     }
 
     /// The modifier will be called on the internal queue.
-    func setAfterIncomingMessageModifier(_ callback: ((ARTProtocolMessage) -> ARTProtocolMessage)?) {
+    ///
+    /// If `callback` returns nil, the message will be ignored.
+    func setAfterIncomingMessageModifier(_ callback: ((ARTProtocolMessage) -> ARTProtocolMessage?)?) {
         self.callbackAfterIncomingMessageModifier = callback
     }
 
@@ -1304,11 +1308,17 @@ class TestProxyTransport: ARTWebSocketTransport {
         }
         var msg = original
         if let performEvent = callbackBeforeIncomingMessageModifier {
-            msg = performEvent(original)
+            guard let modifiedMsg = performEvent(msg) else {
+                return
+            }
+            msg = modifiedMsg
         }
         super.receive(msg)
         if let performEvent = callbackAfterIncomingMessageModifier {
-            msg = performEvent(msg)
+            guard let modifiedMsg = performEvent(msg) else {
+                return
+            }
+            msg = modifiedMsg
         }
         if let performEvent = callbackAfterProcessingIncomingMessage {
             DispatchQueue.main.async {

--- a/Spec/Tests/RealtimeClientPresenceTests.swift
+++ b/Spec/Tests/RealtimeClientPresenceTests.swift
@@ -3483,12 +3483,17 @@ class RealtimeClientPresenceTests: XCTestCase {
             channel.attach { error in
                 expect(error).to(beNil())
                 let transport = client.internal.transport as! TestProxyTransport
-                transport.setListenerBeforeProcessingIncomingMessage { message in
+                var alreadySawSync = false
+                transport.setBeforeIncomingMessageModifier { message in
                     if message.action == .sync {
                         // Ignore next SYNC so that the sync process never finishes.
-                        transport.actionsIgnored += [.sync]
+                        if alreadySawSync {
+                            return nil
+                        }
+                        alreadySawSync = true
                         done()
                     }
+                    return message
                 }
             }
         }

--- a/Spec/Tests/RealtimeClientPresenceTests.swift
+++ b/Spec/Tests/RealtimeClientPresenceTests.swift
@@ -3480,21 +3480,25 @@ class RealtimeClientPresenceTests: XCTestCase {
         query.waitForSync = false
 
         waitUntil(timeout: testTimeout) { done in
+            let partialDone = AblyTests.splitDone(2, done: done)
+            
+            let transport = client.internal.transport as! TestProxyTransport
+            var alreadySawSync = false
+            transport.setBeforeIncomingMessageModifier { message in
+                if message.action == .sync {
+                    // Ignore next SYNC so that the sync process never finishes.
+                    if alreadySawSync {
+                        return nil
+                    }
+                    alreadySawSync = true
+                    partialDone()
+                }
+                return message
+            }
+
             channel.attach { error in
                 expect(error).to(beNil())
-                let transport = client.internal.transport as! TestProxyTransport
-                var alreadySawSync = false
-                transport.setBeforeIncomingMessageModifier { message in
-                    if message.action == .sync {
-                        // Ignore next SYNC so that the sync process never finishes.
-                        if alreadySawSync {
-                            return nil
-                        }
-                        alreadySawSync = true
-                        done()
-                    }
-                    return message
-                }
+                partialDone()
             }
         }
 


### PR DESCRIPTION
## What does this do?

Fixes an intermittent failure in the test mentioned in the title. See commit messages for more details.

## How do I know it's fixed the test?

[These](https://test-observability.herokuapp.com/repos/ably/ably-cocoa/uploads?branches%5B%5D=1395-speculative-fix-for-test-case-ee46a8e6-e4ed-489c-83c7-648774930f92&createdBefore=&createdAfter=&failureMessage=) are the results of the tests running continuously with these fixes applied. There are 756 test runs with no failures in this test.