### PR TITLE
Fix mistake in my recent PR #1332

### DIFF
--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -725,9 +725,10 @@ dispatch_async(_queue, ^{
 }
 
 - (ARTLocalDevice *)device_nosync {
+    NSString *clientId = self.auth.clientId_nosync;
     __block ARTLocalDevice *ret;
     dispatch_sync(ARTRestInternal.deviceAccessQueue, ^{
-        ret = [self deviceWithClientId_onlyCallOnDeviceAccessQueue:self.auth.clientId_nosync];
+        ret = [self deviceWithClientId_onlyCallOnDeviceAccessQueue:clientId];
     });
     return ret;
 }


### PR DESCRIPTION
This slipped past me and code review. I knew that `clientId_nosync` needed to be called on the same thread as its containing method (I even mentioned it in code review) and yet I didn’t actually do it 🤦.