### PR TITLE
Fix symlink command on contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ In order to make available new public APIs to the Carthage users you must put th
 You should generate symlinks from the command line - in Terminal `cd` to the symlinks folder and type:
 
 ```
-ln -s HeaderName.h ../../../Source/HeaderName.h
+ln -s ../../../Source/HeaderName.h HeaderName.h
 ```
 
 *NOTE:*


### PR DESCRIPTION
Symlink command arguments seems to be reversed.
According to [this website](https://www.howtogeek.com/297721/how-to-create-and-use-symbolic-links-aka-symlinks-on-a-mac/) 
The command should be 

`ln -s /path/to/original /path/to/link
`