### PR TITLE
`ARTCipherParams` and `ARTCrypto` doc comments

### DIFF
--- a/Source/ARTCrypto.h
+++ b/Source/ARTCrypto.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// The length of the key in bits; for example 128 or 256.
 @property (readonly, nonatomic) NSUInteger keyLength;
 
-/// The cipher mode. Only "CBC" is supported.
+/// The cipher mode. Only CBC is supported.
 @property (readonly, getter=getMode) NSString *mode;
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;

--- a/Source/ARTCrypto.h
+++ b/Source/ARTCrypto.h
@@ -66,13 +66,13 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Generates a random key to be used in the encryption of the channel.
  @param keyLength The length of the key, in bits, to be generated.
- @return `NSData` The key as a binary data.
+ @return The key as a binary data.
  */
 + (NSData *)generateRandomKey:(NSUInteger)keyLength;
 
 /**
  Same as `+generateRandomKey:`, but with the default key length of the default algorithm: for AES this is 256 bits.
- @return `NSData` The key as a binary data.
+ @return The key as a binary data.
  */
 + (NSData *)generateRandomKey;
 

--- a/Source/ARTCrypto.h
+++ b/Source/ARTCrypto.h
@@ -61,14 +61,14 @@ NS_ASSUME_NONNULL_BEGIN
  @param params Overrides the default parameters. A suitable key must be provided as a minimum.
  @return `ARTCipherParams` A ARTCipherParams object, using the default values for any field not supplied.
  */
-+ (ARTCipherParams *)getDefaultParams:(NSDictionary *)values;
++ (ARTCipherParams *)getDefaultParams:(NSDictionary *)params;
 
 /**
  Generates a random key to be used in the encryption of the channel.
  @param keyLength The length of the key, in bits, to be generated. If not specified, this is equal to the default keyLength of the default algorithm: for AES this is 256 bits.
  @return `NSData` The key as a binary data.
  */
-+ (NSData *)generateRandomKey:(NSUInteger)length;
++ (NSData *)generateRandomKey:(NSUInteger)keyLength;
 
 /**
  Same as `+getDefaultParams:`, but with the default algorithm and key length: AES, 256 bits.

--- a/Source/ARTCrypto.h
+++ b/Source/ARTCrypto.h
@@ -28,13 +28,20 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 /**
- ARTCipherParams contains configuration options for a channel cipher, including algorithm, mode, key length and key.
- Ably client libraries currently support AES with CBC, PKCS#7 with a default key length of 256 bits. All implementations also support AES128.
+ The ARTCipherParams object contains properties to configure encryption for a channel.
  */
 @interface ARTCipherParams : NSObject <ARTCipherParamsCompatible>
+
+/// The algorithm to use for encryption. Only AES is supported.
 @property (readonly, strong, nonatomic) NSString *algorithm;
+
+/// The private key used to encrypt and decrypt payloads.
 @property (readonly, strong, nonatomic) NSData *key;
+
+/// The length of the key in bits; for example 128 or 256.
 @property (readonly, nonatomic) NSUInteger keyLength;
+
+/// The cipher mode. Only "CBC" is supported.
 @property (readonly, getter=getMode) NSString *mode;
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;

--- a/Source/ARTCrypto.h
+++ b/Source/ARTCrypto.h
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Retrieves, or optionally sets, the `ARTCipherParams` for the channel.
  @param params Overrides the default parameters. A suitable key must be provided as a minimum.
- @return `ARTCipherParams` A ARTCipherParams object, using the default values for any field not supplied.
+ @return An `ARTCipherParams` object, using the default values for any field not supplied.
  */
 + (ARTCipherParams *)getDefaultParams:(NSDictionary *)params;
 

--- a/Source/ARTCrypto.h
+++ b/Source/ARTCrypto.h
@@ -51,11 +51,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+/**
+ The ARTCrypto object ensures that message payloads are encrypted, can never be decrypted by Ably, and can only be decrypted by other clients that share the same secret symmetric key.
+ */
 @interface ARTCrypto : NSObject
 
+/**
+ Retrieves, or optionally sets, the `ARTCipherParams` for the channel.
+ @param params Overrides the default parameters. A suitable key must be provided as a minimum.
+ @return `ARTCipherParams` A ARTCipherParams object, using the default values for any field not supplied.
+ */
 + (ARTCipherParams *)getDefaultParams:(NSDictionary *)values;
-+ (NSData *)generateRandomKey;
+
+/**
+ Generates a random key to be used in the encryption of the channel.
+ @param keyLength The length of the key, in bits, to be generated. If not specified, this is equal to the default keyLength of the default algorithm: for AES this is 256 bits.
+ @return `NSData` The key as a binary data.
+ */
 + (NSData *)generateRandomKey:(NSUInteger)length;
+
+/**
+ Same as `+getDefaultParams:`, but with the default algorithm and key length: AES, 256 bits.
+ @return `NSData` The key as a binary data.
+ */
++ (NSData *)generateRandomKey;
 
 @end
 

--- a/Source/ARTCrypto.h
+++ b/Source/ARTCrypto.h
@@ -65,13 +65,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Generates a random key to be used in the encryption of the channel.
- @param keyLength The length of the key, in bits, to be generated. If not specified, this is equal to the default keyLength of the default algorithm: for AES this is 256 bits.
+ @param keyLength The length of the key, in bits, to be generated.
  @return `NSData` The key as a binary data.
  */
 + (NSData *)generateRandomKey:(NSUInteger)keyLength;
 
 /**
- Same as `+getDefaultParams:`, but with the default algorithm and key length: AES, 256 bits.
+ Same as `+generateRandomKey:`, but with the default key length of the default algorithm: for AES this is 256 bits.
  @return `NSData` The key as a binary data.
  */
 + (NSData *)generateRandomKey;

--- a/Source/ARTCrypto.h
+++ b/Source/ARTCrypto.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface ARTCipherParams : NSObject <ARTCipherParamsCompatible>
 
-/// The algorithm to use for encryption. Only AES is supported.
+/// The algorithm to use for encryption. Only `AES` is supported.
 @property (readonly, strong, nonatomic) NSString *algorithm;
 
 /// The private key used to encrypt and decrypt payloads.
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// The length of the key in bits; for example 128 or 256.
 @property (readonly, nonatomic) NSUInteger keyLength;
 
-/// The cipher mode. Only CBC is supported.
+/// The cipher mode. Only `CBC` is supported.
 @property (readonly, getter=getMode) NSString *mode;
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;


### PR DESCRIPTION
Added docstrings according to https://github.com/ably/canonical-api-reference-prototyping/pull/8

Was checked for compatibility with `jazzy`.