### PR TITLE
A `notification` isn't a valid extras field

### DIFF
--- a/Spec/Tests/RestClientChannelTests.swift
+++ b/Spec/Tests/RestClientChannelTests.swift
@@ -508,11 +508,11 @@ class RestClientChannelTests: XCTestCase {
         options.channelNamePrefix = nil
         let client = ARTRest(options: options)
         let channel = client.channels.get(uniqueChannelName(prefix: "pushenabled:test"))
-        let extras = ["notification": ["title": "Hello from Ably!"]] as ARTJsonCompatible
+        let extras = ["push": ["notification": ["title": "Hello from Ably!"]]] as ARTJsonCompatible
 
         expect((client.internal.encoders["application/json"] as! ARTJsonLikeEncoder).message(from: [
             "data": "foo",
-            "extras": ["notification": ["title": "Hello from Ably!"]],
+            "extras": ["push": ["notification": ["title": "Hello from Ably!"]]],
         ])?.extras == extras).to(beTrue())
 
         waitUntil(timeout: testTimeout) { done in


### PR DESCRIPTION
It should be within a `push` object.

Closes #1448 