### PR TITLE
(#1406) Fix and re-enable `UtilitiesTests.test__012`

### DIFF
--- a/Spec/Tests/UtilitiesTests.swift
+++ b/Spec/Tests/UtilitiesTests.swift
@@ -309,14 +309,14 @@ class UtilitiesTests: XCTestCase {
         expect(receivedAll).to(equal(222))
     }
 
-    func skipped__test__012__Utilities__EventEmitter__calling_off_with_a_single_listener_argument__should_remove_the_timeout() {
+    func test__012__Utilities__EventEmitter__calling_off_with_a_single_listener_argument__should_remove_the_timeout() {
         beforeEach__Utilities__EventEmitter()
 
         listenerFoo1!.setTimer(0.1, onTimeout: {
             fail("onTimeout callback shouldn't have been called")
         }).startTimer()
         eventEmitter.off(listenerFoo1!)
-        waitUntil(timeout: DispatchTimeInterval.milliseconds(300)) { done in
+        waitUntil(timeout: testTimeout) { done in
             AblyTests.queue.asyncAfter(deadline: DispatchTime.now() + 0.3) {
                 done()
             }


### PR DESCRIPTION
This fixes the failure “Waited more than 0.3 seconds” in the waitUntil, which I reproduced by running the test once locally.

The waitUntil timeout needs to be higher than the asyncAfter wait, at least by a few milliseconds. So let’s just use the normal test timeout value.

Relates to #1406.