### PR TITLE
(#1406) Fix and re-enable `RealtimeClientConnectionTests.test__081`

### DIFF
--- a/Spec/Tests/RealtimeClientConnectionTests.swift
+++ b/Spec/Tests/RealtimeClientConnectionTests.swift
@@ -3185,9 +3185,8 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
     }
 
-    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
     // RTN16b
-    func skipped__test__081__Connection__Connection_recovery__Connection_recoveryKey_should_be_composed_with_the_connection_key_and_latest_serial_received_and_msgSerial() {
+    func test__081__Connection__Connection_recovery__Connection_recoveryKey_should_be_composed_with_the_connection_key_and_latest_serial_received_and_msgSerial() {
         let options = AblyTests.commonAppSetup()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
@@ -3198,16 +3197,19 @@ class RealtimeClientConnectionTests: XCTestCase {
                 expect(client.connection.serial).to(equal(-1))
                 expect(client.connection.recoveryKey).to(equal("\(client.connection.key!):\(client.connection.serial):\(client.internal.msgSerial)"))
             }
-            channel.publish(nil, data: "message") { error in
+            channel.subscribe(attachCallback: { error in
                 expect(error).to(beNil())
-                partialDone()
-            }
-            channel.subscribe { message in
+                
+                channel.publish(nil, data: "message") { error in
+                    expect(error).to(beNil())
+                    partialDone()
+                }
+            }, callback: { message in
                 expect(message.data as? String).to(equal("message"))
                 expect(client.connection.serial).to(equal(0))
                 channel.unsubscribe()
                 partialDone()
-            }
+            })
         }
         expect(client.internal.msgSerial) == 1
         expect(client.connection.recoveryKey).to(equal("\(client.connection.key!):\(client.connection.serial):\(client.internal.msgSerial)"))

--- a/Spec/Tests/RealtimeClientConnectionTests.swift
+++ b/Spec/Tests/RealtimeClientConnectionTests.swift
@@ -3192,10 +3192,11 @@ class RealtimeClientConnectionTests: XCTestCase {
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
         waitUntil(timeout: testTimeout) { done in
-            let partialDone = AblyTests.splitDone(2, done: done)
+            let partialDone = AblyTests.splitDone(3, done: done)
             client.connection.once(.connected) { _ in
                 expect(client.connection.serial).to(equal(-1))
                 expect(client.connection.recoveryKey).to(equal("\(client.connection.key!):\(client.connection.serial):\(client.internal.msgSerial)"))
+                partialDone()
             }
             channel.subscribe(attachCallback: { error in
                 expect(error).to(beNil())


### PR DESCRIPTION
Fixes an intermittent failure. See commit messages for more details.