### PR TITLE
Temp fix for a crash faced by client using proxy connection

### DIFF
--- a/SocketRocket/SocketRocket/ARTSRWebSocket.m
+++ b/SocketRocket/SocketRocket/ARTSRWebSocket.m
@@ -362,9 +362,9 @@ NSString *const ARTSRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
     }
     // Schedule to run on a work queue, to make sure we don't run this inline and deallocate `self` inside `ARTSRProxyConnect`.
     // TODO: (nlutsenko) Find a better structure for this, maybe Bolts Tasks?
-    dispatch_async(_workQueue, ^{
-        self->_proxyConnect = nil;
-    });
+//    dispatch_async(_workQueue, ^{
+//        self->_proxyConnect = nil;
+//    });
 }
 
 - (BOOL)_checkHandshake:(CFHTTPMessageRef)httpMessage;


### PR DESCRIPTION
Probably closes https://github.com/ably/ably-cocoa/issues/1437

Explanation:
`ARTSRProxyConnect` object can potentially generate a proxy connection error even after initial success (or more than one error in a raw), which can depend on what proxy type is used, which will create a race condition: `self->_proxyConnect = nil;` deallocates `ARTSRProxyConnect` object on a `_workQueue`, and a subsequent call to `_failWithError:`  on a `io.ably.socketrocket.NetworkThread` inside `ARTSRProxyConnect` will cause crash when it'll try to access `self`.