### PR TITLE
Lock to using Xcode 13.4.1 in all CI jobs

### DIFF
--- a/.github/workflows/check-pod.yaml
+++ b/.github/workflows/check-pod.yaml
@@ -12,6 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Select Specific Xcode Version (13.4.1)
+        run: |
+          sudo xcode-select -s /Applications/Xcode_13.4.1.app
+          echo "Selected Xcode version:"
+          xcodebuild -version
+
       # Run the steps we document in the Release Process.
       # unzip commands included as proof-of-life for the Carthage output.
       - name: Print Ruby version

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Select Specific Xcode Version
+      - name: Select Specific Xcode Version (13.4.1)
         run: |
-          sudo xcode-select -s /Applications/Xcode_13.2.app
+          sudo xcode-select -s /Applications/Xcode_13.4.1.app
           echo "Selected Xcode version:"
           xcodebuild -version
 

--- a/.github/workflows/integration-test-iOS14_4.yaml
+++ b/.github/workflows/integration-test-iOS14_4.yaml
@@ -23,6 +23,12 @@ jobs:
       - name: Check out SDK repo
         uses: actions/checkout@v2
 
+      - name: Select Specific Xcode Version (13.4.1)
+        run: |
+          sudo xcode-select -s /Applications/Xcode_13.4.1.app
+          echo "Selected Xcode version:"
+          xcodebuild -version
+
       - name: Check out xcparse repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/integration-test-macOS10_15.yaml
+++ b/.github/workflows/integration-test-macOS10_15.yaml
@@ -23,6 +23,12 @@ jobs:
       - name: Check out SDK repo
         uses: actions/checkout@v2
 
+      - name: Select Specific Xcode Version (13.4.1)
+        run: |
+          sudo xcode-select -s /Applications/Xcode_13.4.1.app
+          echo "Selected Xcode version:"
+          xcodebuild -version
+
       - name: Check out xcparse repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/integration-test-tvOS14_3.yaml
+++ b/.github/workflows/integration-test-tvOS14_3.yaml
@@ -23,6 +23,12 @@ jobs:
       - name: Check out SDK repo
         uses: actions/checkout@v2
 
+      - name: Select Specific Xcode Version (13.4.1)
+        run: |
+          sudo xcode-select -s /Applications/Xcode_13.4.1.app
+          echo "Selected Xcode version:"
+          xcodebuild -version
+
       - name: Check out xcparse repo
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Our CI runners recently started using Xcode 14 by default (this sort of thing can happen since we’re using the macos-latest image).

We want to avoid using Xcode 14 for now, since it gives a warning about our deployment targets for iOS and tvOS being too low (see #1511).

This also has the side effect of fixing our build scripts that use Carthage, which are using the script
Scripts/carthage-with-workaround-for-issue-3019.sh which we haven’t yet updated for Xcode 14. I’d prefer not to spend time updating that script now since hopefully we can get rid of it soon (see #1510, #1509).