### PR TITLE
Lock to using Xcode 13.4.1 in `check-pod` CI job

### DIFF
--- a/.github/workflows/check-pod.yaml
+++ b/.github/workflows/check-pod.yaml
@@ -12,6 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Select Specific Xcode Version (13.4.1)
+        run: |
+          sudo xcode-select -s /Applications/Xcode_13.4.1.app
+          echo "Selected Xcode version:"
+          xcodebuild -version
+
       # Run the steps we document in the Release Process.
       # unzip commands included as proof-of-life for the Carthage output.
       - name: Print Ruby version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,9 +62,10 @@ For each release, the following needs to be done:
 * Once approved and/or any additional commits have been added, merge the PR (f you do this from Github's web interface then use the "Rebase and merge" option)
 * Steps to perform *before* pushing a release tag up:
     1. Checkout `main` locally, pulling in changes from above using `git checkout main && git pull`
-    2. Run `make update` to ensure Carthage dependencies are in sync
-    3. Generate the prebuilt framework for Carthage using `make carthage_package` (the output from this, `Ably.framework.zip`, will be attached to the release later on)
-    4. Validate that the CocoaPods build should succeed using `pod lib lint`
+    2. Make sure you are using Xcode 13.4.1 as your active developer directory (see message of commit [`3771408`](https://github.com/ably/ably-cocoa/commit/37714080f6dbca55b3a43674ebe0962bdae71234) for more information on this temporary requirement) – run `xcode-select --print-path` to confirm
+    3. Run `make update` to ensure Carthage dependencies are in sync
+    4. Generate the prebuilt framework for Carthage using `make carthage_package` (the output from this, `Ably.framework.zip`, will be attached to the release later on)
+    5. Validate that the CocoaPods build should succeed using `pod lib lint`
 * If any fixes are needed (e.g. the lint fails with warnings) then either commit them to `main` branch now if they are simple warning fixes or perhaps consider raising a new PR if they are complex or likely to need review.
 * Create a tag for this version number using `git tag x.x.x`
 * Push the tag using `git push origin x.x.x`


### PR DESCRIPTION
This fixes the failures we’ve been seeing in that job recently. See commit messages for more details.