### PR TITLE
Fix CI step that prepares built framework artifact

### DIFF
--- a/.github/workflows/check-pod.yaml
+++ b/.github/workflows/check-pod.yaml
@@ -49,10 +49,10 @@ jobs:
         # described in CONTRIBUTING.md.
       - name: Prepare built framework for archiving
         run: |
-          mkdir carthage-build-framework
-          mv Ably.framework.zip carthage-built-framework
+          mkdir -p carthage-built-framework-artifact-contents/carthage-built-framework
+          mv Ably.framework.zip carthage-built-framework-artifact-contents/carthage-built-framework
       - name: Archive built framework
         uses: actions/upload-artifact@v3
         with:
           name: carthage-built-framework
-          path: carthage-built-framework
+          path: carthage-built-framework-artifact-contents


### PR DESCRIPTION
Commit 938fe91 contained two different issues:

1. There was a typo `carthage-build-framework` instead of `carthage-built-framework`;
2. We actually required _two_ levels of directories to provide the desired effect of the GitHub artifact not containing a zip file at the top level.

This fixes those issues.
