### PR TITLE
Bring `ARTClientOptions#agents` in line with spec

### DIFF
--- a/Source/ARTClientOptions+Private.h
+++ b/Source/ARTClientOptions+Private.h
@@ -17,5 +17,6 @@
 + (void)setDefaultEnvironment:(NSString *_Nullable)environment;
 + (BOOL)getDefaultIdempotentRestPublishingForVersion:(NSString *_Nonnull)version;
 - (NSURLComponents *_Nonnull)restUrlComponents;
+- (NSString *_Nonnull)agentLibraryIdentifier;
 
 @end

--- a/Source/ARTClientOptions.h
+++ b/Source/ARTClientOptions.h
@@ -10,6 +10,11 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
+ * Use this pointer as a dictionary value in the `ARTClientOptions.agents` property to indicate that an agent does not have a version.
+ */
+extern NSString *ARTClientOptionsAgentNotVersioned;
+
+/**
  * Passes additional client-specific properties to the REST `-[ARTRestProtocol initWithOptions:]` or the Realtime `-[ARTRealtimeProtocol initWithOptions:]`.
  */
 @interface ARTClientOptions : ARTAuthOptions
@@ -193,21 +198,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSURL *)realtimeUrl;
 
 /**
- Method for adding additional agent to the resulting agent header.
- 
- This should only be used by Ably-authored SDKs.
- If you need to use this then you have to add the agent to the agents.json file:
- https://github.com/ably/ably-common/blob/main/protocol/agents.json
- 
- Agent versions are optional, if you don't want to specify it pass `nil`.
-*/
-- (void)addAgent:(NSString *)agentName version:(NSString * _Nullable)version;
-
-/**
- * A set of additional entries for the Ably agent header. Each entry can be a key string or set of key-value pairs.
- * Consists of `+[ARTDefault libraryAgent]`, `+[ARTDefault platformAgent]` and items added with `-[ARTClientOptions addAgent:version:]` function.
+ * A set of additional entries for the Ably agent header. Each entry can be a key string or set of key-value pairs. This should only be used by Ably-authored SDKs. If an agent does not have a version, represent this by using the `ARTClientOptionsAgentNotVersioned` pointer as the version.
  */
-- (NSString *)agents;
+@property (nonatomic, copy, nullable) NSDictionary<NSString *, NSString *> *agents;
 
 @end
 

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -313,7 +313,7 @@
         [mutableRequest setAcceptHeader:self.defaultEncoder encoders:self.encoders];
         [mutableRequest setTimeoutInterval:_options.httpRequestTimeout];
         [mutableRequest setValue:[ARTDefault apiVersion] forHTTPHeaderField:@"X-Ably-Version"];
-        [mutableRequest setValue:[_options agents] forHTTPHeaderField:@"Ably-Agent"];
+        [mutableRequest setValue:[_options agentLibraryIdentifier] forHTTPHeaderField:@"Ably-Agent"];
         if (_options.clientId && !self.auth.isTokenAuth) {
             [mutableRequest setValue:encodeBase64(_options.clientId) forHTTPHeaderField:@"X-Ably-ClientId"];
         }

--- a/Source/ARTWebSocketTransport.m
+++ b/Source/ARTWebSocketTransport.m
@@ -4,6 +4,7 @@
 #import "ARTRest+Private.h"
 #import "ARTProtocolMessage.h"
 #import "ARTClientOptions.h"
+#import "ARTClientOptions+Private.h"
 #import "ARTTokenParams.h"
 #import "ARTTokenDetails.h"
 #import "ARTStatus.h"
@@ -177,7 +178,7 @@ Class configuredWebsocketClass = nil;
     [queryItems addValueAsURLQueryItem:[ARTDefault apiVersion] forKey:@"v"];
     
     // Lib
-    [queryItems addValueAsURLQueryItem:[options agents] forKey:@"agent"];
+    [queryItems addValueAsURLQueryItem:[options agentLibraryIdentifier] forKey:@"agent"];
 
     // Transport Params
     if (options.transportParams != nil) {

--- a/Spec/Tests/ClientOptionsTests.swift
+++ b/Spec/Tests/ClientOptionsTests.swift
@@ -4,11 +4,16 @@ import Ably.ARTClientOptions
 
 class ClientOptionsTests: XCTestCase {
     
-    func testAddAgent() {
+    func testAgentLibraryIdentifier() {
         let options = ARTClientOptions()
-        options.addAgent("demolib", version: "0.0.1")
-        options.addAgent("morelib", version: nil)
-        let agents = "\(ARTDefault.libraryAgent()) demolib/0.0.1 morelib \(ARTDefault.platformAgent())"
-        XCTAssertEqual(options.agents(), agents)
+        
+        let agents = [
+            "demolib": "0.0.1",
+            "morelib": ARTClientOptionsAgentNotVersioned
+        ]
+        options.agents = agents
+        
+        let expectedIdentifier = "\(ARTDefault.libraryAgent()) demolib/0.0.1 morelib \(ARTDefault.platformAgent())"
+        XCTAssertEqual(options.agentLibraryIdentifier(), expectedIdentifier)
     }
 }

--- a/Spec/Tests/RestClientTests.swift
+++ b/Spec/Tests/RestClientTests.swift
@@ -1666,7 +1666,7 @@ class RestClientTests: XCTestCase {
             channel.publish(nil, data: "message") { error in
                 expect(error).to(beNil())
                 let headerAgent = testHTTPExecutor.requests.first!.allHTTPHeaderFields?["Ably-Agent"]
-                let ablyAgent = options.agents()
+                let ablyAgent = options.agentLibraryIdentifier()
                 expect(headerAgent).to(equal(ablyAgent))
                 expect(headerAgent!.hasPrefix("ably-cocoa/1.2.16")).to(beTrue())
                 done()


### PR DESCRIPTION
This removes the non-spec `-[ARTClientOptions addAgent:version:]` and replaces it with a dictionary `-agents` property, hence implementing [RSC7d6](https://sdk.ably.com/builds/ably/specification/main/features/#RSC7d6) as described by the spec.

Closes #1525.