### PR TITLE
Removed deprecated `SecKeychainItemDelete`

### DIFF
--- a/Source/ARTLocalDeviceStorage.m
+++ b/Source/ARTLocalDeviceStorage.m
@@ -152,23 +152,10 @@
 
 - (BOOL)keychainDeletePasswordForService:(NSString *)serviceName account:(NSString *)account error:(NSError *__autoreleasing *)error {
     NSMutableDictionary *query = [self newKeychainQueryForService:serviceName account:account];
-    OSStatus status;
-    #if TARGET_OS_IPHONE
-    status = SecItemDelete((__bridge CFDictionaryRef)query);
-    #else
-    CFTypeRef result = NULL;
-    [query setObject:@YES forKey:(__bridge id)kSecReturnRef];
-    status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
-    if (status == errSecSuccess) {
-        status = SecKeychainItemDelete((SecKeychainItemRef)result);
-        CFRelease(result);
-    }
-    #endif
-
+    OSStatus status = SecItemDelete((__bridge CFDictionaryRef)query);
     if (status != errSecSuccess && error != NULL) {
         *error = [self keychainErrorWithCode:status];
     }
-
     return (status == errSecSuccess);
 }
 

--- a/Source/ARTRest+Private.h
+++ b/Source/ARTRest+Private.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 #if TARGET_OS_IOS
 @property (nonnull, nonatomic, readonly, getter=device) ARTLocalDevice *device;
 @property (nonnull, nonatomic, readonly, getter=device_nosync) ARTLocalDevice *device_nosync;
+@property (nonatomic) id<ARTDeviceStorage> storage;
 #endif
 
 @property (nonatomic, strong, readonly) ARTClientOptions *options;
@@ -32,8 +33,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readwrite, strong, atomic, nullable) NSString *prioritizedHost;
 
 @property (nonatomic, strong) id<ARTHTTPExecutor> httpExecutor;
-@property (nonatomic) id<ARTDeviceStorage> storage;
-
 @property (nonatomic, readonly, getter=getBaseUrl) NSURL *baseUrl;
 @property (nullable, nonatomic, copy) NSString *currentFallbackHost;
 @property (readonly, nonatomic) CFAbsoluteTime fallbackRetryExpiration;

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -172,7 +172,9 @@
 
         _queue = options.internalDispatchQueue;
         _userQueue = options.dispatchQueue;
+#if TARGET_OS_IOS
         _storage = [ARTLocalDeviceStorage newWithLogger:_logger];
+#endif
         _http = [[ARTHttp alloc] init:_queue logger:_logger];
         [_logger verbose:__FILE__ line:__LINE__ message:@"RS:%p %p alloc HTTP", self, _http];
         _httpExecutor = _http;


### PR DESCRIPTION
Closes #1521 

We don't use `ARTLocalDeviceStorage` on macos, hence `SecKeychainItemDelete` can be safely removed.

The code itself was copied from `SAMKeychain` library. More info: https://github.com/soffes/SAMKeychain/blob/d3d64f8c5fa14bf2adb2d51a18ee8b6639232ca5/Sources/SAMKeychainQuery.m#L83