### PR TITLE
Removed `HTTPURLResponse._allHeaderFields`

### DIFF
--- a/Spec/Test Utilities/TestUtilities.swift
+++ b/Spec/Test Utilities/TestUtilities.swift
@@ -1812,16 +1812,7 @@ extension HTTPURLResponse {
         //of the private NSDictionary subclass in CFNetwork directly
         return allHeaderFields as NSDictionary
     }
-
-    /**
-     Don't use 'allHeaderFields' property.
-     It's not case-insensitive.
-     Please use `value(forHTTPHeaderField:)` method.
-     - Warning: Don't use 'allHeaderFields' property. See discussion.
-     */
-    @available(*, deprecated, message: "Don't use 'allHeaderFields'. It's not case-insensitive. Please use 'value(forHTTPHeaderField:)' method")
-    open var _allHeaderFields: [AnyHashable : Any] { return [:] }
-
+    
     /**
      The value which corresponds to the given header
      field. Note that, in keeping with the HTTP RFC, HTTP header field


### PR DESCRIPTION
Closes https://github.com/ably/ably-cocoa/issues/1522

With the new version of the compiler it's not allowed anymore to use `open` modifier because non-'@objc' property in extensions cannot be overridden, hense requirment to use `public`.  But `_allHeaderFields` is't used anywhere and looks like it was added for the sake of provided comment to it. So I've removed it.