### PR TITLE
Fix of priority inversion

### DIFF
--- a/SocketRocket/SocketRocket/Internal/Proxy/ARTSRProxyConnect.m
+++ b/SocketRocket/SocketRocket/Internal/Proxy/ARTSRProxyConnect.m
@@ -296,7 +296,7 @@
         [self _openConnection];
     }
     else {
-        if ([NSThread isMainThread]) {
+        if ([NSThread isMainThread]) { // Due to`dispatch_get_main_queue()` below.
             dispatch_async(_writeQueue, ^{
                 [NSRunLoop ARTSR_waitForNetworkRunLoop];
                 dispatch_async(dispatch_get_main_queue(), ^{
@@ -305,6 +305,7 @@
             });
         }
         else {
+            // Here goes some background thread in which we can call `ARTSR_waitForNetworkRunLoop` without blocking the main thread (in case user decided to call `ARTRealtime` methods from not the main thread).
             [NSRunLoop ARTSR_waitForNetworkRunLoop];
             [self _openConnection];
         }

--- a/SocketRocket/SocketRocket/Internal/Proxy/ARTSRProxyConnect.m
+++ b/SocketRocket/SocketRocket/Internal/Proxy/ARTSRProxyConnect.m
@@ -158,7 +158,7 @@
     NSArray *proxies = CFBridgingRelease(CFNetworkCopyProxiesForURL((__bridge CFURLRef)httpURL, (__bridge CFDictionaryRef)proxySettings));
     if (proxies.count == 0) {
         ARTSRDebugLog(@"configureProxy no proxies");
-        [self _openConnection];
+        [self openConnection];
         return;                 // no proxy
     }
     NSDictionary *settings = [proxies objectAtIndex:0];
@@ -179,7 +179,7 @@
     }
     [self _readProxySettingWithType:proxyType settings:settings];
 
-    [self _openConnection];
+    [self openConnection];
 }
 
 - (void)_readProxySettingWithType:(NSString *)proxyType settings:(NSDictionary *)settings
@@ -220,7 +220,7 @@
                                                        error:&error];
 
         if (error) {
-            [self _openConnection];
+            [self openConnection];
         } else {
             [self _runPACScript:script withProxySettings:proxySettings];
         }
@@ -231,7 +231,7 @@
     if (![scheme isEqualToString:@"http"] && ![scheme isEqualToString:@"https"]) {
         // Don't know how to read data from this URL, we'll have to give up
         // We'll simply assume no proxies, and start the request as normal
-        [self _openConnection];
+        [self openConnection];
         return;
     }
     __weak typeof(self) wself = self;
@@ -253,7 +253,7 @@
             NSString *script = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
             [sself _runPACScript:script withProxySettings:proxySettings];
         } else {
-            [sself _openConnection];
+            [sself openConnection];
         }
     }] resume];
 }
@@ -261,7 +261,7 @@
 - (void)_runPACScript:(NSString *)script withProxySettings:(NSDictionary *)proxySettings
 {
     if (!script) {
-        [self _openConnection];
+        [self openConnection];
         return;
     }
     ARTSRDebugLog(@"runPACScript");
@@ -287,7 +287,28 @@
         NSString *proxyType = settings[(NSString *)kCFProxyTypeKey];
         [self _readProxySettingWithType:proxyType settings:settings];
     }
-    [self _openConnection];
+    [self openConnection];
+}
+
+- (void)openConnection
+{
+    if ([NSRunLoop ARTSR_networkRunLoop] != nil) {
+        [self _openConnection];
+    }
+    else {
+        if ([NSThread isMainThread]) {
+            dispatch_async(_writeQueue, ^{
+                [NSRunLoop ARTSR_waitForNetworkRunLoop];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [self _openConnection];
+                });
+            });
+        }
+        else {
+            [NSRunLoop ARTSR_waitForNetworkRunLoop];
+            [self _openConnection];
+        }
+    }
 }
 
 - (void)_openConnection

--- a/SocketRocket/SocketRocket/Internal/Proxy/ARTSRProxyConnect.m
+++ b/SocketRocket/SocketRocket/Internal/Proxy/ARTSRProxyConnect.m
@@ -296,9 +296,10 @@
         [self _openConnection];
     }
     else {
-        if ([NSThread isMainThread]) { // Due to`dispatch_get_main_queue()` below.
+        if ([NSThread isMainThread]) {
             dispatch_async(_writeQueue, ^{
                 [NSRunLoop ARTSR_waitForNetworkRunLoop];
+                // Dispatch back to main:
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [self _openConnection];
                 });

--- a/SocketRocket/SocketRocket/Internal/RunLoop/ARTSRRunLoopThread.h
+++ b/SocketRocket/SocketRocket/Internal/RunLoop/ARTSRRunLoopThread.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ARTSRRunLoopThread : NSThread
 
-@property (nonatomic, strong, readonly) NSRunLoop *runLoop;
+@property (atomic, strong, readonly) NSRunLoop *runLoop;
 
 + (instancetype)sharedThread;
 

--- a/SocketRocket/SocketRocket/Internal/RunLoop/ARTSRRunLoopThread.m
+++ b/SocketRocket/SocketRocket/Internal/RunLoop/ARTSRRunLoopThread.m
@@ -12,11 +12,8 @@
 #import "ARTSRRunLoopThread.h"
 
 @interface ARTSRRunLoopThread ()
-{
-    dispatch_group_t _waitGroup;
-}
 
-@property (nonatomic, strong, readwrite) NSRunLoop *runLoop;
+@property (atomic, strong, readwrite) NSRunLoop *runLoop;
 
 @end
 
@@ -34,21 +31,10 @@
     return thread;
 }
 
-- (instancetype)init
-{
-    self = [super init];
-    if (self) {
-        _waitGroup = dispatch_group_create();
-        dispatch_group_enter(_waitGroup);
-    }
-    return self;
-}
-
 - (void)main
 {
     @autoreleasepool {
-        _runLoop = [NSRunLoop currentRunLoop];
-        dispatch_group_leave(_waitGroup);
+        self.runLoop = [NSRunLoop currentRunLoop];
 
         // Add an empty run loop source to prevent runloop from spinning.
         CFRunLoopSourceContext sourceCtx = {
@@ -72,12 +58,6 @@
         }
         assert(NO);
     }
-}
-
-- (NSRunLoop *)runLoop;
-{
-    dispatch_group_wait(_waitGroup, DISPATCH_TIME_FOREVER);
-    return _runLoop;
 }
 
 @end

--- a/SocketRocket/SocketRocket/Internal/RunLoop/ARTSRRunLoopThread.m
+++ b/SocketRocket/SocketRocket/Internal/RunLoop/ARTSRRunLoopThread.m
@@ -29,6 +29,10 @@
     dispatch_once(&onceToken, ^{
         thread = [[ARTSRRunLoopThread alloc] init];
         thread.name = @"io.ably.socketrocket.NetworkThread";
+        // To avoid runtime warning "Thread running at QOS_CLASS_USER_INTERACTIVE waiting on a lower QoS thread running at QOS_CLASS_DEFAULT.
+        // Investigate ways to avoid priority inversions". Since `dispatch_group_wait(...)` will be called on a main thread which is
+        // QOS_CLASS_USER_INTERACTIVE.
+        thread.qualityOfService = NSQualityOfServiceUserInteractive;
         [thread start];
     });
     return thread;

--- a/SocketRocket/SocketRocket/Internal/RunLoop/ARTSRRunLoopThread.m
+++ b/SocketRocket/SocketRocket/Internal/RunLoop/ARTSRRunLoopThread.m
@@ -29,10 +29,6 @@
     dispatch_once(&onceToken, ^{
         thread = [[ARTSRRunLoopThread alloc] init];
         thread.name = @"io.ably.socketrocket.NetworkThread";
-        // To avoid runtime warning "Thread running at QOS_CLASS_USER_INTERACTIVE waiting on a lower QoS thread running at QOS_CLASS_DEFAULT.
-        // Investigate ways to avoid priority inversions". Since `dispatch_group_wait(...)` will be called on a main thread which is
-        // QOS_CLASS_USER_INTERACTIVE.
-        thread.qualityOfService = NSQualityOfServiceUserInteractive;
         [thread start];
     });
     return thread;

--- a/SocketRocket/SocketRocket/NSRunLoop+ARTSRWebSocket.h
+++ b/SocketRocket/SocketRocket/NSRunLoop+ARTSRWebSocket.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSRunLoop *)ARTSR_networkRunLoop;
 
++ (void)ARTSR_waitForNetworkRunLoop;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SocketRocket/SocketRocket/NSRunLoop+ARTSRWebSocket.m
+++ b/SocketRocket/SocketRocket/NSRunLoop+ARTSRWebSocket.m
@@ -24,4 +24,11 @@ void import_NSRunLoop_ARTSRWebSocket() { }
     return [ARTSRRunLoopThread sharedThread].runLoop;
 }
 
++ (void)ARTSR_waitForNetworkRunLoop
+{
+    while ([ARTSRRunLoopThread sharedThread].runLoop == nil) {
+        usleep(1);
+    }
+}
+
 @end

--- a/SocketRocket/SocketRocket/NSRunLoop+ARTSRWebSocket.m
+++ b/SocketRocket/SocketRocket/NSRunLoop+ARTSRWebSocket.m
@@ -26,7 +26,7 @@ void import_NSRunLoop_ARTSRWebSocket() { }
 
 + (void)ARTSR_waitForNetworkRunLoop
 {
-    while ([ARTSRRunLoopThread sharedThread].runLoop == nil) {
+    while ([self ARTSR_networkRunLoop] == nil) {
         usleep(1);
     }
 }


### PR DESCRIPTION
Closes #1516 

<strike>Upgraded SocketRocket thread to `NSQualityOfServiceUserInteractive`</strike> to avoid runtime warning "Thread running at QOS_CLASS_USER_INTERACTIVE waiting on a lower QoS thread running at QOS_CLASS_DEFAULT. Investigate ways to avoid priority inversions"