### PR TITLE
Remove `protocolMessagesLogger` from `ARTWebSocketTransport`

### DIFF
--- a/Source/ARTRealtimeTransport.h
+++ b/Source/ARTRealtimeTransport.h
@@ -70,7 +70,6 @@ typedef NS_ENUM(NSUInteger, ARTRealtimeTransportState) {
 @property (readonly, strong, nonatomic) NSNumber *connectionSerial;
 @property (readonly, assign, nonatomic) ARTRealtimeTransportState state;
 @property (nullable, readwrite, strong, nonatomic) id<ARTRealtimeTransportDelegate> delegate;
-@property (readonly, strong, nonatomic) ARTLog *protocolMessagesLogger;
 @property (nonatomic, readonly) ARTEventEmitter<ARTEvent *, id> *stateEmitter;
 
 - (BOOL)send:(NSData *)data withSource:(nullable id)decodedObject;

--- a/Source/ARTWebSocketTransport.h
+++ b/Source/ARTWebSocketTransport.h
@@ -14,7 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly, strong, nonatomic) NSString *resumeKey;
 @property (readonly, strong, nonatomic) NSNumber *connectionSerial;
-@property (readonly, strong, nonatomic) ARTLog *protocolMessagesLogger;
 
 @end
 

--- a/Source/ARTWebSocketTransport.m
+++ b/Source/ARTWebSocketTransport.m
@@ -65,7 +65,6 @@ Class configuredWebsocketClass = nil;
         _state = ARTRealtimeTransportStateClosed;
         _encoder = rest.defaultEncoder;
         _logger = rest.logger;
-        _protocolMessagesLogger = [[ARTLog alloc] initCapturingOutput:false historyLines:50];
         _options = [options copy];
         _resumeKey = resumeKey;
         _connectionSerial = connectionSerial;
@@ -85,9 +84,6 @@ Class configuredWebsocketClass = nil;
 
 - (BOOL)send:(NSData *)data withSource:(id)decodedObject {
     if (self.websocket.readyState == ARTSR_OPEN) {
-        if ([decodedObject isKindOfClass:[ARTProtocolMessage class]]) {
-            [_protocolMessagesLogger info:@"send %@", [decodedObject description]];
-        }
         [self.websocket send:data];
         return true;
     }
@@ -104,13 +100,11 @@ Class configuredWebsocketClass = nil;
 
 - (void)internalSend:(ARTProtocolMessage *)msg {
     [self.logger debug:__FILE__ line:__LINE__ message:@"R:%p WS:%p websocket sending action %tu - %@", _delegate, self, msg.action, ARTProtocolMessageActionToStr(msg.action)];
-    [_protocolMessagesLogger info:@"send %@", [msg description]];
     NSData *data = [self.encoder encodeProtocolMessage:msg error:nil];
     [self send:data withSource:msg];
 }
 
 - (void)receive:(ARTProtocolMessage *)msg {
-    [_protocolMessagesLogger info:@"recv %@", [msg description]];
     [self.delegate realtimeTransport:self didReceiveMessage:msg];
 }
 


### PR DESCRIPTION
This was introduced in eb3a8f6, where as far as I can tell it did nothing useful, since the logger (which is using `ARTLog`’s default behaviour) only logs messages of level `warn` or above, and we only ever log to it at level `info`, hence it never logs anything.

I’m not sure what the original intention was behind this logger, but it seems safe to remove it.

Closes #1556.