### PR TITLE
Updated example project with basic messaging functionality

### DIFF
--- a/Examples/AblyPush/AblyPushExample/AblyHelper.swift
+++ b/Examples/AblyPush/AblyPushExample/AblyHelper.swift
@@ -3,19 +3,23 @@ import UIKit
 
 class AblyHelper: NSObject {
     
-    static let shared = AblyHelper()
+    static let shared = AblyHelper(clientId: UIDevice.current.name)
     
     private(set) var realtime: ARTRealtime!
     
+    private var testChannel: ARTRealtimeChannel {
+        realtime.channels.get("testChannel")
+    }
+    
     private let key = "" // Your API Key from your app's dashboard
     
-    private override init() {
-        super.init()
+    private convenience init(clientId: String) {
+        self.init()
         guard key != "" else {
             preconditionFailure("Obtain your API key at https://ably.com/accounts/")
         }
         let options = ARTClientOptions(key: key)
-        options.clientId = "basic-apns-example"
+        options.clientId = clientId
         options.pushRegistererDelegate = self
         self.realtime = ARTRealtime(options: options)
         UNUserNotificationCenter.current().delegate = self
@@ -65,6 +69,22 @@ extension AblyHelper {
         ]
         realtime.push.admin.publish(recipient, data: data) { error in
             print("Publish result: \(error?.localizedDescription ?? "Success")")
+        }
+    }
+    
+    func subscribe(event: String) {
+        testChannel.subscribe(event) { m in
+            print("Received a '\(m.name!)' message: '\(m.data!)' from \(m.clientId!)")
+        }
+    }
+    
+    func publish(event: String, message: String) {
+        testChannel.publish(event, data: message) { error in
+            if let error = error {
+                print("Message '\(event)' send error: \(error.localizedDescription)")
+            } else {
+                print("Message '\(event)' sent from \(UIDevice.current.name)")
+            }
         }
     }
 }

--- a/Examples/AblyPush/AblyPushExample/AblyHelper.swift
+++ b/Examples/AblyPush/AblyPushExample/AblyHelper.swift
@@ -5,6 +5,8 @@ class AblyHelper: NSObject {
     
     static let shared = AblyHelper(clientId: UIDevice.current.name)
     
+    private var clientId: String!
+    
     private(set) var realtime: ARTRealtime!
     
     private var testChannel: ARTRealtimeChannel {
@@ -13,15 +15,20 @@ class AblyHelper: NSObject {
     
     private let key = "" // Your API Key from your app's dashboard
     
+    func createRealtime() {
+        self.realtime?.close()
+        let options = ARTClientOptions(key: key)
+        options.clientId = clientId
+        options.pushRegistererDelegate = self
+        self.realtime = ARTRealtime(options: options)
+    }
+    
     private convenience init(clientId: String) {
         self.init()
         guard key != "" else {
             preconditionFailure("Obtain your API key at https://ably.com/accounts/")
         }
-        let options = ARTClientOptions(key: key)
-        options.clientId = clientId
-        options.pushRegistererDelegate = self
-        self.realtime = ARTRealtime(options: options)
+        self.clientId = clientId
         UNUserNotificationCenter.current().delegate = self
     }
 }

--- a/Examples/AblyPush/AblyPushExample/App.swift
+++ b/Examples/AblyPush/AblyPushExample/App.swift
@@ -22,4 +22,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         ARTPush.didFailToRegisterForRemoteNotificationsWithError(error, realtime: AblyHelper.shared.realtime)
     }
+    
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) { n in
+            AblyHelper.shared.createRealtime()
+        }
+        return true
+    }
 }

--- a/Examples/AblyPush/AblyPushExample/ContentView.swift
+++ b/Examples/AblyPush/AblyPushExample/ContentView.swift
@@ -10,39 +10,54 @@ struct ContentView: View {
     var body: some View {
         VStack {
             Spacer()
-            Button("Activate") {
-                AblyHelper.shared.activatePush()
+            Group {
+                Text("Push Notifications")
+                .padding()
+                Button("Activate") {
+                    AblyHelper.shared.activatePush()
+                }
+                .padding()
+                Button("Deactivate") {
+                    AblyHelper.shared.deactivatePush()
+                }
+                .padding()
+                Button("Print Token") {
+                    AblyHelper.shared.printIdentityToken()
+                }
+                .padding()
+                Button("Device Details") {
+                    AblyHelper.shared.getDeviceDetails { details, error in
+                        deviceDetails = details
+                        deviceDetailsError = error
+                        showDeviceDetailsAlert = true
+                    }
+                }
+                .alert(isPresented: $showDeviceDetailsAlert) {
+                    if deviceDetails != nil {
+                        return Alert(title: Text("Device Details"), message: Text("\(deviceDetails!)"))
+                    }
+                    else if deviceDetailsError != nil {
+                        return Alert(title: Text("Device Details Error"), message: Text("\(deviceDetailsError!)"))
+                    }
+                    return Alert(title: Text("Device Details Error"), message: Text("Unknown result."))
+                }
+                .padding()
+                Button("Send Push") {
+                    AblyHelper.shared.sendAdminPush(title: "Hello", body: "This push was sent with deviceId")
+                }
+                .padding()
             }
-            .padding()
-            Button("Dectivate") {
-                AblyHelper.shared.deactivatePush()
-            }
-            .padding()
-            Button("Print Token") {
-                AblyHelper.shared.printIdentityToken()
-            }
-            .padding()
-            Button("Device Details") {
-                AblyHelper.shared.getDeviceDetails { details, error in
-                    deviceDetails = details
-                    deviceDetailsError = error
-                    showDeviceDetailsAlert = true
+            Group {
+                Text("Basic Messaging")
+                .padding()
+                Button("Subscribe") {
+                    AblyHelper.shared.subscribe(event: "test")
+                }
+                .padding()
+                Button("Publish") {
+                    AblyHelper.shared.publish(event: "test", message: "Hi there!")
                 }
             }
-            .alert(isPresented: $showDeviceDetailsAlert) {
-                if deviceDetails != nil {
-                    return Alert(title: Text("Device Details"), message: Text("\(deviceDetails!)"))
-                }
-                else if deviceDetailsError != nil {
-                    return Alert(title: Text("Device Details Error"), message: Text("\(deviceDetailsError!)"))
-                }
-                return Alert(title: Text("Device Details Error"), message: Text("Unknown result."))
-            }
-            .padding()
-            Button("Send Push") {
-                AblyHelper.shared.sendAdminPush(title: "Hello", body: "This push was sent with deviceId")
-            }
-            .padding()
             Spacer()
         }
     }


### PR DESCRIPTION
This change adds basic subscribe/publish buttons to the only UI example provided with the framework. It's better to have it there since it allows manual testing quickly.