### PR TITLE
Call to `connect` instead of `_connect` to avoid potential race conditions

### DIFF
--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -210,7 +210,7 @@
         self.rest.prioritizedHost = nil;
         
         if (options.autoConnect) {
-            [self _connect];
+            [self connect];
         }
     }
     return self;


### PR DESCRIPTION
Closes #1566