### PR TITLE
Add a type to represent the Realtime service’s response to a connection resume request

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -30,6 +30,15 @@
 		2132C22929D23484000C4355 /* MockErrorChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C22529D2347F000C4355 /* MockErrorChecker.swift */; };
 		2132C22A29D23484000C4355 /* MockErrorChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C22529D2347F000C4355 /* MockErrorChecker.swift */; };
 		2132C22B29D23485000C4355 /* MockErrorChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C22529D2347F000C4355 /* MockErrorChecker.swift */; };
+		2132C20E29D20EEC000C4355 /* ARTResumeRequestResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2132C20D29D20EEC000C4355 /* ARTResumeRequestResponse.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2132C20F29D20EEC000C4355 /* ARTResumeRequestResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2132C20D29D20EEC000C4355 /* ARTResumeRequestResponse.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2132C21029D20EEC000C4355 /* ARTResumeRequestResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2132C20D29D20EEC000C4355 /* ARTResumeRequestResponse.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2132C21229D20F05000C4355 /* ARTResumeRequestResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 2132C21129D20F05000C4355 /* ARTResumeRequestResponse.m */; };
+		2132C21329D20F05000C4355 /* ARTResumeRequestResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 2132C21129D20F05000C4355 /* ARTResumeRequestResponse.m */; };
+		2132C21429D20F05000C4355 /* ARTResumeRequestResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 2132C21129D20F05000C4355 /* ARTResumeRequestResponse.m */; };
+		2132C21629D20F69000C4355 /* ResumeRequestResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C21529D20F69000C4355 /* ResumeRequestResponseTests.swift */; };
+		2132C21729D20F69000C4355 /* ResumeRequestResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C21529D20F69000C4355 /* ResumeRequestResponseTests.swift */; };
+		2132C21829D20F69000C4355 /* ResumeRequestResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C21529D20F69000C4355 /* ResumeRequestResponseTests.swift */; };
 		21447D3B254A2ECB00B3905A /* ARTSRWebSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 217D181B25421FED00DFF07E /* ARTSRWebSocket.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21447D40254A2ECE00B3905A /* ARTSRWebSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 217D181B25421FED00DFF07E /* ARTSRWebSocket.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21447D45254A2ED100B3905A /* ARTSRWebSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 217D181B25421FED00DFF07E /* ARTSRWebSocket.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -987,6 +996,9 @@
 		2132C21D29D23196000C4355 /* ARTErrorChecker.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTErrorChecker.m; sourceTree = "<group>"; };
 		2132C22129D233EB000C4355 /* DefaultErrorCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultErrorCheckerTests.swift; sourceTree = "<group>"; };
 		2132C22529D2347F000C4355 /* MockErrorChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockErrorChecker.swift; sourceTree = "<group>"; };
+		2132C20D29D20EEC000C4355 /* ARTResumeRequestResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTResumeRequestResponse.h; path = PrivateHeaders/Ably/ARTResumeRequestResponse.h; sourceTree = "<group>"; };
+		2132C21129D20F05000C4355 /* ARTResumeRequestResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTResumeRequestResponse.m; sourceTree = "<group>"; };
+		2132C21529D20F69000C4355 /* ResumeRequestResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumeRequestResponseTests.swift; sourceTree = "<group>"; };
 		215F75F62922B1DB009E0E76 /* ARTClientInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTClientInformation.h; path = include/Ably/ARTClientInformation.h; sourceTree = "<group>"; };
 		215F75F72922B1DB009E0E76 /* ARTClientInformation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTClientInformation.m; sourceTree = "<group>"; };
 		215F75FE2922B30F009E0E76 /* ClientInformationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientInformationTests.swift; sourceTree = "<group>"; };
@@ -1518,6 +1530,7 @@
 				D72768201C9C19040022F8B2 /* RestClientPresenceTests.swift */,
 				853ED7C31B7A1A3C006F1C6F /* RestClientStatsTests.swift */,
 				D74CBC09212EC02C00D090E4 /* RestPaginatedTests.swift */,
+				2132C21529D20F69000C4355 /* ResumeRequestResponseTests.swift */,
 				851674EE1B7BA5CD00D35169 /* StatsTests.swift */,
 				D520C4DD2680A1E3000012B2 /* StringifiableTests.swift */,
 				EB1AE0CD1C5C3A4900D62250 /* UtilitiesTests.swift */,
@@ -1698,6 +1711,8 @@
 				EB89D4081C61C5ED007FA5B7 /* ARTRealtimeChannels.h */,
 				D7CEF12C1C8D821D004FB242 /* ARTRealtimeChannels+Private.h */,
 				EB89D40A1C61C6EA007FA5B7 /* ARTRealtimeChannels.m */,
+				2132C20D29D20EEC000C4355 /* ARTResumeRequestResponse.h */,
+				2132C21129D20F05000C4355 /* ARTResumeRequestResponse.m */,
 			);
 			name = Realtime;
 			sourceTree = "<group>";
@@ -1948,6 +1963,7 @@
 				961343D81A42E0B7006DC822 /* ARTClientOptions.h in Headers */,
 				D7534C321D79E5C20054C182 /* Ably.h in Headers */,
 				D777EEE0206285CF002EBA03 /* ARTDeviceIdentityTokenDetails.h in Headers */,
+				2132C20E29D20EEC000C4355 /* ARTResumeRequestResponse.h in Headers */,
 				215F76032922C76C009E0E76 /* ARTClientInformation+Private.h in Headers */,
 				96BF615E1A35C1C8004CF2B3 /* ARTTypes.h in Headers */,
 				EB503C881C7E4A090053AF00 /* ARTClientOptions+Private.h in Headers */,
@@ -2214,6 +2230,7 @@
 				D5BB211026AA993C00AA5F3E /* ARTNSURL+ARTUtils.h in Headers */,
 				D710D60E21949DDB008F54AD /* ARTPaginatedResult.h in Headers */,
 				D710D4BF21949B6C008F54AD /* ARTNSMutableRequest+ARTRest.h in Headers */,
+				2132C20F29D20EEC000C4355 /* ARTResumeRequestResponse.h in Headers */,
 				D710D5BE21949D4F008F54AD /* ARTBaseMessage+Private.h in Headers */,
 				D5BB20FE26A7F50000AA5F3E /* ARTSRPinningSecurityPolicy.h in Headers */,
 				215F75F92922B1DB009E0E76 /* ARTClientInformation.h in Headers */,
@@ -2359,6 +2376,7 @@
 				D710D61821949DDC008F54AD /* ARTPaginatedResult.h in Headers */,
 				D5BB213B26AAA60500AA5F3E /* ARTNSError+ARTUtils.h in Headers */,
 				D710D4C121949B6D008F54AD /* ARTNSMutableRequest+ARTRest.h in Headers */,
+				2132C21029D20EEC000C4355 /* ARTResumeRequestResponse.h in Headers */,
 				D710D5CE21949D50008F54AD /* ARTBaseMessage+Private.h in Headers */,
 				D5BB20FF26A7F50800AA5F3E /* ARTSRPinningSecurityPolicy.h in Headers */,
 				215F75FA2922B1DB009E0E76 /* ARTClientInformation.h in Headers */,
@@ -2694,6 +2712,7 @@
 				D72304701BB72CED00F1ABDA /* RealtimeClientTests.swift in Sources */,
 				841134782722205400CFA837 /* ARTArchiveTests.m in Sources */,
 				D74A17B81FA0D9A3006D27B5 /* PushAdminTests.swift in Sources */,
+				2132C21629D20F69000C4355 /* ResumeRequestResponseTests.swift in Sources */,
 				EB7913A81C6E54C3000ABF9B /* CryptoTests.swift in Sources */,
 				2132C22229D233EB000C4355 /* DefaultErrorCheckerTests.swift in Sources */,
 				D777EEE820650ADF002EBA03 /* PushChannelTests.swift in Sources */,
@@ -2778,6 +2797,7 @@
 				D7D29B421BE3DEB300374295 /* ARTConnection.m in Sources */,
 				D74CBC08212EB5B900D090E4 /* ARTNSMutableURLRequest+ARTPaginated.m in Sources */,
 				96BF61711A35FB7C004CF2B3 /* ARTAuth.m in Sources */,
+				2132C21229D20F05000C4355 /* ARTResumeRequestResponse.m in Sources */,
 				96E408441A38939E00087F77 /* ARTProtocolMessage.m in Sources */,
 				D71966E51E5DF360000974DD /* ARTPushActivationStateMachine.m in Sources */,
 				EB9121401CA0AD8200BA0A40 /* ARTMsgPackEncoder.m in Sources */,
@@ -2844,6 +2864,7 @@
 				EB1B53FA22F85CE4006A59AC /* ObjectLifetimesTests.swift in Sources */,
 				D7093C2A219E466E00723F17 /* UtilitiesTests.swift in Sources */,
 				D798554923EB96C000946BE2 /* DeltaCodecTests.swift in Sources */,
+				2132C21729D20F69000C4355 /* ResumeRequestResponseTests.swift in Sources */,
 				D7093C21219E466E00723F17 /* RestClientChannelsTests.swift in Sources */,
 				2132C22A29D23484000C4355 /* MockErrorChecker.swift in Sources */,
 				D7093C26219E466E00723F17 /* RealtimeClientChannelTests.swift in Sources */,
@@ -2880,6 +2901,7 @@
 				EB1B53FB22F85CE4006A59AC /* ObjectLifetimesTests.swift in Sources */,
 				D7093C7C219EE26400723F17 /* RealtimeClientConnectionTests.swift in Sources */,
 				D798554A23EB96C000946BE2 /* DeltaCodecTests.swift in Sources */,
+				2132C21829D20F69000C4355 /* ResumeRequestResponseTests.swift in Sources */,
 				D7093C74219EE26400723F17 /* AuthTests.swift in Sources */,
 				2132C22B29D23485000C4355 /* MockErrorChecker.swift in Sources */,
 				D7093C72219EE25B00723F17 /* NSObject+TestSuite.swift in Sources */,
@@ -2962,6 +2984,7 @@
 				D710D49921949ACA008F54AD /* ARTAuth.m in Sources */,
 				D710D5D321949D78008F54AD /* ARTTokenParams.m in Sources */,
 				D710D53221949C54008F54AD /* ARTPushChannel.m in Sources */,
+				2132C21329D20F05000C4355 /* ARTResumeRequestResponse.m in Sources */,
 				D710D5D421949D78008F54AD /* ARTTokenDetails.m in Sources */,
 				D710D49B21949ACA008F54AD /* ARTRestChannels.m in Sources */,
 				D710D62E21949E03008F54AD /* ARTURLSessionServerTrust.m in Sources */,
@@ -3074,6 +3097,7 @@
 				D710D5F921949D79008F54AD /* ARTTokenParams.m in Sources */,
 				D710D54421949C55008F54AD /* ARTPushChannel.m in Sources */,
 				D710D5FA21949D79008F54AD /* ARTTokenDetails.m in Sources */,
+				2132C21429D20F05000C4355 /* ARTResumeRequestResponse.m in Sources */,
 				D710D4A521949ACB008F54AD /* ARTRestChannels.m in Sources */,
 				D710D63E21949E04008F54AD /* ARTURLSessionServerTrust.m in Sources */,
 				D710D65121949E77008F54AD /* ARTJsonEncoder.m in Sources */,

--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -18,6 +18,18 @@
 		1C6C18A41ADFDAB100AB79E4 /* ARTLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C6C18A21ADFDAB100AB79E4 /* ARTLog.m */; };
 		1CD8DC9F1B1C7315007EAF36 /* ARTDefault.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CD8DC9D1B1C7315007EAF36 /* ARTDefault.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1CD8DCA01B1C7315007EAF36 /* ARTDefault.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CD8DC9E1B1C7315007EAF36 /* ARTDefault.m */; };
+		2132C21A29D230CE000C4355 /* ARTErrorChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = 2132C21929D230AE000C4355 /* ARTErrorChecker.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2132C21B29D230CF000C4355 /* ARTErrorChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = 2132C21929D230AE000C4355 /* ARTErrorChecker.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2132C21C29D230D0000C4355 /* ARTErrorChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = 2132C21929D230AE000C4355 /* ARTErrorChecker.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2132C21E29D23196000C4355 /* ARTErrorChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 2132C21D29D23196000C4355 /* ARTErrorChecker.m */; };
+		2132C21F29D23196000C4355 /* ARTErrorChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 2132C21D29D23196000C4355 /* ARTErrorChecker.m */; };
+		2132C22029D23196000C4355 /* ARTErrorChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 2132C21D29D23196000C4355 /* ARTErrorChecker.m */; };
+		2132C22229D233EB000C4355 /* DefaultErrorCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C22129D233EB000C4355 /* DefaultErrorCheckerTests.swift */; };
+		2132C22329D233EB000C4355 /* DefaultErrorCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C22129D233EB000C4355 /* DefaultErrorCheckerTests.swift */; };
+		2132C22429D233EB000C4355 /* DefaultErrorCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C22129D233EB000C4355 /* DefaultErrorCheckerTests.swift */; };
+		2132C22929D23484000C4355 /* MockErrorChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C22529D2347F000C4355 /* MockErrorChecker.swift */; };
+		2132C22A29D23484000C4355 /* MockErrorChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C22529D2347F000C4355 /* MockErrorChecker.swift */; };
+		2132C22B29D23485000C4355 /* MockErrorChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C22529D2347F000C4355 /* MockErrorChecker.swift */; };
 		21447D3B254A2ECB00B3905A /* ARTSRWebSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 217D181B25421FED00DFF07E /* ARTSRWebSocket.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21447D40254A2ECE00B3905A /* ARTSRWebSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 217D181B25421FED00DFF07E /* ARTSRWebSocket.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21447D45254A2ED100B3905A /* ARTSRWebSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 217D181B25421FED00DFF07E /* ARTSRWebSocket.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -971,6 +983,10 @@
 		1C6C18A21ADFDAB100AB79E4 /* ARTLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTLog.m; sourceTree = "<group>"; };
 		1CD8DC9D1B1C7315007EAF36 /* ARTDefault.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARTDefault.h; path = include/Ably/ARTDefault.h; sourceTree = "<group>"; };
 		1CD8DC9E1B1C7315007EAF36 /* ARTDefault.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTDefault.m; sourceTree = "<group>"; };
+		2132C21929D230AE000C4355 /* ARTErrorChecker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTErrorChecker.h; path = PrivateHeaders/Ably/ARTErrorChecker.h; sourceTree = "<group>"; };
+		2132C21D29D23196000C4355 /* ARTErrorChecker.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTErrorChecker.m; sourceTree = "<group>"; };
+		2132C22129D233EB000C4355 /* DefaultErrorCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultErrorCheckerTests.swift; sourceTree = "<group>"; };
+		2132C22529D2347F000C4355 /* MockErrorChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockErrorChecker.swift; sourceTree = "<group>"; };
 		215F75F62922B1DB009E0E76 /* ARTClientInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTClientInformation.h; path = include/Ably/ARTClientInformation.h; sourceTree = "<group>"; };
 		215F75F72922B1DB009E0E76 /* ARTClientInformation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTClientInformation.m; sourceTree = "<group>"; };
 		215F75FE2922B30F009E0E76 /* ClientInformationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientInformationTests.swift; sourceTree = "<group>"; };
@@ -1481,6 +1497,7 @@
 				215F75FE2922B30F009E0E76 /* ClientInformationTests.swift */,
 				EB7913A71C6E54C3000ABF9B /* CryptoTests.swift */,
 				56190953238C3D3200A862A6 /* CryptoTest.m */,
+				2132C22129D233EB000C4355 /* DefaultErrorCheckerTests.swift */,
 				D798554723EB96C000946BE2 /* DeltaCodecTests.swift */,
 				D5A22171266F526600C87C42 /* GCDTests.swift */,
 				848ED97226E50D0F0087E800 /* ObjcppTest.mm */,
@@ -1516,6 +1533,7 @@
 				D780846D1C68B3E50083009D /* NSObject+TestSuite.m */,
 				D714A63D1C74D4B2002F2CA0 /* NSObject+TestSuite.swift */,
 				856AAC961B6E30C800B07119 /* TestUtilities.swift */,
+				2132C22529D2347F000C4355 /* MockErrorChecker.swift */,
 			);
 			path = "Test Utilities";
 			sourceTree = "<group>";
@@ -1807,6 +1825,8 @@
 				215F75F62922B1DB009E0E76 /* ARTClientInformation.h */,
 				215F75F72922B1DB009E0E76 /* ARTClientInformation.m */,
 				215F76022922C76C009E0E76 /* ARTClientInformation+Private.h */,
+				2132C21929D230AE000C4355 /* ARTErrorChecker.h */,
+				2132C21D29D23196000C4355 /* ARTErrorChecker.m */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -2051,6 +2071,7 @@
 				215F75F82922B1DB009E0E76 /* ARTClientInformation.h in Headers */,
 				D7DF738A1EA645300013CD36 /* ARTLocalDeviceStorage.h in Headers */,
 				960D07931A45F1D800ED8C8C /* ARTCrypto.h in Headers */,
+				2132C21A29D230CE000C4355 /* ARTErrorChecker.h in Headers */,
 				D5BB20FC26A7F3FF00AA5F3E /* NSURLRequest+ARTSRWebSocket.h in Headers */,
 				D5C0CB3D268317B500C06521 /* NSURLQueryItem+Stringifiable.h in Headers */,
 				D5BB20FB26A7F3C800AA5F3E /* NSRunLoop+ARTSRWebSocket.h in Headers */,
@@ -2143,6 +2164,7 @@
 				D710D51E21949C42008F54AD /* ARTLocalDeviceStorage.h in Headers */,
 				D5BB210626AA988200AA5F3E /* ARTTime.h in Headers */,
 				D710D50721949C18008F54AD /* ARTConnectionDetails+Private.h in Headers */,
+				2132C21B29D230CF000C4355 /* ARTErrorChecker.h in Headers */,
 				D7BDDD3E21959CC100CC0632 /* CompatibilityMacros.h in Headers */,
 				D710D51B21949C42008F54AD /* ARTDeviceIdentityTokenDetails.h in Headers */,
 				D76F153D23DB012100B5133C /* ARTRealtimeChannelOptions.h in Headers */,
@@ -2287,6 +2309,7 @@
 				D710D53021949C44008F54AD /* ARTLocalDeviceStorage.h in Headers */,
 				D710D51321949C19008F54AD /* ARTConnectionDetails+Private.h in Headers */,
 				D7BDDD3F21959CC200CC0632 /* CompatibilityMacros.h in Headers */,
+				2132C21C29D230D0000C4355 /* ARTErrorChecker.h in Headers */,
 				D5BB210F26AA98A900AA5F3E /* ARTStringifiable.h in Headers */,
 				D5C0CB3F268317B500C06521 /* NSURLQueryItem+Stringifiable.h in Headers */,
 				D710D52D21949C44008F54AD /* ARTDeviceIdentityTokenDetails.h in Headers */,
@@ -2651,6 +2674,7 @@
 				EB1B53F922F85CE4006A59AC /* ObjectLifetimesTests.swift in Sources */,
 				D7DF73851EA600240013CD36 /* PushActivationStateMachineTests.swift in Sources */,
 				D7FC1ECB209CEA2E001E4153 /* PushTests.swift in Sources */,
+				2132C22929D23484000C4355 /* MockErrorChecker.swift in Sources */,
 				D714A63E1C74D4B2002F2CA0 /* NSObject+TestSuite.swift in Sources */,
 				21881E7C283BD0E100CFD9E2 /* StringifiableTests.swift in Sources */,
 				856AAC971B6E30C800B07119 /* TestUtilities.swift in Sources */,
@@ -2671,6 +2695,7 @@
 				841134782722205400CFA837 /* ARTArchiveTests.m in Sources */,
 				D74A17B81FA0D9A3006D27B5 /* PushAdminTests.swift in Sources */,
 				EB7913A81C6E54C3000ABF9B /* CryptoTests.swift in Sources */,
+				2132C22229D233EB000C4355 /* DefaultErrorCheckerTests.swift in Sources */,
 				D777EEE820650ADF002EBA03 /* PushChannelTests.swift in Sources */,
 				D746AE2D1BBB625E003ECEF8 /* RestClientChannelsTests.swift in Sources */,
 				EBAB9A6F1C69702800AF036B /* ReadmeExamplesTests.swift in Sources */,
@@ -2772,6 +2797,7 @@
 				D746AE501BBD84E7003ECEF8 /* ARTChannelOptions.m in Sources */,
 				EB89D4051C61C1A4007FA5B7 /* ARTRestChannels.m in Sources */,
 				217D1834254222F600DFF07E /* ARTSRURLUtilities.m in Sources */,
+				2132C21E29D23196000C4355 /* ARTErrorChecker.m in Sources */,
 				D777EEE1206285CF002EBA03 /* ARTDeviceIdentityTokenDetails.m in Sources */,
 				D73B655823EF2B2900D459A6 /* ARTDeltaCodec.m in Sources */,
 				D5BB211B26AA9AA700AA5F3E /* ARTNSMutableDictionary+ARTDictionaryUtil.m in Sources */,
@@ -2802,6 +2828,7 @@
 				D7093C23219E466E00723F17 /* RestPaginatedTests.swift in Sources */,
 				D7093C19219E465300723F17 /* TestUtilities.swift in Sources */,
 				560579DA24AF1BA900A4D03D /* ARTDefaultTests.swift in Sources */,
+				2132C22329D233EB000C4355 /* DefaultErrorCheckerTests.swift in Sources */,
 				D7093C1C219E466400723F17 /* ReadmeExamplesTests.swift in Sources */,
 				21881E7B283BD0DF00CFD9E2 /* StringifiableTests.swift in Sources */,
 				D7093C27219E466E00723F17 /* RealtimeClientChannelsTests.swift in Sources */,
@@ -2818,6 +2845,7 @@
 				D7093C2A219E466E00723F17 /* UtilitiesTests.swift in Sources */,
 				D798554923EB96C000946BE2 /* DeltaCodecTests.swift in Sources */,
 				D7093C21219E466E00723F17 /* RestClientChannelsTests.swift in Sources */,
+				2132C22A29D23484000C4355 /* MockErrorChecker.swift in Sources */,
 				D7093C26219E466E00723F17 /* RealtimeClientChannelTests.swift in Sources */,
 				D7093C22219E466E00723F17 /* RestClientPresenceTests.swift in Sources */,
 				56190955238C3D3200A862A6 /* CryptoTest.m in Sources */,
@@ -2836,6 +2864,7 @@
 				D7093C7F219EE26400723F17 /* RealtimeClientPresenceTests.swift in Sources */,
 				D7093C73219EE26000723F17 /* ReadmeExamplesTests.swift in Sources */,
 				560579DB24AF1BA900A4D03D /* ARTDefaultTests.swift in Sources */,
+				2132C22429D233EB000C4355 /* DefaultErrorCheckerTests.swift in Sources */,
 				D7093C71219EE25800723F17 /* NSObject+TestSuite.m in Sources */,
 				D7093C70219EE25400723F17 /* TestUtilities.swift in Sources */,
 				D7093C80219EE26400723F17 /* StatsTests.swift in Sources */,
@@ -2852,6 +2881,7 @@
 				D7093C7C219EE26400723F17 /* RealtimeClientConnectionTests.swift in Sources */,
 				D798554A23EB96C000946BE2 /* DeltaCodecTests.swift in Sources */,
 				D7093C74219EE26400723F17 /* AuthTests.swift in Sources */,
+				2132C22B29D23485000C4355 /* MockErrorChecker.swift in Sources */,
 				D7093C72219EE25B00723F17 /* NSObject+TestSuite.swift in Sources */,
 				D7093C7B219EE26400723F17 /* RealtimeClientTests.swift in Sources */,
 				56190956238C3D3200A862A6 /* CryptoTest.m in Sources */,
@@ -2951,6 +2981,7 @@
 				D710D57421949CC4008F54AD /* ARTPushDeviceRegistrations.m in Sources */,
 				D710D5D821949D78008F54AD /* ARTChannelOptions.m in Sources */,
 				217D184B254222F700DFF07E /* ARTSRURLUtilities.m in Sources */,
+				2132C21F29D23196000C4355 /* ARTErrorChecker.m in Sources */,
 				D73B655923EF2B2900D459A6 /* ARTDeltaCodec.m in Sources */,
 				D710D62D21949E03008F54AD /* ARTHttp.m in Sources */,
 				D5BB211A26AA9AA600AA5F3E /* ARTNSMutableDictionary+ARTDictionaryUtil.m in Sources */,
@@ -3062,6 +3093,7 @@
 				D710D5FE21949D79008F54AD /* ARTChannelOptions.m in Sources */,
 				D5BB213826AAA60500AA5F3E /* ARTNSError+ARTUtils.m in Sources */,
 				217D1862254222FA00DFF07E /* ARTSRURLUtilities.m in Sources */,
+				2132C22029D23196000C4355 /* ARTErrorChecker.m in Sources */,
 				D73B655A23EF2B2900D459A6 /* ARTDeltaCodec.m in Sources */,
 				D710D63D21949E04008F54AD /* ARTHttp.m in Sources */,
 				D710D64021949E04008F54AD /* ARTPaginatedResult.m in Sources */,

--- a/Source/ARTErrorChecker.m
+++ b/Source/ARTErrorChecker.m
@@ -1,0 +1,12 @@
+#import "ARTErrorChecker.h"
+#import "ARTTypes.h"
+#import "ARTStatus.h"
+
+@implementation ARTDefaultErrorChecker
+
+- (BOOL)isTokenError:(ARTErrorInfo *)errorInfo {
+    // RTH15h1
+    return errorInfo.statusCode == 401 && errorInfo.code >= ARTErrorTokenErrorUnspecified && errorInfo.code < ARTErrorConnectionLimitsExceeded;
+}
+
+@end

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -37,6 +37,7 @@
 #import "ARTRealtimeChannels+Private.h"
 #import "ARTPush+Private.h"
 #import "ARTQueuedDealloc.h"
+#import "ARTErrorChecker.h"
 
 @interface ARTConnectionStateChange ()
 
@@ -959,7 +960,7 @@
 }
 
 - (BOOL)isTokenError:(nullable ARTErrorInfo *)error {
-    return error != nil && error.statusCode == 401 && error.code >= ARTErrorTokenErrorUnspecified && error.code < ARTErrorConnectionLimitsExceeded;
+    return error != nil && [[[ARTDefaultErrorChecker alloc] init] isTokenError:error];
 }
 
 - (void)transportReconnectWithHost:(NSString *)host {

--- a/Source/ARTResumeRequestResponse.m
+++ b/Source/ARTResumeRequestResponse.m
@@ -1,0 +1,68 @@
+#import "ARTResumeRequestResponse.h"
+#import "ARTStatus.h"
+#import "ARTProtocolMessage.h"
+#import "ARTErrorChecker.h"
+
+static NSString *TypeDescription(const ARTResumeRequestResponseType type) {
+    switch (type) {
+        case ARTResumeRequestResponseTypeValid:
+            return @"Valid";
+        case ARTResumeRequestResponseTypeInvalid:
+            return @"Invalid";
+        case ARTResumeRequestResponseTypeFatalError:
+            return @"FatalError";
+        case ARTResumeRequestResponseTypeTokenError:
+            return @"TokenError";
+        case ARTResumeRequestResponseTypeUnknown:
+            return @"Unknown";
+    }
+}
+
+@implementation ARTResumeRequestResponse
+
+- (instancetype)initWithCurrentConnectionID:(NSString *const)currentConnectionID
+                            protocolMessage:(ARTProtocolMessage *const)protocolMessage
+                               errorChecker:(const id<ARTErrorChecker>)errorChecker {
+    if (!(self = [super init])) {
+        return nil;
+    }
+
+    // RTN15c6: "A CONNECTED ProtocolMessage with the same connectionId as the current client (and no error property)."
+    if (protocolMessage.action == ARTProtocolMessageConnected && [protocolMessage.connectionId isEqualToString:currentConnectionID] && protocolMessage.error == nil) {
+        _type = ARTResumeRequestResponseTypeValid;
+        return self;
+    }
+
+    // RTN15c7: "CONNECTED ProtocolMessage with a new connectionId and an ErrorInfo in the error field."
+    if (protocolMessage.action == ARTProtocolMessageConnected && ![protocolMessage.connectionId isEqualToString:currentConnectionID] && protocolMessage.error != nil) {
+        _type = ARTResumeRequestResponseTypeInvalid;
+        _error = protocolMessage.error;
+        return self;
+    }
+
+    // RTN15c5: "ERROR ProtocolMessage indicating a failure to authenticate as a result of a token error (see RTN15h)."
+    if (protocolMessage.action == ARTProtocolMessageError && protocolMessage.error != nil && [errorChecker isTokenError:protocolMessage.error]) {
+        _type = ARTResumeRequestResponseTypeTokenError;
+        _error = protocolMessage.error;
+        return self;
+    }
+
+    // RTN15c4: "Any other ERROR ProtocolMessage indicating a fatal error in the connection."
+    // (I’m reading this as "Any other ERROR ProtocolMessage. This indicates a fatal error in the connection." — that is, I am not expected to apply any further criteria to determine if it is a "fatal" error.)
+
+    // We can assume that an ERROR ProtocolMessage will have a non-nil error (see protocol spec), and if it does not then we will treat it as an "unknown" response type.
+    if (protocolMessage.action == ARTProtocolMessageError && protocolMessage.error != nil) {
+        _type = ARTResumeRequestResponseTypeFatalError;
+        _error = protocolMessage.error;
+        return self;
+    }
+
+    _type = ARTResumeRequestResponseTypeUnknown;
+    return self;
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat: @"<%@ %p: type: %@, error: %@>", [self class], self, TypeDescription(self.type), [self.error localizedDescription]];
+}
+
+@end

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -81,5 +81,6 @@ framework module Ably {
         header "ARTNSMutableURLRequest+ARTUtils.h"
         header "ARTTime.h"
         header "ARTErrorChecker.h"
+        header "ARTResumeRequestResponse.h"
     }
 }

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -80,5 +80,6 @@ framework module Ably {
         header "ARTNSURL+ARTUtils.h"
         header "ARTNSMutableURLRequest+ARTUtils.h"
         header "ARTTime.h"
+        header "ARTErrorChecker.h"
     }
 }

--- a/Source/PrivateHeaders/Ably/ARTErrorChecker.h
+++ b/Source/PrivateHeaders/Ably/ARTErrorChecker.h
@@ -1,0 +1,29 @@
+@import Foundation;
+
+@class ARTErrorInfo;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Checks an `ARTErrorInfo` to see whether it falls into a given class of errors defined by the client library specification.
+
+ In addition to putting shared error logic in a common place, it allows us to provide a mock instance when testing components that need to perform error checking, without having to worry about creating representative errors in our test cases.
+ */
+NS_SWIFT_NAME(ErrorChecker)
+@protocol ARTErrorChecker
+
+/**
+ Returns whether the given error is a token error, as defined by RTH15h1.
+ */
+- (BOOL)isTokenError:(ARTErrorInfo *)errorInfo;
+
+@end
+
+/**
+ The implementation of `ARTErrorChecker` that should be used in non-test code.
+ */
+NS_SWIFT_NAME(DefaultErrorChecker)
+@interface ARTDefaultErrorChecker: NSObject <ARTErrorChecker>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTResumeRequestResponse.h
+++ b/Source/PrivateHeaders/Ably/ARTResumeRequestResponse.h
@@ -1,0 +1,72 @@
+@import Foundation;
+
+@class ARTProtocolMessage;
+@class ARTErrorInfo;
+@protocol ARTErrorChecker;
+
+/**
+ The type of the Realtime system’s response to a resume request, as described by RTN15c.
+ */
+typedef NS_ENUM(NSUInteger, ARTResumeRequestResponseType) {
+    /**
+     RTN15c6: "This indicates that the resume attempt was valid. The client library should move all channels that were in the `ATTACHING`, `ATTACHED`, or `SUSPENDED` states to the `ATTACHING` state, and initiate an `RTL4c` attach sequence for each. The connection should also process any messages queued per `RTL6c2` (there is no need to wait for the attaches to finish before processing queued messages)."
+     */
+    ARTResumeRequestResponseTypeValid,
+
+    /**
+     RTN15c7: "In this case, the resume was invalid, and the error indicates the cause. The `error` should be set as the `reason` in the `CONNECTED` event, and as the `Connection#errorReason`. The internal `msgSerial` counter should be reset so that the first message published to Ably will contain a `msgSerial` of `0`. The rest of the process is the same as for `RTN16c6`: The client library should move all channels that were in the `ATTACHING`, `ATTACHED`, or `SUSPENDED` states to the `ATTACHING` state, and initiate an `RTL4c` attach sequence for each. The connection should also process any messages queued per `RTL6c2`."
+     */
+    ARTResumeRequestResponseTypeInvalid,
+
+    /**
+     RTN15c5: "The transport will be closed by the server. The spec described in RTN15h must be followed for a connection being resumed with a token error"
+     */
+    ARTResumeRequestResponseTypeTokenError,
+
+    /**
+     RTN15c4: "Any other `ERROR` `ProtocolMessage` indicating a fatal error in the connection. The server will close the transport immediately after. The client should transition to the `FAILED` state triggering all attached channels to transition to the `FAILED` state as well. Additionally the `Connection#errorReason` will be set should be set with the error received from Ably"
+     */
+    ARTResumeRequestResponseTypeFatalError,
+
+    /**
+     The response from the Realtime system was not one of the expected responses.
+     */
+    ARTResumeRequestResponseTypeUnknown,
+} NS_SWIFT_NAME(ResumeRequestResponse.ResponseType);
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ The Realtime system’s response to a resume request, as described by RTN15c.
+ */
+NS_SWIFT_NAME(ResumeRequestResponse)
+@interface ARTResumeRequestResponse: NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ Creates an `ARTResumeRequestResponse` describing the resume request response that the Realtime system has communicated through the use of a protocol message.
+
+ @param currentConnectionID The ID of the connection that we are trying to resume.
+ @param protocolMessage The first protocol message received on a transport which is trying to resume a connection with ID `currentConnectionID`.
+ @param errorChecker An error checker which will be used to check whether an error is a token error.
+ */
+- (instancetype)initWithCurrentConnectionID:(NSString *)currentConnectionID
+                            protocolMessage:(ARTProtocolMessage *)protocolMessage
+                               errorChecker:(id<ARTErrorChecker>)errorChecker NS_DESIGNATED_INITIALIZER;
+
+/**
+ The type of the response. This indicates how a client is meant to act upon receiving this response.
+ */
+@property (nonatomic, readonly) ARTResumeRequestResponseType type;
+
+/**
+ The error that the Realtime system included in its response.
+
+ Non-nil if and only if `type` is `ARTResumeRequestResponseTypeInvalid`, `ARTResumeRequestResponseTypeTokenError`, or `ARTResumeRequestResponseTypeFatalError`.
+ */
+@property (nullable, nonatomic, readonly, strong) ARTErrorInfo *error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/include/Ably.modulemap
+++ b/Source/include/Ably.modulemap
@@ -80,5 +80,6 @@ framework module Ably {
         header "Ably/ARTNSURL+ARTUtils.h"
         header "Ably/ARTNSMutableURLRequest+ARTUtils.h"
         header "Ably/ARTTime.h"
+        header "Ably/ARTErrorChecker.h"
     }
 }

--- a/Source/include/Ably.modulemap
+++ b/Source/include/Ably.modulemap
@@ -81,5 +81,6 @@ framework module Ably {
         header "Ably/ARTNSMutableURLRequest+ARTUtils.h"
         header "Ably/ARTTime.h"
         header "Ably/ARTErrorChecker.h"
+        header "Ably/ARTResumeRequestResponse.h"
     }
 }

--- a/Test/Test Utilities/MockErrorChecker.swift
+++ b/Test/Test Utilities/MockErrorChecker.swift
@@ -1,0 +1,9 @@
+import Ably.Private
+
+class MockErrorChecker: ErrorChecker {
+    var isTokenError: Bool!
+
+    func isTokenError(_ errorInfo: ARTErrorInfo) -> Bool {
+        return isTokenError
+    }
+}

--- a/Test/Tests/DefaultErrorCheckerTests.swift
+++ b/Test/Tests/DefaultErrorCheckerTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+import Ably.Private
+
+final class DefaultErrorCheckerTests: XCTestCase {
+    private let checker = DefaultErrorChecker()
+
+    func test_isTokenError_statusCode401AndCodeBetween40140And40150() {
+        let errorInfo = ARTErrorInfo.create(
+            withCode: 40145, // arbitrarily chosen in range 40140 ..< 40150
+            status: 401,
+            message: "" // arbitrarily chosen
+        )
+
+        XCTAssertTrue(checker.isTokenError(errorInfo))
+    }
+
+    func test_isTokenError_statusCodeNot401() {
+        let errorInfo = ARTErrorInfo.create(
+            withCode: 40145, // arbitrarily chosen within range 40140 ..< 40150
+            status: 200, // arbitrarily chosen, != 401
+            message: "" // arbitrarily chosen
+        )
+
+        XCTAssertFalse(checker.isTokenError(errorInfo))
+    }
+
+    func test_isTokenError_statusCode401ButCodeLessThan40140() {
+        let errorInfo = ARTErrorInfo.create(
+            withCode: 40139, // arbitrarily chosen < 40140
+            status: 401,
+            message: "" // arbitrarily chosen
+        )
+
+        XCTAssertFalse(checker.isTokenError(errorInfo))
+    }
+
+    func test_isTokenError_statusCode401ButCodeGreaterThanOrEqualTo40150() {
+        let errorInfo = ARTErrorInfo.create(
+            withCode: 40150, // arbitrarily chosen >= 40150
+            status: 401,
+            message: "" // arbitrarily chosen
+        )
+
+        XCTAssertFalse(checker.isTokenError(errorInfo))
+    }
+}

--- a/Test/Tests/ResumeRequestResponseTests.swift
+++ b/Test/Tests/ResumeRequestResponseTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+import Ably.Private
+
+class ResumeRequestResponseTests: XCTestCase {
+    func test_valid() {
+        let protocolMessage = ARTProtocolMessage()
+        protocolMessage.action = .connected
+        protocolMessage.connectionId = "123" // same as currentConnectionID below
+
+        let errorChecker = MockErrorChecker()
+
+        let response = ResumeRequestResponse(
+            currentConnectionID: "123", // arbitrarily chosen
+            protocolMessage: protocolMessage,
+            errorChecker: errorChecker
+        )
+
+        XCTAssertEqual(response.type, .valid)
+        XCTAssertNil(response.error)
+    }
+
+    func test_invalid() {
+        let protocolMessage = ARTProtocolMessage()
+        protocolMessage.action = .connected
+        protocolMessage.connectionId = "456" // arbitrarily chosen, different to currentConnectionID below
+        protocolMessage.error = .init() // arbitrarily chosen
+
+        let errorChecker = MockErrorChecker()
+
+        let response = ResumeRequestResponse(
+            currentConnectionID: "123", // arbitrarily chosen
+            protocolMessage: protocolMessage,
+            errorChecker: errorChecker
+        )
+
+        XCTAssertEqual(response.type, .invalid)
+        XCTAssertEqual(response.error, protocolMessage.error)
+    }
+
+    func test_tokenError() {
+        let protocolMessage = ARTProtocolMessage()
+        protocolMessage.action = .error
+        protocolMessage.error = .init() // arbitrarily chosen
+
+        let errorChecker = MockErrorChecker()
+        errorChecker.isTokenError = true
+
+        let response = ResumeRequestResponse(
+            currentConnectionID: "123", // arbitrarily chosen
+            protocolMessage: protocolMessage,
+            errorChecker: errorChecker
+        )
+
+        XCTAssertEqual(response.type, .tokenError)
+        XCTAssertEqual(response.error, protocolMessage.error)
+    }
+
+    func test_fatalError() {
+        let protocolMessage = ARTProtocolMessage()
+        protocolMessage.action = .error
+        protocolMessage.error = .init() // arbitrarily chosen
+
+        let errorChecker = MockErrorChecker()
+        errorChecker.isTokenError = false
+
+        let response = ResumeRequestResponse(
+            currentConnectionID: "123",
+            protocolMessage: protocolMessage,
+            errorChecker: errorChecker
+        )
+
+        XCTAssertEqual(response.type, .fatalError)
+        XCTAssertEqual(response.error, protocolMessage.error)
+    }
+
+    func test_unknown() {
+        // For example, a CONNECTED ProtocolMessage with the same connection ID but with an error
+
+        let protocolMessage = ARTProtocolMessage()
+        protocolMessage.action = .connected
+        protocolMessage.connectionId = "123" // same as currentConnectionID below
+        protocolMessage.error = .init() // arbitrarily chosen
+
+        let errorChecker = MockErrorChecker()
+
+        let response = ResumeRequestResponse(
+            currentConnectionID: "123", // arbitrarily chosen
+            protocolMessage: protocolMessage,
+            errorChecker: errorChecker
+        )
+
+        XCTAssertEqual(response.type, .unknown)
+        XCTAssertNil(response.error)
+    }
+}


### PR DESCRIPTION
This introduces a `ARTResumeRequestResponse` type to represent the Realtime service’s response to a connection resume request. I’d like us to try incorporating it into https://github.com/ably/ably-cocoa/pull/1496.

See commit messages for more details.