### PR TITLE
Remove `ARTRealtimeChannelInternal` factory method

### DIFF
--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -253,10 +253,6 @@
     return self;
 }
 
-+ (instancetype)channelWithRealtime:(ARTRealtimeInternal *)realtime andName:(NSString *)name withOptions:(ARTRealtimeChannelOptions *)options {
-    return [[ARTRealtimeChannelInternal alloc] initWithRealtime:realtime andName:name withOptions:options];
-}
-
 - (ARTRealtimeChannelState)state {
     __block ARTRealtimeChannelState ret;
 dispatch_sync(_queue, ^{

--- a/Source/ARTRealtimeChannels.m
+++ b/Source/ARTRealtimeChannels.m
@@ -72,7 +72,7 @@
 }
 
 - (id)makeChannel:(NSString *)name options:(ARTRealtimeChannelOptions *)options {
-    return [ARTRealtimeChannelInternal channelWithRealtime:_realtime andName:name withOptions:options];
+    return [[ARTRealtimeChannelInternal alloc] initWithRealtime:_realtime andName:name withOptions:options];
 }
 
 - (id<NSFastEnumeration>)copyIntoIteratorWithMapper:(ARTRealtimeChannel *(^)(ARTRealtimeChannelInternal *))mapper {

--- a/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
@@ -45,7 +45,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readwrite, assign, nonatomic) BOOL attachResume;
 
 - (instancetype)initWithRealtime:(ARTRealtimeInternal *)realtime andName:(NSString *)name withOptions:(ARTRealtimeChannelOptions *)options;
-+ (instancetype)channelWithRealtime:(ARTRealtimeInternal *)realtime andName:(NSString *)name withOptions:(ARTRealtimeChannelOptions *)options;
 
 - (bool)isLastChannelSerial:(NSString *)channelSerial;
 


### PR DESCRIPTION
It buys us nothing over just using the initializer and it’s just another thing to have to update when we change the initializer’s signature.