### PR TITLE
Fix qualified name of `AblyTestsConfiguration` for macOS and tvOS

### DIFF
--- a/Test/Info-macOS.plist
+++ b/Test/Info-macOS.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSPrincipalClass</key>
-	<string>Ably_iOS_Tests.AblyTestsConfiguration</string>
+	<string>Ably_macOS_Tests.AblyTestsConfiguration</string>
 	<key>ABLY_ENV</key>
 	<string>$(ABLY_ENV)</string>
 </dict>

--- a/Test/Info-tvOS.plist
+++ b/Test/Info-tvOS.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSPrincipalClass</key>
-	<string>Ably_iOS_Tests.AblyTestsConfiguration</string>
+	<string>Ably_tvOS_Tests.AblyTestsConfiguration</string>
 </dict>
 </plist>


### PR DESCRIPTION
My mistake in 5d20fbf. Unfortunately it didn’t generate any loud runtime error; I only just now noticed a warning in the logs when running the tests on macOS locally.

I’m not sure what the consequences of this omission have been; it means that the line `AsyncDefaults.timeout = testTimeout` hasn’t been executing on macOS and tvOS. I wonder if that might have had some effect on test stability?