### PR TITLE
Refactor transitions

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -33,6 +33,12 @@
 		211A60FF29D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A60FE29D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m */; };
 		211A610029D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A60FE29D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m */; };
 		211A610129D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A60FE29D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m */; };
+		211A610329DA05C700D169C5 /* ARTAttachRequestMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 211A610229DA05C700D169C5 /* ARTAttachRequestMetadata.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211A610429DA05C700D169C5 /* ARTAttachRequestMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 211A610229DA05C700D169C5 /* ARTAttachRequestMetadata.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211A610529DA05C700D169C5 /* ARTAttachRequestMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 211A610229DA05C700D169C5 /* ARTAttachRequestMetadata.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211A610729DA05D700D169C5 /* ARTAttachRequestMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A610629DA05D700D169C5 /* ARTAttachRequestMetadata.m */; };
+		211A610829DA05D700D169C5 /* ARTAttachRequestMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A610629DA05D700D169C5 /* ARTAttachRequestMetadata.m */; };
+		211A610929DA05D700D169C5 /* ARTAttachRequestMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A610629DA05D700D169C5 /* ARTAttachRequestMetadata.m */; };
 		2132C20E29D20EEC000C4355 /* ARTResumeRequestResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2132C20D29D20EEC000C4355 /* ARTResumeRequestResponse.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2132C20F29D20EEC000C4355 /* ARTResumeRequestResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2132C20D29D20EEC000C4355 /* ARTResumeRequestResponse.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2132C21029D20EEC000C4355 /* ARTResumeRequestResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2132C20D29D20EEC000C4355 /* ARTResumeRequestResponse.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1022,6 +1028,8 @@
 		211A60DE29D7272000D169C5 /* ARTConnectionStateChangeMetadata.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTConnectionStateChangeMetadata.m; sourceTree = "<group>"; };
 		211A60FA29D8ABCF00D169C5 /* ARTChannelStateChangeMetadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTChannelStateChangeMetadata.h; path = PrivateHeaders/Ably/ARTChannelStateChangeMetadata.h; sourceTree = "<group>"; };
 		211A60FE29D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTChannelStateChangeMetadata.m; sourceTree = "<group>"; };
+		211A610229DA05C700D169C5 /* ARTAttachRequestMetadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTAttachRequestMetadata.h; path = PrivateHeaders/Ably/ARTAttachRequestMetadata.h; sourceTree = "<group>"; };
+		211A610629DA05D700D169C5 /* ARTAttachRequestMetadata.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTAttachRequestMetadata.m; sourceTree = "<group>"; };
 		2132C20D29D20EEC000C4355 /* ARTResumeRequestResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTResumeRequestResponse.h; path = PrivateHeaders/Ably/ARTResumeRequestResponse.h; sourceTree = "<group>"; };
 		2132C21129D20F05000C4355 /* ARTResumeRequestResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTResumeRequestResponse.m; sourceTree = "<group>"; };
 		2132C21529D20F69000C4355 /* ResumeRequestResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumeRequestResponseTests.swift; sourceTree = "<group>"; };
@@ -1747,6 +1755,8 @@
 				D746AE3B1BBC5AE1003ECEF8 /* ARTRealtimeChannel.m */,
 				211A60FA29D8ABCF00D169C5 /* ARTChannelStateChangeMetadata.h */,
 				211A60FE29D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m */,
+				211A610229DA05C700D169C5 /* ARTAttachRequestMetadata.h */,
+				211A610629DA05D700D169C5 /* ARTAttachRequestMetadata.m */,
 				D76F153923DB010C00B5133C /* ARTRealtimeChannelOptions.h */,
 				D76F153A23DB010C00B5133C /* ARTRealtimeChannelOptions.m */,
 				D7D29B401BE3DD0600374295 /* ARTConnection.h */,
@@ -2027,6 +2037,7 @@
 				D777EEE0206285CF002EBA03 /* ARTDeviceIdentityTokenDetails.h in Headers */,
 				2132C20E29D20EEC000C4355 /* ARTResumeRequestResponse.h in Headers */,
 				215F76032922C76C009E0E76 /* ARTClientInformation+Private.h in Headers */,
+				211A610329DA05C700D169C5 /* ARTAttachRequestMetadata.h in Headers */,
 				96BF615E1A35C1C8004CF2B3 /* ARTTypes.h in Headers */,
 				EB503C881C7E4A090053AF00 /* ARTClientOptions+Private.h in Headers */,
 				EB2D84F71CD75CCE00F23CDA /* ARTReachability.h in Headers */,
@@ -2242,6 +2253,7 @@
 				D710D51921949C42008F54AD /* ARTDeviceDetails.h in Headers */,
 				D710D50621949C18008F54AD /* ARTConnection+Private.h in Headers */,
 				D710D54E21949C66008F54AD /* ARTNSMutableRequest+ARTPush.h in Headers */,
+				211A610429DA05C700D169C5 /* ARTAttachRequestMetadata.h in Headers */,
 				D7D06F1026330E2800DEBDAD /* ARTHttp+Private.h in Headers */,
 				EB1B541A22FB1D7F006A59AC /* ARTPushChannelSubscriptions+Private.h in Headers */,
 				D710D48921949A85008F54AD /* ARTConstants.h in Headers */,
@@ -2395,6 +2407,7 @@
 				D710D52B21949C44008F54AD /* ARTDeviceDetails.h in Headers */,
 				D710D51221949C19008F54AD /* ARTConnection+Private.h in Headers */,
 				D710D55421949C67008F54AD /* ARTNSMutableRequest+ARTPush.h in Headers */,
+				211A610529DA05C700D169C5 /* ARTAttachRequestMetadata.h in Headers */,
 				D7D06F1126330E2900DEBDAD /* ARTHttp+Private.h in Headers */,
 				EB1B541B22FB1D7F006A59AC /* ARTPushChannelSubscriptions+Private.h in Headers */,
 				D710D48B21949A86008F54AD /* ARTConstants.h in Headers */,
@@ -2898,6 +2911,7 @@
 				D70C36C6233E6831002FD6E3 /* ARTFormEncode.m in Sources */,
 				D7AE18D31E5B410F00478D82 /* ARTPushChannelSubscriptions.m in Sources */,
 				1CD8DCA01B1C7315007EAF36 /* ARTDefault.m in Sources */,
+				211A610729DA05D700D169C5 /* ARTAttachRequestMetadata.m in Sources */,
 				D7AE18CF1E5B40FE00478D82 /* ARTPushDeviceRegistrations.m in Sources */,
 				D7B621951E4A6FE600684474 /* ARTDeviceDetails.m in Sources */,
 				D7588AF41BFF91B800BB8279 /* ARTURLSessionServerTrust.m in Sources */,
@@ -3102,6 +3116,7 @@
 				D710D5D121949D78008F54AD /* ARTAuthDetails.m in Sources */,
 				D710D4EC21949C0D008F54AD /* ARTRealtime.m in Sources */,
 				D710D4ED21949C0D008F54AD /* ARTRealtimeChannel.m in Sources */,
+				211A610829DA05D700D169C5 /* ARTAttachRequestMetadata.m in Sources */,
 				D710D67021949E78008F54AD /* ARTNSDictionary+ARTDictionaryUtil.m in Sources */,
 				D710D48C21949A97008F54AD /* ARTConstants.m in Sources */,
 				D710D5DA21949D78008F54AD /* ARTBaseMessage.m in Sources */,
@@ -3220,6 +3235,7 @@
 				D710D4FC21949C0E008F54AD /* ARTRealtime.m in Sources */,
 				D710D4FD21949C0E008F54AD /* ARTRealtimeChannel.m in Sources */,
 				D710D65621949E77008F54AD /* ARTNSDictionary+ARTDictionaryUtil.m in Sources */,
+				211A610929DA05D700D169C5 /* ARTAttachRequestMetadata.m in Sources */,
 				D710D48E21949A98008F54AD /* ARTConstants.m in Sources */,
 				D710D60021949D79008F54AD /* ARTBaseMessage.m in Sources */,
 				D520C4DB26809BB5000012B2 /* ARTStringifiable.m in Sources */,

--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -21,6 +21,12 @@
 		211A60D729D6D2C300D169C5 /* BackoffRetryDelayCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C31829D5E574000C4355 /* BackoffRetryDelayCalculatorTests.swift */; };
 		211A60D829D6D2C400D169C5 /* BackoffRetryDelayCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C31829D5E574000C4355 /* BackoffRetryDelayCalculatorTests.swift */; };
 		211A60D929D6D2C500D169C5 /* BackoffRetryDelayCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C31829D5E574000C4355 /* BackoffRetryDelayCalculatorTests.swift */; };
+		211A60DB29D726F800D169C5 /* ARTConnectionStateChangeMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 211A60DA29D726F800D169C5 /* ARTConnectionStateChangeMetadata.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211A60DC29D726F800D169C5 /* ARTConnectionStateChangeMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 211A60DA29D726F800D169C5 /* ARTConnectionStateChangeMetadata.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211A60DD29D726F800D169C5 /* ARTConnectionStateChangeMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 211A60DA29D726F800D169C5 /* ARTConnectionStateChangeMetadata.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211A60DF29D7272000D169C5 /* ARTConnectionStateChangeMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A60DE29D7272000D169C5 /* ARTConnectionStateChangeMetadata.m */; };
+		211A60E029D7272000D169C5 /* ARTConnectionStateChangeMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A60DE29D7272000D169C5 /* ARTConnectionStateChangeMetadata.m */; };
+		211A60E129D7272000D169C5 /* ARTConnectionStateChangeMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A60DE29D7272000D169C5 /* ARTConnectionStateChangeMetadata.m */; };
 		2132C20E29D20EEC000C4355 /* ARTResumeRequestResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2132C20D29D20EEC000C4355 /* ARTResumeRequestResponse.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2132C20F29D20EEC000C4355 /* ARTResumeRequestResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2132C20D29D20EEC000C4355 /* ARTResumeRequestResponse.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2132C21029D20EEC000C4355 /* ARTResumeRequestResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2132C20D29D20EEC000C4355 /* ARTResumeRequestResponse.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1006,6 +1012,8 @@
 		1C6C18A21ADFDAB100AB79E4 /* ARTLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTLog.m; sourceTree = "<group>"; };
 		1CD8DC9D1B1C7315007EAF36 /* ARTDefault.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARTDefault.h; path = include/Ably/ARTDefault.h; sourceTree = "<group>"; };
 		1CD8DC9E1B1C7315007EAF36 /* ARTDefault.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTDefault.m; sourceTree = "<group>"; };
+		211A60DA29D726F800D169C5 /* ARTConnectionStateChangeMetadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTConnectionStateChangeMetadata.h; path = PrivateHeaders/Ably/ARTConnectionStateChangeMetadata.h; sourceTree = "<group>"; };
+		211A60DE29D7272000D169C5 /* ARTConnectionStateChangeMetadata.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTConnectionStateChangeMetadata.m; sourceTree = "<group>"; };
 		2132C20D29D20EEC000C4355 /* ARTResumeRequestResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTResumeRequestResponse.h; path = PrivateHeaders/Ably/ARTResumeRequestResponse.h; sourceTree = "<group>"; };
 		2132C21129D20F05000C4355 /* ARTResumeRequestResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTResumeRequestResponse.m; sourceTree = "<group>"; };
 		2132C21529D20F69000C4355 /* ResumeRequestResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumeRequestResponseTests.swift; sourceTree = "<group>"; };
@@ -1724,6 +1732,8 @@
 				96A507BB1A3791490077CDF8 /* ARTRealtime.h */,
 				1C05CF1E1AC1D7EB00687AC9 /* ARTRealtime+Private.h */,
 				96A507BC1A3791490077CDF8 /* ARTRealtime.m */,
+				211A60DA29D726F800D169C5 /* ARTConnectionStateChangeMetadata.h */,
+				211A60DE29D7272000D169C5 /* ARTConnectionStateChangeMetadata.m */,
 				D746AE3A1BBC5AE1003ECEF8 /* ARTRealtimeChannel.h */,
 				D746AE421BBC5CD0003ECEF8 /* ARTRealtimeChannel+Private.h */,
 				D746AE3B1BBC5AE1003ECEF8 /* ARTRealtimeChannel.m */,
@@ -2073,6 +2083,7 @@
 				EB1B541922FB1D7F006A59AC /* ARTPushChannelSubscriptions+Private.h in Headers */,
 				EBF2285B1F4D9AD6009091DD /* ARTWebSocketTransport+Private.h in Headers */,
 				EBFFAC191E97919C003E7326 /* ARTLocalDevice+Private.h in Headers */,
+				211A60DB29D726F800D169C5 /* ARTConnectionStateChangeMetadata.h in Headers */,
 				D737F826263AF4CE0064FA05 /* ARTFallbackHosts.h in Headers */,
 				D746AE4F1BBD84E7003ECEF8 /* ARTChannelOptions.h in Headers */,
 				D7588AF31BFF91B800BB8279 /* ARTURLSessionServerTrust.h in Headers */,
@@ -2166,6 +2177,7 @@
 				D710D60F21949DDB008F54AD /* ARTHTTPPaginatedResponse.h in Headers */,
 				D710D58A21949D29008F54AD /* ARTMessage.h in Headers */,
 				D710D68721949ED5008F54AD /* ARTNSArray+ARTFunctional.h in Headers */,
+				211A60DC29D726F800D169C5 /* ARTConnectionStateChangeMetadata.h in Headers */,
 				D5BB211826AA9A9E00AA5F3E /* ARTNSMutableDictionary+ARTDictionaryUtil.h in Headers */,
 				D710D5BA21949D4F008F54AD /* ARTClientOptions+Private.h in Headers */,
 				D710D58521949D28008F54AD /* ARTChannel.h in Headers */,
@@ -2317,6 +2329,7 @@
 				D710D61921949DDC008F54AD /* ARTHTTPPaginatedResponse.h in Headers */,
 				D710D5B021949D2A008F54AD /* ARTMessage.h in Headers */,
 				D710D5CA21949D50008F54AD /* ARTClientOptions+Private.h in Headers */,
+				211A60DD29D726F800D169C5 /* ARTConnectionStateChangeMetadata.h in Headers */,
 				D710D5AB21949D2A008F54AD /* ARTChannel.h in Headers */,
 				EB1B541322FB1AB4006A59AC /* ARTPushChannel+Private.h in Headers */,
 				D54C55A926957FDE00729EC4 /* ARTNSURL+ARTUtils.h in Headers */,
@@ -2879,6 +2892,7 @@
 				217D1839254222F600DFF07E /* ARTSRHTTPConnectMessage.m in Sources */,
 				D746AE501BBD84E7003ECEF8 /* ARTChannelOptions.m in Sources */,
 				EB89D4051C61C1A4007FA5B7 /* ARTRestChannels.m in Sources */,
+				211A60DF29D7272000D169C5 /* ARTConnectionStateChangeMetadata.m in Sources */,
 				217D1834254222F600DFF07E /* ARTSRURLUtilities.m in Sources */,
 				2132C21E29D23196000C4355 /* ARTErrorChecker.m in Sources */,
 				D777EEE1206285CF002EBA03 /* ARTDeviceIdentityTokenDetails.m in Sources */,
@@ -3081,6 +3095,7 @@
 				D5BB213726AAA60500AA5F3E /* ARTNSError+ARTUtils.m in Sources */,
 				D710D57421949CC4008F54AD /* ARTPushDeviceRegistrations.m in Sources */,
 				D710D5D821949D78008F54AD /* ARTChannelOptions.m in Sources */,
+				211A60E029D7272000D169C5 /* ARTConnectionStateChangeMetadata.m in Sources */,
 				217D184B254222F700DFF07E /* ARTSRURLUtilities.m in Sources */,
 				2132C21F29D23196000C4355 /* ARTErrorChecker.m in Sources */,
 				D73B655923EF2B2900D459A6 /* ARTDeltaCodec.m in Sources */,
@@ -3197,6 +3212,7 @@
 				D710D57A21949CC5008F54AD /* ARTPushDeviceRegistrations.m in Sources */,
 				D710D5FE21949D79008F54AD /* ARTChannelOptions.m in Sources */,
 				D5BB213826AAA60500AA5F3E /* ARTNSError+ARTUtils.m in Sources */,
+				211A60E129D7272000D169C5 /* ARTConnectionStateChangeMetadata.m in Sources */,
 				217D1862254222FA00DFF07E /* ARTSRURLUtilities.m in Sources */,
 				2132C22029D23196000C4355 /* ARTErrorChecker.m in Sources */,
 				D73B655A23EF2B2900D459A6 /* ARTDeltaCodec.m in Sources */,

--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -27,6 +27,12 @@
 		211A60DF29D7272000D169C5 /* ARTConnectionStateChangeMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A60DE29D7272000D169C5 /* ARTConnectionStateChangeMetadata.m */; };
 		211A60E029D7272000D169C5 /* ARTConnectionStateChangeMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A60DE29D7272000D169C5 /* ARTConnectionStateChangeMetadata.m */; };
 		211A60E129D7272000D169C5 /* ARTConnectionStateChangeMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A60DE29D7272000D169C5 /* ARTConnectionStateChangeMetadata.m */; };
+		211A60FB29D8ABCF00D169C5 /* ARTChannelStateChangeMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 211A60FA29D8ABCF00D169C5 /* ARTChannelStateChangeMetadata.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211A60FC29D8ABCF00D169C5 /* ARTChannelStateChangeMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 211A60FA29D8ABCF00D169C5 /* ARTChannelStateChangeMetadata.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211A60FD29D8ABCF00D169C5 /* ARTChannelStateChangeMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 211A60FA29D8ABCF00D169C5 /* ARTChannelStateChangeMetadata.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211A60FF29D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A60FE29D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m */; };
+		211A610029D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A60FE29D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m */; };
+		211A610129D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A60FE29D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m */; };
 		2132C20E29D20EEC000C4355 /* ARTResumeRequestResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2132C20D29D20EEC000C4355 /* ARTResumeRequestResponse.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2132C20F29D20EEC000C4355 /* ARTResumeRequestResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2132C20D29D20EEC000C4355 /* ARTResumeRequestResponse.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2132C21029D20EEC000C4355 /* ARTResumeRequestResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 2132C20D29D20EEC000C4355 /* ARTResumeRequestResponse.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1014,6 +1020,8 @@
 		1CD8DC9E1B1C7315007EAF36 /* ARTDefault.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTDefault.m; sourceTree = "<group>"; };
 		211A60DA29D726F800D169C5 /* ARTConnectionStateChangeMetadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTConnectionStateChangeMetadata.h; path = PrivateHeaders/Ably/ARTConnectionStateChangeMetadata.h; sourceTree = "<group>"; };
 		211A60DE29D7272000D169C5 /* ARTConnectionStateChangeMetadata.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTConnectionStateChangeMetadata.m; sourceTree = "<group>"; };
+		211A60FA29D8ABCF00D169C5 /* ARTChannelStateChangeMetadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTChannelStateChangeMetadata.h; path = PrivateHeaders/Ably/ARTChannelStateChangeMetadata.h; sourceTree = "<group>"; };
+		211A60FE29D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTChannelStateChangeMetadata.m; sourceTree = "<group>"; };
 		2132C20D29D20EEC000C4355 /* ARTResumeRequestResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTResumeRequestResponse.h; path = PrivateHeaders/Ably/ARTResumeRequestResponse.h; sourceTree = "<group>"; };
 		2132C21129D20F05000C4355 /* ARTResumeRequestResponse.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTResumeRequestResponse.m; sourceTree = "<group>"; };
 		2132C21529D20F69000C4355 /* ResumeRequestResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumeRequestResponseTests.swift; sourceTree = "<group>"; };
@@ -1737,6 +1745,8 @@
 				D746AE3A1BBC5AE1003ECEF8 /* ARTRealtimeChannel.h */,
 				D746AE421BBC5CD0003ECEF8 /* ARTRealtimeChannel+Private.h */,
 				D746AE3B1BBC5AE1003ECEF8 /* ARTRealtimeChannel.m */,
+				211A60FA29D8ABCF00D169C5 /* ARTChannelStateChangeMetadata.h */,
+				211A60FE29D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m */,
 				D76F153923DB010C00B5133C /* ARTRealtimeChannelOptions.h */,
 				D76F153A23DB010C00B5133C /* ARTRealtimeChannelOptions.m */,
 				D7D29B401BE3DD0600374295 /* ARTConnection.h */,
@@ -2066,6 +2076,7 @@
 				D746AE401BBC5B14003ECEF8 /* ARTEventEmitter.h in Headers */,
 				D746AE531BBD85C5003ECEF8 /* ARTChannels.h in Headers */,
 				D7D8F82D1BC2C706009718F2 /* ARTTokenParams.h in Headers */,
+				211A60FB29D8ABCF00D169C5 /* ARTChannelStateChangeMetadata.h in Headers */,
 				EB0505FC1C5BD7C4006BA7E2 /* ARTBaseMessage+Private.h in Headers */,
 				D777EEE42063A64E002EBA03 /* ARTNSMutableRequest+ARTPush.h in Headers */,
 				EB20F8D71C653F2300EF3978 /* ARTPresence+Private.h in Headers */,
@@ -2178,6 +2189,7 @@
 				D710D58A21949D29008F54AD /* ARTMessage.h in Headers */,
 				D710D68721949ED5008F54AD /* ARTNSArray+ARTFunctional.h in Headers */,
 				211A60DC29D726F800D169C5 /* ARTConnectionStateChangeMetadata.h in Headers */,
+				211A60FC29D8ABCF00D169C5 /* ARTChannelStateChangeMetadata.h in Headers */,
 				D5BB211826AA9A9E00AA5F3E /* ARTNSMutableDictionary+ARTDictionaryUtil.h in Headers */,
 				D710D5BA21949D4F008F54AD /* ARTClientOptions+Private.h in Headers */,
 				D710D58521949D28008F54AD /* ARTChannel.h in Headers */,
@@ -2330,6 +2342,7 @@
 				D710D5B021949D2A008F54AD /* ARTMessage.h in Headers */,
 				D710D5CA21949D50008F54AD /* ARTClientOptions+Private.h in Headers */,
 				211A60DD29D726F800D169C5 /* ARTConnectionStateChangeMetadata.h in Headers */,
+				211A60FD29D8ABCF00D169C5 /* ARTChannelStateChangeMetadata.h in Headers */,
 				D710D5AB21949D2A008F54AD /* ARTChannel.h in Headers */,
 				EB1B541322FB1AB4006A59AC /* ARTPushChannel+Private.h in Headers */,
 				D54C55A926957FDE00729EC4 /* ARTNSURL+ARTUtils.h in Headers */,
@@ -2809,6 +2822,7 @@
 				217D182B254222F500DFF07E /* ARTSRWebSocket.m in Sources */,
 				EB2D5A911CC941A700AD1A67 /* ARTRealtimeTransport.m in Sources */,
 				D746AE391BBC3201003ECEF8 /* ARTMessage.m in Sources */,
+				211A60FF29D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m in Sources */,
 				D737F829263AF4CE0064FA05 /* ARTFallbackHosts.m in Sources */,
 				D7E0FEB9211DE94700659FAA /* ARTNSMutableRequest+ARTRest.m in Sources */,
 				D7B621991E4A762A00684474 /* ARTPushChannel.m in Sources */,
@@ -3012,6 +3026,7 @@
 				217D1842254222F700DFF07E /* ARTSRWebSocket.m in Sources */,
 				D710D4F021949C0D008F54AD /* ARTRealtimePresence.m in Sources */,
 				D710D4F321949C0D008F54AD /* ARTRealtimeChannels.m in Sources */,
+				211A610029D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m in Sources */,
 				D737F82A263AF4CE0064FA05 /* ARTFallbackHosts.m in Sources */,
 				D710D53521949C54008F54AD /* ARTDevicePushDetails.m in Sources */,
 				D710D62F21949E03008F54AD /* ARTDataQuery.m in Sources */,
@@ -3129,6 +3144,7 @@
 				D710D50021949C0E008F54AD /* ARTRealtimePresence.m in Sources */,
 				D710D50321949C0E008F54AD /* ARTRealtimeChannels.m in Sources */,
 				D737F82B263AF4CE0064FA05 /* ARTFallbackHosts.m in Sources */,
+				211A610129D8ABF100D169C5 /* ARTChannelStateChangeMetadata.m in Sources */,
 				D710D54721949C55008F54AD /* ARTDevicePushDetails.m in Sources */,
 				D710D63F21949E04008F54AD /* ARTDataQuery.m in Sources */,
 				D710D54321949C55008F54AD /* ARTPush.m in Sources */,

--- a/Source/ARTAttachRequestMetadata.m
+++ b/Source/ARTAttachRequestMetadata.m
@@ -1,0 +1,18 @@
+#import "ARTAttachRequestMetadata.h"
+
+@implementation ARTAttachRequestMetadata
+
+- (instancetype)initWithReason:(ARTErrorInfo *)reason {
+    return [self initWithReason:reason channelSerial:nil];
+}
+
+- (instancetype)initWithReason:(ARTErrorInfo *)reason channelSerial:(NSString *)channelSerial {
+    if (self = [super init]) {
+        _reason = reason;
+        _channelSerial = channelSerial;
+    }
+
+    return self;
+}
+
+@end

--- a/Source/ARTChannelStateChangeMetadata.m
+++ b/Source/ARTChannelStateChangeMetadata.m
@@ -1,0 +1,23 @@
+#import "ARTChannelStateChangeMetadata.h"
+
+@implementation ARTChannelStateChangeMetadata
+
+- (instancetype)initWithState:(ARTState)state {
+    return [self initWithState:state errorInfo:nil storeErrorInfo:NO];
+}
+
+- (instancetype)initWithState:(ARTState)state errorInfo:(ARTErrorInfo *)errorInfo {
+    return [self initWithState:state errorInfo:errorInfo storeErrorInfo:YES];
+}
+
+- (instancetype)initWithState:(ARTState)state errorInfo:(ARTErrorInfo *)errorInfo storeErrorInfo:(BOOL)storeErrorInfo {
+    if (self = [super init]) {
+        _state = state;
+        _errorInfo = errorInfo;
+        _storeErrorInfo = storeErrorInfo;
+    }
+
+    return self;
+}
+
+@end

--- a/Source/ARTConnectionStateChangeMetadata.m
+++ b/Source/ARTConnectionStateChangeMetadata.m
@@ -1,0 +1,17 @@
+#import "ARTConnectionStateChangeMetadata.h"
+
+@implementation ARTConnectionStateChangeMetadata
+
+- (instancetype)init {
+    return [self initWithErrorInfo:nil];
+}
+
+- (instancetype)initWithErrorInfo:(ARTErrorInfo *)errorInfo {
+    if (self = [super init]) {
+        _errorInfo = errorInfo;
+    }
+
+    return self;
+}
+
+@end

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -40,6 +40,7 @@
 #import "ARTErrorChecker.h"
 #import "ARTConnectionStateChangeMetadata.h"
 #import "ARTChannelStateChangeMetadata.h"
+#import "ARTAttachRequestMetadata.h"
 
 @interface ARTConnectionStateChange ()
 
@@ -789,7 +790,8 @@
             [self.logger warn:@"RT:%p connection \"%@\" has reconnected, but resume failed. Reattaching any attached channels", self, message.connectionId];
             // Reattach all channels
             for (ARTRealtimeChannelInternal *channel in self.channels.nosyncIterable) {
-                [channel reattachWithReason:message.error];
+                ARTAttachRequestMetadata *const metadata = [[ARTAttachRequestMetadata alloc] initWithReason:message.error];
+                [channel reattachWithMetadata:metadata];
             }
             _resuming = false;
         }

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -960,14 +960,10 @@ dispatch_sync(_queue, ^{
 }
 
 - (void)internalAttach:(ARTCallback)callback withReason:(ARTErrorInfo *)reason {
-    [self internalAttach:callback reason:reason storeErrorInfo:false channelSerial:nil];
+    [self internalAttach:callback reason:reason channelSerial:nil];
 }
 
-- (void)internalAttach:(ARTCallback)callback channelSerial:(NSString *)channelSerial reason:(ARTErrorInfo *)reason {
-    [self internalAttach:callback reason:reason storeErrorInfo:false channelSerial:channelSerial];
-}
-
-- (void)internalAttach:(ARTCallback)callback reason:(ARTErrorInfo *)reason storeErrorInfo:(BOOL)storeErrorInfo channelSerial:(NSString *)channelSerial {
+- (void)internalAttach:(ARTCallback)callback reason:(ARTErrorInfo *)reason channelSerial:(NSString *)channelSerial {
     switch (self.state_nosync) {
         case ARTRealtimeChannelDetaching: {
             [self.realtime.logger debug:__FILE__ line:__LINE__ message:@"RT:%p C:%p (%@) attach after the completion of Detaching", _realtime, self, self.name];
@@ -993,7 +989,7 @@ dispatch_sync(_queue, ^{
     const ARTState metadataState = reason ? ARTStateError : ARTStateOk;
     ARTChannelStateChangeMetadata *const metadata = [[ARTChannelStateChangeMetadata alloc] initWithState:metadataState
                                                                                                errorInfo:reason
-                                                                                          storeErrorInfo:storeErrorInfo];
+                                                                                          storeErrorInfo:NO];
     [self transition:ARTRealtimeChannelAttaching withMetadata:metadata];
 
     [self attachAfterChecks:callback channelSerial:channelSerial];
@@ -1168,7 +1164,7 @@ dispatch_sync(_queue, ^{
     _decodeFailureRecoveryInProgress = true;
     [self internalAttach:^(ARTErrorInfo *e) {
         self->_decodeFailureRecoveryInProgress = false;
-    } channelSerial:channelSerial reason:error];
+    } reason:error channelSerial:channelSerial];
 }
 
 #pragma mark - ARTPresenceMapDelegate

--- a/Source/ARTStatus.m
+++ b/Source/ARTStatus.m
@@ -139,7 +139,6 @@ NSInteger getStatusFromCode(NSInteger code) {
     if (self) {
         _state = ARTStateOk;
         _errorInfo = nil;
-        _storeErrorInfo = false;
    }
     return self;
 }
@@ -153,7 +152,6 @@ NSInteger getStatusFromCode(NSInteger code) {
 + (ARTStatus *)state:(ARTState)state info:(ARTErrorInfo *)info {
     ARTStatus * s = [ARTStatus state:state];
     s.errorInfo = info;
-    s.storeErrorInfo = true;
     return s;
 }
 

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -87,5 +87,6 @@ framework module Ably {
         header "ARTConstantRetryDelayCalculator.h"
         header "ARTBackoffRetryDelayCalculator.h"
         header "ARTClientOptions+TestConfiguration.h"
+        header "ARTConnectionStateChangeMetadata.h"
     }
 }

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -89,5 +89,6 @@ framework module Ably {
         header "ARTClientOptions+TestConfiguration.h"
         header "ARTConnectionStateChangeMetadata.h"
         header "ARTChannelStateChangeMetadata.h"
+        header "ARTAttachRequestMetadata.h"
     }
 }

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -88,5 +88,6 @@ framework module Ably {
         header "ARTBackoffRetryDelayCalculator.h"
         header "ARTClientOptions+TestConfiguration.h"
         header "ARTConnectionStateChangeMetadata.h"
+        header "ARTChannelStateChangeMetadata.h"
     }
 }

--- a/Source/PrivateHeaders/Ably/ARTAttachRequestMetadata.h
+++ b/Source/PrivateHeaders/Ably/ARTAttachRequestMetadata.h
@@ -1,0 +1,34 @@
+@import Foundation;
+
+@class ARTErrorInfo;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Provides metadata for a request to perform an operation that may ultimately call `ARTChannelRealtimeInternal`’s `internalAttach:callback:` method.
+ */
+NS_SWIFT_NAME(AttachRequestMetadata)
+@interface ARTAttachRequestMetadata: NSObject
+
+/**
+ Information about the error that triggered this attach request, if any.
+ */
+@property (nullable, nonatomic, readonly) ARTErrorInfo *reason;
+
+/**
+ The value to set for the `ATTACH` `ProtocolMessage`’s `channelSerial` property.
+ */
+@property (nullable, nonatomic, readonly) NSString *channelSerial;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ Creates an `ARTAttachRequestMetadata` instance with the given `reason`, whose `channelSerial` is `nil`.
+ */
+- (instancetype)initWithReason:(nullable ARTErrorInfo *)reason;
+
+- (instancetype)initWithReason:(nullable ARTErrorInfo *)reason channelSerial:(nullable NSString *)channelSerial NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTChannelStateChangeMetadata.h
+++ b/Source/PrivateHeaders/Ably/ARTChannelStateChangeMetadata.h
@@ -1,0 +1,50 @@
+@import Foundation;
+#import "ARTTypes.h"
+
+@class ARTErrorInfo;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Provides metadata for a request to perform an operation that may cause an `ARTRealtimeChannelInternal` instance to emit a connection state change.
+
+ `ARTRealtimeChannelInternal` will incorporate some of this data into the `ARTChannelStateChange` object that it emits as a result of the connection state change.
+ */
+NS_SWIFT_NAME(ChannelStateChangeMetadata)
+@interface ARTChannelStateChangeMetadata: NSObject
+
+/**
+ A state that some operations will use when failing pending presence operations.
+ */
+@property (nonatomic, readonly) ARTState state;
+
+/**
+ Information about the error that triggered this state change, if any.
+ */
+@property (nullable, nonatomic, readonly) ARTErrorInfo *errorInfo;
+
+/**
+ Whether the `ARTRealtimeChannelInternal` instance should update its `errorReason` property.
+ */
+@property (nonatomic, readonly) BOOL storeErrorInfo;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ Creates an `ARTChannelStateChangeMetadata` instance whose `errorInfo` is `nil`, and whose `storeErrorInfo` is `NO`.
+ */
+- (instancetype)initWithState:(ARTState)state;
+
+/**
+ Creates an `ARTChannelStateChangeMetadata` instance with the given `errorInfo`, whose `storeErrorInfo` is `YES`.
+ */
+- (instancetype)initWithState:(ARTState)state
+                    errorInfo:(nullable ARTErrorInfo *)errorInfo;
+
+- (instancetype)initWithState:(ARTState)state
+                    errorInfo:(nullable ARTErrorInfo *)errorInfo
+               storeErrorInfo:(BOOL)storeErrorInfo NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTConnectionStateChangeMetadata.h
+++ b/Source/PrivateHeaders/Ably/ARTConnectionStateChangeMetadata.h
@@ -1,0 +1,29 @@
+@import Foundation;
+
+@class ARTErrorInfo;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Provides metadata for a request to perform an operation that may cause an `ARTRealtimeInternal` instance to emit a connection state change.
+
+ `ARTRealtimeInternal` will incorporate this data into the `ARTConnectionStateChange` object that it emits as a result of the connection state change.
+ */
+NS_SWIFT_NAME(ConnectionStateChangeMetadata)
+@interface ARTConnectionStateChangeMetadata: NSObject
+
+/**
+ Information about the error that triggered this state change, if any.
+ */
+@property (nullable, nonatomic, readonly) ARTErrorInfo *errorInfo;
+
+/**
+ Creates an `ARTConnectionStateChangeMetadata` instance whose `errorInfo` is `nil`.
+ */
+- (instancetype)init;
+
+- (instancetype)initWithErrorInfo:(nullable ARTErrorInfo *)errorInfo NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTRealtime+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtime+Private.h
@@ -52,7 +52,6 @@ NS_ASSUME_NONNULL_BEGIN
 // State properties
 - (BOOL)shouldSendEvents;
 - (BOOL)shouldQueueEvents;
-- (ARTStatus *)defaultError;
 
 // Message sending
 - (void)sendQueuedMessages;

--- a/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
@@ -14,6 +14,7 @@
 @class ARTProtocolMessage;
 @class ARTRealtimePresenceInternal;
 @class ARTChannelStateChangeMetadata;
+@class ARTAttachRequestMetadata;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -49,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (bool)isLastChannelSerial:(NSString *)channelSerial;
 
-- (void)reattachWithReason:(nullable ARTErrorInfo *)reason;
+- (void)reattachWithMetadata:(ARTAttachRequestMetadata *)metadata;
 
 - (void)_attach:(nullable ARTCallback)callback;
 - (void)_detach:(nullable ARTCallback)callback;

--- a/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
@@ -13,6 +13,7 @@
 
 @class ARTProtocolMessage;
 @class ARTRealtimePresenceInternal;
+@class ARTChannelStateChangeMetadata;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -62,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ARTRealtimeChannelInternal (Private)
 
-- (void)transition:(ARTRealtimeChannelState)state status:(ARTStatus *)status;
+- (void)transition:(ARTRealtimeChannelState)state withMetadata:(ARTChannelStateChangeMetadata *)metadata;
 
 - (void)onChannelMessage:(ARTProtocolMessage *)message;
 - (void)publishProtocolMessage:(ARTProtocolMessage *)pm callback:(ARTStatusCallback)cb;
@@ -75,12 +76,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)onSync:(ARTProtocolMessage *)message;
 - (void)onError:(ARTProtocolMessage *)error;
 
-- (void)setSuspended:(ARTStatus *)status;
-- (void)setFailed:(ARTStatus *)status;
+- (void)setSuspended:(ARTChannelStateChangeMetadata *)metadata;
+- (void)setFailed:(ARTChannelStateChangeMetadata *)metadata;
 - (void)throwOnDisconnectedOrFailed;
 
 - (void)broadcastPresence:(ARTPresenceMessage *)pm;
-- (void)detachChannel:(ARTStatus *)status;
+- (void)detachChannel:(ARTChannelStateChangeMetadata *)metadata;
 
 - (void)sync;
 - (void)sync:(nullable ARTCallback)callback;

--- a/Source/include/Ably.modulemap
+++ b/Source/include/Ably.modulemap
@@ -88,5 +88,6 @@ framework module Ably {
         header "Ably/ARTBackoffRetryDelayCalculator.h"
         header "Ably/ARTClientOptions+TestConfiguration.h"
         header "Ably/ARTConnectionStateChangeMetadata.h"
+        header "Ably/ARTChannelStateChangeMetadata.h"
     }
 }

--- a/Source/include/Ably.modulemap
+++ b/Source/include/Ably.modulemap
@@ -89,5 +89,6 @@ framework module Ably {
         header "Ably/ARTClientOptions+TestConfiguration.h"
         header "Ably/ARTConnectionStateChangeMetadata.h"
         header "Ably/ARTChannelStateChangeMetadata.h"
+        header "Ably/ARTAttachRequestMetadata.h"
     }
 }

--- a/Source/include/Ably.modulemap
+++ b/Source/include/Ably.modulemap
@@ -87,5 +87,6 @@ framework module Ably {
         header "Ably/ARTConstantRetryDelayCalculator.h"
         header "Ably/ARTBackoffRetryDelayCalculator.h"
         header "Ably/ARTClientOptions+TestConfiguration.h"
+        header "Ably/ARTConnectionStateChangeMetadata.h"
     }
 }

--- a/Source/include/Ably/ARTStatus.h
+++ b/Source/include/Ably/ARTStatus.h
@@ -260,7 +260,6 @@ FOUNDATION_EXPORT NSString *const ARTAblyMessageNoMeansToRenewToken;
 @interface ARTStatus : NSObject
 
 @property (nullable, readonly, strong, nonatomic) ARTErrorInfo *errorInfo;
-@property (nonatomic, assign) BOOL storeErrorInfo;
 @property (nonatomic, assign) ARTState state;
 
 + (ARTStatus *)state:(ARTState) state;

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -1985,7 +1985,7 @@ class RealtimeClientChannelTests: XCTestCase {
             }
         }
 
-        channel.internal.setSuspended(ARTStatus.state(.ok))
+        channel.internal.setSuspended(.init(state: .ok))
         XCTAssertEqual(channel.state, ARTRealtimeChannelState.suspended)
 
         waitUntil(timeout: testTimeout) { done in
@@ -2492,7 +2492,7 @@ class RealtimeClientChannelTests: XCTestCase {
         rtl6c4TestsClient.connect()
         rtl6c4TestsChannel.attach()
         expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-        rtl6c4TestsChannel.internal.setSuspended(ARTStatus.state(.ok))
+        rtl6c4TestsChannel.internal.setSuspended(.init(state: .ok))
         expect(rtl6c4TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.suspended), timeout: testTimeout)
         waitUntil(timeout: testTimeout) { done in
             rtl6c4TestsPublish(done)

--- a/Test/Tests/RealtimeClientPresenceTests.swift
+++ b/Test/Tests/RealtimeClientPresenceTests.swift
@@ -722,7 +722,7 @@ class RealtimeClientPresenceTests: XCTestCase {
                 XCTAssertNil(stateChange.reason)
                 XCTAssertEqual(channel.presence.internal.pendingPresence.count, 1)
                 channel.internalAsync { _internal in
-                    _internal.setSuspended(ARTStatus.state(.error, info: ARTErrorInfo.create(withCode: 1234, message: "unknown error")))
+                    _internal.setSuspended(.init(state: .error, errorInfo: ARTErrorInfo.create(withCode: 1234, message: "unknown error")))
                 }
                 partialDone()
             }
@@ -801,7 +801,7 @@ class RealtimeClientPresenceTests: XCTestCase {
                 partialDone()
             }
             channel.internalAsync { _internal in
-                _internal.setSuspended(ARTStatus.state(.ok))
+                _internal.setSuspended(.init(state: .ok))
             }
         }
 


### PR DESCRIPTION
This creates objects that encapsulate all of the metadata related to a request to perform an operation that may cause a connection or channel to emit a state change. See commit messages for more details.

This is a refactor, which will form part of our implementation of #1431.