### PR TITLE
Remove some unusable logging in crypto classes

### DIFF
--- a/Source/ARTCrypto.m
+++ b/Source/ARTCrypto.m
@@ -10,12 +10,6 @@
 
 @end
 
-@interface ARTCrypto ()
-
-@property (nonatomic, strong) ARTLog * logger;
-
-@end
-
 @interface ARTCbcCipher ()
 
 @property CCAlgorithm algorithm;

--- a/Source/ARTCrypto.m
+++ b/Source/ARTCrypto.m
@@ -88,7 +88,6 @@
     }
 
     if (errorMsg) {
-        [self.logger error:@"ARTCrypto.ccAlgorithm: %@", errorMsg];
         if (error) *error = [NSError errorWithDomain:ARTAblyErrorDomain code:0 userInfo:@{NSLocalizedFailureReasonErrorKey: errorMsg}];
         return NO;
     }

--- a/Source/PrivateHeaders/Ably/ARTCrypto+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTCrypto+Private.h
@@ -6,7 +6,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ARTCipherParams ()
 
 @property (readonly, strong, nonatomic, nullable) NSData *iv;
-@property (nonatomic, strong) ARTLog *logger;
 - (instancetype)initWithAlgorithm:(NSString *)algorithm key:(id<ARTCipherKeyCompatible>)key iv:(NSData *_Nullable)iv;
 
 @end


### PR DESCRIPTION
This removes some logging functionality which the crypto classes are unable to make use of. See commit messages for more details.