### PR TITLE
Pass `retryAttempt` from attach metadata to state change metadata

### DIFF
--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -1014,7 +1014,8 @@ dispatch_sync(_queue, ^{
     const ARTState stateChangeMetadataState = metadata.reason ? ARTStateError : ARTStateOk;
     ARTChannelStateChangeMetadata *const stateChangeMetadata = [[ARTChannelStateChangeMetadata alloc] initWithState:stateChangeMetadataState
                                                                                                           errorInfo:metadata.reason
-                                                                                                     storeErrorInfo:NO];
+                                                                                                     storeErrorInfo:NO
+                                                                                                       retryAttempt:metadata.retryAttempt];
     [self transition:ARTRealtimeChannelAttaching withMetadata:stateChangeMetadata];
 
     [self attachAfterChecks:callback channelSerial:metadata.channelSerial];


### PR DESCRIPTION
I forgot to do this in 47e3a59.