### PR TITLE
Remove some unnecessary use of `static var` in test suite

### DIFF
--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -106,7 +106,7 @@ class AblyTests {
         let label: String
     }
 
-    static var queueIdentityKey = DispatchSpecificKey<QueueIdentity>()
+    static let queueIdentityKey = DispatchSpecificKey<QueueIdentity>()
 
     static var queue: DispatchQueue = {
         let queue = DispatchQueue(label: "io.ably.tests", qos: .userInitiated)


### PR DESCRIPTION
Some low-hanging fruit that I noticed whilst looking into #1604 (removing global mutable state in test suite).