### PR TITLE
Improve channel retry tests

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -57,6 +57,9 @@
 		21113B6329DDF7E800652C86 /* ARTInternalLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 21113B6229DDF7E800652C86 /* ARTInternalLogTests.m */; };
 		21113B6429DDF7ED00652C86 /* ARTInternalLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 21113B6229DDF7E800652C86 /* ARTInternalLogTests.m */; };
 		21113B6529DDF7EF00652C86 /* ARTInternalLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 21113B6229DDF7E800652C86 /* ARTInternalLogTests.m */; };
+		21113B5929DCA4C700652C86 /* DataGatherer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21113B5829DCA4C700652C86 /* DataGatherer.swift */; };
+		21113B5A29DCA4C700652C86 /* DataGatherer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21113B5829DCA4C700652C86 /* DataGatherer.swift */; };
+		21113B5B29DCA4C700652C86 /* DataGatherer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21113B5829DCA4C700652C86 /* DataGatherer.swift */; };
 		211A60D729D6D2C300D169C5 /* BackoffRetryDelayCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C31829D5E574000C4355 /* BackoffRetryDelayCalculatorTests.swift */; };
 		211A60D829D6D2C400D169C5 /* BackoffRetryDelayCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C31829D5E574000C4355 /* BackoffRetryDelayCalculatorTests.swift */; };
 		211A60D929D6D2C500D169C5 /* BackoffRetryDelayCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132C31829D5E574000C4355 /* BackoffRetryDelayCalculatorTests.swift */; };
@@ -1133,6 +1136,7 @@
 		21113B5429DC6ACD00652C86 /* ARTTestClientOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTTestClientOptions.m; sourceTree = "<group>"; };
 		21113B5E29DDDDD000652C86 /* LogAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogAdapterTests.swift; sourceTree = "<group>"; };
 		21113B6229DDF7E800652C86 /* ARTInternalLogTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTInternalLogTests.m; sourceTree = "<group>"; };
+		21113B5829DCA4C700652C86 /* DataGatherer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataGatherer.swift; sourceTree = "<group>"; };
 		211A60DA29D726F800D169C5 /* ARTConnectionStateChangeMetadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTConnectionStateChangeMetadata.h; path = PrivateHeaders/Ably/ARTConnectionStateChangeMetadata.h; sourceTree = "<group>"; };
 		211A60DE29D7272000D169C5 /* ARTConnectionStateChangeMetadata.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTConnectionStateChangeMetadata.m; sourceTree = "<group>"; };
 		211A60FA29D8ABCF00D169C5 /* ARTChannelStateChangeMetadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTChannelStateChangeMetadata.h; path = PrivateHeaders/Ably/ARTChannelStateChangeMetadata.h; sourceTree = "<group>"; };
@@ -1741,6 +1745,7 @@
 				D50D86E829E9444600EA72EA /* JSON.swift */,
 				210F67B029E9DB62007B9345 /* TestProxyTransportFactory.swift */,
 				21FD9F262A015BE400216482 /* Test.swift */,
+				21113B5829DCA4C700652C86 /* DataGatherer.swift */,
 			);
 			path = "Test Utilities";
 			sourceTree = "<group>";
@@ -3028,6 +3033,7 @@
 				D780846E1C68B3E50083009D /* NSObject+TestSuite.m in Sources */,
 				21881E7A283BD08300CFD9E2 /* GCDTests.swift in Sources */,
 				2124B79729DB144600AD8361 /* DefaultInternalLogCoreTests.swift in Sources */,
+				21113B5929DCA4C700652C86 /* DataGatherer.swift in Sources */,
 				D7093CA9219EFA8A00723F17 /* MockDeviceStorage.swift in Sources */,
 				D7CEF1321C8DD3BC004FB242 /* RealtimeClientPresenceTests.swift in Sources */,
 				853ED7C41B7A1A3C006F1C6F /* RestClientStatsTests.swift in Sources */,
@@ -3204,6 +3210,7 @@
 				D7093C19219E465300723F17 /* TestUtilities.swift in Sources */,
 				217FCF4729D626F6006E5F2D /* DefaultJitterCoefficientGeneratorTests.swift in Sources */,
 				560579DA24AF1BA900A4D03D /* ARTDefaultTests.swift in Sources */,
+				21113B5A29DCA4C700652C86 /* DataGatherer.swift in Sources */,
 				2132C2EA29D4B91B000C4355 /* BackoffCoefficients.swift in Sources */,
 				2132C22329D233EB000C4355 /* DefaultErrorCheckerTests.swift in Sources */,
 				D5FFA6A929E97EF30082DB4B /* CryptoData.swift in Sources */,
@@ -3261,6 +3268,7 @@
 				D7093C73219EE26000723F17 /* ReadmeExamplesTests.swift in Sources */,
 				217FCF4829D626F6006E5F2D /* DefaultJitterCoefficientGeneratorTests.swift in Sources */,
 				560579DB24AF1BA900A4D03D /* ARTDefaultTests.swift in Sources */,
+				21113B5B29DCA4C700652C86 /* DataGatherer.swift in Sources */,
 				2132C2EB29D4B91B000C4355 /* BackoffCoefficients.swift in Sources */,
 				2132C22429D233EB000C4355 /* DefaultErrorCheckerTests.swift in Sources */,
 				D5FFA6AA29E97EF30082DB4B /* CryptoData.swift in Sources */,

--- a/Test/Test Utilities/DataGatherer.swift
+++ b/Test/Test Utilities/DataGatherer.swift
@@ -1,0 +1,75 @@
+import Foundation
+import XCTest
+
+/**
+ A `DataGatherer` instance initiates a user-specified data-gathering activity, and provides a method for waiting until the activity submits some data.
+
+ The `DataGatherer` instance only cares about the _first_ data that is submitted to it, and will ignore any subsequently-submitted data. When the gathered data has value semantics, this can simplify the implementation of tests, since they do not need to be so careful about making sure to stop their data-gathering process at the right time.
+ */
+class DataGatherer<T> {
+    private let expectation: XCTestExpectation
+
+    // The value that the initializer’s `gather` block passed to its `submit` argument.
+    private var value: T?
+    // Synchronises access to `value`.
+    private let semaphore = DispatchSemaphore(value: 1)
+
+    /**
+     Initiates the data-gathering process specified by `gather`.
+
+     - Parameters:
+       - description: A human-readable description of the data-gathering process.
+       - gather: A function which implements the data-gathering process. It should call the `submit` callback with the gathered data when ready. Subsequent calls to `submit` will have no effect. `submit` can be safely called from any thread.
+     */
+    init(description: String, gather: (_ submit: @escaping (T) -> Void) -> Void) {
+        expectation = XCTestExpectation(description: description)
+        gather(complete(withValue:))
+    }
+
+    enum Error: Swift.Error {
+        case unexpectedResult(XCTWaiter.Result)
+    }
+
+    /**
+     Waits for the initializer’s `gather` function to submit data and then returns the submitted data. If data has already been submitted then it is returned immediately. This method can be safely called from any thread.
+     */
+    func waitForData(timeout: TimeInterval) throws -> T {
+        semaphore.wait()
+        if let value {
+            semaphore.signal()
+            return value
+        }
+        semaphore.signal()
+
+        let waiter = XCTWaiter()
+        let result = waiter.wait(for: [expectation], timeout: timeout)
+
+        switch result {
+        case .completed:
+            let value: T
+            semaphore.wait()
+            value = self.value!
+            semaphore.signal()
+            return value
+        default:
+            throw Error.unexpectedResult(result)
+        }
+    }
+
+    /**
+     Waits for the initializer’s `gather` function to submit data and then returns the submitted data. If data has already been submitted then it is returned immediately. This method can be safely called from any thread.
+     */
+    func waitForData(timeout: DispatchTimeInterval) throws -> T {
+        return try waitForData(timeout: timeout.toTimeInterval())
+    }
+
+    private func complete(withValue value: T) {
+        semaphore.wait()
+        if self.value == nil {
+            self.value = value
+        }
+        semaphore.signal()
+
+        expectation.fulfill()
+    }
+}

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -4097,10 +4097,11 @@ class RealtimeClientChannelTests: XCTestCase {
         for retryNumber in 1 ... numberOfRetriesToWaitFor {
             let observedStateChangesStartIndexForThisRetry = 1 + 2 * (retryNumber - 1)
 
-            // the channel emits a state change to the ATTACHING state...
+            // after channelRetryTimeout seconds (as described by the retry metadata attached to the channel state change), the channel emits a state change to the ATTACHING state...
             let firstObservedStateChange = observedStateChanges[observedStateChangesStartIndexForThisRetry]
             XCTAssertEqual(firstObservedStateChange.previous, .suspended)
             XCTAssertEqual(firstObservedStateChange.current, .attaching)
+            XCTAssertEqual(firstObservedStateChange.retryAttempt?.delay, options.channelRetryTimeout)
 
             // ...and the channel emits a state change to the SUSPENDED state, whose `reason` is non-nil.
             let secondObservedStateChange = observedStateChanges[observedStateChangesStartIndexForThisRetry + 1]

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -4005,50 +4005,108 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__131b__Channel__if_the_channel_receives_a_server_initiated_DETACHED_message_and_if_the_attempt_to_reattach_fails_then_the_channel_will_transition_to_SUSPENDED_state_with_periodic_reattach_with_channelRetryTimeout() throws {
         let test = Test()
         
+        // Given...
+
+        /* ...a Realtime client, configured with a realtimeRequestTimeout of 1 second and a channelRetryTimeout of 1 second...
+
+           ## Motivation for chosen realtimeRequestTimeout value
+
+           As described by (C), in this test we aim to trigger a sequence of attach retries by making each attach attempt time out after realtimeRequestTimeout. Thus, the execution time of this test case will be proportional to the value of retryRequestTimeout. The default value is 20 seconds, which would lead to a very long test execution time, so we reduce it to 1 second.
+
+           ## Motivation for chosen channelRetryTimeout value
+
+           We expect the retries in this sequence to be spaced apart by channelRetryTimeout seconds. The default value is 15 seconds, so as above, in order to avoid a very long test execution time we reduce it to 1 second.
+         */
         let options = try AblyTests.commonAppSetup(for: test)
         options.channelRetryTimeout = 1.0
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
         options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        
         client.connect()
-        
         defer { client.dispose(); client.close() }
-        
-        let transport = client.internal.transport as! TestProxyTransport
-        transport.actionsIgnored += [.attached] // Make sure that each attach attempt times out (after realtimeRequestTimeout = 1.0)
-
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
 
+        /* ...whose transport drops all incoming ATTACHED messages...
+
+           ## Motivation
+
+           1. So that the initial attach attempt triggered in (A) doesn’t complete, and hence we are sure that when the client receives the DETACHED ProtocolMessage injected in (B), the channel is still in the ATTACHING state, thus satisfying one of the preconditions of RTL13b;
+           2. (C) So that none of the client’s subsequent re-attach attempts (as described by the "repeated, indefinitely" of RTL13b) succeed, since they will each time out after realtimeRequestTimeout, hence creating conditions for the RTL13b retry sequence to indeed repeat indefinitely
+        */
+        let transport = client.internal.transport as! TestProxyTransport
+        transport.actionsIgnored += [.attached]
+
+        // ...from which we retrieve a channel...
         let channel = client.channels.get(test.uniqueChannelName())
+
+        // ...(A) which we put into the ATTACHING state,
         channel.attach()
-        
         XCTAssertEqual(channel.state, ARTRealtimeChannelState.attaching)
 
+        // When...
+
+        let numberOfRetriesToWaitFor = 5 // arbitrarily-chosen, see (D)
+        let retrySequenceDataGatherer = DataGatherer(description: "Observe emitted state changes") { submit in
+            var retryNumber = 1
+            var observedStateChanges: [ARTChannelStateChange] = []
+
+            channel.on { stateChange in
+                observedStateChanges.append(stateChange)
+
+                if (stateChange.current == .attaching) {
+                    retryNumber += 1
+                }
+
+                if (stateChange.current == .suspended) {
+                    if retryNumber > numberOfRetriesToWaitFor {
+                        submit(observedStateChanges)
+                    }
+                }
+            }
+        }
+
+        // (B) ...the channel receives a DETACHED ProtocolMessage,
         let detachedMessageWithError = AblyTests.newErrorProtocolMessage()
         detachedMessageWithError.action = .detached
         detachedMessageWithError.channel = channel.name
-        
-        var retryNumber = 1
-        let numberOfRetriesToWaitFor = 5 // An arbitrary number to finish test before timeout for `waitUntil` fires
-        
-        waitUntil(timeout: testTimeout) { done in
-            channel.on(.attaching) { stateChange in
-                XCTAssertEqual(stateChange.previous, ARTRealtimeChannelState.suspended)
-                retryNumber += 1
-            }
-            channel.on(.suspended) { stateChange in
-                XCTAssertEqual(stateChange.previous, ARTRealtimeChannelState.attaching)
-                XCTAssertNotNil(stateChange.reason)
-                if retryNumber > numberOfRetriesToWaitFor {
-                    done()
-                }
-            }
-            channel.on(.attached) { _ in
-                fail("Should not receive attached message")
-            }
-            client.internal.transport?.receive(detachedMessageWithError) // force to .suspended
+        client.internal.transport?.receive(detachedMessageWithError)
+
+        // Then...
+
+        let timeout = Double(numberOfRetriesToWaitFor) * (
+            options.testOptions.realtimeRequestTimeout // waiting for attach to time out
+            + options.channelRetryTimeout // waiting for retry to occur
+            + 0.2 // some extra tolerance, arbitrarily chosen
+        )
+        let observedStateChanges = try retrySequenceDataGatherer.waitForData(timeout: timeout)
+
+        let expectedNumberOfObservedStateChanges = 1 + 2 * numberOfRetriesToWaitFor
+        XCTAssertEqual(observedStateChanges.count, expectedNumberOfObservedStateChanges)
+        guard observedStateChanges.count == expectedNumberOfObservedStateChanges else {
+            return
+        }
+
+        // ...the channel emits a state change to the SUSPENDED state...
+        let startObservedStateChange = observedStateChanges[0]
+        XCTAssertEqual(startObservedStateChange.previous, .attaching)
+        XCTAssertEqual(startObservedStateChange.current, .suspended)
+        XCTAssertNotNil(startObservedStateChange.reason)
+
+        // (D) ...and then, in the following order, we observe the following sequence of events occur numberOfRetriesToWaitFor (a number arbitrarily chosen to give us confidence that this sequence is going to repeat indefinitely) times:
+        for retryNumber in 1 ... numberOfRetriesToWaitFor {
+            let observedStateChangesStartIndexForThisRetry = 1 + 2 * (retryNumber - 1)
+
+            // the channel emits a state change to the ATTACHING state...
+            let firstObservedStateChange = observedStateChanges[observedStateChangesStartIndexForThisRetry]
+            XCTAssertEqual(firstObservedStateChange.previous, .suspended)
+            XCTAssertEqual(firstObservedStateChange.current, .attaching)
+
+            // ...and the channel emits a state change to the SUSPENDED state, whose `reason` is non-nil.
+            let secondObservedStateChange = observedStateChanges[observedStateChangesStartIndexForThisRetry + 1]
+            XCTAssertEqual(secondObservedStateChange.previous, .attaching)
+            XCTAssertEqual(secondObservedStateChange.current, .suspended)
+            XCTAssertNotNil(secondObservedStateChange.reason)
         }
     }
 


### PR DESCRIPTION
This is preparation for modifying `test__131b__Channel__if_the_channel_receives_a_server_initiated_DETACHED_message_and_if_the_attempt_to_reattach_fails_then_the_channel_will_transition_to_SUSPENDED_state_with_periodic_reattach_with_channelRetryTimeout` in #1431.

I didn't find the test very readable in its current state, and this is an attempt at improving that. I've also added assertions about the retry delays, which will become more important when we introduce the backoff and jitter logic.

See commit messages for more details.