### PR TITLE
Stop using the `-logWithError:` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Internal changes:**
 
-- The ably-cocoa library no longer calls any of the `ARTLog` methods in the `ARTLog (Shorthand)` category. Be aware that if you have created a custom subclass of `ARTLog` which overrides any of these methods, they will no longer be called. `ARTLog` now performs all of its logging using only the `-log:withLevel:` and `-logWithError:` methods.
+- The ably-cocoa library no longer calls any of the `ARTLog` methods in the `ARTLog (Shorthand)` category, nor the `-logWithError:` method. Be aware that if you have created a custom subclass of `ARTLog` which overrides any of these methods, they will no longer be called. `ARTLog` now performs all of its logging using only the `-log:withLevel:` method.
 
 ## [1.2.19](https://github.com/ably/ably-cocoa/tree/1.2.19)
 

--- a/Source/ARTInternalLog.m
+++ b/Source/ARTInternalLog.m
@@ -23,10 +23,6 @@
     [self.logger log:message withLevel:level];
 }
 
-- (void)logWithError:(ARTErrorInfo *)error {
-    [self.logger logWithError:error];
-}
-
 // MARK: Log level
 
 - (ARTLogLevel)logLevel {

--- a/Source/ARTLogAdapter.m
+++ b/Source/ARTLogAdapter.m
@@ -25,10 +25,6 @@ NS_ASSUME_NONNULL_END
     [self.logger log:message withLevel:level];
 }
 
-- (void)logWithError:(ARTErrorInfo *)error {
-    [self.logger logWithError:error];
-}
-
 - (ARTLogLevel)logLevel {
     return self.logger.logLevel;
 }

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -400,7 +400,7 @@ dispatch_sync(_queue, ^{
         case ARTRealtimeChannelDetached: {
             ARTErrorInfo *error = [ARTErrorInfo createWithCode:ARTErrorBadRequest
                                                        message:@"Unable to sync to channel; not attached."];
-            [self.logger logWithError:error];
+            [self.logger error:@"%@", error.message];
             if (callback) callback(error);
             return;
         }

--- a/Source/PrivateHeaders/Ably/ARTInternalLog.h
+++ b/Source/PrivateHeaders/Ably/ARTInternalLog.h
@@ -24,7 +24,6 @@ NS_SWIFT_NAME(InternalLog)
 - (instancetype)init NS_UNAVAILABLE;
 
 - (void)log:(NSString *)message withLevel:(ARTLogLevel)level;
-- (void)logWithError:(ARTErrorInfo *)error;
 
 @property (nonatomic, assign) ARTLogLevel logLevel;
 

--- a/Source/PrivateHeaders/Ably/ARTLogAdapter.h
+++ b/Source/PrivateHeaders/Ably/ARTLogAdapter.h
@@ -34,13 +34,6 @@ NS_SWIFT_NAME(LogAdapter)
 - (void)log:(NSString *)message withLevel:(ARTLogLevel)level;
 
 /**
- `ARTLogAdapter` implements this `ARTVersion2Log` protocol requirement by calling the `-logWithError:` method on its underlying `ARTLog` instance.
-
- As with `-log:withLevel:`, the implementation of this method may change, or the method may disappear entirely, as we evolve the `ARTVersion2Log` protocol.
- */
-- (void)logWithError:(ARTErrorInfo *)error;
-
-/**
  `ARTLogAdapter` implements this `ARTVersion2Log` protocol requirement by forwarding the setter and getter calls to its underlying `ARTLog` instance.
  */
 @property (nonatomic, assign) ARTLogLevel logLevel;

--- a/Source/PrivateHeaders/Ably/ARTVersion2Log.h
+++ b/Source/PrivateHeaders/Ably/ARTVersion2Log.h
@@ -19,8 +19,6 @@ NS_SWIFT_NAME(Version2Log)
 
 - (void)log:(NSString *)message withLevel:(ARTLogLevel)level;
 
-- (void)logWithError:(ARTErrorInfo *)error;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/include/Ably/ARTLog.h
+++ b/Source/include/Ably/ARTLog.h
@@ -20,6 +20,8 @@ typedef NS_ENUM(NSUInteger, ARTLogLevel) {
 @property (nonatomic, assign) ARTLogLevel logLevel;
 
 - (void)log:(NSString *)message withLevel:(ARTLogLevel)level;
+
+// This method should be considered obsolete. It is no longer called by the ably-cocoa SDK.
 - (void)logWithError:(ARTErrorInfo *)error;
 
 - (ARTLog *)verboseMode;

--- a/Test/Test Utilities/MockVersion2Log.swift
+++ b/Test/Test Utilities/MockVersion2Log.swift
@@ -8,15 +8,9 @@ class MockVersion2Log: NSObject, Version2Log {
     @objc var lastReceivedLogMessageArgumentMessage: String?
     @objc var lastReceivedLogMessageArgumentLevel: ARTLogLevel = .none
 
-    @objc var lastReceivedLogErrorArgument: ARTErrorInfo?
-
     func log(_ message: String, with level: ARTLogLevel) {
         lastReceivedLogMessageArguments = (message: message, level: level)
         lastReceivedLogMessageArgumentMessage = message
         lastReceivedLogMessageArgumentLevel = level
-    }
-
-    func logWithError(_ error: ARTErrorInfo) {
-        lastReceivedLogErrorArgument = error
     }
 }

--- a/Test/Tests/InternalLogTests.swift
+++ b/Test/Tests/InternalLogTests.swift
@@ -17,17 +17,6 @@ class InternalLogTests: XCTestCase {
         }
     }
 
-    func test_logError() {
-        let mock = MockVersion2Log()
-        let internalLog = InternalLog(logger: mock)
-
-        let error = ARTErrorInfo.createUnknownError()
-        internalLog.logWithError(error)
-
-        let logged = mock.lastReceivedLogErrorArgument!
-        XCTAssertEqual(logged, error)
-    }
-
     func test_logLevel() {
         let mock = MockVersion2Log()
         mock.logLevel = .info

--- a/Test/Tests/LogAdapterTests.swift
+++ b/Test/Tests/LogAdapterTests.swift
@@ -4,14 +4,9 @@ import Ably.Private
 class LogAdapterTests: XCTestCase {
     class MockARTLog: ARTLog {
         var lastReceivedLogMessageArguments: (message: String, level: ARTLogLevel)?
-        var lastReceivedLogErrorArgument: ARTErrorInfo?
 
         override func log(_ message: String, with level: ARTLogLevel) {
             lastReceivedLogMessageArguments = (message: message, level: level)
-        }
-
-        override func logWithError(_ error: ARTErrorInfo) {
-            lastReceivedLogErrorArgument = error
         }
     }
 
@@ -28,17 +23,6 @@ class LogAdapterTests: XCTestCase {
             XCTAssertEqual(logged.level, level)
             XCTAssertEqual(logged.message, message)
         }
-    }
-
-    func test_logError() {
-        let underlyingLogger = MockARTLog()
-        let logger = LogAdapter(logger: underlyingLogger)
-
-        let error = ARTErrorInfo.createUnknownError()
-        logger.logWithError(error)
-
-        let logged = underlyingLogger.lastReceivedLogErrorArgument!
-        XCTAssertEqual(logged, error)
     }
 
     func test_logLevel() {


### PR DESCRIPTION
It’s only being used in one place internally. Furthermore, I don’t think it makes sense to log an error message without describing the context in which the error occurred. We’ll revisit whether there’s something more appropriate this should be replaced by, as part of #1617 and #1628.