### PR TITLE
Remove unnecessary `#include` guards

### DIFF
--- a/Source/PrivateHeaders/Ably/ARTJsonLikeEncoder.h
+++ b/Source/PrivateHeaders/Ably/ARTJsonLikeEncoder.h
@@ -1,6 +1,3 @@
-#ifndef ARTJsonLikeEncoder_h
-#define ARTJsonLikeEncoder_h
-
 #import <Ably/ARTRest+Private.h>
 #import <Ably/ARTEncoder.h>
 #import <Ably/ARTTokenDetails.h>
@@ -70,5 +67,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-
-#endif /* ARTJsonLikeEncoder_h */

--- a/Source/PrivateHeaders/Ably/ARTPushChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPushChannel+Private.h
@@ -1,6 +1,3 @@
-#ifndef ARTPushChannel_Private_h
-#define ARTPushChannel_Private_h
-
 #import <Ably/ARTPushChannel.h>
 #import "ARTQueuedDealloc.h"
 
@@ -19,5 +16,3 @@
 - (instancetype)initWithInternal:(ARTPushChannelInternal *)internal queuedDealloc:(ARTQueuedDealloc *)dealloc;
 
 @end
-
-#endif /* ARTPushChannel_Private_h */

--- a/Source/PrivateHeaders/Ably/ARTPushChannelSubscriptions+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPushChannelSubscriptions+Private.h
@@ -1,6 +1,3 @@
-#ifndef ARTPushChannelSubscriptions_Private_h
-#define ARTPushChannelSubscriptions_Private_h
-
 #import <Ably/ARTPushChannelSubscriptions.h>
 #import "ARTQueuedDealloc.h"
 
@@ -19,5 +16,3 @@
 - (instancetype)initWithInternal:(ARTPushChannelSubscriptionsInternal *)internal queuedDealloc:(ARTQueuedDealloc *)dealloc;
 
 @end
-
-#endif /* ARTPushChannelSubscriptions_Private_h */

--- a/Source/PrivateHeaders/Ably/ARTPushDeviceRegistrations+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPushDeviceRegistrations+Private.h
@@ -1,6 +1,3 @@
-#ifndef ARTPushDeviceRegistrations_Private_h
-#define ARTPushDeviceRegistrations_Private_h
-
 #import <Ably/ARTPushDeviceRegistrations.h>
 #import "ARTQueuedDealloc.h"
 
@@ -19,5 +16,3 @@
 - (instancetype)initWithInternal:(ARTPushDeviceRegistrationsInternal *)internal queuedDealloc:(ARTQueuedDealloc *)dealloc;
 
 @end
-
-#endif /* ARTPushDeviceRegistrations_Private_h */

--- a/Source/PrivateHeaders/Ably/ARTQueuedDealloc.h
+++ b/Source/PrivateHeaders/Ably/ARTQueuedDealloc.h
@@ -1,6 +1,3 @@
-#ifndef ARTQueuedDealloc_h
-#define ARTQueuedDealloc_h
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -13,5 +10,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-
-#endif /* ARTQueuedDealloc_h */

--- a/Source/PrivateHeaders/Ably/ARTURLSession.h
+++ b/Source/PrivateHeaders/Ably/ARTURLSession.h
@@ -1,6 +1,3 @@
-#ifndef ARTURLSession_h
-#define ARTURLSession_h
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -18,5 +15,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-
-#endif /* ARTURLSession_h */

--- a/Source/PrivateHeaders/Ably/ARTWebSocket.h
+++ b/Source/PrivateHeaders/Ably/ARTWebSocket.h
@@ -1,6 +1,3 @@
-#ifndef ARTWebSocket_h
-#define ARTWebSocket_h
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -36,5 +33,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-
-#endif /* ARTWebSocket_h */


### PR DESCRIPTION
These aren’t necessary when using `#import`, and we don’t use them for most of the headers in the project. These probably just came from using Xcode’s default header file template.