### PR TITLE
Remove shared `TestUtilities.userQueue`

### DIFF
--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -113,11 +113,11 @@ class AblyTests {
         return queue
     }()
 
-    static var userQueue: DispatchQueue = {
-        let queue = DispatchQueue(label: "io.ably.tests.callbacks", qos: .userInitiated)
+    static func createUserQueue() -> DispatchQueue {
+        let queue = DispatchQueue(label: "io.ably.tests.callbacks.\(UUID().uuidString)", qos: .userInitiated)
         queue.setSpecific(key: queueIdentityKey, value: QueueIdentity(label: queue.label))
         return queue
-    }()
+    }
 
     static func currentQueueLabel() -> String? {
         return DispatchQueue.getSpecific(key: queueIdentityKey)?.label

--- a/Test/Tests/PushAdminTests.swift
+++ b/Test/Tests/PushAdminTests.swift
@@ -105,7 +105,7 @@ class PushAdminTests: XCTestCase {
         super.setUp()
         let options = AblyTests.commonAppSetup()
         options.pushFullWait = true
-        options.dispatchQueue = AblyTests.userQueue
+        options.dispatchQueue = AblyTests.createUserQueue()
         let rest = ARTRest(options: options)
         rest.internal.storage = MockDeviceStorage()
         let group = DispatchGroup()
@@ -136,7 +136,7 @@ class PushAdminTests: XCTestCase {
 
     override class func tearDown() {
         let options = AblyTests.commonAppSetup()
-        options.dispatchQueue = AblyTests.userQueue
+        options.dispatchQueue = AblyTests.createUserQueue()
         let rest = ARTRest(options: options)
         rest.internal.storage = MockDeviceStorage()
         let group = DispatchGroup()

--- a/Test/Tests/PushChannelTests.swift
+++ b/Test/Tests/PushChannelTests.swift
@@ -14,12 +14,15 @@ class PushChannelTests: XCTestCase {
         return super.defaultTestSuite
     }
 
+    private var userQueue: DispatchQueue!
+
     override func setUp() {
         super.setUp()
 
         mockHttpExecutor = MockHTTPExecutor()
         let options = ARTClientOptions(key: "xxxx:xxxx")
-        options.dispatchQueue = AblyTests.userQueue
+        userQueue = AblyTests.createUserQueue()
+        options.dispatchQueue = userQueue
         options.internalDispatchQueue = AblyTests.queue
         rest = ARTRest(options: options)
         rest.internal.options.clientId = "tester"
@@ -33,13 +36,13 @@ class PushChannelTests: XCTestCase {
 
     // RSH7a1
     func test__001__Push_Channel__subscribeDevice__should_fail_if_the_LocalDevice_doesn_t_have_an_deviceIdentityToken() {
-        waitUntil(timeout: testTimeout) { done in
+        waitUntil(timeout: testTimeout) { [userQueue] done in
             rest.channels.get(uniqueChannelName()).push.subscribeDevice { error in
                 guard let error = error else {
                     fail("Error is nil"); done(); return
                 }
                 expect(error.message).to(contain("cannot use device before device activation has finished"))
-                XCTAssertTrue(AblyTests.currentQueueLabel() == AblyTests.userQueue.label)
+                XCTAssertTrue(AblyTests.currentQueueLabel() == userQueue!.label)
                 done()
             }
         }
@@ -87,13 +90,13 @@ class PushChannelTests: XCTestCase {
         rest.device.clientId = nil
         defer { rest.device.clientId = originalClientId }
 
-        waitUntil(timeout: testTimeout) { done in
+        waitUntil(timeout: testTimeout) { [userQueue] done in
             rest.channels.get(uniqueChannelName()).push.subscribeClient { error in
                 guard let error = error else {
                     fail("Error is nil"); done(); return
                 }
                 expect(error.message).to(contain("null client ID"))
-                XCTAssertTrue(AblyTests.currentQueueLabel() == AblyTests.userQueue.label)
+                XCTAssertTrue(AblyTests.currentQueueLabel() == userQueue!.label)
                 done()
             }
         }
@@ -132,13 +135,13 @@ class PushChannelTests: XCTestCase {
 
     // RSH7c1
     func test__005__Push_Channel__unsubscribeDevice__should_fail_if_the_LocalDevice_doesn_t_have_a_deviceIdentityToken() {
-        waitUntil(timeout: testTimeout) { done in
+        waitUntil(timeout: testTimeout) { [userQueue] done in
             rest.channels.get(uniqueChannelName()).push.unsubscribeDevice { error in
                 guard let error = error else {
                     fail("Error is nil"); done(); return
                 }
                 expect(error.message).to(contain("cannot use device before device activation has finished"))
-                XCTAssertTrue(AblyTests.currentQueueLabel() == AblyTests.userQueue.label)
+                XCTAssertTrue(AblyTests.currentQueueLabel() == userQueue!.label)
                 done()
             }
         }
@@ -184,13 +187,13 @@ class PushChannelTests: XCTestCase {
         rest.device.clientId = nil
         defer { rest.device.clientId = originalClientId }
 
-        waitUntil(timeout: testTimeout) { done in
+        waitUntil(timeout: testTimeout) { [userQueue] done in
             rest.channels.get(uniqueChannelName()).push.unsubscribeClient { error in
                 guard let error = error else {
                     fail("Error is nil"); done(); return
                 }
                 expect(error.message).to(contain("null client ID"))
-                XCTAssertTrue(AblyTests.currentQueueLabel() == AblyTests.userQueue.label)
+                XCTAssertTrue(AblyTests.currentQueueLabel() == userQueue!.label)
                 done()
             }
         }


### PR DESCRIPTION
Part of #1604 (removing global mutable state in test suite).

The makes it less likely that work enqueued by one test will impact work enqueued by other tests. (I say "less likely" and not "impossible" because separate dispatch queues will impact each other if you have too many of them performing work at the same time.)