### PR TITLE
Remove static `setupOptionsCounter` variable

### DIFF
--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -100,7 +100,6 @@ class AblyTests {
     }
 
     static var testApplication: JSON?
-    static fileprivate var setupOptionsCounter = 0
 
     struct QueueIdentity {
         let label: String
@@ -131,8 +130,7 @@ class AblyTests {
     }
 
     class func setupOptions(_ options: ARTClientOptions, forceNewApp: Bool = false, debug: Bool = false) -> ARTClientOptions {
-        options.testOptions.channelNamePrefix = "test-\(setupOptionsCounter)"
-        setupOptionsCounter += 1
+        options.testOptions.channelNamePrefix = "test-\(UUID().uuidString)"
 
         if forceNewApp {
             testApplication = nil


### PR DESCRIPTION
Part of #1604 (removing shared mutable state in test suite). A UUID is just as good, and one less variable to worry about.