### PR TITLE
Add a couple of missing parameter labels

### DIFF
--- a/Source/ARTHttp.m
+++ b/Source/ARTHttp.m
@@ -21,7 +21,7 @@ Class configuredUrlSessionClass = nil;
     configuredUrlSessionClass = urlSessionClass;
 }
 
-- (instancetype)init:(dispatch_queue_t)queue logger:(ARTInternalLog *)logger {
+- (instancetype)initWithQueue:(dispatch_queue_t)queue logger:(ARTInternalLog *)logger {
     self = [super init];
     if (self) {
         const Class urlSessionClass = configuredUrlSessionClass ? configuredUrlSessionClass : [ARTURLSessionServerTrust class];

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -178,7 +178,7 @@ NS_ASSUME_NONNULL_END
 #if TARGET_OS_IOS
         _storage = [ARTLocalDeviceStorage newWithLogger:_logger];
 #endif
-        _http = [[ARTHttp alloc] init:_queue logger:_logger];
+        _http = [[ARTHttp alloc] initWithQueue:_queue logger:_logger];
         ARTLogVerbose(_logger, @"RS:%p %p alloc HTTP", self, _http);
         _httpExecutor = _http;
 

--- a/Source/PrivateHeaders/Ably/ARTHttp.h
+++ b/Source/PrivateHeaders/Ably/ARTHttp.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setURLSessionClass:(Class)urlSessionClass;
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
-- (instancetype)init:(dispatch_queue_t)queue logger:(ARTInternalLog *)logger;
+- (instancetype)initWithQueue:(dispatch_queue_t)queue logger:(ARTInternalLog *)logger;
 
 @end
 

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -801,7 +801,7 @@ class MockHTTP: ARTHttp {
     private var count: Int = 0
 
     init(logger: InternalLog) {
-        super.init(AblyTests.queue, logger: logger)
+        super.init(queue: AblyTests.queue, logger: logger)
     }
 
     func setNetworkState(network: FakeNetworkResponse, resetAfter numberOfRequests: Int) {
@@ -992,7 +992,7 @@ class TestProxyHTTPExecutor: NSObject, ARTHTTPExecutor {
 
     init(_ logger: InternalLog) {
         self.logger = logger
-        self.http = ARTHttp(AblyTests.queue, logger: logger)
+        self.http = ARTHttp(queue: AblyTests.queue, logger: logger)
     }
 
     init(http: ARTHttp, logger: InternalLog) {

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -990,7 +990,7 @@ class TestProxyHTTPExecutor: NSObject, ARTHTTPExecutor {
     private var callbackAfterRequest: ((URLRequest) -> Void)?
     private var callbackProcessingDataResponse: ((Data?) -> Data)?
 
-    init(_ logger: InternalLog) {
+    init(logger: InternalLog) {
         self.logger = logger
         self.http = ARTHttp(queue: AblyTests.queue, logger: logger)
     }

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -130,7 +130,7 @@ class AuthTests: XCTestCase {
     func test__004__Basic__should_send_the_API_key_in_the_Authorization_header() throws {
         let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -166,7 +166,7 @@ class AuthTests: XCTestCase {
         let options = AblyTests.clientOptions(requestToken: true)
         options.tls = false
         let clientHTTP = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         clientHTTP.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -184,7 +184,7 @@ class AuthTests: XCTestCase {
         let options = AblyTests.clientOptions(requestToken: true)
         options.tls = true
         let clientHTTPS = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         clientHTTPS.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -205,7 +205,7 @@ class AuthTests: XCTestCase {
         options.token = getTestToken()
 
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -280,7 +280,7 @@ class AuthTests: XCTestCase {
         XCTAssertNil(rest.internal.options.key)
         XCTAssertNil(rest.internal.options.authCallback)
         XCTAssertNil(rest.internal.options.authUrl)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
 
         let channel = rest.channels.get(uniqueChannelName())
@@ -344,7 +344,7 @@ class AuthTests: XCTestCase {
         }
 
         let rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
 
         let channel = rest.channels.get(uniqueChannelName())
@@ -371,7 +371,7 @@ class AuthTests: XCTestCase {
         options.useTokenAuth = true
 
         let rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
 
         let channel = rest.channels.get(uniqueChannelName())
@@ -463,7 +463,7 @@ class AuthTests: XCTestCase {
         options.key = nil
 
         let rest = ARTRest(options: options)
-        let proxyHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        let proxyHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
 
         // Sync server time offset
         let authOptions = ARTAuthOptions(key: testKey)
@@ -513,7 +513,7 @@ class AuthTests: XCTestCase {
         options.key = nil
 
         let rest = ARTRest(options: options)
-        let proxyHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        let proxyHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = proxyHTTPExecutor
 
         // No server time offset
@@ -898,7 +898,7 @@ class AuthTests: XCTestCase {
         options.clientId = expectedClientId
 
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -1068,7 +1068,7 @@ class AuthTests: XCTestCase {
 
         let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
         let rest = ARTRest(options: options)
-        let testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -1100,7 +1100,7 @@ class AuthTests: XCTestCase {
 
         let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
         let rest = ARTRest(options: options)
-        let testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -1131,7 +1131,7 @@ class AuthTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.clientId = "mary"
         let rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
         let channel = rest.channels.get(uniqueChannelName())
         waitUntil(timeout: testTimeout) { done in
@@ -1156,7 +1156,7 @@ class AuthTests: XCTestCase {
         options.clientId = "client_string"
 
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -1283,7 +1283,7 @@ class AuthTests: XCTestCase {
         options.useTokenAuth = true
 
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         // TokenDetails
@@ -1470,7 +1470,7 @@ class AuthTests: XCTestCase {
         options.authParams!.append(URLQueryItem(name: "body", value: testToken))
 
         let rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -1497,7 +1497,7 @@ class AuthTests: XCTestCase {
         options.authParams?.append(URLQueryItem(name: "body", value: jsonTokenDetails.toUTF8String))
 
         let rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -1549,7 +1549,7 @@ class AuthTests: XCTestCase {
         options.authParams?.append(URLQueryItem(name: "body", value: jsonTokenRequest.toUTF8String))
 
         rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -1674,7 +1674,7 @@ class AuthTests: XCTestCase {
         tokenParams.clientId = "tester"
 
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -1845,7 +1845,7 @@ class AuthTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.token = getTestToken(clientId: nil)
         let rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
         let channel = rest.channels.get(uniqueChannelName())
 
@@ -1906,7 +1906,7 @@ class AuthTests: XCTestCase {
             }
         }
 
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
         let channel = rest.channels.get(uniqueChannelName())
 
@@ -2644,7 +2644,7 @@ class AuthTests: XCTestCase {
     func test__099__authorize__on_subsequent_authorisations__should_store_the_AuthOptions_with_authUrl() {
         let options = AblyTests.commonAppSetup()
         let rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
         let auth = rest.auth
 
@@ -4342,7 +4342,7 @@ class AuthTests: XCTestCase {
         #if TARGET_OS_IOS
             XCTAssertNil(rest.device.clientId)
         #endif
-        let testHttpExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        let testHttpExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHttpExecutor
         let channel = rest.channels.get(channelName)
 

--- a/Test/Tests/PushAdminTests.swift
+++ b/Test/Tests/PushAdminTests.swift
@@ -647,7 +647,7 @@ class PushAdminTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         let realtime = ARTRealtime(options: options)
         defer { realtime.dispose(); realtime.close() }
-        let testProxyHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        let testProxyHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         realtime.internal.rest.httpExecutor = testProxyHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -787,7 +787,7 @@ class PushAdminTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         let realtime = ARTRealtime(options: options)
         defer { realtime.dispose(); realtime.close() }
-        let testProxyHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        let testProxyHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         realtime.internal.rest.httpExecutor = testProxyHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -114,7 +114,7 @@ private func testWithUntilAttach(_ untilAttach: Bool, channelName: String) {
     defer { client.dispose(); client.close() }
     let channel = client.channels.get(channelName)
 
-    let testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+    let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
     client.internal.rest.httpExecutor = testHTTPExecutor
 
     let query = ARTRealtimeHistoryQuery()

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -3683,7 +3683,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         defer { client.dispose(); client.close() }
         client.channels.get(uniqueChannelName())
 
-        let testHttpExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        let testHttpExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.rest.httpExecutor = testHttpExecutor
 
         client.internal.setTransport(TestProxyTransport.self)
@@ -3816,7 +3816,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         defer { client.dispose(); client.close() }
         client.channels.get(uniqueChannelName())
 
-        let testHttpExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        let testHttpExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.rest.httpExecutor = testHttpExecutor
 
         client.internal.setTransport(TestProxyTransport.self)
@@ -3891,7 +3891,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         let client = ARTRealtime(options: options)
         let channel = client.channels.get(uniqueChannelName())
 
-        let testHttpExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        let testHttpExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.rest.httpExecutor = testHttpExecutor
 
         client.internal.setTransport(TestProxyTransport.self)
@@ -3929,7 +3929,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.autoConnect = false
         let client = ARTRealtime(options: options)
 
-        let testHttpExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        let testHttpExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.rest.httpExecutor = testHttpExecutor
 
         client.internal.setTransport(TestProxyTransport.self)

--- a/Test/Tests/RestClientChannelTests.swift
+++ b/Test/Tests/RestClientChannelTests.swift
@@ -121,7 +121,7 @@ class RestClientChannelTests: XCTestCase {
 
         let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
         client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
     }
 
     // RSL1
@@ -318,7 +318,7 @@ class RestClientChannelTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.clientId = "john-doe"
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
         waitUntil(timeout: testTimeout) { done in
             client.channels.get(uniqueChannelName(prefix: "RSA7e1"))
@@ -841,7 +841,7 @@ class RestClientChannelTests: XCTestCase {
     func test__004__publish__should_include_attributes_supplied_by_the_caller_in_the_encoded_message() {
         let options = AblyTests.commonAppSetup()
         let client = ARTRest(options: options)
-        let proxyHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        let proxyHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = proxyHTTPExecutor
 
         let channel = client.channels.get(uniqueChannelName())

--- a/Test/Tests/RestClientTests.swift
+++ b/Test/Tests/RestClientTests.swift
@@ -148,7 +148,7 @@ class RestClientTests: XCTestCase {
     func test__001__RestClient__All_REST_requests_should_include_the_current_API_version() {
         let options = AblyTests.commonAppSetup()
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
         let channel = client.channels.get(uniqueChannelName())
         waitUntil(timeout: testTimeout) { done in
@@ -295,7 +295,7 @@ class RestClientTests: XCTestCase {
         let options = ARTClientOptions(key: "fake:key")
         options.restHost = "fake.ably.io"
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         publishTestMessage(client, channelName: uniqueChannelName(), failOnError: false)
@@ -308,7 +308,7 @@ class RestClientTests: XCTestCase {
         options.environment = "test"
         options.restHost = "fake.ably.io"
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         publishTestMessage(client, channelName: uniqueChannelName(), failOnError: false)
@@ -321,7 +321,7 @@ class RestClientTests: XCTestCase {
         let options = ARTClientOptions(key: "fake:key")
         options.environment = "myEnvironment"
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         publishTestMessage(client, channelName: uniqueChannelName(), failOnError: false)
@@ -332,7 +332,7 @@ class RestClientTests: XCTestCase {
     func test__028__RestClient__endpoint__should_default_to_https___rest_ably_io() {
         let options = ARTClientOptions(key: "fake:key")
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         publishTestMessage(client, channelName: uniqueChannelName(), failOnError: false)
@@ -344,7 +344,7 @@ class RestClientTests: XCTestCase {
         let options = AblyTests.clientOptions(requestToken: true)
         options.tls = false
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         publishTestMessage(client, channelName: uniqueChannelName(), failOnError: false)
@@ -449,7 +449,7 @@ class RestClientTests: XCTestCase {
         options.restHost = "rest.ably.test"
         XCTAssertEqual(options.restHost, "rest.ably.test")
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
         waitUntil(timeout: testTimeout) { done in
             client.channels.get(uniqueChannelName()).publish(nil, data: "message") { error in
@@ -483,7 +483,7 @@ class RestClientTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
 
         let clientHttps = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         clientHttps.internal.httpExecutor = testHTTPExecutor
 
         let channelName = uniqueChannelName()
@@ -502,7 +502,7 @@ class RestClientTests: XCTestCase {
         options.useTokenAuth = true
         options.tls = false
         let clientHttp = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         clientHttp.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -552,7 +552,7 @@ class RestClientTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.token = getTestToken(ttl: 0.5)
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
         let auth = client.auth
 
@@ -581,7 +581,7 @@ class RestClientTests: XCTestCase {
         let options = AblyTests.clientOptions()
         options.token = getTestToken(capability: "{ \"main\":[\"subscribe\"] }")
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -697,7 +697,7 @@ class RestClientTests: XCTestCase {
         }
 
         let rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -753,7 +753,7 @@ class RestClientTests: XCTestCase {
                 )
 
                 let rest = ARTRest(options: options)
-                testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+                testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
                 rest.internal.httpExecutor = testHTTPExecutor
 
                 // Delay for token expiration
@@ -1594,7 +1594,7 @@ class RestClientTests: XCTestCase {
         XCTAssertTrue(options.useBinaryProtocol)
 
         let rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
         waitUntil(timeout: testTimeout) { done in
             rest.channels.get(uniqueChannelName(prefix: "rest")).publish(nil, data: "message") { _ in
@@ -1630,7 +1630,7 @@ class RestClientTests: XCTestCase {
         options.useBinaryProtocol = false
 
         let rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
         waitUntil(timeout: testTimeout) { done in
             rest.channels.get(uniqueChannelName(prefix: "rest")).publish(nil, data: "message") { _ in
@@ -1663,7 +1663,7 @@ class RestClientTests: XCTestCase {
     func test__010__RestClient__X_Ably_Version_must_be_included_in_all_REST_requests() {
         let options = AblyTests.commonAppSetup()
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
         waitUntil(timeout: testTimeout) { done in
             client.channels.get(uniqueChannelName()).publish(nil, data: "message") { error in
@@ -1688,7 +1688,7 @@ class RestClientTests: XCTestCase {
     func test__011__RestClient__The_Agent_library_identifier_is_composed_of_a_series_of_key__value__entries_joined_by_spaces() {
         let options = AblyTests.commonAppSetup()
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
         let channel = client.channels.get(uniqueChannelName())
         waitUntil(timeout: testTimeout) { done in
@@ -1914,7 +1914,7 @@ class RestClientTests: XCTestCase {
             }
         }
 
-        let proxyHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        let proxyHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = proxyHTTPExecutor
 
         var httpPaginatedResponse: ARTHTTPPaginatedResponse!
@@ -1963,7 +1963,7 @@ class RestClientTests: XCTestCase {
             }
         }
 
-        let proxyHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        let proxyHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = proxyHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in

--- a/Test/Tests/UtilitiesTests.swift
+++ b/Test/Tests/UtilitiesTests.swift
@@ -203,7 +203,7 @@ class UtilitiesTests: XCTestCase {
 
         let options = AblyTests.commonAppSetup()
         let rest = ARTRest(options: options)
-        let testHTTPExecutor = TestProxyHTTPExecutor(.init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
         let channel = rest.channels.get(uniqueChannelName())
 


### PR DESCRIPTION
Adds a couple of missing parameter labels that led to confusing expressions at call sites.