### PR TITLE
Remove top-level mutable state in `AuthTests`

### DIFF
--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -49,7 +49,6 @@ private func createAuthUrlTestsOptions() -> ARTClientOptions {
     return options
 }
 
-private let authCallbackTestsOptions = AblyTests.clientOptions()
 private func createJsonEncoder() -> ARTJsonLikeEncoder {
     let encoder = ARTJsonLikeEncoder()
     encoder.delegate = ARTJsonEncoder()
@@ -74,7 +73,6 @@ class AuthTests: XCTestCase {
         _ = json
         _ = channelName
         _ = messageName
-        _ = authCallbackTestsOptions
 
         return super.defaultTestSuite
     }
@@ -4097,11 +4095,12 @@ class AuthTests: XCTestCase {
     // RSA8g
 
     func skipped__test__146__JWT_and_realtime__when_using_authCallback__with_valid_credentials__pulls_stats_successfully() {
-        authCallbackTestsOptions.authCallback = { _, completion in
+        let options = AblyTests.clientOptions()
+        options.authCallback = { _, completion in
             let token = ARTTokenDetails(token: getJWTToken()!)
             completion(token, nil)
         }
-        let client = ARTRealtime(options: authCallbackTestsOptions)
+        let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in
@@ -4113,11 +4112,12 @@ class AuthTests: XCTestCase {
     }
 
     func test__147__JWT_and_realtime__when_using_authCallback__with_invalid_credentials__fails_to_connect() {
-        authCallbackTestsOptions.authCallback = { _, completion in
+        let options = AblyTests.clientOptions()
+        options.authCallback = { _, completion in
             let token = ARTTokenDetails(token: getJWTToken(invalid: true)!)
             completion(token, nil)
         }
-        let client = ARTRealtime(options: authCallbackTestsOptions)
+        let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -26,15 +26,6 @@ private func testStopsClientWithOptions(caseSetter: (ARTClientOptions) -> Void) 
 private let currentClientId = "client_string"
 
 private var options: ARTClientOptions!
-private var rest: ARTRest!
-
-private func tokenParamsTestsSetupDependencies() {
-    if options == nil {
-        options = AblyTests.commonAppSetup()
-        options.clientId = currentClientId
-        rest = ARTRest(options: options)
-    }
-}
 
 private let json = "{" +
     "    \"token\": \"xxxxxx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\"," +
@@ -96,7 +87,6 @@ class AuthTests: XCTestCase {
     override class var defaultTestSuite: XCTestSuite {
         _ = currentClientId
         _ = options
-        _ = rest
         _ = json
         _ = channelName
         _ = messageName
@@ -1724,7 +1714,9 @@ class AuthTests: XCTestCase {
     // RSA8b
 
     func test__071__requestToken__should_support_all_TokenParams__using_defaults() {
-        tokenParamsTestsSetupDependencies()
+        let options = AblyTests.commonAppSetup()
+        options.clientId = currentClientId
+        let rest = ARTRest(options: options)
 
         // Default values
         let defaultTokenParams = ARTTokenParams(clientId: currentClientId)
@@ -1746,7 +1738,9 @@ class AuthTests: XCTestCase {
     }
 
     func test__072__requestToken__should_support_all_TokenParams__overriding_defaults() {
-        tokenParamsTestsSetupDependencies()
+        let options = AblyTests.commonAppSetup()
+        options.clientId = currentClientId
+        let rest = ARTRest(options: options)
 
         // Custom values
         let expectedTtl = 4800.0

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -52,14 +52,6 @@ private let authUrlTestsOptions: ARTClientOptions = {
     return options
 }()
 
-private var keys: [String: String]!
-
-private func rsa8gTestsSetupDependencies() {
-    if keys == nil {
-        keys = getKeys()
-    }
-}
-
 private let authCallbackTestsOptions = AblyTests.clientOptions()
 private let jwtAndRestTestsOptions = AblyTests.clientOptions()
 private func createJsonEncoder() -> ARTJsonLikeEncoder {
@@ -89,7 +81,6 @@ class AuthTests: XCTestCase {
         _ = messageName
         _ = jwtTestsOptions
         _ = authUrlTestsOptions
-        _ = keys
         _ = authCallbackTestsOptions
         _ = jwtAndRestTestsOptions
 
@@ -4002,7 +3993,7 @@ class AuthTests: XCTestCase {
     // RSA8g RSA8c
 
     func test__142__JWT_and_realtime__when_using_authUrl__with_valid_credentials__fetches_a_channels_and_posts_a_message() {
-        rsa8gTestsSetupDependencies()
+        let keys = getKeys()
 
         authUrlTestsOptions.authParams = [URLQueryItem]()
         authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
@@ -4023,7 +4014,7 @@ class AuthTests: XCTestCase {
     }
 
     func test__143__JWT_and_realtime__when_using_authUrl__with_wrong_credentials__fails_to_connect_with_reason__invalid_signature_() {
-        rsa8gTestsSetupDependencies()
+        let keys = getKeys()
 
         authUrlTestsOptions.authParams = [URLQueryItem]()
         authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
@@ -4045,7 +4036,7 @@ class AuthTests: XCTestCase {
     }
 
     func test__144__JWT_and_realtime__when_using_authUrl__when_token_expires__receives_a_40142_error_from_the_server() {
-        rsa8gTestsSetupDependencies()
+        let keys = getKeys()
 
         let tokenDuration = 5.0
         authUrlTestsOptions.authParams = [URLQueryItem]()
@@ -4070,7 +4061,7 @@ class AuthTests: XCTestCase {
     // RTC8a4
 
     func test__145__JWT_and_realtime__when_using_authUrl__when_the_server_sends_and_AUTH_protocol_message__client_reauths_correctly_without_going_through_a_disconnection() {
-        rsa8gTestsSetupDependencies()
+        let keys = getKeys()
 
         // The server sends an AUTH protocol message 30 seconds before a token expires
         // We create a token that lasts 35 seconds, so there's room to receive the AUTH message

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -4,7 +4,6 @@ import Aspects
 import Nimble
 import XCTest
 
-private var testHTTPExecutor: TestProxyHTTPExecutor!
 private func testOptionsGiveDefaultAuthMethod(_ caseSetter: (ARTAuthOptions) -> Void) {
     let options = ARTClientOptions()
     caseSetter(options)
@@ -95,7 +94,6 @@ private func jwtContentTypeTestsSetupDependencies() {
 class AuthTests: XCTestCase {
     // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
     override class var defaultTestSuite: XCTestSuite {
-        _ = testHTTPExecutor
         _ = currentClientId
         _ = options
         _ = rest
@@ -130,7 +128,7 @@ class AuthTests: XCTestCase {
     func test__004__Basic__should_send_the_API_key_in_the_Authorization_header() throws {
         let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -166,7 +164,7 @@ class AuthTests: XCTestCase {
         let options = AblyTests.clientOptions(requestToken: true)
         options.tls = false
         let clientHTTP = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         clientHTTP.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -184,7 +182,7 @@ class AuthTests: XCTestCase {
         let options = AblyTests.clientOptions(requestToken: true)
         options.tls = true
         let clientHTTPS = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         clientHTTPS.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -205,7 +203,7 @@ class AuthTests: XCTestCase {
         options.token = getTestToken()
 
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -280,7 +278,7 @@ class AuthTests: XCTestCase {
         XCTAssertNil(rest.internal.options.key)
         XCTAssertNil(rest.internal.options.authCallback)
         XCTAssertNil(rest.internal.options.authUrl)
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
 
         let channel = rest.channels.get(uniqueChannelName())
@@ -344,7 +342,7 @@ class AuthTests: XCTestCase {
         }
 
         let rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
 
         let channel = rest.channels.get(uniqueChannelName())
@@ -371,7 +369,7 @@ class AuthTests: XCTestCase {
         options.useTokenAuth = true
 
         let rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
 
         let channel = rest.channels.get(uniqueChannelName())
@@ -898,7 +896,7 @@ class AuthTests: XCTestCase {
         options.clientId = expectedClientId
 
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -1131,7 +1129,7 @@ class AuthTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.clientId = "mary"
         let rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
         let channel = rest.channels.get(uniqueChannelName())
         waitUntil(timeout: testTimeout) { done in
@@ -1156,7 +1154,7 @@ class AuthTests: XCTestCase {
         options.clientId = "client_string"
 
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -1283,7 +1281,7 @@ class AuthTests: XCTestCase {
         options.useTokenAuth = true
 
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         // TokenDetails
@@ -1470,7 +1468,7 @@ class AuthTests: XCTestCase {
         options.authParams!.append(URLQueryItem(name: "body", value: testToken))
 
         let rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -1497,7 +1495,7 @@ class AuthTests: XCTestCase {
         options.authParams?.append(URLQueryItem(name: "body", value: jsonTokenDetails.toUTF8String))
 
         let rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -1549,7 +1547,7 @@ class AuthTests: XCTestCase {
         options.authParams?.append(URLQueryItem(name: "body", value: jsonTokenRequest.toUTF8String))
 
         rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -1674,7 +1672,7 @@ class AuthTests: XCTestCase {
         tokenParams.clientId = "tester"
 
         let client = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
 
         waitUntil(timeout: testTimeout) { done in
@@ -1845,7 +1843,7 @@ class AuthTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.token = getTestToken(clientId: nil)
         let rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
         let channel = rest.channels.get(uniqueChannelName())
 
@@ -1906,7 +1904,7 @@ class AuthTests: XCTestCase {
             }
         }
 
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
         let channel = rest.channels.get(uniqueChannelName())
 
@@ -2644,7 +2642,7 @@ class AuthTests: XCTestCase {
     func test__099__authorize__on_subsequent_authorisations__should_store_the_AuthOptions_with_authUrl() {
         let options = AblyTests.commonAppSetup()
         let rest = ARTRest(options: options)
-        testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
+        let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
         let auth = rest.auth
 

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -50,7 +50,6 @@ private let authUrlTestsOptions: ARTClientOptions = {
 }()
 
 private let authCallbackTestsOptions = AblyTests.clientOptions()
-private let jwtAndRestTestsOptions = AblyTests.clientOptions()
 private func createJsonEncoder() -> ARTJsonLikeEncoder {
     let encoder = ARTJsonLikeEncoder()
     encoder.delegate = ARTJsonEncoder()
@@ -77,7 +76,6 @@ class AuthTests: XCTestCase {
         _ = messageName
         _ = authUrlTestsOptions
         _ = authCallbackTestsOptions
-        _ = jwtAndRestTestsOptions
 
         return super.defaultTestSuite
     }
@@ -4225,8 +4223,9 @@ class AuthTests: XCTestCase {
     // RSC1 RSC1a RSC1c RSA3d
 
     func test__154__JWT_and_rest__when_the_JWT_token_embeds_an_Ably_token__pulls_stats_successfully() {
-        jwtAndRestTestsOptions.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded")!)
-        let client = ARTRest(options: jwtAndRestTestsOptions)
+        let options = AblyTests.clientOptions()
+        options.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded")!)
+        let client = ARTRest(options: options)
         waitUntil(timeout: testTimeout) { done in
             client.stats { _, error in
                 XCTAssertNil(error)
@@ -4236,8 +4235,9 @@ class AuthTests: XCTestCase {
     }
 
     func test__155__JWT_and_rest__when_the_JWT_token_embeds_an_Ably_token_and_it_is_requested_as_encrypted__pulls_stats_successfully() {
-        jwtAndRestTestsOptions.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded", encrypted: 1)!)
-        let client = ARTRest(options: jwtAndRestTestsOptions)
+        let options = AblyTests.clientOptions()
+        options.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded", encrypted: 1)!)
+        let client = ARTRest(options: options)
         waitUntil(timeout: testTimeout) { done in
             client.stats { _, error in
                 XCTAssertNil(error)

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -67,16 +67,6 @@ private func jwtContentTypeTestsSetupDependencies() -> ARTRest {
 }
 
 class AuthTests: XCTestCase {
-    // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
-    override class var defaultTestSuite: XCTestSuite {
-        _ = currentClientId
-        _ = json
-        _ = channelName
-        _ = messageName
-
-        return super.defaultTestSuite
-    }
-
     enum ExpectedTokenParams {
         static let clientId = "client_from_params"
         static let ttl = 1.0

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -43,7 +43,6 @@ private func check(_ details: ARTTokenDetails) {
 
 private let channelName = "test_JWT"
 private let messageName = "message_JWT"
-private let jwtTestsOptions = AblyTests.clientOptions()
 private let authUrlTestsOptions: ARTClientOptions = {
     let options = AblyTests.clientOptions()
     options.authUrl = URL(string: echoServerAddress)!
@@ -76,7 +75,6 @@ class AuthTests: XCTestCase {
         _ = json
         _ = channelName
         _ = messageName
-        _ = jwtTestsOptions
         _ = authUrlTestsOptions
         _ = authCallbackTestsOptions
         _ = jwtAndRestTestsOptions
@@ -3956,8 +3954,9 @@ class AuthTests: XCTestCase {
     }
 
     func skipped__test__140__JWT_and_realtime__client_initialized_with_a_JWT_token_in_ClientOptions__with_valid_credentials__pulls_stats_successfully() {
-        jwtTestsOptions.token = getJWTToken()
-        let client = AblyTests.newRealtime(jwtTestsOptions)
+        let options = AblyTests.clientOptions()
+        options.token = getJWTToken()
+        let client = AblyTests.newRealtime(options)
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in
@@ -3969,9 +3968,10 @@ class AuthTests: XCTestCase {
     }
 
     func test__141__JWT_and_realtime__client_initialized_with_a_JWT_token_in_ClientOptions__with_invalid_credentials__fails_to_connect_with_reason__invalid_signature_() {
-        jwtTestsOptions.token = getJWTToken(invalid: true)
-        jwtTestsOptions.autoConnect = false
-        let client = AblyTests.newRealtime(jwtTestsOptions)
+        let options = AblyTests.clientOptions()
+        options.token = getJWTToken(invalid: true)
+        options.autoConnect = false
+        let client = AblyTests.newRealtime(options)
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -25,8 +25,6 @@ private func testStopsClientWithOptions(caseSetter: (ARTClientOptions) -> Void) 
 
 private let currentClientId = "client_string"
 
-private var options: ARTClientOptions!
-
 private let json = "{" +
     "    \"token\": \"xxxxxx.yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\"," +
     "    \"issued\": 1479087321934," +
@@ -75,7 +73,6 @@ class AuthTests: XCTestCase {
     // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
     override class var defaultTestSuite: XCTestSuite {
         _ = currentClientId
-        _ = options
         _ = json
         _ = channelName
         _ = messageName

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -62,24 +62,21 @@ private func rsa8gTestsSetupDependencies() {
 
 private let authCallbackTestsOptions = AblyTests.clientOptions()
 private let jwtAndRestTestsOptions = AblyTests.clientOptions()
-private var client: ARTRest!
 private func createJsonEncoder() -> ARTJsonLikeEncoder {
     let encoder = ARTJsonLikeEncoder()
     encoder.delegate = ARTJsonEncoder()
     return encoder
 }
 
-private func jwtContentTypeTestsSetupDependencies() {
-    if client == nil {
-        let options = AblyTests.clientOptions()
-        let keys = getKeys()
-        options.authUrl = URL(string: echoServerAddress)!
-        options.authParams = [URLQueryItem]()
-        options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
-        options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
-        options.authParams?.append(URLQueryItem(name: "returnType", value: "jwt"))
-        client = ARTRest(options: options)
-    }
+private func jwtContentTypeTestsSetupDependencies() -> ARTRest {
+    let options = AblyTests.clientOptions()
+    let keys = getKeys()
+    options.authUrl = URL(string: echoServerAddress)!
+    options.authParams = [URLQueryItem]()
+    options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
+    options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
+    options.authParams?.append(URLQueryItem(name: "returnType", value: "jwt"))
+    return ARTRest(options: options)
 }
 
 class AuthTests: XCTestCase {
@@ -95,7 +92,6 @@ class AuthTests: XCTestCase {
         _ = keys
         _ = authCallbackTestsOptions
         _ = jwtAndRestTestsOptions
-        _ = client
 
         return super.defaultTestSuite
     }
@@ -4264,12 +4260,8 @@ class AuthTests: XCTestCase {
 
     // RSA4f, RSA8c
 
-    func beforeEach__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type() {
-        jwtContentTypeTestsSetupDependencies()
-    }
-
     func test__156__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type__the_client_successfully_connects_and_pulls_stats() {
-        beforeEach__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type()
+        let client = jwtContentTypeTestsSetupDependencies()
 
         waitUntil(timeout: testTimeout) { done in
             client.stats { _, error in
@@ -4280,7 +4272,7 @@ class AuthTests: XCTestCase {
     }
 
     func test__157__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type__the_client_can_request_a_new_token_to_initilize_another_client_that_connects_and_pulls_stats() {
-        beforeEach__JWT_and_rest__when_the_JWT_token_is_returned_with_application_jwt_content_type()
+        let client = jwtContentTypeTestsSetupDependencies()
 
         waitUntil(timeout: testTimeout) { done in
             client.auth.requestToken(nil, with: nil, callback: { tokenDetails, error in

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -43,11 +43,11 @@ private func check(_ details: ARTTokenDetails) {
 
 private let channelName = "test_JWT"
 private let messageName = "message_JWT"
-private let authUrlTestsOptions: ARTClientOptions = {
+private func createAuthUrlTestsOptions() -> ARTClientOptions {
     let options = AblyTests.clientOptions()
     options.authUrl = URL(string: echoServerAddress)!
     return options
-}()
+}
 
 private let authCallbackTestsOptions = AblyTests.clientOptions()
 private func createJsonEncoder() -> ARTJsonLikeEncoder {
@@ -74,7 +74,6 @@ class AuthTests: XCTestCase {
         _ = json
         _ = channelName
         _ = messageName
-        _ = authUrlTestsOptions
         _ = authCallbackTestsOptions
 
         return super.defaultTestSuite
@@ -3990,10 +3989,12 @@ class AuthTests: XCTestCase {
     func test__142__JWT_and_realtime__when_using_authUrl__with_valid_credentials__fetches_a_channels_and_posts_a_message() {
         let keys = getKeys()
 
-        authUrlTestsOptions.authParams = [URLQueryItem]()
-        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
-        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
-        let client = ARTRealtime(options: authUrlTestsOptions)
+        let options = createAuthUrlTestsOptions()
+        options.authParams = [URLQueryItem]()
+        options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
+        options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
+        let client = ARTRealtime(options: options)
+
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in
@@ -4011,10 +4012,12 @@ class AuthTests: XCTestCase {
     func test__143__JWT_and_realtime__when_using_authUrl__with_wrong_credentials__fails_to_connect_with_reason__invalid_signature_() {
         let keys = getKeys()
 
-        authUrlTestsOptions.authParams = [URLQueryItem]()
-        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
-        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keySecret", value: "INVALID"))
-        let client = ARTRealtime(options: authUrlTestsOptions)
+        let options = createAuthUrlTestsOptions()
+        options.authParams = [URLQueryItem]()
+        options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
+        options.authParams?.append(URLQueryItem(name: "keySecret", value: "INVALID"))
+
+        let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in
@@ -4034,11 +4037,14 @@ class AuthTests: XCTestCase {
         let keys = getKeys()
 
         let tokenDuration = 5.0
-        authUrlTestsOptions.authParams = [URLQueryItem]()
-        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
-        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
-        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "expiresIn", value: String(UInt(tokenDuration))))
-        let client = ARTRealtime(options: authUrlTestsOptions)
+
+        let options = createAuthUrlTestsOptions()
+        options.authParams = [URLQueryItem]()
+        options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
+        options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
+        options.authParams?.append(URLQueryItem(name: "expiresIn", value: String(UInt(tokenDuration))))
+
+        let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in
@@ -4061,12 +4067,15 @@ class AuthTests: XCTestCase {
         // The server sends an AUTH protocol message 30 seconds before a token expires
         // We create a token that lasts 35 seconds, so there's room to receive the AUTH message
         let tokenDuration = 35.0
-        authUrlTestsOptions.authParams = [URLQueryItem]()
-        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
-        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
-        authUrlTestsOptions.authParams?.append(URLQueryItem(name: "expiresIn", value: String(UInt(tokenDuration))))
-        authUrlTestsOptions.autoConnect = false // Prevent auto connection so we can set the transport proxy
-        let client = ARTRealtime(options: authUrlTestsOptions)
+
+        let options = createAuthUrlTestsOptions()
+        options.authParams = [URLQueryItem]()
+        options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]))
+        options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
+        options.authParams?.append(URLQueryItem(name: "expiresIn", value: String(UInt(tokenDuration))))
+        options.autoConnect = false // Prevent auto connection so we can set the transport proxy
+
+        let client = ARTRealtime(options: options)
         client.internal.setTransport(TestProxyTransport.self)
         defer { client.dispose(); client.close() }
 


### PR DESCRIPTION
Part of #1604. See commit messages for more details.