### PR TITLE
Remove `TestProxyTransport.queue`

### DIFF
--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -1104,33 +1104,32 @@ class TestProxyTransport: ARTWebSocketTransport {
     static var fakeNetworkResponse: FakeNetworkResponse?
     static var networkConnectEvent: ((ARTRealtimeTransport, URL) -> Void)?
 
+    // For synchronising access to mutable state
+    private let semaphore = DispatchSemaphore(value: 1)
 
     fileprivate(set) var lastUrl: URL?
 
     private var _protocolMessagesReceived: [ARTProtocolMessage] = []
     var protocolMessagesReceived: [ARTProtocolMessage] {
-        var result: [ARTProtocolMessage] = []
-        queue.sync {
-            result = self._protocolMessagesReceived
-        }
+        semaphore.wait()
+        let result = self._protocolMessagesReceived
+        semaphore.signal()
         return result
     }
 
     private var _protocolMessagesSent: [ARTProtocolMessage] = []
     var protocolMessagesSent: [ARTProtocolMessage] {
-        var result: [ARTProtocolMessage] = []
-        queue.sync {
-            result = self._protocolMessagesSent
-        }
+        semaphore.wait()
+        let result = self._protocolMessagesSent
+        semaphore.signal()
         return result
     }
 
     private var _protocolMessagesSentIgnored: [ARTProtocolMessage] = []
     var protocolMessagesSentIgnored: [ARTProtocolMessage] {
-        var result: [ARTProtocolMessage] = []
-        queue.sync {
-            result = self._protocolMessagesSentIgnored
-        }
+        semaphore.wait()
+        let result = self._protocolMessagesSentIgnored
+        semaphore.signal()
         return result
     }
 
@@ -1154,21 +1153,21 @@ class TestProxyTransport: ARTWebSocketTransport {
     private var callbackAfterIncomingMessageModifier: ((ARTProtocolMessage) -> ARTProtocolMessage?)?
 
     func setListenerBeforeProcessingIncomingMessage(_ callback: ((ARTProtocolMessage) -> Void)?) {
-        queue.sync {
-            self.callbackBeforeProcessingIncomingMessage = callback
-        }
+        semaphore.wait()
+        self.callbackBeforeProcessingIncomingMessage = callback
+        semaphore.signal()
     }
 
     func setListenerAfterProcessingIncomingMessage(_ callback: ((ARTProtocolMessage) -> Void)?) {
-        queue.sync {
-            self.callbackAfterProcessingIncomingMessage = callback
-        }
+        semaphore.wait()
+        self.callbackAfterProcessingIncomingMessage = callback
+        semaphore.signal()
     }
 
     func setListenerBeforeProcessingOutgoingMessage(_ callback: ((ARTProtocolMessage) -> Void)?) {
-        queue.sync {
-            self.callbackBeforeProcessingOutgoingMessage = callback
-        }
+        semaphore.wait()
+        self.callbackBeforeProcessingOutgoingMessage = callback
+        semaphore.signal()
     }
 
     /// The modifier will be called on the internal queue.
@@ -1186,15 +1185,15 @@ class TestProxyTransport: ARTWebSocketTransport {
     }
 
     func enableReplaceAcksWithNacks(with errorInfo: ARTErrorInfo) {
-        queue.sync {
-            self.replacingAcksWithNacks = errorInfo
-        }
+        semaphore.wait()
+        self.replacingAcksWithNacks = errorInfo
+        semaphore.signal()
     }
 
     func disableReplaceAcksWithNacks() {
-        queue.sync {
-            self.replacingAcksWithNacks = nil
-        }
+        semaphore.wait()
+        self.replacingAcksWithNacks = nil
+        semaphore.signal()
     }
 
     // MARK: ARTWebSocket

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -1142,10 +1142,6 @@ class TestProxyTransport: ARTWebSocketTransport {
     var ignoreSends = false
     var actionsIgnored = [ARTProtocolMessageAction]()
 
-    var queue: DispatchQueue {
-        return websocket?.delegateDispatchQueue ?? AblyTests.queue
-    }
-
     private var callbackBeforeProcessingIncomingMessage: ((ARTProtocolMessage) -> Void)?
     private var callbackAfterProcessingIncomingMessage: ((ARTProtocolMessage) -> Void)?
     private var callbackBeforeProcessingOutgoingMessage: ((ARTProtocolMessage) -> Void)?
@@ -1255,7 +1251,7 @@ class TestProxyTransport: ARTWebSocketTransport {
             networkConnectEventHandler(self, lastUrl)
         }
         else {
-            queue.asyncAfter(deadline: .now() + 0.1) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 // Repeat until `lastUrl` is assigned.
                 self.performNetworkConnectEvent()
             }

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -1222,7 +1222,10 @@ class TestProxyTransport: ARTWebSocketTransport {
             }
 
             func performFakeConnectionError(_ secondsForDelay: TimeInterval, error: ARTRealtimeTransportError) {
-                self.queue.asyncAfter(deadline: .now() + secondsForDelay) {
+                guard let delegateQueue = self.websocket?.delegateDispatchQueue else {
+                    preconditionFailure("Don't know what queue to dispatch delegate event to")
+                }
+                delegateQueue.asyncAfter(deadline: .now() + secondsForDelay) {
                     self.delegate?.realtimeTransportFailed(self, withError: error)
                     hook?.remove()
                 }


### PR DESCRIPTION
Part of the larger goal of removing `AblyTests.queue` as part of #1604. See commit messages for more details.