### PR TITLE
Make `ARTFallback_shuffleArray` constant

### DIFF
--- a/Source/ARTFallback.m
+++ b/Source/ARTFallback.m
@@ -4,7 +4,7 @@
 #import "ARTStatus.h"
 #import "ARTHttp.h"
 
-void (^ARTFallback_shuffleArray)(NSMutableArray *) = ^void(NSMutableArray *a) {
+void (^const ARTFallback_shuffleArray)(NSMutableArray *) = ^void(NSMutableArray *a) {
     for (NSUInteger i = a.count; i > 1; i--) {
         [a exchangeObjectAtIndex:i - 1 withObjectAtIndex:arc4random_uniform((u_int32_t)i)];
     }
@@ -16,20 +16,16 @@ void (^ARTFallback_shuffleArray)(NSMutableArray *) = ^void(NSMutableArray *a) {
 
 @implementation ARTFallback
 
-- (instancetype)initWithFallbackHosts:(nullable NSArray<NSString *> *)fallbackHosts {
+- (instancetype)initWithFallbackHosts:(nullable NSArray<NSString *> *)fallbackHosts shuffleArray:(void (^)(NSMutableArray *))shuffleArray {
     self = [super init];
     if (self) {
         if (fallbackHosts == nil || fallbackHosts.count == 0) {
             return nil;
         }
         self.hosts = [[NSMutableArray alloc] initWithArray:fallbackHosts];
-        ARTFallback_shuffleArray(self.hosts);
+        shuffleArray(self.hosts);
     }
     return self;
-}
-
-- (instancetype)init {
-    return [self initWithFallbackHosts:nil];
 }
 
 - (NSString *)popFallbackHost {

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -1566,8 +1566,9 @@ NS_ASSUME_NONNULL_END
     if ([self shouldRetryWithFallback:transportError]) {
         ARTLogDebug(self.logger, @"R:%p host is down; can retry with fallback host", self);
         if (!_fallbacks && [transportError.url.host isEqualToString:[ARTDefault realtimeHost]]) {
-            NSArray *hosts = [ARTFallbackHosts hostsFromOptions:[self getClientOptions]];
-            self->_fallbacks = [[ARTFallback alloc] initWithFallbackHosts:hosts];
+            ARTClientOptions *const clientOptions = [self getClientOptions];
+            NSArray *hosts = [ARTFallbackHosts hostsFromOptions:clientOptions];
+            self->_fallbacks = [[ARTFallback alloc] initWithFallbackHosts:hosts shuffleArray:clientOptions.testOptions.shuffleArray];
             if (self->_fallbacks != nil) {
                 [self reconnectWithFallback];
             } else {

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -41,6 +41,8 @@
 #import "ARTErrorChecker.h"
 #import "ARTInternalLog.h"
 #import "ARTLogAdapter.h"
+#import "ARTClientOptions+TestConfiguration.h"
+#import "ARTTestClientOptions.h"
 
 @implementation ARTRest {
     ARTQueuedDealloc *_dealloc;
@@ -414,7 +416,7 @@ NS_ASSUME_NONNULL_END
         if (retries < self->_options.httpMaxRetryCount && [self shouldRetryWithFallback:request response:response error:error]) {
             if (!blockFallbacks) {
                 NSArray *hosts = [ARTFallbackHosts hostsFromOptions:self->_options];
-                blockFallbacks = [[ARTFallback alloc] initWithFallbackHosts:hosts];
+                blockFallbacks = [[ARTFallback alloc] initWithFallbackHosts:hosts shuffleArray:self->_options.testOptions.shuffleArray];
             }
             if (blockFallbacks) {
                 NSString *host = [blockFallbacks popFallbackHost];

--- a/Source/ARTTestClientOptions.m
+++ b/Source/ARTTestClientOptions.m
@@ -1,11 +1,13 @@
 #import "ARTTestClientOptions.h"
 #import "ARTDefault.h"
+#import "ARTFallback+Private.h"
 
 @implementation ARTTestClientOptions
 
 - (instancetype)init {
     if (self = [super init]) {
         _realtimeRequestTimeout = [ARTDefault realtimeRequestTimeout];
+        _shuffleArray = ARTFallback_shuffleArray;
     }
 
     return self;
@@ -15,6 +17,7 @@
     ARTTestClientOptions *const copied = [[ARTTestClientOptions alloc] init];
     copied.channelNamePrefix = self.channelNamePrefix;
     copied.realtimeRequestTimeout = self.realtimeRequestTimeout;
+    copied.shuffleArray = self.shuffleArray;
 
     return copied;
 }

--- a/Source/PrivateHeaders/Ably/ARTFallback+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTFallback+Private.h
@@ -2,7 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern void (^ARTFallback_shuffleArray)(NSMutableArray *);
+extern void (^const ARTFallback_shuffleArray)(NSMutableArray *);
 
 @interface ARTFallback ()
 

--- a/Source/PrivateHeaders/Ably/ARTTestClientOptions.h
+++ b/Source/PrivateHeaders/Ably/ARTTestClientOptions.h
@@ -19,6 +19,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) NSTimeInterval realtimeRequestTimeout;
 
+/**
+ Initial value is `ARTFallback_shuffleArray`.
+ */
+@property (nonatomic) void (^shuffleArray)(NSMutableArray *);
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/include/Ably/ARTFallback.h
+++ b/Source/include/Ably/ARTFallback.h
@@ -11,7 +11,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Init with fallback hosts array.
  */
-- (instancetype)initWithFallbackHosts:(nullable NSArray<NSString *> *)fallbackHosts;
+- (instancetype)initWithFallbackHosts:(nullable NSArray<NSString *> *)fallbackHosts shuffleArray:(void (^)(NSMutableArray *))shuffleArray;
+- (instancetype)init NS_UNAVAILABLE;
 
 /**
  returns a random fallback host, returns null when all hosts have been popped.

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -19,7 +19,12 @@ private let customIdleInterval: TimeInterval = 0.1
 private var ttlAndIdleIntervalNotPassedTestsClient: ARTRealtime!
 private var ttlAndIdleIntervalNotPassedTestsConnectionId = ""
 private let expectedHostOrder = [3, 4, 0, 2, 1]
-private let originalARTFallback_shuffleArray = ARTFallback_shuffleArray
+private let shuffleArrayInExpectedHostOrder = { (array: NSMutableArray) in
+    let arranged = expectedHostOrder.reversed().map { array[$0] }
+    for (i, element) in arranged.enumerated() {
+        array[i] = element
+    }
+}
 private func testUsesAlternativeHostOnResponse(_ caseTest: FakeNetworkResponse, channelName: String) {
     let options = ARTClientOptions(key: "xxxx:xxxx")
     options.autoConnect = false
@@ -145,7 +150,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         _ = ttlAndIdleIntervalNotPassedTestsClient
         _ = ttlAndIdleIntervalNotPassedTestsConnectionId
         _ = expectedHostOrder
-        _ = originalARTFallback_shuffleArray
         _ = internetConnectionNotAvailableTestsClient
         _ = fixtures
         _ = jsonOptions
@@ -3314,26 +3318,9 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
     }
 
-    // RTN17
-
-    func beforeEach__Connection__Host_Fallback() {
-        ARTFallback_shuffleArray = { array in
-            let arranged = expectedHostOrder.reversed().map { array[$0] }
-            for (i, element) in arranged.enumerated() {
-                array[i] = element
-            }
-        }
-    }
-
-    func afterEach__Connection__Host_Fallback() {
-        ARTFallback_shuffleArray = originalARTFallback_shuffleArray
-    }
-
     // RTN17b
     @available(*, deprecated, message: "This test is marked as deprecated so as to not trigger a compiler warning for using the -ARTClientOptions.fallbackHostsUseDefault property. Remove this deprecation when removing the property.")
     func test__086__Connection__Host_Fallback__failing_connections_with_custom_endpoint_should_result_in_an_error_immediately() {
-        beforeEach__Connection__Host_Fallback()
-
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.environment = "test" // do not use the default endpoint
         XCTAssertFalse(options.fallbackHostsUseDefault)
@@ -3380,15 +3367,11 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
 
         XCTAssertEqual(urlConnections.count, 1)
-
-        afterEach__Connection__Host_Fallback()
     }
 
     // RTN17b
     @available(*, deprecated, message: "This test is marked as deprecated so as to not trigger a compiler warning for using the -ARTClientOptions.fallbackHostsUseDefault property. Remove this deprecation when removing the property.")
     func test__087__Connection__Host_Fallback__failing_connections_with_custom_endpoint_should_result_in_time_outs() {
-        beforeEach__Connection__Host_Fallback()
-
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.environment = "test" // do not use the default endpoint
         options.testOptions.realtimeRequestTimeout = 1.0
@@ -3426,14 +3409,10 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
 
         XCTAssertEqual(urlConnections.count, 1)
-
-        afterEach__Connection__Host_Fallback()
     }
 
     // RTN17b
     func test__088__Connection__Host_Fallback__applies_when_the_default_realtime_ably_io_endpoint_is_being_used() {
-        beforeEach__Connection__Host_Fallback()
-
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
@@ -3475,13 +3454,9 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
         XCTAssertTrue(NSRegularExpression.match(urlConnections[0].absoluteString, pattern: "//realtime.ably.io"))
         XCTAssertTrue(NSRegularExpression.match(urlConnections[1].absoluteString, pattern: "//[a-e].ably-realtime.com"))
-
-        afterEach__Connection__Host_Fallback()
     }
 
     func test__089__Connection__Host_Fallback__applies_when_an_array_of_ClientOptions_fallbackHosts_is_provided() {
-        beforeEach__Connection__Host_Fallback()
-
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         options.fallbackHosts = ["f.ably-realtime.com", "g.ably-realtime.com", "h.ably-realtime.com", "i.ably-realtime.com", "j.ably-realtime.com"]
@@ -3523,63 +3498,35 @@ class RealtimeClientConnectionTests: XCTestCase {
         for connection in urlConnections.dropFirst() {
             XCTAssertTrue(NSRegularExpression.match(connection.absoluteString, pattern: "//[f-j].ably-realtime.com"))
         }
-
-        afterEach__Connection__Host_Fallback()
     }
 
     // RTN17d
 
     func skipped__test__097__Connection__Host_Fallback__should_use_an_alternative_host_when___hostUnreachable() {
-        beforeEach__Connection__Host_Fallback()
-
         testUsesAlternativeHostOnResponse(.hostUnreachable, channelName: uniqueChannelName())
-
-        afterEach__Connection__Host_Fallback()
     }
 
     func skipped__test__098__Connection__Host_Fallback__should_use_an_alternative_host_when___requestTimeout_timeout__0_1_() {
-        beforeEach__Connection__Host_Fallback()
-
         testUsesAlternativeHostOnResponse(.requestTimeout(timeout: 0.1), channelName: uniqueChannelName())
-
-        afterEach__Connection__Host_Fallback()
     }
 
     func skipped__test__099__Connection__Host_Fallback__should_use_an_alternative_host_when___hostInternalError_code__501_() {
-        beforeEach__Connection__Host_Fallback()
-
         testUsesAlternativeHostOnResponse(.hostInternalError(code: 501), channelName: uniqueChannelName())
-
-        afterEach__Connection__Host_Fallback()
     }
 
     func test__100__Connection__Host_Fallback__should_move_to_disconnected_when_there_s_no_internet__with_NSPOSIXErrorDomain_with_code_57() {
-        beforeEach__Connection__Host_Fallback()
-
         testMovesToDisconnectedWithNetworkingError(NSError(domain: "NSPOSIXErrorDomain", code: 57, userInfo: [NSLocalizedDescriptionKey: "shouldn't matter"]))
-
-        afterEach__Connection__Host_Fallback()
     }
 
     func test__101__Connection__Host_Fallback__should_move_to_disconnected_when_there_s_no_internet__with_NSPOSIXErrorDomain_with_code_50() {
-        beforeEach__Connection__Host_Fallback()
-
         testMovesToDisconnectedWithNetworkingError(NSError(domain: "NSPOSIXErrorDomain", code: 50, userInfo: [NSLocalizedDescriptionKey: "shouldn't matter"]))
-
-        afterEach__Connection__Host_Fallback()
     }
 
     func test__102__Connection__Host_Fallback__should_move_to_disconnected_when_there_s_no_internet__with_any_kCFErrorDomainCFNetwork() {
-        beforeEach__Connection__Host_Fallback()
-
         testMovesToDisconnectedWithNetworkingError(NSError(domain: "kCFErrorDomainCFNetwork", code: 1337, userInfo: [NSLocalizedDescriptionKey: "shouldn't matter"]))
-
-        afterEach__Connection__Host_Fallback()
     }
 
     func test__090__Connection__Host_Fallback__should_not_use_an_alternative_host_when_the_client_receives_a_bad_request() {
-        beforeEach__Connection__Host_Fallback()
-
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
@@ -3610,14 +3557,10 @@ class RealtimeClientConnectionTests: XCTestCase {
 
         XCTAssertEqual(urlConnections.count, 1)
         XCTAssertTrue(NSRegularExpression.match(urlConnections[0].absoluteString, pattern: "//realtime.ably.io"))
-
-        afterEach__Connection__Host_Fallback()
     }
 
     // RTN17a
     func test__091__Connection__Host_Fallback__every_connection_is_first_attempted_to_the_primary_host_realtime_ably_io() {
-        beforeEach__Connection__Host_Fallback()
-
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
@@ -3668,17 +3611,14 @@ class RealtimeClientConnectionTests: XCTestCase {
         XCTAssertTrue(NSRegularExpression.match(urlConnections.at(0)?.absoluteString, pattern: "//realtime.ably.io"))
         XCTAssertTrue(NSRegularExpression.match(urlConnections.at(1)?.absoluteString, pattern: "//[a-e].ably-realtime.com"))
         XCTAssertTrue(NSRegularExpression.match(urlConnections.at(2)?.absoluteString, pattern: "//realtime.ably.io"))
-
-        afterEach__Connection__Host_Fallback()
     }
 
     // RTN17c
     func test__092__Connection__Host_Fallback__should_retry_hosts_in_random_order_after_checkin_if_an_internet_connection_is_available() {
-        beforeEach__Connection__Host_Fallback()
-
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 5.0
+        options.testOptions.shuffleArray = shuffleArrayInExpectedHostOrder
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
         client.channels.get(uniqueChannelName())
@@ -3747,14 +3687,10 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
 
         XCTAssertEqual(resultFallbackHosts, expectedFallbackHosts)
-
-        afterEach__Connection__Host_Fallback()
     }
 
     // RTN17c
     func test__093__Connection__Host_Fallback__doesn_t_try_fallback_host_if_Internet_connection_check_fails() {
-        beforeEach__Connection__Host_Fallback()
-
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
@@ -3798,13 +3734,9 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
             client.connect()
         }
-
-        afterEach__Connection__Host_Fallback()
     }
 
     func test__094__Connection__Host_Fallback__should_retry_custom_fallback_hosts_in_random_order_after_checkin_if_an_internet_connection_is_available() {
-        beforeEach__Connection__Host_Fallback()
-
         let hostPrefixes = Array("fghij")
         let expectedFallbackHosts = Array(expectedHostOrder.map { "\(hostPrefixes[$0]).ably-realtime.com" })
 
@@ -3812,6 +3744,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.autoConnect = false
         options.fallbackHosts = expectedFallbackHosts.sorted() // will be picked "randomly" as of expectedHostOrder
         options.testOptions.realtimeRequestTimeout = 5.0
+        options.testOptions.shuffleArray = shuffleArrayInExpectedHostOrder
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
         client.channels.get(uniqueChannelName())
@@ -3878,13 +3811,9 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
 
         XCTAssertEqual(resultFallbackHosts, expectedFallbackHosts)
-
-        afterEach__Connection__Host_Fallback()
     }
 
     func test__095__Connection__Host_Fallback__won_t_use_fallback_hosts_feature_if_an_empty_array_is_provided() {
-        beforeEach__Connection__Host_Fallback()
-
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         options.fallbackHosts = []
@@ -3917,14 +3846,10 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
 
         XCTAssertEqual(urlConnections.count, 1)
-
-        afterEach__Connection__Host_Fallback()
     }
 
     // RTN17e
     func test__096__Connection__Host_Fallback__client_is_connected_to_a_fallback_host_endpoint_should_do_HTTP_requests_to_the_same_data_centre() {
-        beforeEach__Connection__Host_Fallback()
-
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         let client = ARTRealtime(options: options)
@@ -3966,8 +3891,6 @@ class RealtimeClientConnectionTests: XCTestCase {
 
         let timeRequestUrl = testHttpExecutor.requests.last!.url!
         XCTAssertEqual(timeRequestUrl.host, urlConnections.at(1)?.host)
-
-        afterEach__Connection__Host_Fallback()
     }
 
     // RTN19


### PR DESCRIPTION
This is part of #1601 (don’t use global SDK state for controlling test behaviour).