### PR TITLE
wip factory for transport

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -30,6 +30,15 @@
 		2105ED2629E830D600DE6D67 /* ARTInternalLog+Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 2105ED2529E830D600DE6D67 /* ARTInternalLog+Testing.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2105ED2729E830D600DE6D67 /* ARTInternalLog+Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 2105ED2529E830D600DE6D67 /* ARTInternalLog+Testing.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2105ED2829E830D600DE6D67 /* ARTInternalLog+Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 2105ED2529E830D600DE6D67 /* ARTInternalLog+Testing.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		210F67A229E9D718007B9345 /* ARTRealtimeTransportFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 210F67A129E9D718007B9345 /* ARTRealtimeTransportFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		210F67A329E9D718007B9345 /* ARTRealtimeTransportFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 210F67A129E9D718007B9345 /* ARTRealtimeTransportFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		210F67A429E9D718007B9345 /* ARTRealtimeTransportFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 210F67A129E9D718007B9345 /* ARTRealtimeTransportFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		210F67A629E9D93D007B9345 /* ARTRealtimeTransportFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 210F67A529E9D93D007B9345 /* ARTRealtimeTransportFactory.m */; };
+		210F67A729E9D93D007B9345 /* ARTRealtimeTransportFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 210F67A529E9D93D007B9345 /* ARTRealtimeTransportFactory.m */; };
+		210F67A829E9D93D007B9345 /* ARTRealtimeTransportFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 210F67A529E9D93D007B9345 /* ARTRealtimeTransportFactory.m */; };
+		210F67B129E9DB62007B9345 /* TestProxyTransportFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210F67B029E9DB62007B9345 /* TestProxyTransportFactory.swift */; };
+		210F67B229E9DB62007B9345 /* TestProxyTransportFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210F67B029E9DB62007B9345 /* TestProxyTransportFactory.swift */; };
+		210F67B329E9DB62007B9345 /* TestProxyTransportFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210F67B029E9DB62007B9345 /* TestProxyTransportFactory.swift */; };
 		21113B4529DB484200652C86 /* ARTChannel+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 21113B4429DB484200652C86 /* ARTChannel+Subclass.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21113B4629DB484200652C86 /* ARTChannel+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 21113B4429DB484200652C86 /* ARTChannel+Subclass.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21113B4729DB484200652C86 /* ARTChannel+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 21113B4429DB484200652C86 /* ARTChannel+Subclass.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1100,6 +1109,9 @@
 		2105ED1D29E7242400DE6D67 /* ARTLogAdapter+Testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTLogAdapter+Testing.h"; path = "PrivateHeaders/Ably/ARTLogAdapter+Testing.h"; sourceTree = "<group>"; };
 		2105ED2129E7429E00DE6D67 /* ARTPaginatedResult+Subclass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTPaginatedResult+Subclass.h"; path = "PrivateHeaders/Ably/ARTPaginatedResult+Subclass.h"; sourceTree = "<group>"; };
 		2105ED2529E830D600DE6D67 /* ARTInternalLog+Testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTInternalLog+Testing.h"; path = "PrivateHeaders/Ably/ARTInternalLog+Testing.h"; sourceTree = "<group>"; };
+		210F67A129E9D718007B9345 /* ARTRealtimeTransportFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTRealtimeTransportFactory.h; path = PrivateHeaders/Ably/ARTRealtimeTransportFactory.h; sourceTree = "<group>"; };
+		210F67A529E9D93D007B9345 /* ARTRealtimeTransportFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTRealtimeTransportFactory.m; sourceTree = "<group>"; };
+		210F67B029E9DB62007B9345 /* TestProxyTransportFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestProxyTransportFactory.swift; sourceTree = "<group>"; };
 		21113B4429DB484200652C86 /* ARTChannel+Subclass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTChannel+Subclass.h"; path = "PrivateHeaders/Ably/ARTChannel+Subclass.h"; sourceTree = "<group>"; };
 		21113B4829DB60F800652C86 /* MockRetryDelayCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRetryDelayCalculator.swift; sourceTree = "<group>"; };
 		21113B5029DC6AAF00652C86 /* ARTTestClientOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTTestClientOptions.h; path = PrivateHeaders/Ably/ARTTestClientOptions.h; sourceTree = "<group>"; };
@@ -1708,6 +1720,7 @@
 				21113B4829DB60F800652C86 /* MockRetryDelayCalculator.swift */,
 				2124B78629DB127900AD8361 /* MockVersion2Log.swift */,
 				2147F03429E5872C0071CB94 /* MockInternalLogCore.swift */,
+				210F67B029E9DB62007B9345 /* TestProxyTransportFactory.swift */,
 			);
 			path = "Test Utilities";
 			sourceTree = "<group>";
@@ -1887,6 +1900,8 @@
 			isa = PBXGroup;
 			children = (
 				96E4083D1A3892C700087F77 /* ARTRealtimeTransport.h */,
+				210F67A129E9D718007B9345 /* ARTRealtimeTransportFactory.h */,
+				210F67A529E9D93D007B9345 /* ARTRealtimeTransportFactory.m */,
 				D7B17EE21C07208B00A6958E /* ARTConnectionDetails.m */,
 				EB2D5A901CC941A700AD1A67 /* ARTRealtimeTransport.m */,
 				96E408451A3895E800087F77 /* ARTWebSocketTransport.h */,
@@ -2146,6 +2161,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				210F67A229E9D718007B9345 /* ARTRealtimeTransportFactory.h in Headers */,
 				96BF61531A35B39C004CF2B3 /* ARTRest.h in Headers */,
 				EB91213E1CA0AD6600BA0A40 /* ARTMsgPackEncoder.h in Headers */,
 				96A507BD1A3791490077CDF8 /* ARTRealtime.h in Headers */,
@@ -2393,6 +2409,7 @@
 				D710D54E21949C66008F54AD /* ARTNSMutableRequest+ARTPush.h in Headers */,
 				211A610429DA05C700D169C5 /* ARTAttachRequestMetadata.h in Headers */,
 				D7D06F1026330E2800DEBDAD /* ARTHttp+Private.h in Headers */,
+				210F67A329E9D718007B9345 /* ARTRealtimeTransportFactory.h in Headers */,
 				EB1B541A22FB1D7F006A59AC /* ARTPushChannelSubscriptions+Private.h in Headers */,
 				D710D48921949A85008F54AD /* ARTConstants.h in Headers */,
 				D710D60921949DA9008F54AD /* ARTURLSessionServerTrust.h in Headers */,
@@ -2559,6 +2576,7 @@
 				D710D55421949C67008F54AD /* ARTNSMutableRequest+ARTPush.h in Headers */,
 				211A610529DA05C700D169C5 /* ARTAttachRequestMetadata.h in Headers */,
 				D7D06F1126330E2900DEBDAD /* ARTHttp+Private.h in Headers */,
+				210F67A429E9D718007B9345 /* ARTRealtimeTransportFactory.h in Headers */,
 				EB1B541B22FB1D7F006A59AC /* ARTPushChannelSubscriptions+Private.h in Headers */,
 				D710D48B21949A86008F54AD /* ARTConstants.h in Headers */,
 				D710D60B21949DAA008F54AD /* ARTURLSessionServerTrust.h in Headers */,
@@ -2941,6 +2959,7 @@
 				D746AE2C1BBB625E003ECEF8 /* RestClientChannelTests.swift in Sources */,
 				D71D30041C5F7B2F002115B0 /* RealtimeClientChannelsTests.swift in Sources */,
 				EB1B53F922F85CE4006A59AC /* ObjectLifetimesTests.swift in Sources */,
+				210F67B129E9DB62007B9345 /* TestProxyTransportFactory.swift in Sources */,
 				D7DF73851EA600240013CD36 /* PushActivationStateMachineTests.swift in Sources */,
 				211A60D729D6D2C300D169C5 /* BackoffRetryDelayCalculatorTests.swift in Sources */,
 				217FCF3229D62460006E5F2D /* RetrySequenceTests.swift in Sources */,
@@ -3039,6 +3058,7 @@
 				D785C42A1E549E33008FEC05 /* ARTPushChannelSubscription.m in Sources */,
 				D7B17EE41C07208B00A6958E /* ARTConnectionDetails.m in Sources */,
 				2124B79B29DB14C000AD8361 /* ARTLogAdapter.m in Sources */,
+				210F67A629E9D93D007B9345 /* ARTRealtimeTransportFactory.m in Sources */,
 				217FCF3A29D626C1006E5F2D /* ARTJitterCoefficientGenerator.m in Sources */,
 				96BF61591A35B52C004CF2B3 /* ARTHttp.m in Sources */,
 				217D1833254222F600DFF07E /* ARTSRPinningSecurityPolicy.m in Sources */,
@@ -3133,6 +3153,7 @@
 				848ED97426E50D0F0087E800 /* ObjcppTest.mm in Sources */,
 				D7093C28219E466E00723F17 /* RealtimeClientPresenceTests.swift in Sources */,
 				D7093C24219E466E00723F17 /* RealtimeClientTests.swift in Sources */,
+				210F67B229E9DB62007B9345 /* TestProxyTransportFactory.swift in Sources */,
 				D7093C1F219E466E00723F17 /* RestClientStatsTests.swift in Sources */,
 				D7093C1A219E465C00723F17 /* NSObject+TestSuite.m in Sources */,
 				211A60D829D6D2C400D169C5 /* BackoffRetryDelayCalculatorTests.swift in Sources */,
@@ -3183,6 +3204,7 @@
 				D7093C77219EE26400723F17 /* RestClientChannelTests.swift in Sources */,
 				D520C4E32680A1FC000012B2 /* StringifiableTests.swift in Sources */,
 				D7093C7E219EE26400723F17 /* RealtimeClientChannelsTests.swift in Sources */,
+				210F67B329E9DB62007B9345 /* TestProxyTransportFactory.swift in Sources */,
 				D7093C79219EE26400723F17 /* RestClientPresenceTests.swift in Sources */,
 				215F76012922B30F009E0E76 /* ClientInformationTests.swift in Sources */,
 				211A60D929D6D2C500D169C5 /* BackoffRetryDelayCalculatorTests.swift in Sources */,
@@ -3263,6 +3285,7 @@
 				D710D53721949C54008F54AD /* ARTLocalDevice.m in Sources */,
 				D710D53621949C54008F54AD /* ARTDeviceIdentityTokenDetails.m in Sources */,
 				2124B79C29DB14C000AD8361 /* ARTLogAdapter.m in Sources */,
+				210F67A729E9D93D007B9345 /* ARTRealtimeTransportFactory.m in Sources */,
 				217FCF3B29D626C1006E5F2D /* ARTJitterCoefficientGenerator.m in Sources */,
 				D710D4C821949BAA008F54AD /* ARTRealtimeTransport.m in Sources */,
 				217D184A254222F700DFF07E /* ARTSRPinningSecurityPolicy.m in Sources */,
@@ -3387,6 +3410,7 @@
 				D710D54921949C55008F54AD /* ARTLocalDevice.m in Sources */,
 				D710D54821949C55008F54AD /* ARTDeviceIdentityTokenDetails.m in Sources */,
 				2124B79D29DB14C000AD8361 /* ARTLogAdapter.m in Sources */,
+				210F67A829E9D93D007B9345 /* ARTRealtimeTransportFactory.m in Sources */,
 				217FCF3C29D626C1006E5F2D /* ARTJitterCoefficientGenerator.m in Sources */,
 				D710D4CC21949BAB008F54AD /* ARTRealtimeTransport.m in Sources */,
 				217D1861254222FA00DFF07E /* ARTSRPinningSecurityPolicy.m in Sources */,

--- a/Source/ARTRealtimeTransportFactory.m
+++ b/Source/ARTRealtimeTransportFactory.m
@@ -1,0 +1,14 @@
+#import "ARTRealtimeTransportFactory.h"
+#import "ARTWebsocketTransport+Private.h"
+
+@implementation ARTDefaultRealtimeTransportFactory
+
+- (id<ARTRealtimeTransport>)transportWithRest:(ARTRestInternal *)rest options:(ARTClientOptions *)options resumeKey:(NSString *)resumeKey connectionSerial:(NSNumber *)connectionSerial logger:(ARTInternalLog *)logger {
+    return [[ARTWebSocketTransport alloc] initWithRest:rest
+                                               options:options
+                                             resumeKey:resumeKey
+                                      connectionSerial:connectionSerial
+                                                logger:logger];
+}
+
+@end

--- a/Source/ARTTestClientOptions.m
+++ b/Source/ARTTestClientOptions.m
@@ -1,6 +1,7 @@
 #import "ARTTestClientOptions.h"
 #import "ARTDefault.h"
 #import "ARTFallback+Private.h"
+#import "ARTRealtimeTransportFactory.h"
 
 @implementation ARTTestClientOptions
 
@@ -8,6 +9,7 @@
     if (self = [super init]) {
         _realtimeRequestTimeout = [ARTDefault realtimeRequestTimeout];
         _shuffleArray = ARTFallback_shuffleArray;
+        _transportFactory = [[ARTDefaultRealtimeTransportFactory alloc] init];
     }
 
     return self;
@@ -18,6 +20,7 @@
     copied.channelNamePrefix = self.channelNamePrefix;
     copied.realtimeRequestTimeout = self.realtimeRequestTimeout;
     copied.shuffleArray = self.shuffleArray;
+    copied.transportFactory = self.transportFactory;
 
     return copied;
 }

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -106,5 +106,6 @@ framework module Ably {
         header "ARTInternalLogCore.h"
         header "ARTInternalLogCore+Testing.h"
         header "ARTDataEncoder.h"
+        header "ARTRealtimeTransportFactory.h"
     }
 }

--- a/Source/PrivateHeaders/Ably/ARTRealtime+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtime+Private.h
@@ -105,7 +105,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)onNack:(ARTProtocolMessage *)message;
 - (void)onChannelMessage:(ARTProtocolMessage *)message;
 
-- (void)setTransportClass:(Class)transportClass;
 - (void)setReachabilityClass:(Class _Nullable)reachabilityClass;
 
 // Message sending

--- a/Source/PrivateHeaders/Ably/ARTRealtimeTransport.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeTransport.h
@@ -65,8 +65,6 @@ typedef NS_ENUM(NSUInteger, ARTRealtimeTransportState) {
 
 // All methods must be called from rest's serial queue.
 
-- (instancetype)initWithRest:(ARTRestInternal *)rest options:(ARTClientOptions *)options resumeKey:(nullable NSString *)resumeKey connectionSerial:(nullable NSNumber *)connectionSerial logger:(ARTInternalLog *)logger;
-
 @property (readonly, nonatomic) NSString *resumeKey;
 @property (readonly, nonatomic) NSNumber *connectionSerial;
 @property (readonly, nonatomic) ARTRealtimeTransportState state;

--- a/Source/PrivateHeaders/Ably/ARTRealtimeTransportFactory.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeTransportFactory.h
@@ -1,0 +1,25 @@
+@import Foundation;
+
+@class ARTRestInternal;
+@class ARTClientOptions;
+@class ARTInternalLog;
+@protocol ARTRealtimeTransport;
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(RealtimeTransportFactory)
+@protocol ARTRealtimeTransportFactory
+
+- (id<ARTRealtimeTransport>)transportWithRest:(ARTRestInternal *)rest
+                                      options:(ARTClientOptions *)options
+                                    resumeKey:(nullable NSString *)resumeKey
+                             connectionSerial:(nullable NSNumber *)connectionSerial
+                                       logger:(ARTInternalLog *)logger;
+
+@end
+
+NS_SWIFT_NAME(DefaultRealtimeTransportFactory)
+@interface ARTDefaultRealtimeTransportFactory: NSObject<ARTRealtimeTransportFactory>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTTestClientOptions.h
+++ b/Source/PrivateHeaders/Ably/ARTTestClientOptions.h
@@ -1,5 +1,7 @@
 @import Foundation;
 
+@protocol ARTRealtimeTransportFactory;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -23,6 +25,11 @@ NS_ASSUME_NONNULL_BEGIN
  Initial value is `ARTFallback_shuffleArray`.
  */
 @property (nonatomic) void (^shuffleArray)(NSMutableArray *);
+
+/**
+ Initial value is an instance of `ARTDefaultRealtimeTransportFactory`.
+ */
+@property (nonatomic) id<ARTRealtimeTransportFactory> transportFactory;
 
 @end
 

--- a/Source/PrivateHeaders/Ably/ARTWebSocketTransport.h
+++ b/Source/PrivateHeaders/Ably/ARTWebSocketTransport.h
@@ -10,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ARTWebSocketTransport : NSObject <ARTRealtimeTransport>
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
+- (instancetype)initWithRest:(ARTRestInternal *)rest options:(ARTClientOptions *)options resumeKey:(nullable NSString *)resumeKey connectionSerial:(nullable NSNumber *)connectionSerial logger:(ARTInternalLog *)logger NS_DESIGNATED_INITIALIZER;
 
 @property (readonly, nonatomic) NSString *resumeKey;
 @property (readonly, nonatomic) NSNumber *connectionSerial;

--- a/Source/include/Ably.modulemap
+++ b/Source/include/Ably.modulemap
@@ -106,5 +106,6 @@ framework module Ably {
         header "Ably/ARTInternalLogCore.h"
         header "Ably/ARTInternalLogCore+Testing.h"
         header "Ably/ARTDataEncoder.h"
+        header "Ably/ARTRealtimeTransportFactory.h"
     }
 }

--- a/Test/Test Utilities/TestProxyTransportFactory.swift
+++ b/Test/Test Utilities/TestProxyTransportFactory.swift
@@ -1,0 +1,13 @@
+import Ably.Private
+
+class TestProxyTransportFactory: RealtimeTransportFactory {
+    func transport(withRest rest: ARTRestInternal, options: ARTClientOptions, resumeKey: String?, connectionSerial: NSNumber?, logger: InternalLog) -> ARTRealtimeTransport {
+        return TestProxyTransport(
+            rest: rest,
+            options: options,
+            resumeKey: resumeKey,
+            connectionSerial: connectionSerial,
+            logger: logger
+        )
+    }
+}

--- a/Test/Test Utilities/TestProxyTransportFactory.swift
+++ b/Test/Test Utilities/TestProxyTransportFactory.swift
@@ -1,6 +1,21 @@
 import Ably.Private
 
 class TestProxyTransportFactory: RealtimeTransportFactory {
+    private let semaphore = DispatchSemaphore(value: 1)
+    private var createdTransportCount = 0
+    private var firstCreatedTransport: TestProxyTransport?
+    var onlyCreatedTransport: TestProxyTransport {
+        get {
+            semaphore.wait()
+            guard createdTransportCount == 1 else {
+                preconditionFailure("Expected precisely 1 transport to have already been created, but \(createdTransportCount) have")
+            }
+            let onlyCreatedTransport = self.firstCreatedTransport
+            semaphore.signal()
+            return onlyCreatedTransport!
+        }
+    }
+
     var actionsIgnored: [ARTProtocolMessageAction]
 
     init(
@@ -19,6 +34,13 @@ class TestProxyTransportFactory: RealtimeTransportFactory {
         )
 
         transport.actionsIgnored = actionsIgnored
+
+        semaphore.wait()
+        if (createdTransportCount == 0) {
+            firstCreatedTransport = transport
+        }
+        createdTransportCount += 1
+        semaphore.signal()
 
         return transport
     }

--- a/Test/Test Utilities/TestProxyTransportFactory.swift
+++ b/Test/Test Utilities/TestProxyTransportFactory.swift
@@ -1,13 +1,25 @@
 import Ably.Private
 
 class TestProxyTransportFactory: RealtimeTransportFactory {
+    var actionsIgnored: [ARTProtocolMessageAction]
+
+    init(
+        actionsIgnored: [ARTProtocolMessageAction] = []
+    ) {
+        self.actionsIgnored = actionsIgnored
+    }
+
     func transport(withRest rest: ARTRestInternal, options: ARTClientOptions, resumeKey: String?, connectionSerial: NSNumber?, logger: InternalLog) -> ARTRealtimeTransport {
-        return TestProxyTransport(
+        let transport = TestProxyTransport(
             rest: rest,
             options: options,
             resumeKey: resumeKey,
             connectionSerial: connectionSerial,
             logger: logger
         )
+
+        transport.actionsIgnored = actionsIgnored
+
+        return transport
     }
 }

--- a/Test/Test Utilities/TestProxyTransportFactory.swift
+++ b/Test/Test Utilities/TestProxyTransportFactory.swift
@@ -17,11 +17,17 @@ class TestProxyTransportFactory: RealtimeTransportFactory {
     }
 
     var actionsIgnored: [ARTProtocolMessageAction]
+    var fakeNetworkResponse: FakeNetworkResponse?
+    var allowMultipleTransportsToBeCreated: Bool
 
     init(
-        actionsIgnored: [ARTProtocolMessageAction] = []
+        actionsIgnored: [ARTProtocolMessageAction] = [],
+        fakeNetworkResponse: FakeNetworkResponse? = nil,
+        allowMultipleTransportsToBeCreated: Bool = false
     ) {
         self.actionsIgnored = actionsIgnored
+        self.fakeNetworkResponse = fakeNetworkResponse
+        self.allowMultipleTransportsToBeCreated = allowMultipleTransportsToBeCreated // this exists so that if want to turn off properties that'll happen
     }
 
     func transport(withRest rest: ARTRestInternal, options: ARTClientOptions, resumeKey: String?, connectionSerial: NSNumber?, logger: InternalLog) -> ARTRealtimeTransport {
@@ -38,6 +44,8 @@ class TestProxyTransportFactory: RealtimeTransportFactory {
         semaphore.wait()
         if (createdTransportCount == 0) {
             firstCreatedTransport = transport
+        } else if !allowMultipleTransportsToBeCreated {
+            preconditionFailure("Factory configured to not allow multiple transports to be created")
         }
         createdTransportCount += 1
         semaphore.signal()

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -210,8 +210,8 @@ class AblyTests {
     class func newRealtime(_ options: ARTClientOptions) -> ARTRealtime {
         let autoConnect = options.autoConnect
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let realtime = ARTRealtime(options: options)
-        realtime.internal.setTransport(TestProxyTransport.self)
         realtime.internal.setReachabilityClass(TestReachability.self)
         if autoConnect {
             options.autoConnect = true

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -186,10 +186,10 @@ class AuthTests: XCTestCase {
         let options = AblyTests.clientOptions()
         options.token = getTestToken()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
 
         if let transport = client.internal.transport as? TestProxyTransport, let query = transport.lastUrl?.query {
@@ -257,6 +257,7 @@ class AuthTests: XCTestCase {
         let options = AblyTests.clientOptions()
         options.tokenDetails = getTestTokenDetails(ttl: 0.1)
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         // Token will expire, expecting 40142
         waitUntil(timeout: testTimeout) { done in
@@ -269,7 +270,6 @@ class AuthTests: XCTestCase {
         XCTAssertNil(realtime.internal.options.key)
         XCTAssertNil(realtime.internal.options.authCallback)
         XCTAssertNil(realtime.internal.options.authUrl)
-        realtime.internal.setTransport(TestProxyTransport.self)
 
         let channel = realtime.channels.get(uniqueChannelName())
 
@@ -885,10 +885,10 @@ class AuthTests: XCTestCase {
         let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
         options.clientId = expectedClientId
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
 
         waitUntil(timeout: testTimeout) { done in
@@ -4062,9 +4062,9 @@ class AuthTests: XCTestCase {
         options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
         options.authParams?.append(URLQueryItem(name: "expiresIn", value: String(UInt(tokenDuration))))
         options.autoConnect = false // Prevent auto connection so we can set the transport proxy
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in

--- a/Test/Tests/PushTests.swift
+++ b/Test/Tests/PushTests.swift
@@ -257,11 +257,10 @@ class PushTests: XCTestCase {
     func test__013__LocalDevice__when_getting_a_client_ID_from_CONNECTED_message__new_clientID_is_set() {
         let options = ARTClientOptions(key: "fake:key")
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let realtime = ARTRealtime(options: options)
         XCTAssertNil(realtime.device.clientId)
-
-        realtime.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             realtime.connection.once(.connected) { _ in

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -567,15 +567,13 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__017__Channel__connection_state__changes_to_FAILED__ATTACHING_channel_should_transition_to_FAILED() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
-        options.testOptions.transportFactory = TestProxyTransportFactory()
+        options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.attached])
         let client = ARTRealtime(options: options)
         client.connect()
         defer { client.dispose(); client.close() }
 
         let channel = client.channels.get(uniqueChannelName())
         channel.attach()
-        let transport = client.internal.transport as! TestProxyTransport
-        transport.actionsIgnored += [.attached]
 
         XCTAssertEqual(channel.state, ARTRealtimeChannelState.attaching)
 
@@ -742,7 +740,7 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__022__Channel__connection_state__changes_to_CLOSED__ATTACHING_channel_should_transition_to_DETACHED() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
-        options.testOptions.transportFactory = TestProxyTransportFactory()
+        options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.attached])
         let client = ARTRealtime(options: options)
         client.connect()
         defer { client.dispose(); client.close() }
@@ -750,8 +748,6 @@ class RealtimeClientChannelTests: XCTestCase {
 
         let channel = client.channels.get(uniqueChannelName())
         channel.attach()
-        let transport = client.internal.transport as! TestProxyTransport
-        transport.actionsIgnored += [.attached]
 
         XCTAssertEqual(channel.state, ARTRealtimeChannelState.attaching)
         client.close()
@@ -780,15 +776,13 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__024__Channel__connection_state__changes_to_SUSPENDED__ATTACHING_channel_should_transition_to_SUSPENDED() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
-        options.testOptions.transportFactory = TestProxyTransportFactory()
+        options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.attached])
         let client = ARTRealtime(options: options)
         client.connect()
         defer { client.dispose(); client.close() }
 
         let channel = client.channels.get(uniqueChannelName())
         channel.attach()
-        let transport = client.internal.transport as! TestProxyTransport
-        transport.actionsIgnored += [.attached]
 
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
         XCTAssertEqual(channel.state, ARTRealtimeChannelState.attaching)
@@ -811,15 +805,12 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__026__Channel__connection_state__changes_to_SUSPENDED__channel_being_released_waiting_for_DETACH_shouldn_t_crash__issue__918_() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
-        options.testOptions.transportFactory = TestProxyTransportFactory()
+        // Force the callback on .release below to be triggered by our
+        // forced SUSPENDED message, not by a DETACHED.
+        options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.detached])
         let client = ARTRealtime(options: options)
         client.connect()
         defer { client.dispose(); client.close() }
-
-        // Force the callback on .release below to be triggered by our
-        // forced SUSPENDED message, not by a DETACHED.
-        let transport = client.internal.transport as! TestProxyTransport
-        transport.actionsIgnored += [.detached]
         
         var channel0Name = ""
         for i in 0 ..< 100 { // We need a few channels to trigger iterator invalidation.
@@ -1083,14 +1074,12 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__039__Channel__attach__results_in_an_error_if_the_connection_state_is__CLOSING() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
-        options.testOptions.transportFactory = TestProxyTransportFactory()
+        options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.closed])
         let client = ARTRealtime(options: options)
         client.connect()
         defer { client.dispose(); client.close() }
 
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-        let transport = client.internal.transport as! TestProxyTransport
-        transport.actionsIgnored += [.closed]
 
         let channel = client.channels.get(uniqueChannelName())
 
@@ -1812,14 +1801,12 @@ class RealtimeClientChannelTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
-        options.testOptions.transportFactory = TestProxyTransportFactory()
+        options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.detached])
         let client = ARTRealtime(options: options)
         client.connect()
         defer { client.dispose(); client.close() }
 
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-        let transport = client.internal.transport as! TestProxyTransport
-        transport.actionsIgnored += [.detached]
 
         let channel = client.channels.get(uniqueChannelName())
         channel.attach()

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -49,8 +49,8 @@ private func testHandlesDecodingErrorInFixture(_ cryptoFixtureFileName: String, 
     let options = AblyTests.commonAppSetup()
     options.autoConnect = false
     options.logHandler = ARTLog(capturingOutput: true)
+    options.testOptions.transportFactory = TestProxyTransportFactory()
     let client = ARTRealtime(options: options)
-    client.internal.setTransport(TestProxyTransport.self)
     client.connect()
     defer { client.dispose(); client.close() }
 
@@ -567,8 +567,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__017__Channel__connection_state__changes_to_FAILED__ATTACHING_channel_should_transition_to_FAILED() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -622,8 +622,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__019__Channel__connection_state__changes_to_FAILED__channel_being_released_waiting_for_DETACH_shouldn_t_crash__issue__918_() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -690,9 +690,9 @@ class RealtimeClientChannelTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.queueMessages = false
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
         client.internal.setReachabilityClass(TestReachability.self)
         let channel = client.channels.get(uniqueChannelName())
 
@@ -742,8 +742,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__022__Channel__connection_state__changes_to_CLOSED__ATTACHING_channel_should_transition_to_DETACHED() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
@@ -780,8 +780,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__024__Channel__connection_state__changes_to_SUSPENDED__ATTACHING_channel_should_transition_to_SUSPENDED() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -811,8 +811,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__026__Channel__connection_state__changes_to_SUSPENDED__channel_being_released_waiting_for_DETACH_shouldn_t_crash__issue__918_() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -901,9 +901,9 @@ class RealtimeClientChannelTests: XCTestCase {
         options.suspendedRetryTimeout = 3.0
         options.channelRetryTimeout = 0.5
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.internal.setReachabilityClass(TestReachability.self)
         defer {
             client.simulateRestoreInternetConnection()
@@ -1083,8 +1083,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__039__Channel__attach__results_in_an_error_if_the_connection_state_is__CLOSING() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -1219,8 +1219,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__030__Channel__attach__should_send_an_ATTACH_ProtocolMessage__change_state_to_ATTACHING_and_change_state_to_ATTACHED_after_confirmation() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -1727,8 +1727,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__053__Channel__detach__should_send_a_DETACH_ProtocolMessage__change_state_to_DETACHING_and_change_state_to_DETACHED_after_confirmation() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -1812,8 +1812,8 @@ class RealtimeClientChannelTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -1847,8 +1847,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__059__Channel__detach__results_in_an_error_if_the_connection_state_is__CLOSING() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -2854,8 +2854,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__096__Channel__publish__expect_either__an_array_of_Message_objects() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
@@ -2895,8 +2895,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__098__Channel__publish__expect_either__allows_name_to_be_null() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
@@ -2933,8 +2933,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__099__Channel__publish__expect_either__allows_data_to_be_null() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
@@ -2971,8 +2971,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__100__Channel__publish__expect_either__allows_name_and_data_to_be_assigned() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
@@ -3006,8 +3006,8 @@ class RealtimeClientChannelTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.clientId = "client_string"
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
@@ -3262,8 +3262,8 @@ class RealtimeClientChannelTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.logHandler = ARTLog(capturingOutput: true)
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -3880,8 +3880,8 @@ class RealtimeClientChannelTests: XCTestCase {
         options.channelRetryTimeout = 1.0
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         
         client.connect()
         
@@ -4330,14 +4330,13 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__138__Channel__crypto__if_configured_for_encryption__channels_encrypt_and_decrypt_messages__data() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let clientSender = ARTRealtime(options: options)
-        clientSender.internal.setTransport(TestProxyTransport.self)
         defer { clientSender.close() }
         clientSender.connect()
 
         let clientReceiver = ARTRealtime(options: options)
-        clientReceiver.internal.setTransport(TestProxyTransport.self)
         defer { clientReceiver.close() }
         clientReceiver.connect()
 

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -566,10 +566,8 @@ class RealtimeClientChannelTests: XCTestCase {
 
     func test__017__Channel__connection_state__changes_to_FAILED__ATTACHING_channel_should_transition_to_FAILED() {
         let options = AblyTests.commonAppSetup()
-        options.autoConnect = false
         options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.attached])
         let client = ARTRealtime(options: options)
-        client.connect()
         defer { client.dispose(); client.close() }
 
         let channel = client.channels.get(uniqueChannelName())
@@ -739,10 +737,8 @@ class RealtimeClientChannelTests: XCTestCase {
 
     func test__022__Channel__connection_state__changes_to_CLOSED__ATTACHING_channel_should_transition_to_DETACHED() {
         let options = AblyTests.commonAppSetup()
-        options.autoConnect = false
         options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.attached])
         let client = ARTRealtime(options: options)
-        client.connect()
         defer { client.dispose(); client.close() }
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
 
@@ -775,10 +771,8 @@ class RealtimeClientChannelTests: XCTestCase {
 
     func test__024__Channel__connection_state__changes_to_SUSPENDED__ATTACHING_channel_should_transition_to_SUSPENDED() {
         let options = AblyTests.commonAppSetup()
-        options.autoConnect = false
         options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.attached])
         let client = ARTRealtime(options: options)
-        client.connect()
         defer { client.dispose(); client.close() }
 
         let channel = client.channels.get(uniqueChannelName())
@@ -804,12 +798,10 @@ class RealtimeClientChannelTests: XCTestCase {
 
     func test__026__Channel__connection_state__changes_to_SUSPENDED__channel_being_released_waiting_for_DETACH_shouldn_t_crash__issue__918_() {
         let options = AblyTests.commonAppSetup()
-        options.autoConnect = false
         // Force the callback on .release below to be triggered by our
         // forced SUSPENDED message, not by a DETACHED.
         options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.detached])
         let client = ARTRealtime(options: options)
-        client.connect()
         defer { client.dispose(); client.close() }
         
         var channel0Name = ""
@@ -1073,10 +1065,8 @@ class RealtimeClientChannelTests: XCTestCase {
 
     func test__039__Channel__attach__results_in_an_error_if_the_connection_state_is__CLOSING() {
         let options = AblyTests.commonAppSetup()
-        options.autoConnect = false
         options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.closed])
         let client = ARTRealtime(options: options)
-        client.connect()
         defer { client.dispose(); client.close() }
 
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
@@ -1799,11 +1789,9 @@ class RealtimeClientChannelTests: XCTestCase {
     // RTL5f
     func test__057__Channel__detach__if_a_DETACHED_is_not_received_within_the_default_realtime_request_timeout__the_detach_request_should_be_treated_as_though_it_has_failed_and_the_channel_will_return_to_its_previous_state() {
         let options = AblyTests.commonAppSetup()
-        options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
         options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.detached])
         let client = ARTRealtime(options: options)
-        client.connect()
         defer { client.dispose(); client.close() }
 
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -1173,14 +1173,12 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.clientId = "client_string"
-        options.testOptions.transportFactory = TestProxyTransportFactory()
+        options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.ack, .nack])
         let client = ARTRealtime(options: options)
         client.connect()
         defer { client.dispose(); client.close() }
 
         let channel = client.channels.get(uniqueChannelName())
-        let transport = client.internal.transport as! TestProxyTransport
-        transport.actionsIgnored += [.ack, .nack]
 
         waitUntil(timeout: testTimeout) { done in
             channel.attach { error in
@@ -1211,14 +1209,12 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.clientId = "client_string"
-        options.testOptions.transportFactory = TestProxyTransportFactory()
+        options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.ack, .nack])
         let client = ARTRealtime(options: options)
         client.connect()
         defer { client.dispose(); client.close() }
 
         let channel = client.channels.get(uniqueChannelName())
-        let transport = client.internal.transport as! TestProxyTransport
-        transport.actionsIgnored += [.ack, .nack]
 
         waitUntil(timeout: testTimeout) { done in
             channel.attach { error in
@@ -1238,7 +1234,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__037__Connection__ACK_and_NACK__should_trigger_the_failure_callback_for_the_remaining_pending_messages_if__lost_connection_state() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
-        options.testOptions.transportFactory = TestProxyTransportFactory()
+        options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.ack, .nack])
         let client = ARTRealtime(options: options)
         client.connect()
         defer {
@@ -1247,9 +1243,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
 
         let channel = client.channels.get(uniqueChannelName())
-
-        let transport = client.internal.transport as! TestProxyTransport
-        transport.actionsIgnored += [.ack, .nack]
 
         waitUntil(timeout: testTimeout) { done in
             channel.attach { _ in
@@ -1706,16 +1699,13 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__047__Connection__close__should_transition_to_CLOSED_action_when_the_close_process_timeouts() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
-        options.testOptions.transportFactory = TestProxyTransportFactory()
+        options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.closed])
         let client = ARTRealtime(options: options)
         client.connect()
         defer {
             client.dispose()
             client.close()
         }
-
-        let transport = client.internal.transport as! TestProxyTransport
-        transport.actionsIgnored += [.closed]
 
         var states: [ARTRealtimeConnectionState] = []
         var start: NSDate?

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -1171,11 +1171,9 @@ class RealtimeClientConnectionTests: XCTestCase {
 
     func test__035__Connection__ACK_and_NACK__should_trigger_the_failure_callback_for_the_remaining_pending_messages_if__connection_is_closed() {
         let options = AblyTests.commonAppSetup()
-        options.autoConnect = false
         options.clientId = "client_string"
         options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.ack, .nack])
         let client = ARTRealtime(options: options)
-        client.connect()
         defer { client.dispose(); client.close() }
 
         let channel = client.channels.get(uniqueChannelName())
@@ -1207,11 +1205,9 @@ class RealtimeClientConnectionTests: XCTestCase {
 
     func test__036__Connection__ACK_and_NACK__should_trigger_the_failure_callback_for_the_remaining_pending_messages_if__connection_state_enters_FAILED() {
         let options = AblyTests.commonAppSetup()
-        options.autoConnect = false
         options.clientId = "client_string"
         options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.ack, .nack])
         let client = ARTRealtime(options: options)
-        client.connect()
         defer { client.dispose(); client.close() }
 
         let channel = client.channels.get(uniqueChannelName())
@@ -1233,10 +1229,8 @@ class RealtimeClientConnectionTests: XCTestCase {
 
     func test__037__Connection__ACK_and_NACK__should_trigger_the_failure_callback_for_the_remaining_pending_messages_if__lost_connection_state() {
         let options = AblyTests.commonAppSetup()
-        options.autoConnect = false
         options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.ack, .nack])
         let client = ARTRealtime(options: options)
-        client.connect()
         defer {
             client.dispose()
             client.close()
@@ -1698,10 +1692,8 @@ class RealtimeClientConnectionTests: XCTestCase {
     // RTN12b
     func test__047__Connection__close__should_transition_to_CLOSED_action_when_the_close_process_timeouts() {
         let options = AblyTests.commonAppSetup()
-        options.autoConnect = false
         options.testOptions.transportFactory = TestProxyTransportFactory(actionsIgnored: [.closed])
         let client = ARTRealtime(options: options)
-        client.connect()
         defer {
             client.dispose()
             client.close()

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -29,11 +29,11 @@ private func testUsesAlternativeHostOnResponse(_ caseTest: FakeNetworkResponse, 
     let options = ARTClientOptions(key: "xxxx:xxxx")
     options.autoConnect = false
     options.testOptions.realtimeRequestTimeout = 1.0
+    options.testOptions.transportFactory = TestProxyTransportFactory()
     let client = ARTRealtime(options: options)
     defer { client.dispose(); client.close() }
     client.channels.get(channelName)
 
-    client.internal.setTransport(TestProxyTransport.self)
     TestProxyTransport.fakeNetworkResponse = caseTest
     defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -69,12 +69,12 @@ private func testUsesAlternativeHostOnResponse(_ caseTest: FakeNetworkResponse, 
 private func testMovesToDisconnectedWithNetworkingError(_ error: Error) {
     let options = AblyTests.commonAppSetup()
     options.autoConnect = false
+    options.testOptions.transportFactory = TestProxyTransportFactory()
     let client = AblyTests.newRealtime(options)
     defer {
         client.dispose()
         client.close()
     }
-    client.internal.setTransport(TestProxyTransport.self)
 
     waitUntil(timeout: testTimeout) { done in
         client.connection.once(.connected) { _ in
@@ -163,8 +163,8 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__016__Connection__ConnectionDetails__maxMessageSize_overrides_the_default_maxMessageSize() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         let defaultMaxMessageSize = ARTDefault.maxMessageSize()
         XCTAssertEqual(defaultMaxMessageSize, 65536)
         defer {
@@ -190,9 +190,9 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__017__Connection__url__should_connect_to_the_default_host() {
         let options = ARTClientOptions(key: "keytest:secret")
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -206,9 +206,9 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__018__Connection__url__should_connect_with_query_string_params() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -242,9 +242,9 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.useTokenAuth = true
         options.autoConnect = false
         options.echoMessages = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -358,9 +358,9 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__004__Connection__Library_and_version_param__agent__should_include_the__Ably_Agent__header_value() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
 
         waitUntil(timeout: testTimeout) { done in
@@ -749,8 +749,8 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__006__Connection__should_have_an_opened_websocket_connection_and_received_a_CONNECTED_ProtocolMessage() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer {
             client.dispose()
@@ -790,8 +790,8 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.clientId = "client_string"
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -819,8 +819,8 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.clientId = "client_string"
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -861,8 +861,8 @@ class RealtimeClientConnectionTests: XCTestCase {
         let channelName = uniqueChannelName()
         options.token = getTestToken(key: options.key, capability: "{ \"\(options.testOptions.channelNamePrefix!)-\(channelName)\":[\"subscribe\"] }")
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -890,8 +890,8 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.clientId = "client_string"
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -932,8 +932,8 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.clientId = "client_string"
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -1173,8 +1173,8 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.clientId = "client_string"
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -1211,8 +1211,8 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.clientId = "client_string"
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -1238,8 +1238,8 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__037__Connection__ACK_and_NACK__should_trigger_the_failure_callback_for_the_remaining_pending_messages_if__lost_connection_state() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer {
             client.dispose()
@@ -1663,8 +1663,8 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__046__Connection__close__if_CONNECTED__should_send_a_CLOSE_action__change_state_to_CLOSING_and_receive_a_CLOSED_action() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer {
             client.dispose()
@@ -1706,8 +1706,8 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__047__Connection__close__should_transition_to_CLOSED_action_when_the_close_process_timeouts() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer {
             client.dispose()
@@ -1757,8 +1757,8 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__048__Connection__close__transitions_to_the_CLOSING_state_and_then_to_the_CLOSED_state_if_the_transport_is_abruptly_closed() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer {
             client.dispose()
@@ -2005,9 +2005,9 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
         let tokenTtl = 3.0
         options.token = getTestToken(key: options.key, ttl: tokenTtl)
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         defer {
             client.dispose()
             client.close()
@@ -2089,6 +2089,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__056__Connection__connection_request_fails__should_transition_to_disconnected_when_the_token_renewal_fails() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let tokenTtl = 3.0
         let tokenDetails = getTestTokenDetails(key: options.key, capability: nil, ttl: tokenTtl)!
         options.token = tokenDetails.token
@@ -2099,7 +2100,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         defer {
             client.dispose()
             client.close()
@@ -2129,6 +2129,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.autoConnect = false
         let tokenTtl = 1.0
         options.token = getTestToken(ttl: tokenTtl)
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         // Let the token expire
         waitUntil(timeout: testTimeout) { done in
@@ -2138,7 +2139,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         defer {
             client.dispose()
             client.close()
@@ -2300,9 +2300,9 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.disconnectedRetryTimeout = 0.5
         options.suspendedRetryTimeout = 2.0
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.internal.setReachabilityClass(TestReachability.self)
         defer {
             client.simulateRestoreInternetConnection()
@@ -2811,9 +2811,9 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__073__Connection__connection_failures_once_CONNECTED__when_a_connection_is_resumed__the_connection_key_may_change_and_will_be_provided_in_the_first_CONNECTED_ProtocolMessage_connectionDetails() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
@@ -3014,9 +3014,9 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
         let tokenTtl = 2.0
         options.token = getTestToken(key: options.key, ttl: tokenTtl)
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         defer {
             client.dispose()
             client.close()
@@ -3093,9 +3093,9 @@ class RealtimeClientConnectionTests: XCTestCase {
                 callback(tokenDetails, nil) // Return the same expired token again.
             }
         }
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         defer {
             client.dispose()
             client.close()
@@ -3416,11 +3416,11 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
         client.channels.get(uniqueChannelName())
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .hostUnreachable
         defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -3461,11 +3461,11 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.autoConnect = false
         options.fallbackHosts = ["f.ably-realtime.com", "g.ably-realtime.com", "h.ably-realtime.com", "i.ably-realtime.com", "j.ably-realtime.com"]
         options.testOptions.realtimeRequestTimeout = 1.0
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
         client.channels.get(uniqueChannelName())
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .hostUnreachable
         defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -3530,10 +3530,10 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         let channel = client.channels.get(uniqueChannelName())
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .host400BadRequest
         defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -3564,11 +3564,11 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
         client.channels.get(uniqueChannelName())
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .hostUnreachable
         defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -3619,6 +3619,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 5.0
         options.testOptions.shuffleArray = shuffleArrayInExpectedHostOrder
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
         client.channels.get(uniqueChannelName())
@@ -3626,7 +3627,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         let testHttpExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.rest.httpExecutor = testHttpExecutor
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .hostUnreachable
         defer { TestProxyTransport.fakeNetworkResponse = nil }
         
@@ -3694,6 +3694,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
         client.channels.get(uniqueChannelName())
@@ -3703,7 +3704,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         let testHttpExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: internalLog)
         client.internal.rest.httpExecutor = testHttpExecutor
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .hostUnreachable
         defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -3745,6 +3745,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.fallbackHosts = expectedFallbackHosts.sorted() // will be picked "randomly" as of expectedHostOrder
         options.testOptions.realtimeRequestTimeout = 5.0
         options.testOptions.shuffleArray = shuffleArrayInExpectedHostOrder
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
         client.channels.get(uniqueChannelName())
@@ -3752,7 +3753,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         let testHttpExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.rest.httpExecutor = testHttpExecutor
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .hostUnreachable
         defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -3817,13 +3817,13 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         options.fallbackHosts = []
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         let channel = client.channels.get(uniqueChannelName())
 
         let testHttpExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.rest.httpExecutor = testHttpExecutor
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .hostUnreachable
         defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -3852,12 +3852,12 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__096__Connection__Host_Fallback__client_is_connected_to_a_fallback_host_endpoint_should_do_HTTP_requests_to_the_same_data_centre() {
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
 
         let testHttpExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.rest.httpExecutor = testHttpExecutor
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .hostUnreachable
         defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -4153,9 +4153,9 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.useTokenAuth = true
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
         
         let channelName = uniqueChannelName()
         let channel = client.channels.get(channelName)

--- a/Test/Tests/RealtimeClientPresenceTests.swift
+++ b/Test/Tests/RealtimeClientPresenceTests.swift
@@ -110,8 +110,8 @@ class RealtimeClientPresenceTests: XCTestCase {
     func skipped__test__009__Presence__ProtocolMessage_bit_flag__when_no_members_are_present() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
@@ -143,8 +143,8 @@ class RealtimeClientPresenceTests: XCTestCase {
         disposable += [AblyTests.addMembersSequentiallyToChannel(channelName, members: 250, options: options)]
 
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(channelName)

--- a/Test/Tests/RealtimeClientTests.swift
+++ b/Test/Tests/RealtimeClientTests.swift
@@ -419,9 +419,9 @@ class RealtimeClientTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.useTokenAuth = true
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -476,9 +476,9 @@ class RealtimeClientTests: XCTestCase {
         options.autoConnect = false
         let testToken = getTestToken()
         options.token = testToken
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -536,9 +536,9 @@ class RealtimeClientTests: XCTestCase {
         options.autoConnect = false
         let testToken = getTestToken(capability: "{\"test\":[\"subscribe\"]}")
         options.token = testToken
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -627,9 +627,9 @@ class RealtimeClientTests: XCTestCase {
         options.autoConnect = false
         let testToken = getTestToken()
         options.token = testToken
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         let channel = client.channels.get(uniqueChannelName())
         waitUntil(timeout: testTimeout) { done in
@@ -688,9 +688,9 @@ class RealtimeClientTests: XCTestCase {
         options.autoConnect = false
         options.clientId = "ios"
         options.useTokenAuth = true
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -779,9 +779,9 @@ class RealtimeClientTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.useTokenAuth = true
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -813,9 +813,9 @@ class RealtimeClientTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.useTokenAuth = true
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         var connections = 0
         let hook1 = TestProxyTransport.testSuite_injectIntoClassMethod(#selector(TestProxyTransport.connect(withToken:))) {
@@ -891,9 +891,9 @@ class RealtimeClientTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.useTokenAuth = true
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -941,9 +941,9 @@ class RealtimeClientTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.useTokenAuth = true
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -1027,9 +1027,9 @@ class RealtimeClientTests: XCTestCase {
         options.autoConnect = false
         let testToken = getTestToken()
         options.token = testToken
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -1082,9 +1082,9 @@ class RealtimeClientTests: XCTestCase {
         options.autoConnect = false
         let testToken = getTestToken()
         options.token = testToken
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -1137,9 +1137,9 @@ class RealtimeClientTests: XCTestCase {
         options.autoConnect = false
         let testToken = getTestToken()
         options.token = testToken
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -1192,9 +1192,9 @@ class RealtimeClientTests: XCTestCase {
         options.autoConnect = false
         let testToken = getTestToken()
         options.token = testToken
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in


### PR DESCRIPTION
the idea here being that it will allow us to configure the transport before the realtime instance initiates a connection attempt, helping reduce timing issues

and we can also allow autoconnect

and we can remove the static properties on TestProxyTransport