### PR TITLE
Remove static `TestProxyTransport` properties

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -30,6 +30,15 @@
 		2105ED2629E830D600DE6D67 /* ARTInternalLog+Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 2105ED2529E830D600DE6D67 /* ARTInternalLog+Testing.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2105ED2729E830D600DE6D67 /* ARTInternalLog+Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 2105ED2529E830D600DE6D67 /* ARTInternalLog+Testing.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2105ED2829E830D600DE6D67 /* ARTInternalLog+Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 2105ED2529E830D600DE6D67 /* ARTInternalLog+Testing.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		210F67A229E9D718007B9345 /* ARTRealtimeTransportFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 210F67A129E9D718007B9345 /* ARTRealtimeTransportFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		210F67A329E9D718007B9345 /* ARTRealtimeTransportFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 210F67A129E9D718007B9345 /* ARTRealtimeTransportFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		210F67A429E9D718007B9345 /* ARTRealtimeTransportFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 210F67A129E9D718007B9345 /* ARTRealtimeTransportFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		210F67A629E9D93D007B9345 /* ARTRealtimeTransportFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 210F67A529E9D93D007B9345 /* ARTRealtimeTransportFactory.m */; };
+		210F67A729E9D93D007B9345 /* ARTRealtimeTransportFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 210F67A529E9D93D007B9345 /* ARTRealtimeTransportFactory.m */; };
+		210F67A829E9D93D007B9345 /* ARTRealtimeTransportFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 210F67A529E9D93D007B9345 /* ARTRealtimeTransportFactory.m */; };
+		210F67B129E9DB62007B9345 /* TestProxyTransportFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210F67B029E9DB62007B9345 /* TestProxyTransportFactory.swift */; };
+		210F67B229E9DB62007B9345 /* TestProxyTransportFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210F67B029E9DB62007B9345 /* TestProxyTransportFactory.swift */; };
+		210F67B329E9DB62007B9345 /* TestProxyTransportFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210F67B029E9DB62007B9345 /* TestProxyTransportFactory.swift */; };
 		21113B4529DB484200652C86 /* ARTChannel+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 21113B4429DB484200652C86 /* ARTChannel+Subclass.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21113B4629DB484200652C86 /* ARTChannel+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 21113B4429DB484200652C86 /* ARTChannel+Subclass.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21113B4729DB484200652C86 /* ARTChannel+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 21113B4429DB484200652C86 /* ARTChannel+Subclass.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1100,6 +1109,9 @@
 		2105ED1D29E7242400DE6D67 /* ARTLogAdapter+Testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTLogAdapter+Testing.h"; path = "PrivateHeaders/Ably/ARTLogAdapter+Testing.h"; sourceTree = "<group>"; };
 		2105ED2129E7429E00DE6D67 /* ARTPaginatedResult+Subclass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTPaginatedResult+Subclass.h"; path = "PrivateHeaders/Ably/ARTPaginatedResult+Subclass.h"; sourceTree = "<group>"; };
 		2105ED2529E830D600DE6D67 /* ARTInternalLog+Testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTInternalLog+Testing.h"; path = "PrivateHeaders/Ably/ARTInternalLog+Testing.h"; sourceTree = "<group>"; };
+		210F67A129E9D718007B9345 /* ARTRealtimeTransportFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTRealtimeTransportFactory.h; path = PrivateHeaders/Ably/ARTRealtimeTransportFactory.h; sourceTree = "<group>"; };
+		210F67A529E9D93D007B9345 /* ARTRealtimeTransportFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTRealtimeTransportFactory.m; sourceTree = "<group>"; };
+		210F67B029E9DB62007B9345 /* TestProxyTransportFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestProxyTransportFactory.swift; sourceTree = "<group>"; };
 		21113B4429DB484200652C86 /* ARTChannel+Subclass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTChannel+Subclass.h"; path = "PrivateHeaders/Ably/ARTChannel+Subclass.h"; sourceTree = "<group>"; };
 		21113B4829DB60F800652C86 /* MockRetryDelayCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRetryDelayCalculator.swift; sourceTree = "<group>"; };
 		21113B5029DC6AAF00652C86 /* ARTTestClientOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTTestClientOptions.h; path = PrivateHeaders/Ably/ARTTestClientOptions.h; sourceTree = "<group>"; };
@@ -1708,6 +1720,7 @@
 				21113B4829DB60F800652C86 /* MockRetryDelayCalculator.swift */,
 				2124B78629DB127900AD8361 /* MockVersion2Log.swift */,
 				2147F03429E5872C0071CB94 /* MockInternalLogCore.swift */,
+				210F67B029E9DB62007B9345 /* TestProxyTransportFactory.swift */,
 			);
 			path = "Test Utilities";
 			sourceTree = "<group>";
@@ -1887,6 +1900,8 @@
 			isa = PBXGroup;
 			children = (
 				96E4083D1A3892C700087F77 /* ARTRealtimeTransport.h */,
+				210F67A129E9D718007B9345 /* ARTRealtimeTransportFactory.h */,
+				210F67A529E9D93D007B9345 /* ARTRealtimeTransportFactory.m */,
 				D7B17EE21C07208B00A6958E /* ARTConnectionDetails.m */,
 				EB2D5A901CC941A700AD1A67 /* ARTRealtimeTransport.m */,
 				96E408451A3895E800087F77 /* ARTWebSocketTransport.h */,
@@ -2146,6 +2161,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				210F67A229E9D718007B9345 /* ARTRealtimeTransportFactory.h in Headers */,
 				96BF61531A35B39C004CF2B3 /* ARTRest.h in Headers */,
 				EB91213E1CA0AD6600BA0A40 /* ARTMsgPackEncoder.h in Headers */,
 				96A507BD1A3791490077CDF8 /* ARTRealtime.h in Headers */,
@@ -2393,6 +2409,7 @@
 				D710D54E21949C66008F54AD /* ARTNSMutableRequest+ARTPush.h in Headers */,
 				211A610429DA05C700D169C5 /* ARTAttachRequestMetadata.h in Headers */,
 				D7D06F1026330E2800DEBDAD /* ARTHttp+Private.h in Headers */,
+				210F67A329E9D718007B9345 /* ARTRealtimeTransportFactory.h in Headers */,
 				EB1B541A22FB1D7F006A59AC /* ARTPushChannelSubscriptions+Private.h in Headers */,
 				D710D48921949A85008F54AD /* ARTConstants.h in Headers */,
 				D710D60921949DA9008F54AD /* ARTURLSessionServerTrust.h in Headers */,
@@ -2559,6 +2576,7 @@
 				D710D55421949C67008F54AD /* ARTNSMutableRequest+ARTPush.h in Headers */,
 				211A610529DA05C700D169C5 /* ARTAttachRequestMetadata.h in Headers */,
 				D7D06F1126330E2900DEBDAD /* ARTHttp+Private.h in Headers */,
+				210F67A429E9D718007B9345 /* ARTRealtimeTransportFactory.h in Headers */,
 				EB1B541B22FB1D7F006A59AC /* ARTPushChannelSubscriptions+Private.h in Headers */,
 				D710D48B21949A86008F54AD /* ARTConstants.h in Headers */,
 				D710D60B21949DAA008F54AD /* ARTURLSessionServerTrust.h in Headers */,
@@ -2941,6 +2959,7 @@
 				D746AE2C1BBB625E003ECEF8 /* RestClientChannelTests.swift in Sources */,
 				D71D30041C5F7B2F002115B0 /* RealtimeClientChannelsTests.swift in Sources */,
 				EB1B53F922F85CE4006A59AC /* ObjectLifetimesTests.swift in Sources */,
+				210F67B129E9DB62007B9345 /* TestProxyTransportFactory.swift in Sources */,
 				D7DF73851EA600240013CD36 /* PushActivationStateMachineTests.swift in Sources */,
 				211A60D729D6D2C300D169C5 /* BackoffRetryDelayCalculatorTests.swift in Sources */,
 				217FCF3229D62460006E5F2D /* RetrySequenceTests.swift in Sources */,
@@ -3039,6 +3058,7 @@
 				D785C42A1E549E33008FEC05 /* ARTPushChannelSubscription.m in Sources */,
 				D7B17EE41C07208B00A6958E /* ARTConnectionDetails.m in Sources */,
 				2124B79B29DB14C000AD8361 /* ARTLogAdapter.m in Sources */,
+				210F67A629E9D93D007B9345 /* ARTRealtimeTransportFactory.m in Sources */,
 				217FCF3A29D626C1006E5F2D /* ARTJitterCoefficientGenerator.m in Sources */,
 				96BF61591A35B52C004CF2B3 /* ARTHttp.m in Sources */,
 				217D1833254222F600DFF07E /* ARTSRPinningSecurityPolicy.m in Sources */,
@@ -3133,6 +3153,7 @@
 				848ED97426E50D0F0087E800 /* ObjcppTest.mm in Sources */,
 				D7093C28219E466E00723F17 /* RealtimeClientPresenceTests.swift in Sources */,
 				D7093C24219E466E00723F17 /* RealtimeClientTests.swift in Sources */,
+				210F67B229E9DB62007B9345 /* TestProxyTransportFactory.swift in Sources */,
 				D7093C1F219E466E00723F17 /* RestClientStatsTests.swift in Sources */,
 				D7093C1A219E465C00723F17 /* NSObject+TestSuite.m in Sources */,
 				211A60D829D6D2C400D169C5 /* BackoffRetryDelayCalculatorTests.swift in Sources */,
@@ -3183,6 +3204,7 @@
 				D7093C77219EE26400723F17 /* RestClientChannelTests.swift in Sources */,
 				D520C4E32680A1FC000012B2 /* StringifiableTests.swift in Sources */,
 				D7093C7E219EE26400723F17 /* RealtimeClientChannelsTests.swift in Sources */,
+				210F67B329E9DB62007B9345 /* TestProxyTransportFactory.swift in Sources */,
 				D7093C79219EE26400723F17 /* RestClientPresenceTests.swift in Sources */,
 				215F76012922B30F009E0E76 /* ClientInformationTests.swift in Sources */,
 				211A60D929D6D2C500D169C5 /* BackoffRetryDelayCalculatorTests.swift in Sources */,
@@ -3263,6 +3285,7 @@
 				D710D53721949C54008F54AD /* ARTLocalDevice.m in Sources */,
 				D710D53621949C54008F54AD /* ARTDeviceIdentityTokenDetails.m in Sources */,
 				2124B79C29DB14C000AD8361 /* ARTLogAdapter.m in Sources */,
+				210F67A729E9D93D007B9345 /* ARTRealtimeTransportFactory.m in Sources */,
 				217FCF3B29D626C1006E5F2D /* ARTJitterCoefficientGenerator.m in Sources */,
 				D710D4C821949BAA008F54AD /* ARTRealtimeTransport.m in Sources */,
 				217D184A254222F700DFF07E /* ARTSRPinningSecurityPolicy.m in Sources */,
@@ -3387,6 +3410,7 @@
 				D710D54921949C55008F54AD /* ARTLocalDevice.m in Sources */,
 				D710D54821949C55008F54AD /* ARTDeviceIdentityTokenDetails.m in Sources */,
 				2124B79D29DB14C000AD8361 /* ARTLogAdapter.m in Sources */,
+				210F67A829E9D93D007B9345 /* ARTRealtimeTransportFactory.m in Sources */,
 				217FCF3C29D626C1006E5F2D /* ARTJitterCoefficientGenerator.m in Sources */,
 				D710D4CC21949BAB008F54AD /* ARTRealtimeTransport.m in Sources */,
 				217D1861254222FA00DFF07E /* ARTSRPinningSecurityPolicy.m in Sources */,

--- a/Source/ARTRealtimeTransportFactory.m
+++ b/Source/ARTRealtimeTransportFactory.m
@@ -1,0 +1,14 @@
+#import "ARTRealtimeTransportFactory.h"
+#import "ARTWebsocketTransport+Private.h"
+
+@implementation ARTDefaultRealtimeTransportFactory
+
+- (id<ARTRealtimeTransport>)transportWithRest:(ARTRestInternal *)rest options:(ARTClientOptions *)options resumeKey:(NSString *)resumeKey connectionSerial:(NSNumber *)connectionSerial logger:(ARTInternalLog *)logger {
+    return [[ARTWebSocketTransport alloc] initWithRest:rest
+                                               options:options
+                                             resumeKey:resumeKey
+                                      connectionSerial:connectionSerial
+                                                logger:logger];
+}
+
+@end

--- a/Source/ARTTestClientOptions.m
+++ b/Source/ARTTestClientOptions.m
@@ -1,6 +1,7 @@
 #import "ARTTestClientOptions.h"
 #import "ARTDefault.h"
 #import "ARTFallback+Private.h"
+#import "ARTRealtimeTransportFactory.h"
 
 @implementation ARTTestClientOptions
 
@@ -8,6 +9,7 @@
     if (self = [super init]) {
         _realtimeRequestTimeout = [ARTDefault realtimeRequestTimeout];
         _shuffleArray = ARTFallback_shuffleArray;
+        _transportFactory = [[ARTDefaultRealtimeTransportFactory alloc] init];
     }
 
     return self;
@@ -18,6 +20,7 @@
     copied.channelNamePrefix = self.channelNamePrefix;
     copied.realtimeRequestTimeout = self.realtimeRequestTimeout;
     copied.shuffleArray = self.shuffleArray;
+    copied.transportFactory = self.transportFactory;
 
     return copied;
 }

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -106,5 +106,6 @@ framework module Ably {
         header "ARTInternalLogCore.h"
         header "ARTInternalLogCore+Testing.h"
         header "ARTDataEncoder.h"
+        header "ARTRealtimeTransportFactory.h"
     }
 }

--- a/Source/PrivateHeaders/Ably/ARTRealtime+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtime+Private.h
@@ -105,7 +105,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)onNack:(ARTProtocolMessage *)message;
 - (void)onChannelMessage:(ARTProtocolMessage *)message;
 
-- (void)setTransportClass:(Class)transportClass;
 - (void)setReachabilityClass:(Class _Nullable)reachabilityClass;
 
 // Message sending

--- a/Source/PrivateHeaders/Ably/ARTRealtimeTransport.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeTransport.h
@@ -65,8 +65,6 @@ typedef NS_ENUM(NSUInteger, ARTRealtimeTransportState) {
 
 // All methods must be called from rest's serial queue.
 
-- (instancetype)initWithRest:(ARTRestInternal *)rest options:(ARTClientOptions *)options resumeKey:(nullable NSString *)resumeKey connectionSerial:(nullable NSNumber *)connectionSerial logger:(ARTInternalLog *)logger;
-
 @property (readonly, nonatomic) NSString *resumeKey;
 @property (readonly, nonatomic) NSNumber *connectionSerial;
 @property (readonly, nonatomic) ARTRealtimeTransportState state;

--- a/Source/PrivateHeaders/Ably/ARTRealtimeTransportFactory.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeTransportFactory.h
@@ -1,0 +1,31 @@
+@import Foundation;
+
+@class ARTRestInternal;
+@class ARTClientOptions;
+@class ARTInternalLog;
+@protocol ARTRealtimeTransport;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ A factory for creating an `ARTRealtimeTransport` instance.
+ */
+NS_SWIFT_NAME(RealtimeTransportFactory)
+@protocol ARTRealtimeTransportFactory
+
+- (id<ARTRealtimeTransport>)transportWithRest:(ARTRestInternal *)rest
+                                      options:(ARTClientOptions *)options
+                                    resumeKey:(nullable NSString *)resumeKey
+                             connectionSerial:(nullable NSNumber *)connectionSerial
+                                       logger:(ARTInternalLog *)logger;
+
+@end
+
+/**
+ The implementation of `ARTRealtimeTransportFactory` that should be used in non-test code.
+ */
+NS_SWIFT_NAME(DefaultRealtimeTransportFactory)
+@interface ARTDefaultRealtimeTransportFactory: NSObject<ARTRealtimeTransportFactory>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTTestClientOptions.h
+++ b/Source/PrivateHeaders/Ably/ARTTestClientOptions.h
@@ -1,5 +1,7 @@
 @import Foundation;
 
+@protocol ARTRealtimeTransportFactory;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -23,6 +25,11 @@ NS_ASSUME_NONNULL_BEGIN
  Initial value is `ARTFallback_shuffleArray`.
  */
 @property (nonatomic) void (^shuffleArray)(NSMutableArray *);
+
+/**
+ Initial value is an instance of `ARTDefaultRealtimeTransportFactory`.
+ */
+@property (nonatomic) id<ARTRealtimeTransportFactory> transportFactory;
 
 @end
 

--- a/Source/PrivateHeaders/Ably/ARTWebSocketTransport.h
+++ b/Source/PrivateHeaders/Ably/ARTWebSocketTransport.h
@@ -10,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ARTWebSocketTransport : NSObject <ARTRealtimeTransport>
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
+- (instancetype)initWithRest:(ARTRestInternal *)rest options:(ARTClientOptions *)options resumeKey:(nullable NSString *)resumeKey connectionSerial:(nullable NSNumber *)connectionSerial logger:(ARTInternalLog *)logger NS_DESIGNATED_INITIALIZER;
 
 @property (readonly, nonatomic) NSString *resumeKey;
 @property (readonly, nonatomic) NSNumber *connectionSerial;

--- a/Source/include/Ably.modulemap
+++ b/Source/include/Ably.modulemap
@@ -106,5 +106,6 @@ framework module Ably {
         header "Ably/ARTInternalLogCore.h"
         header "Ably/ARTInternalLogCore+Testing.h"
         header "Ably/ARTDataEncoder.h"
+        header "Ably/ARTRealtimeTransportFactory.h"
     }
 }

--- a/Test/Test Utilities/TestProxyTransportFactory.swift
+++ b/Test/Test Utilities/TestProxyTransportFactory.swift
@@ -1,0 +1,13 @@
+import Ably.Private
+
+class TestProxyTransportFactory: RealtimeTransportFactory {
+    func transport(withRest rest: ARTRestInternal, options: ARTClientOptions, resumeKey: String?, connectionSerial: NSNumber?, logger: InternalLog) -> ARTRealtimeTransport {
+        return TestProxyTransport(
+            rest: rest,
+            options: options,
+            resumeKey: resumeKey,
+            connectionSerial: connectionSerial,
+            logger: logger
+        )
+    }
+}

--- a/Test/Test Utilities/TestProxyTransportFactory.swift
+++ b/Test/Test Utilities/TestProxyTransportFactory.swift
@@ -3,6 +3,7 @@ import Ably.Private
 class TestProxyTransportFactory: RealtimeTransportFactory {
     func transport(withRest rest: ARTRestInternal, options: ARTClientOptions, resumeKey: String?, connectionSerial: NSNumber?, logger: InternalLog) -> ARTRealtimeTransport {
         return TestProxyTransport(
+            factory: self,
             rest: rest,
             options: options,
             resumeKey: resumeKey,

--- a/Test/Test Utilities/TestProxyTransportFactory.swift
+++ b/Test/Test Utilities/TestProxyTransportFactory.swift
@@ -1,6 +1,9 @@
 import Ably.Private
 
 class TestProxyTransportFactory: RealtimeTransportFactory {
+    // This value will be used by all TestProxyTransportFactory instances created by this factory (including those created before this property is updated).
+    var fakeNetworkResponse: FakeNetworkResponse?
+
     func transport(withRest rest: ARTRestInternal, options: ARTClientOptions, resumeKey: String?, connectionSerial: NSNumber?, logger: InternalLog) -> ARTRealtimeTransport {
         return TestProxyTransport(
             factory: self,

--- a/Test/Test Utilities/TestProxyTransportFactory.swift
+++ b/Test/Test Utilities/TestProxyTransportFactory.swift
@@ -4,6 +4,9 @@ class TestProxyTransportFactory: RealtimeTransportFactory {
     // This value will be used by all TestProxyTransportFactory instances created by this factory (including those created before this property is updated).
     var fakeNetworkResponse: FakeNetworkResponse?
 
+    // This value will be used by all TestProxyTransportFactory instances created by this factory (including those created before this property is updated).
+    var networkConnectEvent: ((ARTRealtimeTransport, URL) -> Void)?
+
     func transport(withRest rest: ARTRestInternal, options: ARTClientOptions, resumeKey: String?, connectionSerial: NSNumber?, logger: InternalLog) -> ARTRealtimeTransport {
         return TestProxyTransport(
             factory: self,

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -207,18 +207,24 @@ class AblyTests {
         return protocolMessage
     }
 
-    class func newRealtime(_ options: ARTClientOptions) -> ARTRealtime {
+    struct RealtimeTestEnvironment {
+        let client: ARTRealtime
+        let transportFactory: TestProxyTransportFactory
+    }
+
+    class func newRealtime(_ options: ARTClientOptions) -> RealtimeTestEnvironment {
         let modifiedOptions = options.copy() as! ARTClientOptions
 
         let autoConnect = modifiedOptions.autoConnect
         modifiedOptions.autoConnect = false
-        modifiedOptions.testOptions.transportFactory = TestProxyTransportFactory()
+        let transportFactory = TestProxyTransportFactory()
+        modifiedOptions.testOptions.transportFactory = transportFactory
         let realtime = ARTRealtime(options: modifiedOptions)
         realtime.internal.setReachabilityClass(TestReachability.self)
         if autoConnect {
             realtime.connect()
         }
-        return realtime
+        return .init(client: realtime, transportFactory: transportFactory)
     }
 
     class func newRandomString() -> String {

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -212,8 +212,8 @@ class AblyTests {
 
         let autoConnect = modifiedOptions.autoConnect
         modifiedOptions.autoConnect = false
+        modifiedOptions.testOptions.transportFactory = TestProxyTransportFactory()
         let realtime = ARTRealtime(options: modifiedOptions)
-        realtime.internal.setTransport(TestProxyTransport.self)
         realtime.internal.setReachabilityClass(TestReachability.self)
         if autoConnect {
             realtime.connect()

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -1088,7 +1088,6 @@ class TestProxyTransport: ARTWebSocketTransport {
 
     /// This will affect all WebSocketTransport instances.
     /// Set it to nil after the test ends.
-    static var fakeNetworkResponse: FakeNetworkResponse?
     static var networkConnectEvent: ((ARTRealtimeTransport, URL) -> Void)?
 
     /// The factory that created this TestProxyTransport instance.
@@ -1200,7 +1199,7 @@ class TestProxyTransport: ARTWebSocketTransport {
     // MARK: ARTWebSocket
 
     override func connect(withKey key: String) {
-        if let fakeResponse = TestProxyTransport.fakeNetworkResponse {
+        if let fakeResponse = factory.fakeNetworkResponse {
             setupFakeNetworkResponse(fakeResponse)
         }
         super.connect(withKey: key)
@@ -1208,7 +1207,7 @@ class TestProxyTransport: ARTWebSocketTransport {
     }
 
     override func connect(withToken token: String) {
-        if let fakeResponse = TestProxyTransport.fakeNetworkResponse {
+        if let fakeResponse = factory.fakeNetworkResponse {
             setupFakeNetworkResponse(fakeResponse)
         }
         super.connect(withToken: token)
@@ -1218,7 +1217,7 @@ class TestProxyTransport: ARTWebSocketTransport {
     private func setupFakeNetworkResponse(_ networkResponse: FakeNetworkResponse) {
         var hook: AspectToken?
         hook = ARTSRWebSocket.testSuite_replaceClassMethod(#selector(ARTSRWebSocket.open)) {
-            if TestProxyTransport.fakeNetworkResponse == nil {
+            if self.factory.fakeNetworkResponse == nil {
                 return
             }
 
@@ -1273,7 +1272,7 @@ class TestProxyTransport: ARTWebSocketTransport {
 
     @discardableResult
     override func send(_ data: Data, withSource decodedObject: Any?) -> Bool {
-        if let networkAnswer = TestProxyTransport.fakeNetworkResponse, let ws = self.websocket {
+        if let networkAnswer = factory.fakeNetworkResponse, let ws = self.websocket {
             // Ignore it because it should fake a failure.
             self.webSocket(ws, didFailWithError: networkAnswer.error)
             return false
@@ -1350,7 +1349,7 @@ class TestProxyTransport: ARTWebSocketTransport {
     }
 
     override func webSocket(_ webSocket: ARTWebSocket, didReceiveMessage message: Any?) {
-        if let networkAnswer = TestProxyTransport.fakeNetworkResponse, let ws = self.websocket {
+        if let networkAnswer = factory.fakeNetworkResponse, let ws = self.websocket {
             // Ignore it because it should fake a failure.
             self.webSocket(ws, didFailWithError: networkAnswer.error)
             return
@@ -1564,24 +1563,24 @@ extension ARTRealtime {
         }
     }
 
-    func simulateNoInternetConnection() {
+    func simulateNoInternetConnection(transportFactory: TestProxyTransportFactory) {
         guard let reachability = self.internal.reachability as? TestReachability else {
             fatalError("Expected test reachability")
         }
 
         AblyTests.queue.async {
-            TestProxyTransport.fakeNetworkResponse = .noInternet
+            transportFactory.fakeNetworkResponse = .noInternet
             reachability.simulate(false)
         }
     }
 
-    func simulateRestoreInternetConnection(after seconds: TimeInterval? = nil) {
+    func simulateRestoreInternetConnection(after seconds: TimeInterval? = nil, transportFactory: TestProxyTransportFactory) {
         guard let reachability = self.internal.reachability as? TestReachability else {
             fatalError("Expected test reachability")
         }
 
         AblyTests.queue.asyncAfter(deadline: .now() + (seconds ?? 0)) {
-            TestProxyTransport.fakeNetworkResponse = nil
+            transportFactory.fakeNetworkResponse = nil
             reachability.simulate(true)
         }
     }

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -1085,6 +1085,19 @@ class TestProxyTransport: ARTWebSocketTransport {
     static var fakeNetworkResponse: FakeNetworkResponse?
     static var networkConnectEvent: ((ARTRealtimeTransport, URL) -> Void)?
 
+    /// The factory that created this TestProxyTransport instance.
+    private weak var _factory: TestProxyTransportFactory?
+    private var factory: TestProxyTransportFactory {
+        guard let _factory else {
+            preconditionFailure("Tried to fetch factory but it's already been deallocated")
+        }
+        return _factory
+    }
+
+    init(factory: TestProxyTransportFactory, rest: ARTRestInternal, options: ARTClientOptions, resumeKey: String?, connectionSerial: NSNumber?, logger: InternalLog) {
+        self._factory = factory
+        super.init(rest: rest, options: options, resumeKey: resumeKey, connectionSerial: connectionSerial, logger: logger)
+    }
 
     fileprivate(set) var lastUrl: URL?
 

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -208,13 +208,14 @@ class AblyTests {
     }
 
     class func newRealtime(_ options: ARTClientOptions) -> ARTRealtime {
-        let autoConnect = options.autoConnect
-        options.autoConnect = false
-        let realtime = ARTRealtime(options: options)
+        let modifiedOptions = options.copy() as! ARTClientOptions
+
+        let autoConnect = modifiedOptions.autoConnect
+        modifiedOptions.autoConnect = false
+        let realtime = ARTRealtime(options: modifiedOptions)
         realtime.internal.setTransport(TestProxyTransport.self)
         realtime.internal.setReachabilityClass(TestReachability.self)
         if autoConnect {
-            options.autoConnect = true
             realtime.connect()
         }
         return realtime

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -1085,11 +1085,6 @@ class TestProxyHTTPExecutor: NSObject, ARTHTTPExecutor {
 
 /// Records each message for test purpose.
 class TestProxyTransport: ARTWebSocketTransport {
-
-    /// This will affect all WebSocketTransport instances.
-    /// Set it to nil after the test ends.
-    static var networkConnectEvent: ((ARTRealtimeTransport, URL) -> Void)?
-
     /// The factory that created this TestProxyTransport instance.
     private weak var _factory: TestProxyTransportFactory?
     private var factory: TestProxyTransportFactory {
@@ -1245,7 +1240,7 @@ class TestProxyTransport: ARTWebSocketTransport {
     }
 
     private func performNetworkConnectEvent() {
-        guard let networkConnectEventHandler = TestProxyTransport.networkConnectEvent else {
+        guard let networkConnectEventHandler = factory.networkConnectEvent else {
             return
         }
         if let lastUrl = self.lastUrl {

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -1174,7 +1174,7 @@ class AuthTests: XCTestCase {
     func test__051__Token__clientId_and_authenticated_clients__Auth_clientId_attribute_is_null__identity_should_be_anonymous_for_all_operations() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
-        let realtime = AblyTests.newRealtime(options)
+        let realtime = AblyTests.newRealtime(options).client
         defer { realtime.dispose(); realtime.close() }
         XCTAssertNil(realtime.auth.clientId)
 
@@ -1268,7 +1268,7 @@ class AuthTests: XCTestCase {
         options.token = getTestToken(clientId: "john")
         XCTAssertNil(options.clientId)
         options.autoConnect = false
-        let realtime = AblyTests.newRealtime(options)
+        let realtime = AblyTests.newRealtime(options).client
         defer { realtime.dispose(); realtime.close() }
 
         waitUntil(timeout: testTimeout) { done in
@@ -3594,7 +3594,7 @@ class AuthTests: XCTestCase {
     func test__122__authorize__two_consecutive_authorizations__using_Realtime_and_connection_is_CONNECTING__should_call_each_Realtime_authorize_callback() {
         let options = AblyTests.commonAppSetup()
         options.useTokenAuth = true
-        let realtime = AblyTests.newRealtime(options)
+        let realtime = AblyTests.newRealtime(options).client
         defer { realtime.close(); realtime.dispose() }
 
         var connectedStateCount = 0
@@ -3941,7 +3941,7 @@ class AuthTests: XCTestCase {
     func skipped__test__140__JWT_and_realtime__client_initialized_with_a_JWT_token_in_ClientOptions__with_valid_credentials__pulls_stats_successfully() {
         let options = AblyTests.clientOptions()
         options.token = getJWTToken()
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in
@@ -3956,7 +3956,7 @@ class AuthTests: XCTestCase {
         let options = AblyTests.clientOptions()
         options.token = getJWTToken(invalid: true)
         options.autoConnect = false
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -186,10 +186,10 @@ class AuthTests: XCTestCase {
         let options = AblyTests.clientOptions()
         options.token = getTestToken()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
 
         if let transport = client.internal.transport as? TestProxyTransport, let query = transport.lastUrl?.query {
@@ -257,6 +257,7 @@ class AuthTests: XCTestCase {
         let options = AblyTests.clientOptions()
         options.tokenDetails = getTestTokenDetails(ttl: 0.1)
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         // Token will expire, expecting 40142
         waitUntil(timeout: testTimeout) { done in
@@ -269,7 +270,6 @@ class AuthTests: XCTestCase {
         XCTAssertNil(realtime.internal.options.key)
         XCTAssertNil(realtime.internal.options.authCallback)
         XCTAssertNil(realtime.internal.options.authUrl)
-        realtime.internal.setTransport(TestProxyTransport.self)
 
         let channel = realtime.channels.get(uniqueChannelName())
 
@@ -885,10 +885,10 @@ class AuthTests: XCTestCase {
         let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
         options.clientId = expectedClientId
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
 
         waitUntil(timeout: testTimeout) { done in
@@ -4062,9 +4062,9 @@ class AuthTests: XCTestCase {
         options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]))
         options.authParams?.append(URLQueryItem(name: "expiresIn", value: String(UInt(tokenDuration))))
         options.autoConnect = false // Prevent auto connection so we can set the transport proxy
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in

--- a/Test/Tests/DeltaCodecTests.swift
+++ b/Test/Tests/DeltaCodecTests.swift
@@ -22,7 +22,7 @@ class DeltaCodecTests: XCTestCase {
     // RTL19
     func test__001__DeltaCodec__decoding__should_decode_vcdiff_encoded_messages() {
         let options = AblyTests.commonAppSetup()
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
 
         let channelOptions = ARTRealtimeChannelOptions()
@@ -75,7 +75,7 @@ class DeltaCodecTests: XCTestCase {
     // RTL20
     func test__002__DeltaCodec__decoding__should_fail_and_recover_when_the_vcdiff_messages_are_out_of_order() {
         let options = AblyTests.commonAppSetup()
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channelOptions = ARTRealtimeChannelOptions()
         channelOptions.params = ["delta": "vcdiff"]
@@ -134,7 +134,7 @@ class DeltaCodecTests: XCTestCase {
     // RTL18
     func test__003__DeltaCodec__decoding__should_recover_when_the_vcdiff_message_decoding_fails() {
         let options = AblyTests.commonAppSetup()
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channelOptions = ARTRealtimeChannelOptions()
         channelOptions.params = ["delta": "vcdiff"]

--- a/Test/Tests/PushTests.swift
+++ b/Test/Tests/PushTests.swift
@@ -257,11 +257,10 @@ class PushTests: XCTestCase {
     func test__013__LocalDevice__when_getting_a_client_ID_from_CONNECTED_message__new_clientID_is_set() {
         let options = ARTClientOptions(key: "fake:key")
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let realtime = ARTRealtime(options: options)
         XCTAssertNil(realtime.device.clientId)
-
-        realtime.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             realtime.connection.once(.connected) { _ in

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -690,7 +690,8 @@ class RealtimeClientChannelTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.queueMessages = false
         options.autoConnect = false
-        options.testOptions.transportFactory = TestProxyTransportFactory()
+        let transportFactory = TestProxyTransportFactory()
+        options.testOptions.transportFactory = transportFactory
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
         client.internal.setReachabilityClass(TestReachability.self)
@@ -722,7 +723,7 @@ class RealtimeClientChannelTests: XCTestCase {
                 expect(stateChange.reason?.message).to(satisfyAnyOf(contain("unreachable host"), contain("network is down")))
                 done()
             }
-            client.simulateNoInternetConnection()
+            client.simulateNoInternetConnection(transportFactory: transportFactory)
         }
 
         waitUntil(timeout: testTimeout) { done in
@@ -730,7 +731,7 @@ class RealtimeClientChannelTests: XCTestCase {
                 XCTAssertEqual(stateChange.previous, .connecting)
                 done()
             }
-            client.simulateRestoreInternetConnection()
+            client.simulateRestoreInternetConnection(transportFactory: transportFactory)
         }
 
         channel.off()
@@ -901,12 +902,13 @@ class RealtimeClientChannelTests: XCTestCase {
         options.suspendedRetryTimeout = 3.0
         options.channelRetryTimeout = 0.5
         options.autoConnect = false
-        options.testOptions.transportFactory = TestProxyTransportFactory()
+        let transportFactory = TestProxyTransportFactory()
+        options.testOptions.transportFactory = transportFactory
 
         let client = ARTRealtime(options: options)
         client.internal.setReachabilityClass(TestReachability.self)
         defer {
-            client.simulateRestoreInternetConnection()
+            client.simulateRestoreInternetConnection(transportFactory: transportFactory)
             client.dispose()
             client.close()
         }
@@ -932,7 +934,7 @@ class RealtimeClientChannelTests: XCTestCase {
                 expect(error.message).to(satisfyAnyOf(contain("network is down"), contain("unreachable host")))
                 done()
             }
-            client.simulateNoInternetConnection()
+            client.simulateNoInternetConnection(transportFactory: transportFactory)
         }
 
         AblyTests.queue.async {
@@ -945,7 +947,7 @@ class RealtimeClientChannelTests: XCTestCase {
                 XCTAssertEqual(stateChange.reason?.code, ARTErrorCode.unableToRecoverConnectionExpired.intValue) // didn't resumed
                 done()
             }
-            client.simulateRestoreInternetConnection(after: 1.0)
+            client.simulateRestoreInternetConnection(after: 1.0, transportFactory: transportFactory)
         }
 
         waitUntil(timeout: testTimeout) { done in

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -158,7 +158,7 @@ class RealtimeClientChannelTests: XCTestCase {
     // RTL1
     func skipped__test__001__Channel__should_process_all_incoming_messages_and_presence_messages_as_soon_as_a_Channel_becomes_attached() {
         let options = AblyTests.commonAppSetup()
-        let client1 = AblyTests.newRealtime(options)
+        let client1 = AblyTests.newRealtime(options).client
         defer { client1.dispose(); client1.close() }
         
         let roomName = uniqueChannelName(prefix: "room")
@@ -173,7 +173,7 @@ class RealtimeClientChannelTests: XCTestCase {
         }
 
         options.clientId = "Client 2"
-        let client2 = AblyTests.newRealtime(options)
+        let client2 = AblyTests.newRealtime(options).client
         defer { client2.dispose(); client2.close() }
         let channel2 = client2.channels.get(roomName)
 
@@ -875,7 +875,7 @@ class RealtimeClientChannelTests: XCTestCase {
 
     // RTL3d
     func test__014__Channel__connection_state__if_the_attach_operation_for_the_channel_times_out_and_the_channel_returns_to_the_SUSPENDED_state() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
 
         let channel = client.channels.get(uniqueChannelName())
@@ -1123,7 +1123,7 @@ class RealtimeClientChannelTests: XCTestCase {
     }
 
     func test__041__Channel__attach__results_in_an_error_if_the_connection_state_is__SUSPENDED() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
 
         let channel = client.channels.get(uniqueChannelName())
@@ -1266,7 +1266,7 @@ class RealtimeClientChannelTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.channelRetryTimeout = 1.0
         options.testOptions.realtimeRequestTimeout = 1.0
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
 
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
@@ -1430,7 +1430,7 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__038__Channel__attach__a_channel_in_DETACHING_can_actually_move_back_to_ATTACHED_if_it_fails_to_detach() {
         let options = AblyTests.commonAppSetup()
         options.testOptions.realtimeRequestTimeout = 1.0
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
         waitUntil(timeout: testTimeout) { done in
@@ -1462,7 +1462,7 @@ class RealtimeClientChannelTests: XCTestCase {
     // RTL4j
 
     func test__046__Channel__attach__attach_resume__should_pass_attach_resume_flag_in_attach_message() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -2156,7 +2156,7 @@ class RealtimeClientChannelTests: XCTestCase {
     // RTL6c1
 
     func test__071__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__ATTACHED_then_the_messages_should_be_published_immediately() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
         channel.attach()
@@ -2174,7 +2174,7 @@ class RealtimeClientChannelTests: XCTestCase {
     }
 
     func test__072__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__INITIALIZED_then_the_messages_should_be_published_immediately() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { _ in
@@ -2197,7 +2197,7 @@ class RealtimeClientChannelTests: XCTestCase {
     }
 
     func test__073__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__DETACHED_then_the_messages_should_be_published_immediately() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
         waitUntil(timeout: testTimeout) { done in
@@ -2225,7 +2225,7 @@ class RealtimeClientChannelTests: XCTestCase {
     }
 
     func test__074__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__ATTACHING_then_the_messages_should_be_published_immediately() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
         waitUntil(timeout: testTimeout) { done in
@@ -2252,7 +2252,7 @@ class RealtimeClientChannelTests: XCTestCase {
     }
 
     func test__075__Channel__publish__Connection_state_conditions__if_the_connection_is_CONNECTED_and_the_channel_is__DETACHING_then_the_messages_should_be_published_immediately() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
         waitUntil(timeout: testTimeout) { done in
@@ -2285,7 +2285,7 @@ class RealtimeClientChannelTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.useTokenAuth = true
         options.autoConnect = false
-        rtl6c2TestsClient = AblyTests.newRealtime(options)
+        rtl6c2TestsClient = AblyTests.newRealtime(options).client
         rtl6c2TestsChannel = rtl6c2TestsClient.channels.get(channelName)
         XCTAssertTrue(rtl6c2TestsClient.internal.options.queueMessages)
     }
@@ -2410,7 +2410,7 @@ class RealtimeClientChannelTests: XCTestCase {
     func beforeEach__Channel__publish__Connection_state_conditions__will_result_in_an_error_if_the(channelName: String) {
         setupDependencies()
         ARTDefault.setConnectionStateTtl(0.3)
-        rtl6c4TestsClient = AblyTests.newRealtime(options)
+        rtl6c4TestsClient = AblyTests.newRealtime(options).client
         rtl6c4TestsChannel = rtl6c4TestsClient.channels.get(channelName)
     }
 
@@ -2536,7 +2536,7 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__088__Channel__publish__message_bundling__Messages_are_delivered_using_a_single_ProtocolMessage_where_possible_by_bundling_in_all_messages_for_that_channel() throws {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -2594,7 +2594,7 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__089__Channel__publish__message_bundling__The_resulting_ProtocolMessage_must_not_exceed_the_maxMessageSize() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
         // This amount of messages would be beyond maxMessageSize, if bundled together
@@ -2626,7 +2626,7 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__092__Channel__publish__message_bundling__Messages_with_differing_clientId_values_must_not_be_bundled_together__messages_with_different__non_empty__clientIds_are_posted_via_different_protocol_messages() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
         let clientIDs = ["client1", "client2", "client3"]
@@ -2650,7 +2650,7 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__093__Channel__publish__message_bundling__Messages_with_differing_clientId_values_must_not_be_bundled_together__messages_with_mixed_empty_non_empty_clientIds_are_posted_via_different_protocol_messages() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -2675,7 +2675,7 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__094__Channel__publish__message_bundling__Messages_with_differing_clientId_values_must_not_be_bundled_together__messages_bundled_by_the_user_are_posted_in_a_single_protocol_message_even_if_they_have_mixed_clientIds() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
         var messages = [ARTMessage]()
@@ -3623,7 +3623,7 @@ class RealtimeClientChannelTests: XCTestCase {
 
     // RTL12
     func test__120__Channel__history__attached_channel_may_receive_an_additional_ATTACHED_ProtocolMessage() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
         waitUntil(timeout: testTimeout) { done in
@@ -3684,7 +3684,7 @@ class RealtimeClientChannelTests: XCTestCase {
 
     // RTL13a
     func test__128__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__the_channel_is_in_the_ATTACHED_states__an_attempt_to_reattach_the_channel_should_be_made_immediately_by_sending_a_new_ATTACH_message_and_the_channel_should_transition_to_the_ATTACHING_state_with_the_error_emitted_in_the_ChannelStateChange_event() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -3725,7 +3725,7 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__129__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__the_channel_is_in_the_SUSPENDED_state__an_attempt_to_reattach_the_channel_should_be_made_immediately_by_sending_a_new_ATTACH_message_and_the_channel_should_transition_to_the_ATTACHING_state_with_the_error_emitted_in_the_ChannelStateChange_event() {
         let options = AblyTests.commonAppSetup()
         options.testOptions.realtimeRequestTimeout = 1.0
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in
@@ -3779,7 +3779,7 @@ class RealtimeClientChannelTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.channelRetryTimeout = 1.0
         options.testOptions.realtimeRequestTimeout = 1.0
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -3838,7 +3838,7 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__131__Channel__history__if_the_channel_receives_a_server_initiated_DETACHED_message_when__if_the_channel_was_already_in_the_ATTACHING_state__the_channel_will_transition_to_the_SUSPENDED_state_and_the_error_will_be_emitted_in_the_ChannelStateChange_event() {
         let options = AblyTests.commonAppSetup()
         options.channelRetryTimeout = 1.0
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -3928,7 +3928,7 @@ class RealtimeClientChannelTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.channelRetryTimeout = 1.0
         options.testOptions.realtimeRequestTimeout = 1.0
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
         waitUntil(timeout: testTimeout) { done in
@@ -4015,7 +4015,7 @@ class RealtimeClientChannelTests: XCTestCase {
     // RTL16a
 
     func test__133__Channel__history__Channel_options__setOptions__should_send_an_ATTACH_message_with_params___modes_if_the_channel_is_attached() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -4066,7 +4066,7 @@ class RealtimeClientChannelTests: XCTestCase {
     }
 
     func test__134__Channel__history__Channel_options__setOptions__should_send_an_ATTACH_message_with_params___modes_if_the_channel_is_attaching() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in
@@ -4125,7 +4125,7 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__135__Channel__history__Channel_options__setOptions__should_success_immediately_if_channel_is_not_attaching_or_attached() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -4147,7 +4147,7 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__136__Channel__history__Channel_options__setOptions__should_fail_if_the_attach_moves_to_FAILED() {
         let options = AblyTests.commonAppSetup()
         options.token = getTestToken(capability: "{\"secret\":[\"subscribe\"]}") // access denied
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -4195,7 +4195,7 @@ class RealtimeClientChannelTests: XCTestCase {
     }
 
     func test__137__Channel__history__Channel_options__setOptions__should_fail_if_the_attach_moves_to_DETACHED() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -4248,7 +4248,7 @@ class RealtimeClientChannelTests: XCTestCase {
     }
     
     func test__Channel_options__setOptions__shouldUpdateOptionsOfRestChannel() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -4415,7 +4415,7 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__002__Channel__should_not_crash_when_an_ATTACH_request_is_responded_with_a_DETACHED() {
         let options = AblyTests.commonAppSetup()
         options.testOptions.realtimeRequestTimeout = 1.0
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -49,8 +49,8 @@ private func testHandlesDecodingErrorInFixture(_ cryptoFixtureFileName: String, 
     let options = AblyTests.commonAppSetup()
     options.autoConnect = false
     options.logHandler = ARTLog(capturingOutput: true)
+    options.testOptions.transportFactory = TestProxyTransportFactory()
     let client = ARTRealtime(options: options)
-    client.internal.setTransport(TestProxyTransport.self)
     client.connect()
     defer { client.dispose(); client.close() }
 
@@ -567,8 +567,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__017__Channel__connection_state__changes_to_FAILED__ATTACHING_channel_should_transition_to_FAILED() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -622,8 +622,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__019__Channel__connection_state__changes_to_FAILED__channel_being_released_waiting_for_DETACH_shouldn_t_crash__issue__918_() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -690,9 +690,9 @@ class RealtimeClientChannelTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.queueMessages = false
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
         client.internal.setReachabilityClass(TestReachability.self)
         let channel = client.channels.get(uniqueChannelName())
 
@@ -742,8 +742,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__022__Channel__connection_state__changes_to_CLOSED__ATTACHING_channel_should_transition_to_DETACHED() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
@@ -780,8 +780,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__024__Channel__connection_state__changes_to_SUSPENDED__ATTACHING_channel_should_transition_to_SUSPENDED() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -811,8 +811,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__026__Channel__connection_state__changes_to_SUSPENDED__channel_being_released_waiting_for_DETACH_shouldn_t_crash__issue__918_() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -901,9 +901,9 @@ class RealtimeClientChannelTests: XCTestCase {
         options.suspendedRetryTimeout = 3.0
         options.channelRetryTimeout = 0.5
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.internal.setReachabilityClass(TestReachability.self)
         defer {
             client.simulateRestoreInternetConnection()
@@ -1083,8 +1083,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__039__Channel__attach__results_in_an_error_if_the_connection_state_is__CLOSING() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -1219,8 +1219,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__030__Channel__attach__should_send_an_ATTACH_ProtocolMessage__change_state_to_ATTACHING_and_change_state_to_ATTACHED_after_confirmation() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -1727,8 +1727,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__053__Channel__detach__should_send_a_DETACH_ProtocolMessage__change_state_to_DETACHING_and_change_state_to_DETACHED_after_confirmation() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -1812,8 +1812,8 @@ class RealtimeClientChannelTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -1847,8 +1847,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__059__Channel__detach__results_in_an_error_if_the_connection_state_is__CLOSING() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -2854,8 +2854,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__096__Channel__publish__expect_either__an_array_of_Message_objects() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
@@ -2895,8 +2895,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__098__Channel__publish__expect_either__allows_name_to_be_null() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
@@ -2933,8 +2933,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__099__Channel__publish__expect_either__allows_data_to_be_null() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
@@ -2971,8 +2971,8 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__100__Channel__publish__expect_either__allows_name_and_data_to_be_assigned() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
@@ -3006,8 +3006,8 @@ class RealtimeClientChannelTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.clientId = "client_string"
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
@@ -3262,8 +3262,8 @@ class RealtimeClientChannelTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.logHandler = ARTLog(capturingOutput: true)
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -3880,8 +3880,8 @@ class RealtimeClientChannelTests: XCTestCase {
         options.channelRetryTimeout = 1.0
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         
         client.connect()
         
@@ -4330,14 +4330,13 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__138__Channel__crypto__if_configured_for_encryption__channels_encrypt_and_decrypt_messages__data() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let clientSender = ARTRealtime(options: options)
-        clientSender.internal.setTransport(TestProxyTransport.self)
         defer { clientSender.close() }
         clientSender.connect()
 
         let clientReceiver = ARTRealtime(options: options)
-        clientReceiver.internal.setTransport(TestProxyTransport.self)
         defer { clientReceiver.close() }
         clientReceiver.connect()
 

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -70,7 +70,7 @@ private func testMovesToDisconnectedWithNetworkingError(_ error: Error) {
     let options = AblyTests.commonAppSetup()
     options.autoConnect = false
     options.testOptions.transportFactory = TestProxyTransportFactory()
-    let client = AblyTests.newRealtime(options)
+    let client = AblyTests.newRealtime(options).client
     defer {
         client.dispose()
         client.close()
@@ -648,7 +648,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__027__Connection__event_emitter__any_state_change_triggered_by_a_ProtocolMessage_that_contains_an_Error_member_should_populate_the_Reason_property() {
         let options = AblyTests.commonAppSetup()
         options.useTokenAuth = true
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in
@@ -999,7 +999,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.clientId = "tester"
         options.tokenDetails = getTestTokenDetails(key: options.key!, clientId: options.clientId, ttl: 5.0)
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
 
         let channel = client.channels.get(uniqueChannelName())
@@ -1083,7 +1083,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__034__Connection__ACK_and_NACK__ProtocolMessage__should_reset_msgSerial_serially_if_the_connection_does_not_resume() {
         let options = AblyTests.commonAppSetup()
         options.clientId = "tester"
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
 
         let channel = client.channels.get(uniqueChannelName())
@@ -1578,7 +1578,7 @@ class RealtimeClientConnectionTests: XCTestCase {
 
     // RTN11b
     func test__008__Connection__it_should_make_sure_that__when_the_CLOSED_ProtocolMessage_arrives_for_the_old_connection__it_doesn_t_affect_the_new_one() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in
@@ -1921,7 +1921,7 @@ class RealtimeClientConnectionTests: XCTestCase {
 
     // RTN13a
     func test__052__Connection__ping__should_send_a_ProtocolMessage_with_action_HEARTBEAT_and_expects_a_HEARTBEAT_message_in_response() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
         waitUntil(timeout: testTimeout) { done in
             client.ping { error in
@@ -1939,7 +1939,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         let realtimeRequestTimeout = 3.0
         options.testOptions.realtimeRequestTimeout = realtimeRequestTimeout
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { _ in
@@ -2502,7 +2502,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     // RTN15b1, RTN15b2
     func test__067__Connection__connection_failures_once_CONNECTED__reconnects_to_the_websocket_endpoint_with_additional_querystring_params__resume_is_the_private_connection_key_and_connection_serial_is_the_most_recent_ProtocolMessage_connectionSerial_received() {
         let options = AblyTests.commonAppSetup()
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
 
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
@@ -2526,7 +2526,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     // RTN15c1
     func test__068__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__CONNECTED_ProtocolMessage_with_the_same_connectionId_as_the_current_client__and_no_error() {
         let options = AblyTests.commonAppSetup()
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -2554,7 +2554,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     // RTN15c2
     func test__069__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__CONNECTED_ProtocolMessage_with_the_same_connectionId_as_the_current_client_and_an_non_fatal_error() {
         let options = AblyTests.commonAppSetup()
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -2610,7 +2610,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     // RTN15c3
     func test__070__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__CONNECTED_ProtocolMessage_with_a_new_connectionId_and_an_error() {
         let options = AblyTests.commonAppSetup()
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -2656,7 +2656,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     // RTN15c4
     func test__071__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__ERROR_ProtocolMessage_indicating_a_fatal_error_in_the_connection() {
         let options = AblyTests.commonAppSetup()
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -2688,7 +2688,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     func skipped__test__072__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__should_resume_the_connection_after_an_auth_renewal() {
         let options = AblyTests.commonAppSetup()
         options.tokenDetails = getTestTokenDetails(ttl: 5.0)
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let restOptions = AblyTests.clientOptions(key: options.key!)
         restOptions.testOptions.channelNamePrefix = options.testOptions.channelNamePrefix
@@ -2844,7 +2844,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     // RTN15f
     func test__066__Connection__connection_failures_once_CONNECTED__ACK_and_NACK_responses_for_published_messages_can_only_ever_be_received_on_the_transport_connection_on_which_those_messages_were_sent() {
         let options = AblyTests.commonAppSetup()
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -2908,7 +2908,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         // We want this to be > than the sum of customTtlInterval and customIdleInterval
         options.disconnectedRetryTimeout = 5.0 + customTtlInterval + customIdleInterval
-        ttlAndIdleIntervalPassedTestsClient = AblyTests.newRealtime(options)
+        ttlAndIdleIntervalPassedTestsClient = AblyTests.newRealtime(options).client
         ttlAndIdleIntervalPassedTestsClient.internal.shouldImmediatelyReconnect = false
         ttlAndIdleIntervalPassedTestsClient.connect()
         defer { ttlAndIdleIntervalPassedTestsClient.close() }
@@ -2942,7 +2942,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         // We want this to be > than the sum of customTtlInterval and customIdleInterval
         options.disconnectedRetryTimeout = 5.0
-        ttlAndIdleIntervalPassedTestsClient = AblyTests.newRealtime(options)
+        ttlAndIdleIntervalPassedTestsClient = AblyTests.newRealtime(options).client
         ttlAndIdleIntervalPassedTestsClient.internal.shouldImmediatelyReconnect = false
         defer { ttlAndIdleIntervalPassedTestsClient.close() }
         let channelName = uniqueChannelName()
@@ -2980,7 +2980,7 @@ class RealtimeClientConnectionTests: XCTestCase {
 
     func test__076__Connection__connection_failures_once_CONNECTED__when_connection__ttl_plus_idle_interval__period_has_NOT_passed_since_last_activity__uses_the_same_connection() {
         let options = AblyTests.commonAppSetup()
-        ttlAndIdleIntervalNotPassedTestsClient = AblyTests.newRealtime(options)
+        ttlAndIdleIntervalNotPassedTestsClient = AblyTests.newRealtime(options).client
         ttlAndIdleIntervalNotPassedTestsClient.connect()
         defer { ttlAndIdleIntervalNotPassedTestsClient.close() }
 
@@ -3219,7 +3219,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.recover = clientOriginal.connection.recoveryKey
         clientOriginal.internal.onError(AblyTests.newErrorProtocolMessage())
 
-        let clientRecover = AblyTests.newRealtime(options)
+        let clientRecover = AblyTests.newRealtime(options).client
         defer { clientRecover.close() }
 
         waitUntil(timeout: testTimeout) { done in
@@ -3276,7 +3276,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.autoConnect = false
         options.recover = "99999!xxxxxx-xxxxxxxxx-xxxxxxxxx:-1:7"
 
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
 
         var urlConnections = [URL]()
@@ -3328,7 +3328,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.autoConnect = false
         options.queueMessages = false
 
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -3379,7 +3379,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         XCTAssertNil(options.fallbackHosts)
         options.autoConnect = false
 
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         client.channels.get(uniqueChannelName())
 
@@ -3897,7 +3897,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__010__Connection__attributes_within_ConnectionDetails_should_be_used_as_defaults() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
-        let realtime = AblyTests.newRealtime(options)
+        let realtime = AblyTests.newRealtime(options).client
         defer { realtime.close() }
 
         waitUntil(timeout: testTimeout) { done in
@@ -3935,7 +3935,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     // RTN19a
     func skipped__test__103__Connection__Transport_disconnected_side_effects__should_resend_any_ProtocolMessage_that_is_awaiting_a_ACK_NACK() {
         let options = AblyTests.commonAppSetup()
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
         let transport = client.internal.transport as! TestProxyTransport
@@ -3965,7 +3965,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     // RTN19b
     func skipped__test__104__Connection__Transport_disconnected_side_effects__should_resend_the_ATTACH_message_if_there_are_any_pending_channels() {
         let options = AblyTests.commonAppSetup()
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
 
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
@@ -4001,7 +4001,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     // RTN19b
     func skipped__test__105__Connection__Transport_disconnected_side_effects__should_resent_the_DETACH_message_if_there_are_any_pending_channels() {
         let options = AblyTests.commonAppSetup()
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
         let transport = client.internal.transport as! TestProxyTransport
@@ -4315,7 +4315,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         let realtimeRequestTimeout = 0.5
         options.testOptions.realtimeRequestTimeout = realtimeRequestTimeout
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
 
         var expectedInactivityTimeout: TimeInterval?
@@ -4412,7 +4412,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__013__Connection__should_set_the_Connection_reason_attribute_based_on_the_Error_member_of_the_CONNECTED_ProtocolMessage() {
         let options = AblyTests.commonAppSetup()
         options.useTokenAuth = true
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
 
         waitUntil(timeout: testTimeout) { done in
@@ -4477,7 +4477,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     func skipped__test__111__Connection__with_fixture_messages__should_encode_and_decode_fixture_messages_as_expected() {
         let options = AblyTests.commonAppSetup()
         options.useBinaryProtocol = false
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
         channel.attach()
@@ -4547,8 +4547,8 @@ class RealtimeClientConnectionTests: XCTestCase {
     func skipped__test__112__Connection__with_fixture_messages__should_send_messages_through_raw_JSON_POST_and_retrieve_equal_messages_through_MsgPack_and_JSON() {
         setupDependencies()
         let restPublishClient = ARTRest(options: jsonOptions)
-        let realtimeSubscribeClientMsgPack = AblyTests.newRealtime(msgpackOptions)
-        let realtimeSubscribeClientJSON = AblyTests.newRealtime(jsonOptions)
+        let realtimeSubscribeClientMsgPack = AblyTests.newRealtime(msgpackOptions).client
+        let realtimeSubscribeClientJSON = AblyTests.newRealtime(jsonOptions).client
         defer {
             realtimeSubscribeClientMsgPack.close()
             realtimeSubscribeClientJSON.close()

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -29,11 +29,11 @@ private func testUsesAlternativeHostOnResponse(_ caseTest: FakeNetworkResponse, 
     let options = ARTClientOptions(key: "xxxx:xxxx")
     options.autoConnect = false
     options.testOptions.realtimeRequestTimeout = 1.0
+    options.testOptions.transportFactory = TestProxyTransportFactory()
     let client = ARTRealtime(options: options)
     defer { client.dispose(); client.close() }
     client.channels.get(channelName)
 
-    client.internal.setTransport(TestProxyTransport.self)
     TestProxyTransport.fakeNetworkResponse = caseTest
     defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -69,12 +69,12 @@ private func testUsesAlternativeHostOnResponse(_ caseTest: FakeNetworkResponse, 
 private func testMovesToDisconnectedWithNetworkingError(_ error: Error) {
     let options = AblyTests.commonAppSetup()
     options.autoConnect = false
+    options.testOptions.transportFactory = TestProxyTransportFactory()
     let client = AblyTests.newRealtime(options)
     defer {
         client.dispose()
         client.close()
     }
-    client.internal.setTransport(TestProxyTransport.self)
 
     waitUntil(timeout: testTimeout) { done in
         client.connection.once(.connected) { _ in
@@ -163,8 +163,8 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__016__Connection__ConnectionDetails__maxMessageSize_overrides_the_default_maxMessageSize() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         let defaultMaxMessageSize = ARTDefault.maxMessageSize()
         XCTAssertEqual(defaultMaxMessageSize, 65536)
         defer {
@@ -190,9 +190,9 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__017__Connection__url__should_connect_to_the_default_host() {
         let options = ARTClientOptions(key: "keytest:secret")
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -206,9 +206,9 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__018__Connection__url__should_connect_with_query_string_params() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -242,9 +242,9 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.useTokenAuth = true
         options.autoConnect = false
         options.echoMessages = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -358,9 +358,9 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__004__Connection__Library_and_version_param__agent__should_include_the__Ably_Agent__header_value() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
 
         waitUntil(timeout: testTimeout) { done in
@@ -749,8 +749,8 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__006__Connection__should_have_an_opened_websocket_connection_and_received_a_CONNECTED_ProtocolMessage() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer {
             client.dispose()
@@ -790,8 +790,8 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.clientId = "client_string"
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -819,8 +819,8 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.clientId = "client_string"
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -861,8 +861,8 @@ class RealtimeClientConnectionTests: XCTestCase {
         let channelName = uniqueChannelName()
         options.token = getTestToken(key: options.key, capability: "{ \"\(options.testOptions.channelNamePrefix!)-\(channelName)\":[\"subscribe\"] }")
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -890,8 +890,8 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.clientId = "client_string"
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -932,8 +932,8 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.clientId = "client_string"
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -1173,8 +1173,8 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.clientId = "client_string"
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -1211,8 +1211,8 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.clientId = "client_string"
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
 
@@ -1238,8 +1238,8 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__037__Connection__ACK_and_NACK__should_trigger_the_failure_callback_for_the_remaining_pending_messages_if__lost_connection_state() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer {
             client.dispose()
@@ -1663,8 +1663,8 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__046__Connection__close__if_CONNECTED__should_send_a_CLOSE_action__change_state_to_CLOSING_and_receive_a_CLOSED_action() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer {
             client.dispose()
@@ -1706,8 +1706,8 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__047__Connection__close__should_transition_to_CLOSED_action_when_the_close_process_timeouts() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer {
             client.dispose()
@@ -1757,8 +1757,8 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__048__Connection__close__transitions_to_the_CLOSING_state_and_then_to_the_CLOSED_state_if_the_transport_is_abruptly_closed() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer {
             client.dispose()
@@ -2005,9 +2005,9 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
         let tokenTtl = 3.0
         options.token = getTestToken(key: options.key, ttl: tokenTtl)
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         defer {
             client.dispose()
             client.close()
@@ -2089,6 +2089,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__056__Connection__connection_request_fails__should_transition_to_disconnected_when_the_token_renewal_fails() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let tokenTtl = 3.0
         let tokenDetails = getTestTokenDetails(key: options.key, capability: nil, ttl: tokenTtl)!
         options.token = tokenDetails.token
@@ -2099,7 +2100,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         defer {
             client.dispose()
             client.close()
@@ -2129,6 +2129,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.autoConnect = false
         let tokenTtl = 1.0
         options.token = getTestToken(ttl: tokenTtl)
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         // Let the token expire
         waitUntil(timeout: testTimeout) { done in
@@ -2138,7 +2139,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         defer {
             client.dispose()
             client.close()
@@ -2300,9 +2300,9 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.disconnectedRetryTimeout = 0.5
         options.suspendedRetryTimeout = 2.0
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.internal.setReachabilityClass(TestReachability.self)
         defer {
             client.simulateRestoreInternetConnection()
@@ -2811,9 +2811,9 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__073__Connection__connection_failures_once_CONNECTED__when_a_connection_is_resumed__the_connection_key_may_change_and_will_be_provided_in_the_first_CONNECTED_ProtocolMessage_connectionDetails() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
@@ -3014,9 +3014,9 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
         let tokenTtl = 2.0
         options.token = getTestToken(key: options.key, ttl: tokenTtl)
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         defer {
             client.dispose()
             client.close()
@@ -3093,9 +3093,9 @@ class RealtimeClientConnectionTests: XCTestCase {
                 callback(tokenDetails, nil) // Return the same expired token again.
             }
         }
+        options.testOptions.transportFactory = TestProxyTransportFactory()
 
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         defer {
             client.dispose()
             client.close()
@@ -3416,11 +3416,11 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
         client.channels.get(uniqueChannelName())
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .hostUnreachable
         defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -3461,11 +3461,11 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.autoConnect = false
         options.fallbackHosts = ["f.ably-realtime.com", "g.ably-realtime.com", "h.ably-realtime.com", "i.ably-realtime.com", "j.ably-realtime.com"]
         options.testOptions.realtimeRequestTimeout = 1.0
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
         client.channels.get(uniqueChannelName())
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .hostUnreachable
         defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -3530,10 +3530,10 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         let channel = client.channels.get(uniqueChannelName())
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .host400BadRequest
         defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -3564,11 +3564,11 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
         client.channels.get(uniqueChannelName())
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .hostUnreachable
         defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -3619,6 +3619,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 5.0
         options.testOptions.shuffleArray = shuffleArrayInExpectedHostOrder
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
         client.channels.get(uniqueChannelName())
@@ -3626,7 +3627,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         let testHttpExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.rest.httpExecutor = testHttpExecutor
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .hostUnreachable
         defer { TestProxyTransport.fakeNetworkResponse = nil }
         
@@ -3694,6 +3694,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 1.0
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
         client.channels.get(uniqueChannelName())
@@ -3703,7 +3704,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         let testHttpExecutor = TestProxyHTTPExecutor(http: mockHTTP, logger: internalLog)
         client.internal.rest.httpExecutor = testHttpExecutor
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .hostUnreachable
         defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -3745,6 +3745,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.fallbackHosts = expectedFallbackHosts.sorted() // will be picked "randomly" as of expectedHostOrder
         options.testOptions.realtimeRequestTimeout = 5.0
         options.testOptions.shuffleArray = shuffleArrayInExpectedHostOrder
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
         client.channels.get(uniqueChannelName())
@@ -3752,7 +3753,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         let testHttpExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.rest.httpExecutor = testHttpExecutor
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .hostUnreachable
         defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -3817,13 +3817,13 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
         options.fallbackHosts = []
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         let channel = client.channels.get(uniqueChannelName())
 
         let testHttpExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.rest.httpExecutor = testHttpExecutor
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .hostUnreachable
         defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -3852,12 +3852,12 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__096__Connection__Host_Fallback__client_is_connected_to_a_fallback_host_endpoint_should_do_HTTP_requests_to_the_same_data_centre() {
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
 
         let testHttpExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.rest.httpExecutor = testHttpExecutor
 
-        client.internal.setTransport(TestProxyTransport.self)
         TestProxyTransport.fakeNetworkResponse = .hostUnreachable
         defer { TestProxyTransport.fakeNetworkResponse = nil }
 
@@ -4153,9 +4153,9 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.useTokenAuth = true
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
         
         let channelName = uniqueChannelName()
         let channel = client.channels.get(channelName)

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -47,7 +47,6 @@ private func testUsesAlternativeHostOnResponse(_ caseTest: FakeNetworkResponse, 
             transportFactory.fakeNetworkResponse = nil
         }
     }
-    defer { transportFactory.networkConnectEvent = nil }
 
     waitUntil(timeout: testTimeout) { done in
         // wss://[a-e].ably-realtime.com: when a timeout occurs
@@ -3291,7 +3290,6 @@ class RealtimeClientConnectionTests: XCTestCase {
                 testEnvironment.transportFactory.networkConnectEvent = nil
             }
         }
-        defer { testEnvironment.transportFactory.networkConnectEvent = nil }
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -3344,7 +3342,6 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
             urlConnections.append(url)
         }
-        defer { testEnvironment.transportFactory.networkConnectEvent = nil }
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.disconnected) { stateChange in
@@ -3395,7 +3392,6 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
             urlConnections.append(url)
         }
-        defer { testEnvironment.transportFactory.networkConnectEvent = nil }
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.on(.disconnected) { stateChange in
@@ -3436,7 +3432,6 @@ class RealtimeClientConnectionTests: XCTestCase {
                 transportFactory.fakeNetworkResponse = nil
             }
         }
-        defer { transportFactory.networkConnectEvent = nil }
 
         waitUntil(timeout: testTimeout) { done in
             // wss://[a-e].ably-realtime.com: when a timeout occurs
@@ -3481,7 +3476,6 @@ class RealtimeClientConnectionTests: XCTestCase {
                 transportFactory.fakeNetworkResponse = nil
             }
         }
-        defer { transportFactory.networkConnectEvent = nil }
 
         waitUntil(timeout: testTimeout) { done in
             // wss://[a-e].ably-realtime.com: when a timeout occurs
@@ -3546,7 +3540,6 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
             urlConnections.append(url)
         }
-        defer { transportFactory.networkConnectEvent = nil }
 
         client.connect()
         defer { client.dispose(); client.close() }
@@ -3582,7 +3575,6 @@ class RealtimeClientConnectionTests: XCTestCase {
             urlConnections.append(url)
             transportFactory.fakeNetworkResponse = nil
         }
-        defer { transportFactory.networkConnectEvent = nil }
 
         waitUntil(timeout: testTimeout) { done in
             // Unreachable and try a fallback
@@ -3650,8 +3642,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                 urls.append(url)
             }
         }
-        defer { transportFactory.networkConnectEvent = nil }
-        
+
         testHttpExecutor.setListenerAfterRequest { request in
             urls.append(request.url!)
         }
@@ -3721,7 +3712,6 @@ class RealtimeClientConnectionTests: XCTestCase {
                 fail("shouldn't try fallback host after failed connectivity check")
             }
         }
-        defer { transportFactory.networkConnectEvent = nil }
 
         mockHTTP.setNetworkState(network: .hostInternalError(code: 500), forHost: "internet-up.ably-realtime.com")
 
@@ -3773,8 +3763,6 @@ class RealtimeClientConnectionTests: XCTestCase {
                 urls.append(url)
             }
         }
-        
-        defer { transportFactory.networkConnectEvent = nil }
 
         testHttpExecutor.setListenerAfterRequest { request in
             urls.append(request.url!)
@@ -3836,7 +3824,6 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
             urlConnections.append(url)
         }
-        defer { transportFactory.networkConnectEvent = nil }
 
         client.connect()
         defer { client.dispose(); client.close() }
@@ -3874,7 +3861,6 @@ class RealtimeClientConnectionTests: XCTestCase {
                 (client.internal.transport as! TestProxyTransport).simulateTransportSuccess()
             }
         }
-        defer { transportFactory.networkConnectEvent = nil }
 
         client.connect()
         // Because we're faking the CONNECTED state, we can't client.close() or it

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -38,7 +38,7 @@ private func testUsesAlternativeHostOnResponse(_ caseTest: FakeNetworkResponse, 
     transportFactory.fakeNetworkResponse = caseTest
 
     var urlConnections = [URL]()
-    TestProxyTransport.networkConnectEvent = { transport, url in
+    transportFactory.networkConnectEvent = { transport, url in
         if client.internal.transport !== transport {
             return
         }
@@ -47,7 +47,7 @@ private func testUsesAlternativeHostOnResponse(_ caseTest: FakeNetworkResponse, 
             transportFactory.fakeNetworkResponse = nil
         }
     }
-    defer { TestProxyTransport.networkConnectEvent = nil }
+    defer { transportFactory.networkConnectEvent = nil }
 
     waitUntil(timeout: testTimeout) { done in
         // wss://[a-e].ably-realtime.com: when a timeout occurs
@@ -3277,20 +3277,21 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.autoConnect = false
         options.recover = "99999!xxxxxx-xxxxxxxxx-xxxxxxxxx:-1:7"
 
-        let client = AblyTests.newRealtime(options).client
+        let testEnvironment = AblyTests.newRealtime(options)
+        let client = testEnvironment.client
         defer { client.dispose(); client.close() }
 
         var urlConnections = [URL]()
-        TestProxyTransport.networkConnectEvent = { transport, url in
+        testEnvironment.transportFactory.networkConnectEvent = { transport, url in
             if client.internal.transport !== transport {
                 return
             }
             urlConnections.append(url)
             if urlConnections.count == 1 {
-                TestProxyTransport.networkConnectEvent = nil
+                testEnvironment.transportFactory.networkConnectEvent = nil
             }
         }
-        defer { TestProxyTransport.networkConnectEvent = nil }
+        defer { testEnvironment.transportFactory.networkConnectEvent = nil }
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -3337,13 +3338,13 @@ class RealtimeClientConnectionTests: XCTestCase {
         testEnvironment.transportFactory.fakeNetworkResponse = .hostUnreachable
 
         var urlConnections = [URL]()
-        TestProxyTransport.networkConnectEvent = { transport, url in
+        testEnvironment.transportFactory.networkConnectEvent = { transport, url in
             if client.internal.transport !== transport {
                 return
             }
             urlConnections.append(url)
         }
-        defer { TestProxyTransport.networkConnectEvent = nil }
+        defer { testEnvironment.transportFactory.networkConnectEvent = nil }
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.disconnected) { stateChange in
@@ -3388,13 +3389,13 @@ class RealtimeClientConnectionTests: XCTestCase {
         testEnvironment.transportFactory.fakeNetworkResponse = .hostUnreachable
 
         var urlConnections = [URL]()
-        TestProxyTransport.networkConnectEvent = { transport, url in
+        testEnvironment.transportFactory.networkConnectEvent = { transport, url in
             if client.internal.transport !== transport {
                 return
             }
             urlConnections.append(url)
         }
-        defer { TestProxyTransport.networkConnectEvent = nil }
+        defer { testEnvironment.transportFactory.networkConnectEvent = nil }
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.on(.disconnected) { stateChange in
@@ -3426,7 +3427,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         transportFactory.fakeNetworkResponse = .hostUnreachable
 
         var urlConnections = [URL]()
-        TestProxyTransport.networkConnectEvent = { transport, url in
+        transportFactory.networkConnectEvent = { transport, url in
             if client.internal.transport !== transport {
                 return
             }
@@ -3435,7 +3436,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                 transportFactory.fakeNetworkResponse = nil
             }
         }
-        defer { TestProxyTransport.networkConnectEvent = nil }
+        defer { transportFactory.networkConnectEvent = nil }
 
         waitUntil(timeout: testTimeout) { done in
             // wss://[a-e].ably-realtime.com: when a timeout occurs
@@ -3471,7 +3472,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         transportFactory.fakeNetworkResponse = .hostUnreachable
 
         var urlConnections = [URL]()
-        TestProxyTransport.networkConnectEvent = { transport, url in
+        transportFactory.networkConnectEvent = { transport, url in
             if client.internal.transport !== transport {
                 return
             }
@@ -3480,7 +3481,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                 transportFactory.fakeNetworkResponse = nil
             }
         }
-        defer { TestProxyTransport.networkConnectEvent = nil }
+        defer { transportFactory.networkConnectEvent = nil }
 
         waitUntil(timeout: testTimeout) { done in
             // wss://[a-e].ably-realtime.com: when a timeout occurs
@@ -3539,13 +3540,13 @@ class RealtimeClientConnectionTests: XCTestCase {
         transportFactory.fakeNetworkResponse = .host400BadRequest
 
         var urlConnections = [URL]()
-        TestProxyTransport.networkConnectEvent = { transport, url in
+        transportFactory.networkConnectEvent = { transport, url in
             if client.internal.transport !== transport {
                 return
             }
             urlConnections.append(url)
         }
-        defer { TestProxyTransport.networkConnectEvent = nil }
+        defer { transportFactory.networkConnectEvent = nil }
 
         client.connect()
         defer { client.dispose(); client.close() }
@@ -3574,14 +3575,14 @@ class RealtimeClientConnectionTests: XCTestCase {
         transportFactory.fakeNetworkResponse = .hostUnreachable
 
         var urlConnections = [URL]()
-        TestProxyTransport.networkConnectEvent = { transport, url in
+        transportFactory.networkConnectEvent = { transport, url in
             if client.internal.transport !== transport {
                 return
             }
             urlConnections.append(url)
             transportFactory.fakeNetworkResponse = nil
         }
-        defer { TestProxyTransport.networkConnectEvent = nil }
+        defer { transportFactory.networkConnectEvent = nil }
 
         waitUntil(timeout: testTimeout) { done in
             // Unreachable and try a fallback
@@ -3641,7 +3642,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         let expectedFallbackHosts = Array(expectedHostOrder.map { ARTDefault.fallbackHosts()[$0] })
         let allFallbackHostsTriedOfFailedExp = XCTestExpectation(description: "TestProxyTransport should spit 5 fallback hosts on networkConnectEvent")
         
-        TestProxyTransport.networkConnectEvent = { transport, url in
+        transportFactory.networkConnectEvent = { transport, url in
             if client.internal.transport !== transport {
                 return
             }
@@ -3649,7 +3650,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                 urls.append(url)
             }
         }
-        defer { TestProxyTransport.networkConnectEvent = nil }
+        defer { transportFactory.networkConnectEvent = nil }
         
         testHttpExecutor.setListenerAfterRequest { request in
             urls.append(request.url!)
@@ -3712,7 +3713,7 @@ class RealtimeClientConnectionTests: XCTestCase {
             NSRegularExpression.extract(url.absoluteString, pattern: "[a-e].ably-realtime.com")
         }
 
-        TestProxyTransport.networkConnectEvent = { transport, url in
+        transportFactory.networkConnectEvent = { transport, url in
             if client.internal.transport !== transport {
                 return
             }
@@ -3720,7 +3721,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                 fail("shouldn't try fallback host after failed connectivity check")
             }
         }
-        defer { TestProxyTransport.networkConnectEvent = nil }
+        defer { transportFactory.networkConnectEvent = nil }
 
         mockHTTP.setNetworkState(network: .hostInternalError(code: 500), forHost: "internet-up.ably-realtime.com")
 
@@ -3764,7 +3765,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         var urls = [URL]()
         let allFallbackHostsTriedOfFailedExp = XCTestExpectation(description: "TestProxyTransport should spit 5 fallback hosts on networkConnectEvent")
         
-        TestProxyTransport.networkConnectEvent = { transport, url in
+        transportFactory.networkConnectEvent = { transport, url in
             if client.internal.transport !== transport {
                 return
             }
@@ -3773,7 +3774,7 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
         }
         
-        defer { TestProxyTransport.networkConnectEvent = nil }
+        defer { transportFactory.networkConnectEvent = nil }
 
         testHttpExecutor.setListenerAfterRequest { request in
             urls.append(request.url!)
@@ -3829,13 +3830,13 @@ class RealtimeClientConnectionTests: XCTestCase {
         transportFactory.fakeNetworkResponse = .hostUnreachable
 
         var urlConnections = [URL]()
-        TestProxyTransport.networkConnectEvent = { transport, url in
+        transportFactory.networkConnectEvent = { transport, url in
             if client.internal.transport !== transport {
                 return
             }
             urlConnections.append(url)
         }
-        defer { TestProxyTransport.networkConnectEvent = nil }
+        defer { transportFactory.networkConnectEvent = nil }
 
         client.connect()
         defer { client.dispose(); client.close() }
@@ -3863,7 +3864,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         transportFactory.fakeNetworkResponse = .hostUnreachable
 
         var urlConnections = [URL]()
-        TestProxyTransport.networkConnectEvent = { transport, url in
+        transportFactory.networkConnectEvent = { transport, url in
             if client.internal.transport !== transport {
                 return
             }
@@ -3873,7 +3874,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                 (client.internal.transport as! TestProxyTransport).simulateTransportSuccess()
             }
         }
-        defer { TestProxyTransport.networkConnectEvent = nil }
+        defer { transportFactory.networkConnectEvent = nil }
 
         client.connect()
         // Because we're faking the CONNECTED state, we can't client.close() or it

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -36,7 +36,6 @@ private func testUsesAlternativeHostOnResponse(_ caseTest: FakeNetworkResponse, 
     client.channels.get(channelName)
 
     transportFactory.fakeNetworkResponse = caseTest
-    defer { transportFactory.fakeNetworkResponse = nil }
 
     var urlConnections = [URL]()
     TestProxyTransport.networkConnectEvent = { transport, url in
@@ -3336,7 +3335,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         let channel = client.channels.get(uniqueChannelName())
 
         testEnvironment.transportFactory.fakeNetworkResponse = .hostUnreachable
-        defer { testEnvironment.transportFactory.fakeNetworkResponse = nil }
 
         var urlConnections = [URL]()
         TestProxyTransport.networkConnectEvent = { transport, url in
@@ -3388,7 +3386,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         client.channels.get(uniqueChannelName())
 
         testEnvironment.transportFactory.fakeNetworkResponse = .hostUnreachable
-        defer { testEnvironment.transportFactory.fakeNetworkResponse = nil }
 
         var urlConnections = [URL]()
         TestProxyTransport.networkConnectEvent = { transport, url in
@@ -3427,7 +3424,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         client.channels.get(uniqueChannelName())
 
         transportFactory.fakeNetworkResponse = .hostUnreachable
-        defer { transportFactory.fakeNetworkResponse = nil }
 
         var urlConnections = [URL]()
         TestProxyTransport.networkConnectEvent = { transport, url in
@@ -3473,7 +3469,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         client.channels.get(uniqueChannelName())
 
         transportFactory.fakeNetworkResponse = .hostUnreachable
-        defer { transportFactory.fakeNetworkResponse = nil }
 
         var urlConnections = [URL]()
         TestProxyTransport.networkConnectEvent = { transport, url in
@@ -3542,7 +3537,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         let channel = client.channels.get(uniqueChannelName())
 
         transportFactory.fakeNetworkResponse = .host400BadRequest
-        defer { transportFactory.fakeNetworkResponse = nil }
 
         var urlConnections = [URL]()
         TestProxyTransport.networkConnectEvent = { transport, url in
@@ -3578,7 +3572,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         client.channels.get(uniqueChannelName())
 
         transportFactory.fakeNetworkResponse = .hostUnreachable
-        defer { transportFactory.fakeNetworkResponse = nil }
 
         var urlConnections = [URL]()
         TestProxyTransport.networkConnectEvent = { transport, url in
@@ -3637,8 +3630,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         client.internal.rest.httpExecutor = testHttpExecutor
 
         transportFactory.fakeNetworkResponse = .hostUnreachable
-        defer { transportFactory.fakeNetworkResponse = nil }
-        
+
         let hostPrefixes = Array("abcde")
         
         let extractHostname = { (url: URL) in
@@ -3715,7 +3707,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         client.internal.rest.httpExecutor = testHttpExecutor
 
         transportFactory.fakeNetworkResponse = .hostUnreachable
-        defer { transportFactory.fakeNetworkResponse = nil }
 
         let extractHostname = { (url: URL) in
             NSRegularExpression.extract(url.absoluteString, pattern: "[a-e].ably-realtime.com")
@@ -3765,7 +3756,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         client.internal.rest.httpExecutor = testHttpExecutor
 
         transportFactory.fakeNetworkResponse = .hostUnreachable
-        defer { transportFactory.fakeNetworkResponse = nil }
 
         let extractHostname = { (url: URL) in
             NSRegularExpression.extract(url.absoluteString, pattern: "[\(hostPrefixes.first!)-\(hostPrefixes.last!)].ably-realtime.com")
@@ -3837,7 +3827,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         client.internal.rest.httpExecutor = testHttpExecutor
 
         transportFactory.fakeNetworkResponse = .hostUnreachable
-        defer { transportFactory.fakeNetworkResponse = nil }
 
         var urlConnections = [URL]()
         TestProxyTransport.networkConnectEvent = { transport, url in
@@ -3872,7 +3861,6 @@ class RealtimeClientConnectionTests: XCTestCase {
         client.internal.rest.httpExecutor = testHttpExecutor
 
         transportFactory.fakeNetworkResponse = .hostUnreachable
-        defer { transportFactory.fakeNetworkResponse = nil }
 
         var urlConnections = [URL]()
         TestProxyTransport.networkConnectEvent = { transport, url in

--- a/Test/Tests/RealtimeClientPresenceTests.swift
+++ b/Test/Tests/RealtimeClientPresenceTests.swift
@@ -110,8 +110,8 @@ class RealtimeClientPresenceTests: XCTestCase {
     func skipped__test__009__Presence__ProtocolMessage_bit_flag__when_no_members_are_present() {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
@@ -143,8 +143,8 @@ class RealtimeClientPresenceTests: XCTestCase {
         disposable += [AblyTests.addMembersSequentiallyToChannel(channelName, members: 250, options: options)]
 
         options.autoConnect = false
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
-        client.internal.setTransport(TestProxyTransport.self)
         client.connect()
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(channelName)

--- a/Test/Tests/RealtimeClientPresenceTests.swift
+++ b/Test/Tests/RealtimeClientPresenceTests.swift
@@ -171,7 +171,7 @@ class RealtimeClientPresenceTests: XCTestCase {
     // RTP18a, RTP18b
     func skipped__test__011__Presence__realtime_system_reserves_the_right_to_initiate_a_sync_of_the_presence_members_at_any_point_once_a_channel_is_attached__should_do_a_new_sync_whenever_a_SYNC_ProtocolMessage_is_received_with_a_channel_attribute_and_a_new_sync_sequence_identifier_in_the_channelSerial_attribute() {
         let options = AblyTests.commonAppSetup()
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channelName = uniqueChannelName()
         let channel = client.channels.get(channelName)
@@ -254,7 +254,7 @@ class RealtimeClientPresenceTests: XCTestCase {
     // RTP18c, RTP18b
     func skipped__test__012__Presence__realtime_system_reserves_the_right_to_initiate_a_sync_of_the_presence_members_at_any_point_once_a_channel_is_attached__when_a_SYNC_is_sent_with_no_channelSerial_attribute_then_the_sync_data_is_entirely_contained_within_that_ProtocolMessage() {
         let options = AblyTests.commonAppSetup()
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channelName = uniqueChannelName()
         let channel = client.channels.get(channelName)
@@ -322,7 +322,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         defer { clientMembers?.dispose(); clientMembers?.close() }
         clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 2, options: options)
 
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(channelName)
         waitUntil(timeout: testTimeout) { done in
@@ -387,7 +387,7 @@ class RealtimeClientPresenceTests: XCTestCase {
     // RTP19a
     func skipped__test__014__Presence__PresenceMap_has_existing_members_when_a_SYNC_is_started__should_emit_a_LEAVE_event_for_each_existing_member_if_the_PresenceMap_has_existing_members_when_an_ATTACHED_message_is_received_without_a_HAS_PRESENCE_flag() {
         let options = AblyTests.commonAppSetup()
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channelName = uniqueChannelName()
         let channel = client.channels.get(channelName)
@@ -477,7 +477,7 @@ class RealtimeClientPresenceTests: XCTestCase {
     func test__015__Presence__subscribe__with_no_arguments_should_subscribe_a_listener_to_all_presence_messages() {
         let options = AblyTests.commonAppSetup()
 
-        let client1 = AblyTests.newRealtime(options)
+        let client1 = AblyTests.newRealtime(options).client
         defer { client1.close() }
         
         let channelName = uniqueChannelName()
@@ -657,7 +657,7 @@ class RealtimeClientPresenceTests: XCTestCase {
     // RTP5b
     func skipped__test__017__Presence__Channel_state_change_side_effects__if_a_channel_enters_the_ATTACHED_state_then_all_queued_presence_messages_will_be_sent_immediately_and_a_presence_SYNC_may_be_initiated() {
         let options = AblyTests.commonAppSetup()
-        let client1 = AblyTests.newRealtime(options)
+        let client1 = AblyTests.newRealtime(options).client
         defer { client1.dispose(); client1.close() }
         
         let channelName = uniqueChannelName()
@@ -670,7 +670,7 @@ class RealtimeClientPresenceTests: XCTestCase {
             }
         }
 
-        let client2 = AblyTests.newRealtime(options)
+        let client2 = AblyTests.newRealtime(options).client
         defer { client2.dispose(); client2.close() }
         let channel2 = client2.channels.get(channelName)
 
@@ -711,7 +711,7 @@ class RealtimeClientPresenceTests: XCTestCase {
 
     func test__022__Presence__Channel_state_change_side_effects__channel_enters_the_SUSPENDED_state__all_queued_presence_messages_should_fail_immediately() {
         let options = AblyTests.commonAppSetup()
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channelName = uniqueChannelName()
         let channel = client.channels.get(channelName)
@@ -752,7 +752,7 @@ class RealtimeClientPresenceTests: XCTestCase {
 
         options.clientId = "tester"
         options.tokenDetails = getTestTokenDetails(key: options.key!, clientId: options.clientId, ttl: 5.0)
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(channelName)
         waitUntil(timeout: testTimeout) { done in
@@ -1037,7 +1037,7 @@ class RealtimeClientPresenceTests: XCTestCase {
     func test__032__Presence__enter__entering_without_an_explicit_PresenceMessage_clientId_should_implicitly_use_the_clientId_of_the_current_connection() {
         let options = AblyTests.commonAppSetup()
         options.clientId = "john"
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
         // We want to make sure that the ENTER presence action that we publish
@@ -1174,7 +1174,7 @@ class RealtimeClientPresenceTests: XCTestCase {
     func test__037__Presence__update__should_update_the_data_for_the_present_member_with_a_value() {
         let options = AblyTests.commonAppSetup()
         options.clientId = "john"
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
 
         let channel = client.channels.get(uniqueChannelName())
@@ -1270,7 +1270,7 @@ class RealtimeClientPresenceTests: XCTestCase {
     func test__041__Presence__update__optionally_a_callback_can_be_provided_that_is_called_for_failure() {
         let options = AblyTests.commonAppSetup()
         options.clientId = "john"
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -1293,7 +1293,7 @@ class RealtimeClientPresenceTests: XCTestCase {
     func test__042__Presence__update__update_without_an_explicit_PresenceMessage_clientId_should_implicitly_use_the_clientId_of_the_current_connection() {
         let options = AblyTests.commonAppSetup()
         options.clientId = "john"
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -1383,7 +1383,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         let channelName = uniqueChannelName()
         clientSecondary = AblyTests.addMembersSequentiallyToChannel(channelName, members: 100, options: options)
 
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(channelName)
 
@@ -1473,7 +1473,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         defer { clientMembers?.dispose(); clientMembers?.close() }
         clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 101, options: options)
 
-        let clientSubscribed = AblyTests.newRealtime(options)
+        let clientSubscribed = AblyTests.newRealtime(options).client
         defer { clientSubscribed.dispose(); clientSubscribed.close() }
         let channelSubscribed = clientSubscribed.channels.get(channelName)
 
@@ -1552,7 +1552,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         defer { clientMembers?.dispose(); clientMembers?.close() }
         clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 101, options: options)
 
-        let clientSubscribed = AblyTests.newRealtime(options)
+        let clientSubscribed = AblyTests.newRealtime(options).client
         defer { clientSubscribed.dispose(); clientSubscribed.close() }
         let channelSubscribed = clientSubscribed.channels.get(channelName)
 
@@ -1637,7 +1637,7 @@ class RealtimeClientPresenceTests: XCTestCase {
             fail("Members client isn't connected"); return
         }
 
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(channelName)
 
@@ -1690,7 +1690,7 @@ class RealtimeClientPresenceTests: XCTestCase {
             fail("Members client isn't connected"); return
         }
 
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(channelName)
 
@@ -1818,7 +1818,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         let channelName = uniqueChannelName()
         clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 20, options: options)
 
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(channelName)
         channel.attach()
@@ -1863,7 +1863,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         defer { clientMembers?.dispose(); clientMembers?.close() }
         clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 20, options: options)
 
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(channelName)
 
@@ -2083,7 +2083,7 @@ class RealtimeClientPresenceTests: XCTestCase {
     func test__063__Presence__leave__optionally_a_callback_can_be_provided_that_is_called_for_failure() {
         let options = AblyTests.commonAppSetup()
         options.clientId = "john"
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -2123,7 +2123,7 @@ class RealtimeClientPresenceTests: XCTestCase {
     func test__065__Presence__leave__entering_without_an_explicit_PresenceMessage_clientId_should_implicitly_use_the_clientId_of_the_current_connection() {
         let options = AblyTests.commonAppSetup()
         options.clientId = "john"
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -2424,7 +2424,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
 
         options.clientId = "john"
-        let client1 = AblyTests.newRealtime(options)
+        let client1 = AblyTests.newRealtime(options).client
         defer { client1.close() }
         
         let channelName = uniqueChannelName()
@@ -2939,7 +2939,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         func test__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
             contextBeforeEach?()
 
-            let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+            let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
             defer { client.dispose(); client.close() }
             let channel = client.channels.get(uniqueChannelName())
 
@@ -3263,7 +3263,7 @@ class RealtimeClientPresenceTests: XCTestCase {
 
     // RTP11b
     func test__103__Presence__get__should_result_in_an_error_if_the_channel_moves_to_the_FAILED_state() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
 
@@ -3400,7 +3400,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         let channelName = uniqueChannelName()
         clientSecondary = AblyTests.addMembersSequentiallyToChannel(channelName, members: 150, options: options)
 
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(channelName)
 
@@ -3439,7 +3439,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         let channelName = uniqueChannelName()
         clientSecondary = AblyTests.addMembersSequentiallyToChannel(channelName, members: 150, options: options)
 
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(channelName)
 
@@ -3487,7 +3487,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         let now = NSDate()
 
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channelName = uniqueChannelName()
         let channel = client.channels.get(channelName)
@@ -3550,7 +3550,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         defer { clientMembers?.dispose(); clientMembers?.close() }
         clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 101, options: options)
 
-        let clientSubscribed = AblyTests.newRealtime(options)
+        let clientSubscribed = AblyTests.newRealtime(options).client
         defer { clientSubscribed.dispose(); clientSubscribed.close() }
         let channelSubscribed = clientSubscribed.channels.get(channelName)
 
@@ -3750,7 +3750,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         let channelName = uniqueChannelName()
         disposable += [AblyTests.addMembersSequentiallyToChannel(channelName, members: 250, options: options)]
 
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(channelName)
         channel.attach()

--- a/Test/Tests/RealtimeClientTests.swift
+++ b/Test/Tests/RealtimeClientTests.swift
@@ -39,7 +39,7 @@ class RealtimeClientTests: XCTestCase {
 
     // G4
     func test__001__RealtimeClient__All_WebSocket_connections_should_include_the_current_API_version() {
-        let client = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let client = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(uniqueChannelName())
         waitUntil(timeout: testTimeout) { done in
@@ -1257,7 +1257,7 @@ class RealtimeClientTests: XCTestCase {
     }
 
     func test__006__RealtimeClient__should_accept_acks_with_different_order() {
-        let realtime = AblyTests.newRealtime(AblyTests.commonAppSetup())
+        let realtime = AblyTests.newRealtime(AblyTests.commonAppSetup()).client
         defer { realtime.dispose(); realtime.close() }
         let channel = realtime.channels.get(uniqueChannelName())
         waitUntil(timeout: testTimeout) { done in

--- a/Test/Tests/RealtimeClientTests.swift
+++ b/Test/Tests/RealtimeClientTests.swift
@@ -419,9 +419,9 @@ class RealtimeClientTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.useTokenAuth = true
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -476,9 +476,9 @@ class RealtimeClientTests: XCTestCase {
         options.autoConnect = false
         let testToken = getTestToken()
         options.token = testToken
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -536,9 +536,9 @@ class RealtimeClientTests: XCTestCase {
         options.autoConnect = false
         let testToken = getTestToken(capability: "{\"test\":[\"subscribe\"]}")
         options.token = testToken
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -627,9 +627,9 @@ class RealtimeClientTests: XCTestCase {
         options.autoConnect = false
         let testToken = getTestToken()
         options.token = testToken
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         let channel = client.channels.get(uniqueChannelName())
         waitUntil(timeout: testTimeout) { done in
@@ -688,9 +688,9 @@ class RealtimeClientTests: XCTestCase {
         options.autoConnect = false
         options.clientId = "ios"
         options.useTokenAuth = true
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -779,9 +779,9 @@ class RealtimeClientTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.useTokenAuth = true
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -813,9 +813,9 @@ class RealtimeClientTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.useTokenAuth = true
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         var connections = 0
         let hook1 = TestProxyTransport.testSuite_injectIntoClassMethod(#selector(TestProxyTransport.connect(withToken:))) {
@@ -891,9 +891,9 @@ class RealtimeClientTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.useTokenAuth = true
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -941,9 +941,9 @@ class RealtimeClientTests: XCTestCase {
         let options = AblyTests.commonAppSetup()
         options.autoConnect = false
         options.useTokenAuth = true
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -1027,9 +1027,9 @@ class RealtimeClientTests: XCTestCase {
         options.autoConnect = false
         let testToken = getTestToken()
         options.token = testToken
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -1082,9 +1082,9 @@ class RealtimeClientTests: XCTestCase {
         options.autoConnect = false
         let testToken = getTestToken()
         options.token = testToken
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -1137,9 +1137,9 @@ class RealtimeClientTests: XCTestCase {
         options.autoConnect = false
         let testToken = getTestToken()
         options.token = testToken
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -1192,9 +1192,9 @@ class RealtimeClientTests: XCTestCase {
         options.autoConnect = false
         let testToken = getTestToken()
         options.token = testToken
+        options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        client.internal.setTransport(TestProxyTransport.self)
 
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in

--- a/Test/Tests/RestClientChannelTests.swift
+++ b/Test/Tests/RestClientChannelTests.swift
@@ -297,7 +297,7 @@ class RestClientChannelTests: XCTestCase {
     func test__012__publish__ClientOptions_clientId__should_include_the_clientId_as_a_querystring_parameter_in_realtime_connection_requests() {
         let options = AblyTests.commonAppSetup()
         options.clientId = "john-doe"
-        let client = AblyTests.newRealtime(options)
+        let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         waitUntil(timeout: testTimeout) { done in
             client.channels.get(uniqueChannelName(prefix: "RSA7e1"))

--- a/Test/Tests/RestClientTests.swift
+++ b/Test/Tests/RestClientTests.swift
@@ -1569,7 +1569,7 @@ class RestClientTests: XCTestCase {
         default: break
         }
 
-        let realtime = AblyTests.newRealtime(options)
+        let realtime = AblyTests.newRealtime(options).client
         defer { realtime.close() }
         waitUntil(timeout: testTimeout) { done in
             realtime.channels.get(uniqueChannelName(prefix: "realtime")).publish(nil, data: "message") { _ in
@@ -1605,7 +1605,7 @@ class RestClientTests: XCTestCase {
         default: break
         }
 
-        let realtime = AblyTests.newRealtime(options)
+        let realtime = AblyTests.newRealtime(options).client
         defer { realtime.close() }
         waitUntil(timeout: testTimeout) { done in
             realtime.channels.get(uniqueChannelName(prefix: "realtime")).publish(nil, data: "message") { _ in


### PR DESCRIPTION
This is part of #1604 (removing global mutable state in test suite). See commit messages for more details.