### PR TITLE
Tidy up tests’ methods for creating `ARTClientOptions`

### DIFF
--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -117,7 +117,7 @@ class AblyTests {
     }
 
     class func commonAppSetup(debug: Bool = false, forceNewApp: Bool = false) -> ARTClientOptions {
-        let options = AblyTests.clientOptions()
+        let options = AblyTests.clientOptions(debug: debug)
         options.testOptions.channelNamePrefix = "test-\(UUID().uuidString)"
 
         if forceNewApp {
@@ -153,9 +153,7 @@ class AblyTests {
         
         let key = app["keys"][0]
         options.key = key["keyStr"].stringValue
-        if debug {
-            options.logLevel = .verbose
-        }
+
         return options
     }
 
@@ -164,7 +162,7 @@ class AblyTests {
         options.environment = getEnvironment()
         options.logExceptionReportingUrl = nil
         if debug {
-            options.logLevel = .debug
+            options.logLevel = .verbose
         }
         if let key = key {
             options.key = key

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -160,7 +160,6 @@ class AblyTests {
     class func clientOptions(debug: Bool = false, key: String? = nil, requestToken: Bool = false) -> ARTClientOptions {
         let options = ARTClientOptions()
         options.environment = getEnvironment()
-        options.logExceptionReportingUrl = nil
         if debug {
             options.logLevel = .verbose
         }

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -92,13 +92,6 @@ class AblyTests {
         checkError(errorInfo, withAlternative: "")
     }
 
-    class var jsonRestOptions: ARTClientOptions {
-        get {
-            let options = AblyTests.clientOptions()
-            return options
-        }
-    }
-
     static var testApplication: JSON?
 
     struct QueueIdentity {
@@ -166,7 +159,7 @@ class AblyTests {
     }
     
     class func commonAppSetup(_ debug: Bool = false) -> ARTClientOptions {
-        return AblyTests.setupOptions(AblyTests.jsonRestOptions, debug: debug)
+        return AblyTests.setupOptions(AblyTests.clientOptions(), debug: debug)
     }
 
     class func clientOptions(_ debug: Bool = false, key: String? = nil, requestToken: Bool = false) -> ARTClientOptions {

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -153,8 +153,6 @@ class AblyTests {
         
         let key = app["keys"][0]
         options.key = key["keyStr"].stringValue
-        options.dispatchQueue = DispatchQueue.main
-        options.internalDispatchQueue = queue
         if debug {
             options.logLevel = .verbose
         }

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -158,8 +158,8 @@ class AblyTests {
         return options
     }
     
-    class func commonAppSetup(_ debug: Bool = false) -> ARTClientOptions {
-        return AblyTests.setupOptions(AblyTests.clientOptions(), debug: debug)
+    class func commonAppSetup(_ debug: Bool = false, forceNewApp: Bool = false) -> ARTClientOptions {
+        return AblyTests.setupOptions(AblyTests.clientOptions(), forceNewApp: forceNewApp, debug: debug)
     }
 
     class func clientOptions(_ debug: Bool = false, key: String? = nil, requestToken: Bool = false) -> ARTClientOptions {

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -116,7 +116,7 @@ class AblyTests {
         return DispatchQueue.getSpecific(key: queueIdentityKey)?.label
     }
 
-    class func commonAppSetup(_ debug: Bool = false, forceNewApp: Bool = false) -> ARTClientOptions {
+    class func commonAppSetup(debug: Bool = false, forceNewApp: Bool = false) -> ARTClientOptions {
         let options = AblyTests.clientOptions()
         options.testOptions.channelNamePrefix = "test-\(UUID().uuidString)"
 
@@ -161,7 +161,7 @@ class AblyTests {
         return options
     }
 
-    class func clientOptions(_ debug: Bool = false, key: String? = nil, requestToken: Bool = false) -> ARTClientOptions {
+    class func clientOptions(debug: Bool = false, key: String? = nil, requestToken: Bool = false) -> ARTClientOptions {
         let options = ARTClientOptions()
         options.environment = getEnvironment()
         options.logExceptionReportingUrl = nil

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -75,7 +75,7 @@ class AuthTests: XCTestCase {
 
     // RSA1
     func test__003__Basic__should_work_over_HTTPS_only() {
-        let clientOptions = AblyTests.setupOptions(AblyTests.clientOptions())
+        let clientOptions = AblyTests.commonAppSetup()
         clientOptions.tls = false
 
         expect { ARTRest(options: clientOptions) }.to(raiseException())
@@ -83,7 +83,7 @@ class AuthTests: XCTestCase {
 
     // RSA11
     func test__004__Basic__should_send_the_API_key_in_the_Authorization_header() throws {
-        let options = AblyTests.setupOptions(AblyTests.clientOptions())
+        let options = AblyTests.commonAppSetup()
         let client = ARTRest(options: options)
         let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
@@ -882,7 +882,7 @@ class AuthTests: XCTestCase {
 
     func test__042__Token__token_auth_and_clientId__should_check_clientId_consistency__on_realtime() throws {
         let expectedClientId = "client_string"
-        let options = AblyTests.setupOptions(AblyTests.clientOptions())
+        let options = AblyTests.commonAppSetup()
         options.clientId = expectedClientId
         options.autoConnect = false
         options.testOptions.transportFactory = TestProxyTransportFactory()
@@ -913,7 +913,7 @@ class AuthTests: XCTestCase {
     }
 
     func test__043__Token__token_auth_and_clientId__should_check_clientId_consistency__with_wildcard() {
-        let options = AblyTests.setupOptions(AblyTests.clientOptions())
+        let options = AblyTests.commonAppSetup()
         options.clientId = "*"
         expect { ARTRest(options: options) }.to(raiseException())
         expect { ARTRealtime(options: options) }.to(raiseException())
@@ -1021,7 +1021,7 @@ class AuthTests: XCTestCase {
         let tokenParams = ARTTokenParams()
         XCTAssertNil(tokenParams.capability)
 
-        let options = AblyTests.setupOptions(AblyTests.clientOptions())
+        let options = AblyTests.commonAppSetup()
         let rest = ARTRest(options: options)
         let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
@@ -1053,7 +1053,7 @@ class AuthTests: XCTestCase {
         let tokenParams = ARTTokenParams()
         tokenParams.capability = "{\"*\":[\"*\"]}"
 
-        let options = AblyTests.setupOptions(AblyTests.clientOptions())
+        let options = AblyTests.commonAppSetup()
         let rest = ARTRest(options: options)
         let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
@@ -1107,7 +1107,7 @@ class AuthTests: XCTestCase {
 
     // RSA7a2
     func test__047__Token__clientId_and_authenticated_clients__should_obtain_a_token_if_clientId_is_assigned() {
-        let options = AblyTests.setupOptions(AblyTests.clientOptions())
+        let options = AblyTests.commonAppSetup()
         options.clientId = "client_string"
 
         let client = ARTRest(options: options)
@@ -1130,7 +1130,7 @@ class AuthTests: XCTestCase {
 
     // RSA7a3
     func test__048__Token__clientId_and_authenticated_clients__should_convenience_clientId_return_a_string() {
-        let clientOptions = AblyTests.setupOptions(AblyTests.clientOptions())
+        let clientOptions = AblyTests.commonAppSetup()
         clientOptions.clientId = "String"
 
         XCTAssertEqual(ARTRest(options: clientOptions).internal.options.clientId, "String")
@@ -1225,7 +1225,7 @@ class AuthTests: XCTestCase {
 
     // RSA7b1
     func test__053__Token__clientId_and_authenticated_clients__auth_clientId_not_null__when_clientId_attribute_is_assigned_on_client_options() {
-        let clientOptions = AblyTests.setupOptions(AblyTests.clientOptions())
+        let clientOptions = AblyTests.commonAppSetup()
         clientOptions.clientId = "Exist"
 
         XCTAssertEqual(ARTRest(options: clientOptions).auth.clientId, "Exist")
@@ -1301,7 +1301,7 @@ class AuthTests: XCTestCase {
 
     // RSA7c
     func test__050__Token__clientId_and_authenticated_clients__should_clientId_be_null_or_string() {
-        let clientOptions = AblyTests.setupOptions(AblyTests.clientOptions())
+        let clientOptions = AblyTests.commonAppSetup()
         clientOptions.clientId = "*"
 
         expect { ARTRest(options: clientOptions) }.to(raiseException())

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -75,7 +75,7 @@ class AuthTests: XCTestCase {
 
     // RSA1
     func test__003__Basic__should_work_over_HTTPS_only() {
-        let clientOptions = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let clientOptions = AblyTests.setupOptions(AblyTests.clientOptions())
         clientOptions.tls = false
 
         expect { ARTRest(options: clientOptions) }.to(raiseException())
@@ -83,7 +83,7 @@ class AuthTests: XCTestCase {
 
     // RSA11
     func test__004__Basic__should_send_the_API_key_in_the_Authorization_header() throws {
-        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let options = AblyTests.setupOptions(AblyTests.clientOptions())
         let client = ARTRest(options: options)
         let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         client.internal.httpExecutor = testHTTPExecutor
@@ -882,7 +882,7 @@ class AuthTests: XCTestCase {
 
     func test__042__Token__token_auth_and_clientId__should_check_clientId_consistency__on_realtime() throws {
         let expectedClientId = "client_string"
-        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let options = AblyTests.setupOptions(AblyTests.clientOptions())
         options.clientId = expectedClientId
         options.autoConnect = false
         options.testOptions.transportFactory = TestProxyTransportFactory()
@@ -913,7 +913,7 @@ class AuthTests: XCTestCase {
     }
 
     func test__043__Token__token_auth_and_clientId__should_check_clientId_consistency__with_wildcard() {
-        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let options = AblyTests.setupOptions(AblyTests.clientOptions())
         options.clientId = "*"
         expect { ARTRest(options: options) }.to(raiseException())
         expect { ARTRealtime(options: options) }.to(raiseException())
@@ -1021,7 +1021,7 @@ class AuthTests: XCTestCase {
         let tokenParams = ARTTokenParams()
         XCTAssertNil(tokenParams.capability)
 
-        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let options = AblyTests.setupOptions(AblyTests.clientOptions())
         let rest = ARTRest(options: options)
         let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
@@ -1053,7 +1053,7 @@ class AuthTests: XCTestCase {
         let tokenParams = ARTTokenParams()
         tokenParams.capability = "{\"*\":[\"*\"]}"
 
-        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let options = AblyTests.setupOptions(AblyTests.clientOptions())
         let rest = ARTRest(options: options)
         let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
@@ -1107,7 +1107,7 @@ class AuthTests: XCTestCase {
 
     // RSA7a2
     func test__047__Token__clientId_and_authenticated_clients__should_obtain_a_token_if_clientId_is_assigned() {
-        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let options = AblyTests.setupOptions(AblyTests.clientOptions())
         options.clientId = "client_string"
 
         let client = ARTRest(options: options)
@@ -1130,7 +1130,7 @@ class AuthTests: XCTestCase {
 
     // RSA7a3
     func test__048__Token__clientId_and_authenticated_clients__should_convenience_clientId_return_a_string() {
-        let clientOptions = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let clientOptions = AblyTests.setupOptions(AblyTests.clientOptions())
         clientOptions.clientId = "String"
 
         XCTAssertEqual(ARTRest(options: clientOptions).internal.options.clientId, "String")
@@ -1225,7 +1225,7 @@ class AuthTests: XCTestCase {
 
     // RSA7b1
     func test__053__Token__clientId_and_authenticated_clients__auth_clientId_not_null__when_clientId_attribute_is_assigned_on_client_options() {
-        let clientOptions = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let clientOptions = AblyTests.setupOptions(AblyTests.clientOptions())
         clientOptions.clientId = "Exist"
 
         XCTAssertEqual(ARTRest(options: clientOptions).auth.clientId, "Exist")
@@ -1301,7 +1301,7 @@ class AuthTests: XCTestCase {
 
     // RSA7c
     func test__050__Token__clientId_and_authenticated_clients__should_clientId_be_null_or_string() {
-        let clientOptions = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let clientOptions = AblyTests.setupOptions(AblyTests.clientOptions())
         clientOptions.clientId = "*"
 
         expect { ARTRest(options: clientOptions) }.to(raiseException())

--- a/Test/Tests/RestClientChannelTests.swift
+++ b/Test/Tests/RestClientChannelTests.swift
@@ -119,7 +119,7 @@ class RestClientChannelTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        let options = AblyTests.setupOptions(AblyTests.clientOptions())
+        let options = AblyTests.commonAppSetup()
         client = ARTRest(options: options)
         testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
     }

--- a/Test/Tests/RestClientChannelTests.swift
+++ b/Test/Tests/RestClientChannelTests.swift
@@ -119,7 +119,7 @@ class RestClientChannelTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let options = AblyTests.setupOptions(AblyTests.clientOptions())
         client = ARTRest(options: options)
         testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
     }

--- a/Test/Tests/RestClientStatsTests.swift
+++ b/Test/Tests/RestClientStatsTests.swift
@@ -5,7 +5,7 @@ import XCTest
 import SwiftyJSON
 
 private func postTestStats(_ stats: JSON) -> ARTClientOptions {
-    let options = AblyTests.setupOptions(AblyTests.clientOptions(), forceNewApp: true)
+    let options = AblyTests.commonAppSetup(forceNewApp: true)
 
     let keyBase64 = encodeBase64(options.key ?? "")
 

--- a/Test/Tests/RestClientStatsTests.swift
+++ b/Test/Tests/RestClientStatsTests.swift
@@ -5,7 +5,7 @@ import XCTest
 import SwiftyJSON
 
 private func postTestStats(_ stats: JSON) -> ARTClientOptions {
-    let options = AblyTests.setupOptions(AblyTests.jsonRestOptions, forceNewApp: true)
+    let options = AblyTests.setupOptions(AblyTests.clientOptions(), forceNewApp: true)
 
     let keyBase64 = encodeBase64(options.key ?? "")
 

--- a/Test/Tests/RestClientTests.swift
+++ b/Test/Tests/RestClientTests.swift
@@ -437,7 +437,7 @@ class RestClientTests: XCTestCase {
 
     // RSC5
     func test__002__RestClient__should_provide_access_to_the_AuthOptions_object_passed_in_ClientOptions() {
-        let options = AblyTests.setupOptions(AblyTests.clientOptions())
+        let options = AblyTests.commonAppSetup()
         let client = ARTRest(options: options)
 
         let authOptions = client.auth.internal.options
@@ -469,7 +469,7 @@ class RestClientTests: XCTestCase {
     // RSC16
 
     func test__034__RestClient__time__should_return_server_time() {
-        let options = AblyTests.setupOptions(AblyTests.clientOptions())
+        let options = AblyTests.commonAppSetup()
         let client = ARTRest(options: options)
 
         var time: NSDate?

--- a/Test/Tests/RestClientTests.swift
+++ b/Test/Tests/RestClientTests.swift
@@ -437,7 +437,7 @@ class RestClientTests: XCTestCase {
 
     // RSC5
     func test__002__RestClient__should_provide_access_to_the_AuthOptions_object_passed_in_ClientOptions() {
-        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let options = AblyTests.setupOptions(AblyTests.clientOptions())
         let client = ARTRest(options: options)
 
         let authOptions = client.auth.internal.options
@@ -469,7 +469,7 @@ class RestClientTests: XCTestCase {
     // RSC16
 
     func test__034__RestClient__time__should_return_server_time() {
-        let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+        let options = AblyTests.setupOptions(AblyTests.clientOptions())
         let client = ARTRest(options: options)
 
         var time: NSDate?


### PR DESCRIPTION
This does some tidying up of the test helper methods for creating `ARTClientOptions` instances. See commit messages for more details.