### PR TITLE
Fix wait logic in `PushAdminTests.setUp`

### DIFF
--- a/Test/Tests/PushAdminTests.swift
+++ b/Test/Tests/PushAdminTests.swift
@@ -110,24 +110,20 @@ class PushAdminTests: XCTestCase {
         rest.internal.storage = MockDeviceStorage()
         let group = DispatchGroup()
 
-        group.enter()
         for device in allDeviceDetails {
+            group.enter()
             rest.push.admin.deviceRegistrations.save(device) { error in
                 assert(error == nil, error?.message ?? "no message")
-                if allDeviceDetails.last == device {
-                    group.leave()
-                }
+                group.leave()
             }
         }
         group.wait()
 
-        group.enter()
         for subscription in allSubscriptions {
+            group.enter()
             rest.push.admin.channelSubscriptions.save(subscription) { error in
                 assert(error == nil, error?.message ?? "no message")
-                if allSubscriptions.last == subscription {
-                    group.leave()
-                }
+                group.leave()
             }
         }
 


### PR DESCRIPTION
The current logic assumes that the `deviceRegistrations.save` calls will complete in the order that they are started (and hence, that when the final device in the list has been registered, all of the devices have been registered). This is not correct, and means that sometimes we end up trying to create a channel subscription for a device that has not been registered yet, causing the `channelSubscriptions.save` call to fail.