### PR TITLE
Integrate `Aspects` dependency with project codebase

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -333,6 +333,9 @@
 		D50D86E929E9444600EA72EA /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50D86E829E9444600EA72EA /* JSON.swift */; };
 		D50D86EA29E9444600EA72EA /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50D86E829E9444600EA72EA /* JSON.swift */; };
 		D50D86EB29E9444600EA72EA /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50D86E829E9444600EA72EA /* JSON.swift */; };
+		D510E4AB29F1659F00F77F43 /* Aspects.m in Sources */ = {isa = PBXBuildFile; fileRef = D510E4AA29F1659F00F77F43 /* Aspects.m */; };
+		D510E4AC29F1659F00F77F43 /* Aspects.m in Sources */ = {isa = PBXBuildFile; fileRef = D510E4AA29F1659F00F77F43 /* Aspects.m */; };
+		D510E4AD29F1659F00F77F43 /* Aspects.m in Sources */ = {isa = PBXBuildFile; fileRef = D510E4AA29F1659F00F77F43 /* Aspects.m */; };
 		D520C4D626809BB5000012B2 /* ARTStringifiable.h in Headers */ = {isa = PBXBuildFile; fileRef = D520C4D426809BB5000012B2 /* ARTStringifiable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D520C4DB26809BB5000012B2 /* ARTStringifiable.m in Sources */ = {isa = PBXBuildFile; fileRef = D520C4D526809BB5000012B2 /* ARTStringifiable.m */; };
 		D520C4E32680A1FC000012B2 /* StringifiableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D520C4DD2680A1E3000012B2 /* StringifiableTests.swift */; };
@@ -1275,6 +1278,8 @@
 		D3AD0EBB215E2FB000312105 /* ARTNSString+ARTUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTNSString+ARTUtil.h"; path = "PrivateHeaders/Ably/ARTNSString+ARTUtil.h"; sourceTree = "<group>"; };
 		D3AD0EBC215E2FB000312105 /* ARTNSString+ARTUtil.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "ARTNSString+ARTUtil.m"; sourceTree = "<group>"; };
 		D50D86E829E9444600EA72EA /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
+		D510E4A929F1659F00F77F43 /* Aspects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Aspects.h; sourceTree = "<group>"; };
+		D510E4AA29F1659F00F77F43 /* Aspects.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Aspects.m; sourceTree = "<group>"; };
 		D520C4D426809BB5000012B2 /* ARTStringifiable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTStringifiable.h; path = include/Ably/ARTStringifiable.h; sourceTree = "<group>"; };
 		D520C4D526809BB5000012B2 /* ARTStringifiable.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTStringifiable.m; sourceTree = "<group>"; };
 		D520C4DC26809D49000012B2 /* ARTStringifiable+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTStringifiable+Private.h"; path = "PrivateHeaders/Ably/ARTStringifiable+Private.h"; sourceTree = "<group>"; };
@@ -1739,6 +1744,7 @@
 		856AAC8B1B6E304B00B07119 /* Test */ = {
 			isa = PBXGroup;
 			children = (
+				D510E4A729F1656000F77F43 /* Dependencies */,
 				D5FFA6A229E96C790082DB4B /* Codables */,
 				21BF06092758477700AE4C43 /* Tests */,
 				21BF060A2758477E00AE4C43 /* Test Utilities */,
@@ -1813,6 +1819,23 @@
 				D710D478219495FC008F54AD /* Info-tvOS.plist */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		D510E4A729F1656000F77F43 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				D510E4A829F1656000F77F43 /* steipete */,
+			);
+			path = Dependencies;
+			sourceTree = "<group>";
+		};
+		D510E4A829F1656000F77F43 /* steipete */ = {
+			isa = PBXGroup;
+			children = (
+				D510E4A929F1659F00F77F43 /* Aspects.h */,
+				D510E4AA29F1659F00F77F43 /* Aspects.m */,
+			);
+			path = steipete;
 			sourceTree = "<group>";
 		};
 		D5FFA6A229E96C790082DB4B /* Codables */ = {
@@ -3014,6 +3037,7 @@
 				D72304701BB72CED00F1ABDA /* RealtimeClientTests.swift in Sources */,
 				841134782722205400CFA837 /* ARTArchiveTests.m in Sources */,
 				D5FFA6A429E96C960082DB4B /* TestAppSetup.swift in Sources */,
+				D510E4AB29F1659F00F77F43 /* Aspects.m in Sources */,
 				D74A17B81FA0D9A3006D27B5 /* PushAdminTests.swift in Sources */,
 				2132C21629D20F69000C4355 /* ResumeRequestResponseTests.swift in Sources */,
 				EB7913A81C6E54C3000ABF9B /* CryptoTests.swift in Sources */,
@@ -3196,6 +3220,7 @@
 				D7093C2A219E466E00723F17 /* UtilitiesTests.swift in Sources */,
 				D798554923EB96C000946BE2 /* DeltaCodecTests.swift in Sources */,
 				2124B78829DB127900AD8361 /* MockVersion2Log.swift in Sources */,
+				D510E4AC29F1659F00F77F43 /* Aspects.m in Sources */,
 				2132C21729D20F69000C4355 /* ResumeRequestResponseTests.swift in Sources */,
 				21113B4A29DB60F800652C86 /* MockRetryDelayCalculator.swift in Sources */,
 				217FCF4329D626E4006E5F2D /* MockJitterCoefficientGenerator.swift in Sources */,
@@ -3251,6 +3276,7 @@
 				D7093C7C219EE26400723F17 /* RealtimeClientConnectionTests.swift in Sources */,
 				D798554A23EB96C000946BE2 /* DeltaCodecTests.swift in Sources */,
 				2124B78929DB127900AD8361 /* MockVersion2Log.swift in Sources */,
+				D510E4AD29F1659F00F77F43 /* Aspects.m in Sources */,
 				2132C21829D20F69000C4355 /* ResumeRequestResponseTests.swift in Sources */,
 				21113B4B29DB60F800652C86 /* MockRetryDelayCalculator.swift in Sources */,
 				217FCF4429D626E4006E5F2D /* MockJitterCoefficientGenerator.swift in Sources */,

--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -277,9 +277,6 @@
 		841134782722205400CFA837 /* ARTArchiveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 841134772722205400CFA837 /* ARTArchiveTests.m */; };
 		8412FDE72661AC37001FE9E6 /* AblyDeltaCodec.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDE12661AC37001FE9E6 /* AblyDeltaCodec.xcframework */; };
 		8412FDED2661AC37001FE9E6 /* msgpack.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDE32661AC37001FE9E6 /* msgpack.xcframework */; };
-		8412FDF52661AC7B001FE9E6 /* Aspects.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF12661AC7A001FE9E6 /* Aspects.xcframework */; };
-		8412FDF62661AC7B001FE9E6 /* Aspects.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF12661AC7A001FE9E6 /* Aspects.xcframework */; };
-		8412FDF72661AC7B001FE9E6 /* Aspects.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF12661AC7A001FE9E6 /* Aspects.xcframework */; };
 		8412FDFE2661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF42661AC7B001FE9E6 /* Nimble.xcframework */; };
 		8412FDFF2661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF42661AC7B001FE9E6 /* Nimble.xcframework */; };
 		8412FE002661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF42661AC7B001FE9E6 /* Nimble.xcframework */; };
@@ -1224,7 +1221,6 @@
 		841134772722205400CFA837 /* ARTArchiveTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTArchiveTests.m; sourceTree = "<group>"; };
 		8412FDE12661AC37001FE9E6 /* AblyDeltaCodec.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = AblyDeltaCodec.xcframework; path = Carthage/Build/AblyDeltaCodec.xcframework; sourceTree = "<group>"; };
 		8412FDE32661AC37001FE9E6 /* msgpack.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = msgpack.xcframework; path = Carthage/Build/msgpack.xcframework; sourceTree = "<group>"; };
-		8412FDF12661AC7A001FE9E6 /* Aspects.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Aspects.xcframework; path = Carthage/Build/Aspects.xcframework; sourceTree = "<group>"; };
 		8412FDF42661AC7B001FE9E6 /* Nimble.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Nimble.xcframework; path = Carthage/Build/Nimble.xcframework; sourceTree = "<group>"; };
 		848ED97226E50D0F0087E800 /* ObjcppTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjcppTest.mm; sourceTree = "<group>"; };
 		850BFB4A1B79323C009D0ADD /* ARTPaginatedResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARTPaginatedResult.h; path = include/Ably/ARTPaginatedResult.h; sourceTree = "<group>"; };
@@ -1501,7 +1497,6 @@
 			files = (
 				8412FDFE2661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */,
 				D70F277D2261046A00956251 /* Ably.framework in Frameworks */,
-				8412FDF52661AC7B001FE9E6 /* Aspects.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1520,7 +1515,6 @@
 			files = (
 				8412FDFF2661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */,
 				D7093C0F219E2DB200723F17 /* Ably.framework in Frameworks */,
-				8412FDF62661AC7B001FE9E6 /* Aspects.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1530,7 +1524,6 @@
 			files = (
 				8412FE002661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */,
 				D7093C65219EE1AE00723F17 /* Ably.framework in Frameworks */,
-				8412FDF72661AC7B001FE9E6 /* Aspects.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2191,7 +2184,6 @@
 			children = (
 				8412FDE12661AC37001FE9E6 /* AblyDeltaCodec.xcframework */,
 				8412FDE32661AC37001FE9E6 /* msgpack.xcframework */,
-				8412FDF12661AC7A001FE9E6 /* Aspects.xcframework */,
 				8412FDF42661AC7B001FE9E6 /* Nimble.xcframework */,
 			);
 			name = Frameworks;

--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -280,9 +280,6 @@
 		8412FDF52661AC7B001FE9E6 /* Aspects.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF12661AC7A001FE9E6 /* Aspects.xcframework */; };
 		8412FDF62661AC7B001FE9E6 /* Aspects.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF12661AC7A001FE9E6 /* Aspects.xcframework */; };
 		8412FDF72661AC7B001FE9E6 /* Aspects.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF12661AC7A001FE9E6 /* Aspects.xcframework */; };
-		8412FDF82661AC7B001FE9E6 /* SwiftyJSON.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF22661AC7B001FE9E6 /* SwiftyJSON.xcframework */; };
-		8412FDF92661AC7B001FE9E6 /* SwiftyJSON.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF22661AC7B001FE9E6 /* SwiftyJSON.xcframework */; };
-		8412FDFA2661AC7B001FE9E6 /* SwiftyJSON.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF22661AC7B001FE9E6 /* SwiftyJSON.xcframework */; };
 		8412FDFE2661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF42661AC7B001FE9E6 /* Nimble.xcframework */; };
 		8412FDFF2661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF42661AC7B001FE9E6 /* Nimble.xcframework */; };
 		8412FE002661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8412FDF42661AC7B001FE9E6 /* Nimble.xcframework */; };
@@ -1225,7 +1222,6 @@
 		8412FDE12661AC37001FE9E6 /* AblyDeltaCodec.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = AblyDeltaCodec.xcframework; path = Carthage/Build/AblyDeltaCodec.xcframework; sourceTree = "<group>"; };
 		8412FDE32661AC37001FE9E6 /* msgpack.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = msgpack.xcframework; path = Carthage/Build/msgpack.xcframework; sourceTree = "<group>"; };
 		8412FDF12661AC7A001FE9E6 /* Aspects.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Aspects.xcframework; path = Carthage/Build/Aspects.xcframework; sourceTree = "<group>"; };
-		8412FDF22661AC7B001FE9E6 /* SwiftyJSON.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SwiftyJSON.xcframework; path = Carthage/Build/SwiftyJSON.xcframework; sourceTree = "<group>"; };
 		8412FDF42661AC7B001FE9E6 /* Nimble.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Nimble.xcframework; path = Carthage/Build/Nimble.xcframework; sourceTree = "<group>"; };
 		848ED97226E50D0F0087E800 /* ObjcppTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjcppTest.mm; sourceTree = "<group>"; };
 		850BFB4A1B79323C009D0ADD /* ARTPaginatedResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARTPaginatedResult.h; path = include/Ably/ARTPaginatedResult.h; sourceTree = "<group>"; };
@@ -1498,7 +1494,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8412FDF82661AC7B001FE9E6 /* SwiftyJSON.xcframework in Frameworks */,
 				8412FDFE2661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */,
 				D70F277D2261046A00956251 /* Ably.framework in Frameworks */,
 				8412FDF52661AC7B001FE9E6 /* Aspects.xcframework in Frameworks */,
@@ -1518,7 +1513,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8412FDF92661AC7B001FE9E6 /* SwiftyJSON.xcframework in Frameworks */,
 				8412FDFF2661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */,
 				D7093C0F219E2DB200723F17 /* Ably.framework in Frameworks */,
 				8412FDF62661AC7B001FE9E6 /* Aspects.xcframework in Frameworks */,
@@ -1529,7 +1523,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8412FDFA2661AC7B001FE9E6 /* SwiftyJSON.xcframework in Frameworks */,
 				8412FE002661AC7B001FE9E6 /* Nimble.xcframework in Frameworks */,
 				D7093C65219EE1AE00723F17 /* Ably.framework in Frameworks */,
 				8412FDF72661AC7B001FE9E6 /* Aspects.xcframework in Frameworks */,
@@ -2177,7 +2170,6 @@
 				8412FDE32661AC37001FE9E6 /* msgpack.xcframework */,
 				8412FDF12661AC7A001FE9E6 /* Aspects.xcframework */,
 				8412FDF42661AC7B001FE9E6 /* Nimble.xcframework */,
-				8412FDF22661AC7B001FE9E6 /* SwiftyJSON.xcframework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,2 @@
 github "Quick/Nimble" == 9.2.1
 github "whitesmith/Aspects" "1.4.2-ws1"
-github "SwiftyJSON/SwiftyJSON" == 4.3.0

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,1 @@
 github "Quick/Nimble" == 9.2.1
-github "whitesmith/Aspects" "1.4.2-ws1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,3 @@
 github "Quick/Nimble" "v9.2.1"
 github "ably/delta-codec-cocoa" "1.3.3"
 github "rvi/msgpack-objective-C" "0.4.0"
-github "whitesmith/Aspects" "1.4.2-ws1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,4 @@
 github "Quick/Nimble" "v9.2.1"
-github "SwiftyJSON/SwiftyJSON" "4.3.0"
 github "ably/delta-codec-cocoa" "1.3.3"
 github "rvi/msgpack-objective-C" "0.4.0"
 github "whitesmith/Aspects" "1.4.2-ws1"

--- a/Test/AblyTests-Bridging-Header.h
+++ b/Test/AblyTests-Bridging-Header.h
@@ -1,3 +1,4 @@
 #import <asl.h>
 #import "NSObject+TestSuite.h"
 #import "ARTGCD.h"
+#import "Aspects.h"

--- a/Test/Dependencies/steipete/Aspects.h
+++ b/Test/Dependencies/steipete/Aspects.h
@@ -1,0 +1,83 @@
+//
+//  Aspects.h
+//  Aspects - A delightful, simple library for aspect oriented programming.
+//
+//  Copyright (c) 2014 Peter Steinberger. Licensed under the MIT license.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef NS_OPTIONS(NSUInteger, AspectOptions) {
+    AspectPositionAfter   = 0,            /// Called after the original implementation (default)
+    AspectPositionInstead = 1,            /// Will replace the original implementation.
+    AspectPositionBefore  = 2,            /// Called before the original implementation.
+    
+    AspectOptionAutomaticRemoval = 1 << 3 /// Will remove the hook after the first execution.
+};
+
+/// Opaque Aspect Token that allows to deregister the hook.
+@protocol AspectToken <NSObject>
+
+/// Deregisters an aspect.
+/// @return YES if deregistration is successful, otherwise NO.
+- (BOOL)remove;
+
+@end
+
+/// The AspectInfo protocol is the first parameter of our block syntax.
+@protocol AspectInfo <NSObject>
+
+/// The instance that is currently hooked.
+- (id)instance;
+
+/// The original invocation of the hooked method.
+- (NSInvocation *)originalInvocation;
+
+/// All method arguments, boxed. This is lazily evaluated.
+- (NSArray *)arguments;
+
+@end
+
+/**
+ Aspects uses Objective-C message forwarding to hook into messages. This will create some overhead. Don't add aspects to methods that are called a lot. Aspects is meant for view/controller code that is not called a 1000 times per second.
+
+ Adding aspects returns an opaque token which can be used to deregister again. All calls are thread safe.
+ */
+@interface NSObject (Aspects)
+
+/// Adds a block of code before/instead/after the current `selector` for a specific class.
+///
+/// @param block Aspects replicates the type signature of the method being hooked.
+/// The first parameter will be `id<AspectInfo>`, followed by all parameters of the method.
+/// These parameters are optional and will be filled to match the block signature.
+/// You can even use an empty block, or one that simple gets `id<AspectInfo>`.
+///
+/// @note Hooking static methods is not supported.
+/// @return A token which allows to later deregister the aspect.
++ (id<AspectToken>)aspect_hookSelector:(SEL)selector
+                           withOptions:(AspectOptions)options
+                            usingBlock:(id)block
+                                 error:(NSError **)error;
+
+/// Adds a block of code before/instead/after the current `selector` for a specific instance.
+- (id<AspectToken>)aspect_hookSelector:(SEL)selector
+                           withOptions:(AspectOptions)options
+                            usingBlock:(id)block
+                                 error:(NSError **)error;
+
+@end
+
+
+typedef NS_ENUM(NSUInteger, AspectErrorCode) {
+    AspectErrorSelectorBlacklisted,                   /// Selectors like release, retain, autorelease are blacklisted.
+    AspectErrorDoesNotRespondToSelector,              /// Selector could not be found.
+    AspectErrorSelectorDeallocPosition,               /// When hooking dealloc, only AspectPositionBefore is allowed.
+    AspectErrorSelectorAlreadyHookedInClassHierarchy, /// Statically hooking the same method in subclasses is not allowed.
+    AspectErrorFailedToAllocateClassPair,             /// The runtime failed creating a class pair.
+    AspectErrorMissingBlockSignature,                 /// The block misses compile time signature info and can't be called.
+    AspectErrorIncompatibleBlockSignature,            /// The block signature does not match the method or is too large.
+
+    AspectErrorRemoveObjectAlreadyDeallocated = 100   /// (for removing) The object hooked is already deallocated.
+};
+
+extern NSString *const AspectErrorDomain;

--- a/Test/Dependencies/steipete/Aspects.m
+++ b/Test/Dependencies/steipete/Aspects.m
@@ -1,0 +1,946 @@
+//
+//  Aspects.m
+//  Aspects - A delightful, simple library for aspect oriented programming.
+//
+//  Copyright (c) 2014 Peter Steinberger. Licensed under the MIT license.
+//
+
+#import "Aspects.h"
+#import <libkern/OSAtomic.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+#import <os/lock.h>
+
+#define AspectLog(...)
+//#define AspectLog(...) do { NSLog(__VA_ARGS__); }while(0)
+#define AspectLogError(...) do { NSLog(__VA_ARGS__); }while(0)
+
+// Block internals.
+typedef NS_OPTIONS(int, AspectBlockFlags) {
+	AspectBlockFlagsHasCopyDisposeHelpers = (1 << 25),
+	AspectBlockFlagsHasSignature          = (1 << 30)
+};
+typedef struct _AspectBlock {
+	__unused Class isa;
+	AspectBlockFlags flags;
+	__unused int reserved;
+	void (__unused *invoke)(struct _AspectBlock *block, ...);
+	struct {
+		unsigned long int reserved;
+		unsigned long int size;
+		// requires AspectBlockFlagsHasCopyDisposeHelpers
+		void (*copy)(void *dst, const void *src);
+		void (*dispose)(const void *);
+		// requires AspectBlockFlagsHasSignature
+		const char *signature;
+		const char *layout;
+	} *descriptor;
+	// imported variables
+} *AspectBlockRef;
+
+@interface AspectInfo : NSObject <AspectInfo>
+- (id)initWithInstance:(__unsafe_unretained id)instance invocation:(NSInvocation *)invocation;
+@property (nonatomic, unsafe_unretained, readonly) id instance;
+@property (nonatomic, strong, readonly) NSArray *arguments;
+@property (nonatomic, strong, readonly) NSInvocation *originalInvocation;
+@end
+
+// Tracks a single aspect.
+@interface AspectIdentifier : NSObject
++ (instancetype)identifierWithSelector:(SEL)selector object:(id)object options:(AspectOptions)options block:(id)block error:(NSError **)error;
+- (BOOL)invokeWithInfo:(id<AspectInfo>)info;
+@property (nonatomic, assign) SEL selector;
+@property (nonatomic, strong) id block;
+@property (nonatomic, strong) NSMethodSignature *blockSignature;
+@property (nonatomic, weak) id object;
+@property (nonatomic, assign) AspectOptions options;
+@end
+
+// Tracks all aspects for an object/class.
+@interface AspectsContainer : NSObject
+- (void)addAspect:(AspectIdentifier *)aspect withOptions:(AspectOptions)injectPosition;
+- (BOOL)removeAspect:(id)aspect;
+- (BOOL)hasAspects;
+@property (atomic, copy) NSArray *beforeAspects;
+@property (atomic, copy) NSArray *insteadAspects;
+@property (atomic, copy) NSArray *afterAspects;
+@end
+
+@interface AspectTracker : NSObject
+- (id)initWithTrackedClass:(Class)trackedClass;
+@property (nonatomic, strong) Class trackedClass;
+@property (nonatomic, readonly) NSString *trackedClassName;
+@property (nonatomic, strong) NSMutableSet *selectorNames;
+@property (nonatomic, strong) NSMutableDictionary *selectorNamesToSubclassTrackers;
+- (void)addSubclassTracker:(AspectTracker *)subclassTracker hookingSelectorName:(NSString *)selectorName;
+- (void)removeSubclassTracker:(AspectTracker *)subclassTracker hookingSelectorName:(NSString *)selectorName;
+- (BOOL)subclassHasHookedSelectorName:(NSString *)selectorName;
+- (NSSet *)subclassTrackersHookingSelectorName:(NSString *)selectorName;
+@end
+
+@interface NSInvocation (Aspects)
+- (NSArray *)aspects_arguments;
+@end
+
+#define AspectPositionFilter 0x07
+
+#define AspectError(errorCode, errorDescription) do { \
+AspectLogError(@"Aspects: %@", errorDescription); \
+if (error) { *error = [NSError errorWithDomain:AspectErrorDomain code:errorCode userInfo:@{NSLocalizedDescriptionKey: errorDescription}]; }}while(0)
+
+NSString *const AspectErrorDomain = @"AspectErrorDomain";
+static NSString *const AspectsSubclassSuffix = @"_Aspects_";
+static NSString *const AspectsMessagePrefix = @"aspects_";
+
+@implementation NSObject (Aspects)
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - Public Aspects API
+
++ (id<AspectToken>)aspect_hookSelector:(SEL)selector
+                      withOptions:(AspectOptions)options
+                       usingBlock:(id)block
+                            error:(NSError **)error {
+    return aspect_add((id)self, selector, options, block, error);
+}
+
+/// @return A token which allows to later deregister the aspect.
+- (id<AspectToken>)aspect_hookSelector:(SEL)selector
+                      withOptions:(AspectOptions)options
+                       usingBlock:(id)block
+                            error:(NSError **)error {
+    return aspect_add(self, selector, options, block, error);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - Private Helper
+
+static id aspect_add(id self, SEL selector, AspectOptions options, id block, NSError *__autoreleasing*error) {
+    NSCParameterAssert(self);
+    NSCParameterAssert(selector);
+    NSCParameterAssert(block);
+
+    __block AspectIdentifier *identifier = nil;
+    aspect_performLocked(^{
+        if (aspect_isSelectorAllowedAndTrack(self, selector, options, error)) {
+            AspectsContainer *aspectContainer = aspect_getContainerForObject(self, selector);
+            identifier = [AspectIdentifier identifierWithSelector:selector object:self options:options block:block error:error];
+            if (identifier) {
+                [aspectContainer addAspect:identifier withOptions:options];
+
+                // Modify the class to allow message interception.
+                aspect_prepareClassAndHookSelector(self, selector, error);
+            }
+        }
+    });
+    return identifier;
+}
+
+static BOOL aspect_remove(AspectIdentifier *aspect, NSError *__autoreleasing*error) {
+    NSCAssert([aspect isKindOfClass:AspectIdentifier.class], @"Must have correct type.");
+
+    __block BOOL success = NO;
+    aspect_performLocked(^{
+        id self = aspect.object; // strongify
+        if (self) {
+            AspectsContainer *aspectContainer = aspect_getContainerForObject(self, aspect.selector);
+            success = [aspectContainer removeAspect:aspect];
+
+            aspect_cleanupHookedClassAndSelector(self, aspect.selector);
+            // destroy token
+            aspect.object = nil;
+            aspect.block = nil;
+            aspect.selector = NULL;
+        }else {
+            NSString *errrorDesc = [NSString stringWithFormat:@"Unable to deregister hook. Object already deallocated: %@", aspect];
+            AspectError(AspectErrorRemoveObjectAlreadyDeallocated, errrorDesc);
+        }
+    });
+    return success;
+}
+
+static void aspect_performLocked(dispatch_block_t block) {
+    static os_unfair_lock aspect_lock = OS_UNFAIR_LOCK_INIT;
+    os_unfair_lock_lock(&aspect_lock);
+    block();
+    os_unfair_lock_unlock(&aspect_lock);
+}
+
+static SEL aspect_aliasForSelector(SEL selector) {
+    NSCParameterAssert(selector);
+	return NSSelectorFromString([AspectsMessagePrefix stringByAppendingFormat:@"_%@", NSStringFromSelector(selector)]);
+}
+
+static NSMethodSignature *aspect_blockMethodSignature(id block, NSError **error) {
+    AspectBlockRef layout = (__bridge void *)block;
+	if (!(layout->flags & AspectBlockFlagsHasSignature)) {
+        NSString *description = [NSString stringWithFormat:@"The block %@ doesn't contain a type signature.", block];
+        AspectError(AspectErrorMissingBlockSignature, description);
+        return nil;
+    }
+	void *desc = layout->descriptor;
+	desc += 2 * sizeof(unsigned long int);
+	if (layout->flags & AspectBlockFlagsHasCopyDisposeHelpers) {
+		desc += 2 * sizeof(void *);
+    }
+	if (!desc) {
+        NSString *description = [NSString stringWithFormat:@"The block %@ doesn't has a type signature.", block];
+        AspectError(AspectErrorMissingBlockSignature, description);
+        return nil;
+    }
+	const char *signature = (*(const char **)desc);
+	return [NSMethodSignature signatureWithObjCTypes:signature];
+}
+
+static BOOL aspect_isCompatibleBlockSignature(NSMethodSignature *blockSignature, id object, SEL selector, NSError **error) {
+    NSCParameterAssert(blockSignature);
+    NSCParameterAssert(object);
+    NSCParameterAssert(selector);
+
+    BOOL signaturesMatch = YES;
+    NSMethodSignature *methodSignature = [[object class] instanceMethodSignatureForSelector:selector];
+    if (blockSignature.numberOfArguments > methodSignature.numberOfArguments) {
+        signaturesMatch = NO;
+    }else {
+        if (blockSignature.numberOfArguments > 1) {
+            const char *blockType = [blockSignature getArgumentTypeAtIndex:1];
+            if (blockType[0] != '@') {
+                signaturesMatch = NO;
+            }
+        }
+        // Argument 0 is self/block, argument 1 is SEL or id<AspectInfo>. We start comparing at argument 2.
+        // The block can have less arguments than the method, that's ok.
+        if (signaturesMatch) {
+            for (NSUInteger idx = 2; idx < blockSignature.numberOfArguments; idx++) {
+                const char *methodType = [methodSignature getArgumentTypeAtIndex:idx];
+                const char *blockType = [blockSignature getArgumentTypeAtIndex:idx];
+                // Only compare parameter, not the optional type data.
+                if (!methodType || !blockType || methodType[0] != blockType[0]) {
+                    signaturesMatch = NO; break;
+                }
+            }
+        }
+    }
+
+    if (!signaturesMatch) {
+        NSString *description = [NSString stringWithFormat:@"Block signature %@ doesn't match %@.", blockSignature, methodSignature];
+        AspectError(AspectErrorIncompatibleBlockSignature, description);
+        return NO;
+    }
+    return YES;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - Class + Selector Preparation
+
+static BOOL aspect_isMsgForwardIMP(IMP impl) {
+    return impl == _objc_msgForward
+#if !defined(__arm64__)
+    || impl == (IMP)_objc_msgForward_stret
+#endif
+    ;
+}
+
+static IMP aspect_getMsgForwardIMP(NSObject *self, SEL selector) {
+    IMP msgForwardIMP = _objc_msgForward;
+#if !defined(__arm64__)
+    // As an ugly internal runtime implementation detail in the 32bit runtime, we need to determine of the method we hook returns a struct or anything larger than id.
+    // https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/LowLevelABI/000-Introduction/introduction.html
+    // https://github.com/ReactiveCocoa/ReactiveCocoa/issues/783
+    // http://infocenter.arm.com/help/topic/com.arm.doc.ihi0042e/IHI0042E_aapcs.pdf (Section 5.4)
+    Method method = class_getInstanceMethod(self.class, selector);
+    const char *encoding = method_getTypeEncoding(method);
+    BOOL methodReturnsStructValue = encoding[0] == _C_STRUCT_B;
+    if (methodReturnsStructValue) {
+        @try {
+            NSUInteger valueSize = 0;
+            NSGetSizeAndAlignment(encoding, &valueSize, NULL);
+
+            if (valueSize == 1 || valueSize == 2 || valueSize == 4 || valueSize == 8) {
+                methodReturnsStructValue = NO;
+            }
+        } @catch (__unused NSException *e) {}
+    }
+    if (methodReturnsStructValue) {
+        msgForwardIMP = (IMP)_objc_msgForward_stret;
+    }
+#endif
+    return msgForwardIMP;
+}
+
+static void aspect_prepareClassAndHookSelector(NSObject *self, SEL selector, NSError **error) {
+    NSCParameterAssert(selector);
+    Class klass = aspect_hookClass(self, error);
+    Method targetMethod = class_getInstanceMethod(klass, selector);
+    IMP targetMethodIMP = method_getImplementation(targetMethod);
+    if (!aspect_isMsgForwardIMP(targetMethodIMP)) {
+        // Make a method alias for the existing method implementation, it not already copied.
+        const char *typeEncoding = method_getTypeEncoding(targetMethod);
+        SEL aliasSelector = aspect_aliasForSelector(selector);
+        if (![klass instancesRespondToSelector:aliasSelector]) {
+            __unused BOOL addedAlias = class_addMethod(klass, aliasSelector, method_getImplementation(targetMethod), typeEncoding);
+            NSCAssert(addedAlias, @"Original implementation for %@ is already copied to %@ on %@", NSStringFromSelector(selector), NSStringFromSelector(aliasSelector), klass);
+        }
+
+        // We use forwardInvocation to hook in.
+        class_replaceMethod(klass, selector, aspect_getMsgForwardIMP(self, selector), typeEncoding);
+        AspectLog(@"Aspects: Installed hook for -[%@ %@].", klass, NSStringFromSelector(selector));
+    }
+}
+
+// Will undo the runtime changes made.
+static void aspect_cleanupHookedClassAndSelector(NSObject *self, SEL selector) {
+    NSCParameterAssert(self);
+    NSCParameterAssert(selector);
+
+	Class klass = object_getClass(self);
+    BOOL isMetaClass = class_isMetaClass(klass);
+    if (isMetaClass) {
+        klass = (Class)self;
+    }
+
+    // Check if the method is marked as forwarded and undo that.
+    Method targetMethod = class_getInstanceMethod(klass, selector);
+    IMP targetMethodIMP = method_getImplementation(targetMethod);
+    if (aspect_isMsgForwardIMP(targetMethodIMP)) {
+        // Restore the original method implementation.
+        const char *typeEncoding = method_getTypeEncoding(targetMethod);
+        SEL aliasSelector = aspect_aliasForSelector(selector);
+        Method originalMethod = class_getInstanceMethod(klass, aliasSelector);
+        IMP originalIMP = method_getImplementation(originalMethod);
+        NSCAssert(originalMethod, @"Original implementation for %@ not found %@ on %@", NSStringFromSelector(selector), NSStringFromSelector(aliasSelector), klass);
+
+        class_replaceMethod(klass, selector, originalIMP, typeEncoding);
+        AspectLog(@"Aspects: Removed hook for -[%@ %@].", klass, NSStringFromSelector(selector));
+    }
+
+    // Deregister global tracked selector
+    aspect_deregisterTrackedSelector(self, selector);
+
+    // Get the aspect container and check if there are any hooks remaining. Clean up if there are not.
+    AspectsContainer *container = aspect_getContainerForObject(self, selector);
+    if (!container.hasAspects) {
+        // Destroy the container
+        aspect_destroyContainerForObject(self, selector);
+
+        // Figure out how the class was modified to undo the changes.
+        NSString *className = NSStringFromClass(klass);
+        if ([className hasSuffix:AspectsSubclassSuffix]) {
+            Class originalClass = NSClassFromString([className stringByReplacingOccurrencesOfString:AspectsSubclassSuffix withString:@""]);
+            NSCAssert(originalClass != nil, @"Original class must exist");
+            object_setClass(self, originalClass);
+            AspectLog(@"Aspects: %@ has been restored.", NSStringFromClass(originalClass));
+
+            // We can only dispose the class pair if we can ensure that no instances exist using our subclass.
+            // Since we don't globally track this, we can't ensure this - but there's also not much overhead in keeping it around.
+            //objc_disposeClassPair(object.class);
+        }else {
+            // Class is most likely swizzled in place. Undo that.
+            if (isMetaClass) {
+                aspect_undoSwizzleClassInPlace((Class)self);
+            }else if (self.class != klass) {
+            	aspect_undoSwizzleClassInPlace(klass);
+            }
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - Hook Class
+
+static Class aspect_hookClass(NSObject *self, NSError **error) {
+    NSCParameterAssert(self);
+	Class statedClass = self.class;
+	Class baseClass = object_getClass(self);
+	NSString *className = NSStringFromClass(baseClass);
+
+    // Already subclassed
+	if ([className hasSuffix:AspectsSubclassSuffix]) {
+		return baseClass;
+
+        // We swizzle a class object, not a single object.
+	}else if (class_isMetaClass(baseClass)) {
+        return aspect_swizzleClassInPlace((Class)self);
+        // Probably a KVO'ed class. Swizzle in place. Also swizzle meta classes in place.
+    }else if (statedClass != baseClass) {
+        return aspect_swizzleClassInPlace(baseClass);
+    }
+
+    // Default case. Create dynamic subclass.
+	const char *subclassName = [className stringByAppendingString:AspectsSubclassSuffix].UTF8String;
+	Class subclass = objc_getClass(subclassName);
+
+	if (subclass == nil) {
+		subclass = objc_allocateClassPair(baseClass, subclassName, 0);
+		if (subclass == nil) {
+            NSString *errrorDesc = [NSString stringWithFormat:@"objc_allocateClassPair failed to allocate class %s.", subclassName];
+            AspectError(AspectErrorFailedToAllocateClassPair, errrorDesc);
+            return nil;
+        }
+
+		aspect_swizzleForwardInvocation(subclass);
+		aspect_hookedGetClass(subclass, statedClass);
+		aspect_hookedGetClass(object_getClass(subclass), statedClass);
+		objc_registerClassPair(subclass);
+	}
+
+	object_setClass(self, subclass);
+	return subclass;
+}
+
+static NSString *const AspectsForwardInvocationSelectorName = @"__aspects_forwardInvocation:";
+static void aspect_swizzleForwardInvocation(Class klass) {
+    NSCParameterAssert(klass);
+    // If there is no method, replace will act like class_addMethod.
+    IMP originalImplementation = class_replaceMethod(klass, @selector(forwardInvocation:), (IMP)__ASPECTS_ARE_BEING_CALLED__, "v@:@");
+    if (originalImplementation) {
+        class_addMethod(klass, NSSelectorFromString(AspectsForwardInvocationSelectorName), originalImplementation, "v@:@");
+    }
+    AspectLog(@"Aspects: %@ is now aspect aware.", NSStringFromClass(klass));
+}
+
+static void aspect_undoSwizzleForwardInvocation(Class klass) {
+    NSCParameterAssert(klass);
+    Method originalMethod = class_getInstanceMethod(klass, NSSelectorFromString(AspectsForwardInvocationSelectorName));
+    Method objectMethod = class_getInstanceMethod(NSObject.class, @selector(forwardInvocation:));
+    // There is no class_removeMethod, so the best we can do is to retore the original implementation, or use a dummy.
+    IMP originalImplementation = method_getImplementation(originalMethod ?: objectMethod);
+    class_replaceMethod(klass, @selector(forwardInvocation:), originalImplementation, "v@:@");
+
+    AspectLog(@"Aspects: %@ has been restored.", NSStringFromClass(klass));
+}
+
+static void aspect_hookedGetClass(Class class, Class statedClass) {
+    NSCParameterAssert(class);
+    NSCParameterAssert(statedClass);
+	Method method = class_getInstanceMethod(class, @selector(class));
+	IMP newIMP = imp_implementationWithBlock(^(id self) {
+		return statedClass;
+	});
+	class_replaceMethod(class, @selector(class), newIMP, method_getTypeEncoding(method));
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - Swizzle Class In Place
+
+static void _aspect_modifySwizzledClasses(void (^block)(NSMutableSet *swizzledClasses)) {
+    static NSMutableSet *swizzledClasses;
+    static dispatch_once_t pred;
+    dispatch_once(&pred, ^{
+        swizzledClasses = [NSMutableSet new];
+    });
+    @synchronized(swizzledClasses) {
+        block(swizzledClasses);
+    }
+}
+
+static Class aspect_swizzleClassInPlace(Class klass) {
+    NSCParameterAssert(klass);
+    NSString *className = NSStringFromClass(klass);
+
+    _aspect_modifySwizzledClasses(^(NSMutableSet *swizzledClasses) {
+        if (![swizzledClasses containsObject:className]) {
+            aspect_swizzleForwardInvocation(klass);
+            [swizzledClasses addObject:className];
+        }
+    });
+    return klass;
+}
+
+static void aspect_undoSwizzleClassInPlace(Class klass) {
+    NSCParameterAssert(klass);
+    NSString *className = NSStringFromClass(klass);
+
+    _aspect_modifySwizzledClasses(^(NSMutableSet *swizzledClasses) {
+        if ([swizzledClasses containsObject:className]) {
+            aspect_undoSwizzleForwardInvocation(klass);
+            [swizzledClasses removeObject:className];
+        }
+    });
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - Aspect Invoke Point
+
+// This is a macro so we get a cleaner stack trace.
+#define aspect_invoke(aspects, info) \
+for (AspectIdentifier *aspect in aspects) {\
+    [aspect invokeWithInfo:info];\
+    if (aspect.options & AspectOptionAutomaticRemoval) { \
+        aspectsToRemove = [aspectsToRemove?:@[] arrayByAddingObject:aspect]; \
+    } \
+}
+
+// This is the swizzled forwardInvocation: method.
+static void __ASPECTS_ARE_BEING_CALLED__(__unsafe_unretained NSObject *self, SEL selector, NSInvocation *invocation) {
+    NSCParameterAssert(self);
+    NSCParameterAssert(invocation);
+    SEL originalSelector = invocation.selector;
+	SEL aliasSelector = aspect_aliasForSelector(invocation.selector);
+    invocation.selector = aliasSelector;
+    AspectsContainer *objectContainer = objc_getAssociatedObject(self, aliasSelector);
+    AspectsContainer *classContainer = aspect_getContainerForClass(object_getClass(self), aliasSelector);
+    AspectInfo *info = [[AspectInfo alloc] initWithInstance:self invocation:invocation];
+    NSArray *aspectsToRemove = nil;
+
+    // Before hooks.
+    aspect_invoke(classContainer.beforeAspects, info);
+    aspect_invoke(objectContainer.beforeAspects, info);
+
+    // Instead hooks.
+    BOOL respondsToAlias = YES;
+    if (objectContainer.insteadAspects.count || classContainer.insteadAspects.count) {
+        aspect_invoke(classContainer.insteadAspects, info);
+        aspect_invoke(objectContainer.insteadAspects, info);
+    }else {
+        Class klass = object_getClass(invocation.target);
+        do {
+            if ((respondsToAlias = [klass instancesRespondToSelector:aliasSelector])) {
+                [invocation invoke];
+                break;
+            }
+        }while (!respondsToAlias && (klass = class_getSuperclass(klass)));
+    }
+
+    // After hooks.
+    aspect_invoke(classContainer.afterAspects, info);
+    aspect_invoke(objectContainer.afterAspects, info);
+
+    // If no hooks are installed, call original implementation (usually to throw an exception)
+    if (!respondsToAlias) {
+        invocation.selector = originalSelector;
+        SEL originalForwardInvocationSEL = NSSelectorFromString(AspectsForwardInvocationSelectorName);
+        if ([self respondsToSelector:originalForwardInvocationSEL]) {
+            ((void( *)(id, SEL, NSInvocation *))objc_msgSend)(self, originalForwardInvocationSEL, invocation);
+        }else {
+            [self doesNotRecognizeSelector:invocation.selector];
+        }
+    }
+
+    // Remove any hooks that are queued for deregistration.
+    [aspectsToRemove makeObjectsPerformSelector:@selector(remove)];
+}
+#undef aspect_invoke
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - Aspect Container Management
+
+// Loads or creates the aspect container.
+static AspectsContainer *aspect_getContainerForObject(NSObject *self, SEL selector) {
+    NSCParameterAssert(self);
+    SEL aliasSelector = aspect_aliasForSelector(selector);
+    AspectsContainer *aspectContainer = objc_getAssociatedObject(self, aliasSelector);
+    if (!aspectContainer) {
+        aspectContainer = [AspectsContainer new];
+        objc_setAssociatedObject(self, aliasSelector, aspectContainer, OBJC_ASSOCIATION_RETAIN);
+    }
+    return aspectContainer;
+}
+
+static AspectsContainer *aspect_getContainerForClass(Class klass, SEL selector) {
+    NSCParameterAssert(klass);
+    AspectsContainer *classContainer = nil;
+    do {
+        classContainer = objc_getAssociatedObject(klass, selector);
+        if (classContainer.hasAspects) break;
+    }while ((klass = class_getSuperclass(klass)));
+
+    return classContainer;
+}
+
+static void aspect_destroyContainerForObject(id<NSObject> self, SEL selector) {
+    NSCParameterAssert(self);
+    SEL aliasSelector = aspect_aliasForSelector(selector);
+    objc_setAssociatedObject(self, aliasSelector, nil, OBJC_ASSOCIATION_RETAIN);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - Selector Blacklist Checking
+
+static NSMutableDictionary *aspect_getSwizzledClassesDict(void) {
+    static NSMutableDictionary *swizzledClassesDict;
+    static dispatch_once_t pred;
+    dispatch_once(&pred, ^{
+        swizzledClassesDict = [NSMutableDictionary new];
+    });
+    return swizzledClassesDict;
+}
+
+static BOOL aspect_isSelectorAllowedAndTrack(NSObject *self, SEL selector, AspectOptions options, NSError *__autoreleasing*error) {
+    static NSSet *disallowedSelectorList;
+    static dispatch_once_t pred;
+    dispatch_once(&pred, ^{
+        disallowedSelectorList = [NSSet setWithObjects:@"retain", @"release", @"autorelease", @"forwardInvocation:", nil];
+    });
+
+    // Check against the blacklist.
+    NSString *selectorName = NSStringFromSelector(selector);
+    if ([disallowedSelectorList containsObject:selectorName]) {
+        NSString *errorDescription = [NSString stringWithFormat:@"Selector %@ is blacklisted.", selectorName];
+        AspectError(AspectErrorSelectorBlacklisted, errorDescription);
+        return NO;
+    }
+
+    // Additional checks.
+    AspectOptions position = options&AspectPositionFilter;
+    if ([selectorName isEqualToString:@"dealloc"] && position != AspectPositionBefore) {
+        NSString *errorDesc = @"AspectPositionBefore is the only valid position when hooking dealloc.";
+        AspectError(AspectErrorSelectorDeallocPosition, errorDesc);
+        return NO;
+    }
+
+    if (![self respondsToSelector:selector] && ![self.class instancesRespondToSelector:selector]) {
+        NSString *errorDesc = [NSString stringWithFormat:@"Unable to find selector -[%@ %@].", NSStringFromClass(self.class), selectorName];
+        AspectError(AspectErrorDoesNotRespondToSelector, errorDesc);
+        return NO;
+    }
+
+    // Search for the current class and the class hierarchy IF we are modifying a class object
+    if (class_isMetaClass(object_getClass(self))) {
+        Class klass = [self class];
+        NSMutableDictionary *swizzledClassesDict = aspect_getSwizzledClassesDict();
+        Class currentClass = [self class];
+
+        AspectTracker *tracker = swizzledClassesDict[currentClass];
+        if ([tracker subclassHasHookedSelectorName:selectorName]) {
+            NSSet *subclassTracker = [tracker subclassTrackersHookingSelectorName:selectorName];
+            NSSet *subclassNames = [subclassTracker valueForKey:@"trackedClassName"];
+            NSString *errorDescription = [NSString stringWithFormat:@"Error: %@ already hooked subclasses: %@. A method can only be hooked once per class hierarchy.", selectorName, subclassNames];
+            AspectError(AspectErrorSelectorAlreadyHookedInClassHierarchy, errorDescription);
+            return NO;
+        }
+
+        do {
+            tracker = swizzledClassesDict[currentClass];
+            if ([tracker.selectorNames containsObject:selectorName]) {
+                if (klass == currentClass) {
+                    // Already modified and topmost!
+                    return YES;
+                }
+                NSString *errorDescription = [NSString stringWithFormat:@"Error: %@ already hooked in %@. A method can only be hooked once per class hierarchy.", selectorName, NSStringFromClass(currentClass)];
+                AspectError(AspectErrorSelectorAlreadyHookedInClassHierarchy, errorDescription);
+                return NO;
+            }
+        } while ((currentClass = class_getSuperclass(currentClass)));
+
+        // Add the selector as being modified.
+        currentClass = klass;
+        AspectTracker *subclassTracker = nil;
+        do {
+            tracker = swizzledClassesDict[currentClass];
+            if (!tracker) {
+                tracker = [[AspectTracker alloc] initWithTrackedClass:currentClass];
+                swizzledClassesDict[(id<NSCopying>)currentClass] = tracker;
+            }
+            if (subclassTracker) {
+                [tracker addSubclassTracker:subclassTracker hookingSelectorName:selectorName];
+            } else {
+                [tracker.selectorNames addObject:selectorName];
+            }
+
+            // All superclasses get marked as having a subclass that is modified.
+            subclassTracker = tracker;
+        }while ((currentClass = class_getSuperclass(currentClass)));
+	} else {
+		return YES;
+	}
+
+    return YES;
+}
+
+static void aspect_deregisterTrackedSelector(id self, SEL selector) {
+    if (!class_isMetaClass(object_getClass(self))) return;
+
+    NSMutableDictionary *swizzledClassesDict = aspect_getSwizzledClassesDict();
+    NSString *selectorName = NSStringFromSelector(selector);
+    Class currentClass = [self class];
+    AspectTracker *subclassTracker = nil;
+    do {
+        AspectTracker *tracker = swizzledClassesDict[currentClass];
+        if (subclassTracker) {
+            [tracker removeSubclassTracker:subclassTracker hookingSelectorName:selectorName];
+        } else {
+            [tracker.selectorNames removeObject:selectorName];
+        }
+        if (tracker.selectorNames.count == 0 && tracker.selectorNamesToSubclassTrackers) {
+            [swizzledClassesDict removeObjectForKey:currentClass];
+        }
+        subclassTracker = tracker;
+    }while ((currentClass = class_getSuperclass(currentClass)));
+}
+
+@end
+
+@implementation AspectTracker
+
+- (id)initWithTrackedClass:(Class)trackedClass {
+    if (self = [super init]) {
+        _trackedClass = trackedClass;
+        _selectorNames = [NSMutableSet new];
+        _selectorNamesToSubclassTrackers = [NSMutableDictionary new];
+    }
+    return self;
+}
+
+- (BOOL)subclassHasHookedSelectorName:(NSString *)selectorName {
+    return self.selectorNamesToSubclassTrackers[selectorName] != nil;
+}
+
+- (void)addSubclassTracker:(AspectTracker *)subclassTracker hookingSelectorName:(NSString *)selectorName {
+    NSMutableSet *trackerSet = self.selectorNamesToSubclassTrackers[selectorName];
+    if (!trackerSet) {
+        trackerSet = [NSMutableSet new];
+        self.selectorNamesToSubclassTrackers[selectorName] = trackerSet;
+    }
+    [trackerSet addObject:subclassTracker];
+}
+- (void)removeSubclassTracker:(AspectTracker *)subclassTracker hookingSelectorName:(NSString *)selectorName {
+    NSMutableSet *trackerSet = self.selectorNamesToSubclassTrackers[selectorName];
+    [trackerSet removeObject:subclassTracker];
+    if (trackerSet.count == 0) {
+        [self.selectorNamesToSubclassTrackers removeObjectForKey:selectorName];
+    }
+}
+- (NSSet *)subclassTrackersHookingSelectorName:(NSString *)selectorName {
+    NSMutableSet *hookingSubclassTrackers = [NSMutableSet new];
+    for (AspectTracker *tracker in self.selectorNamesToSubclassTrackers[selectorName]) {
+        if ([tracker.selectorNames containsObject:selectorName]) {
+            [hookingSubclassTrackers addObject:tracker];
+        }
+        [hookingSubclassTrackers unionSet:[tracker subclassTrackersHookingSelectorName:selectorName]];
+    }
+    return hookingSubclassTrackers;
+}
+- (NSString *)trackedClassName {
+    return NSStringFromClass(self.trackedClass);
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@: %@, trackedClass: %@, selectorNames:%@, subclass selector names: %@>", self.class, self, NSStringFromClass(self.trackedClass), self.selectorNames, self.selectorNamesToSubclassTrackers.allKeys];
+}
+
+@end
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - NSInvocation (Aspects)
+
+@implementation NSInvocation (Aspects)
+
+// Thanks to the ReactiveCocoa team for providing a generic solution for this.
+- (id)aspect_argumentAtIndex:(NSUInteger)index {
+	const char *argType = [self.methodSignature getArgumentTypeAtIndex:index];
+	// Skip const type qualifier.
+	if (argType[0] == _C_CONST) argType++;
+
+#define WRAP_AND_RETURN(type) do { type val = 0; [self getArgument:&val atIndex:(NSInteger)index]; return @(val); } while (0)
+	if (strcmp(argType, @encode(id)) == 0 || strcmp(argType, @encode(Class)) == 0) {
+		__autoreleasing id returnObj;
+		[self getArgument:&returnObj atIndex:(NSInteger)index];
+		return returnObj;
+	} else if (strcmp(argType, @encode(SEL)) == 0) {
+        SEL selector = 0;
+        [self getArgument:&selector atIndex:(NSInteger)index];
+        return NSStringFromSelector(selector);
+    } else if (strcmp(argType, @encode(Class)) == 0) {
+        __autoreleasing Class theClass = Nil;
+        [self getArgument:&theClass atIndex:(NSInteger)index];
+        return theClass;
+        // Using this list will box the number with the appropriate constructor, instead of the generic NSValue.
+	} else if (strcmp(argType, @encode(char)) == 0) {
+		WRAP_AND_RETURN(char);
+	} else if (strcmp(argType, @encode(int)) == 0) {
+		WRAP_AND_RETURN(int);
+	} else if (strcmp(argType, @encode(short)) == 0) {
+		WRAP_AND_RETURN(short);
+	} else if (strcmp(argType, @encode(long)) == 0) {
+		WRAP_AND_RETURN(long);
+	} else if (strcmp(argType, @encode(long long)) == 0) {
+		WRAP_AND_RETURN(long long);
+	} else if (strcmp(argType, @encode(unsigned char)) == 0) {
+		WRAP_AND_RETURN(unsigned char);
+	} else if (strcmp(argType, @encode(unsigned int)) == 0) {
+		WRAP_AND_RETURN(unsigned int);
+	} else if (strcmp(argType, @encode(unsigned short)) == 0) {
+		WRAP_AND_RETURN(unsigned short);
+	} else if (strcmp(argType, @encode(unsigned long)) == 0) {
+		WRAP_AND_RETURN(unsigned long);
+	} else if (strcmp(argType, @encode(unsigned long long)) == 0) {
+		WRAP_AND_RETURN(unsigned long long);
+	} else if (strcmp(argType, @encode(float)) == 0) {
+		WRAP_AND_RETURN(float);
+	} else if (strcmp(argType, @encode(double)) == 0) {
+		WRAP_AND_RETURN(double);
+	} else if (strcmp(argType, @encode(BOOL)) == 0) {
+		WRAP_AND_RETURN(BOOL);
+	} else if (strcmp(argType, @encode(bool)) == 0) {
+		WRAP_AND_RETURN(BOOL);
+	} else if (strcmp(argType, @encode(char *)) == 0) {
+		WRAP_AND_RETURN(const char *);
+	} else if (strcmp(argType, @encode(void (^)(void))) == 0) {
+		__unsafe_unretained id block = nil;
+		[self getArgument:&block atIndex:(NSInteger)index];
+		return [block copy];
+	} else {
+		NSUInteger valueSize = 0;
+		NSGetSizeAndAlignment(argType, &valueSize, NULL);
+
+		unsigned char valueBytes[valueSize];
+		[self getArgument:valueBytes atIndex:(NSInteger)index];
+
+		return [NSValue valueWithBytes:valueBytes objCType:argType];
+	}
+	return nil;
+#undef WRAP_AND_RETURN
+}
+
+- (NSArray *)aspects_arguments {
+	NSMutableArray *argumentsArray = [NSMutableArray array];
+	for (NSUInteger idx = 2; idx < self.methodSignature.numberOfArguments; idx++) {
+		[argumentsArray addObject:[self aspect_argumentAtIndex:idx] ?: NSNull.null];
+	}
+	return [argumentsArray copy];
+}
+
+@end
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - AspectIdentifier
+
+@implementation AspectIdentifier
+
++ (instancetype)identifierWithSelector:(SEL)selector object:(id)object options:(AspectOptions)options block:(id)block error:(NSError **)error {
+    NSCParameterAssert(block);
+    NSCParameterAssert(selector);
+    NSMethodSignature *blockSignature = aspect_blockMethodSignature(block, error); // TODO: check signature compatibility, etc.
+    if (!aspect_isCompatibleBlockSignature(blockSignature, object, selector, error)) {
+        return nil;
+    }
+
+    AspectIdentifier *identifier = nil;
+    if (blockSignature) {
+        identifier = [AspectIdentifier new];
+        identifier.selector = selector;
+        identifier.block = block;
+        identifier.blockSignature = blockSignature;
+        identifier.options = options;
+        identifier.object = object; // weak
+    }
+    return identifier;
+}
+
+- (BOOL)invokeWithInfo:(id<AspectInfo>)info {
+    NSInvocation *blockInvocation = [NSInvocation invocationWithMethodSignature:self.blockSignature];
+    NSInvocation *originalInvocation = info.originalInvocation;
+    NSUInteger numberOfArguments = self.blockSignature.numberOfArguments;
+
+    // Be extra paranoid. We already check that on hook registration.
+    if (numberOfArguments > originalInvocation.methodSignature.numberOfArguments) {
+        AspectLogError(@"Block has too many arguments. Not calling %@", info);
+        return NO;
+    }
+
+    // The `self` of the block will be the AspectInfo. Optional.
+    if (numberOfArguments > 1) {
+        [blockInvocation setArgument:&info atIndex:1];
+    }
+    
+	void *argBuf = NULL;
+    for (NSUInteger idx = 2; idx < numberOfArguments; idx++) {
+        const char *type = [originalInvocation.methodSignature getArgumentTypeAtIndex:idx];
+		NSUInteger argSize;
+		NSGetSizeAndAlignment(type, &argSize, NULL);
+        
+		if (!(argBuf = reallocf(argBuf, argSize))) {
+            AspectLogError(@"Failed to allocate memory for block invocation.");
+			return NO;
+		}
+        
+		[originalInvocation getArgument:argBuf atIndex:idx];
+		[blockInvocation setArgument:argBuf atIndex:idx];
+    }
+    
+    [blockInvocation invokeWithTarget:self.block];
+    
+    if (argBuf != NULL) {
+        free(argBuf);
+    }
+    return YES;
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@: %p, SEL:%@ object:%@ options:%tu block:%@ (#%tu args)>", self.class, self, NSStringFromSelector(self.selector), self.object, self.options, self.block, self.blockSignature.numberOfArguments];
+}
+
+- (BOOL)remove {
+    return aspect_remove(self, NULL);
+}
+
+@end
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - AspectsContainer
+
+@implementation AspectsContainer
+
+- (BOOL)hasAspects {
+    return self.beforeAspects.count > 0 || self.insteadAspects.count > 0 || self.afterAspects.count > 0;
+}
+
+- (void)addAspect:(AspectIdentifier *)aspect withOptions:(AspectOptions)options {
+    NSParameterAssert(aspect);
+    NSUInteger position = options&AspectPositionFilter;
+    switch (position) {
+        case AspectPositionBefore:  self.beforeAspects  = [(self.beforeAspects ?:@[]) arrayByAddingObject:aspect]; break;
+        case AspectPositionInstead: self.insteadAspects = [(self.insteadAspects?:@[]) arrayByAddingObject:aspect]; break;
+        case AspectPositionAfter:   self.afterAspects   = [(self.afterAspects  ?:@[]) arrayByAddingObject:aspect]; break;
+    }
+}
+
+- (BOOL)removeAspect:(id)aspect {
+    for (NSString *aspectArrayName in @[NSStringFromSelector(@selector(beforeAspects)),
+                                        NSStringFromSelector(@selector(insteadAspects)),
+                                        NSStringFromSelector(@selector(afterAspects))]) {
+        NSArray *array = [self valueForKey:aspectArrayName];
+        NSUInteger index = [array indexOfObjectIdenticalTo:aspect];
+        if (array && index != NSNotFound) {
+            NSMutableArray *newArray = [NSMutableArray arrayWithArray:array];
+            [newArray removeObjectAtIndex:index];
+            [self setValue:newArray forKey:aspectArrayName];
+            return YES;
+        }
+    }
+    return NO;
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@: %p, before:%@, instead:%@, after:%@>", self.class, self, self.beforeAspects, self.insteadAspects, self.afterAspects];
+}
+
+@end
+
+///////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark - AspectInfo
+
+@implementation AspectInfo
+
+@synthesize arguments = _arguments;
+
+- (id)initWithInstance:(__unsafe_unretained id)instance invocation:(NSInvocation *)invocation {
+    NSCParameterAssert(instance);
+    NSCParameterAssert(invocation);
+    if (self = [super init]) {
+        _instance = instance;
+        _originalInvocation = invocation;
+    }
+    return self;
+}
+
+- (NSArray *)arguments {
+    // Lazily evaluate arguments, boxing is expensive.
+    if (!_arguments) {
+        _arguments = self.originalInvocation.aspects_arguments;
+    }
+    return _arguments;
+}
+
+@end

--- a/Test/Test Utilities/NSObject+TestSuite.m
+++ b/Test/Test Utilities/NSObject+TestSuite.m
@@ -1,7 +1,7 @@
 //
 
 #import "NSObject+TestSuite.h"
-#import <Aspects/Aspects.h>
+#import "Aspects.h"
 
 @implementation NSObject (TestSuite)
 

--- a/Test/Test Utilities/NSObject+TestSuite.swift
+++ b/Test/Test Utilities/NSObject+TestSuite.swift
@@ -1,5 +1,3 @@
-import Aspects
-
 extension NSObject {
 
     /// Inject a block of code to the identified class method.

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -3,8 +3,6 @@ import Foundation
 import XCTest
 import Nimble
 
-import Aspects
-
 import Ably.Private
 
 typealias HookToken = AspectToken

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -1,6 +1,5 @@
 import Ably
 import Ably.Private
-import Aspects
 import Nimble
 import XCTest
 

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -1,5 +1,4 @@
 import Ably
-import Aspects
 import Nimble
 import XCTest
 

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -1,5 +1,4 @@
 import Ably
-import Aspects
 import Nimble
 import XCTest
 

--- a/Test/Tests/RealtimeClientPresenceTests.swift
+++ b/Test/Tests/RealtimeClientPresenceTests.swift
@@ -1,5 +1,4 @@
 import Ably
-import Aspects
 import Foundation
 import Nimble
 import XCTest

--- a/Test/Tests/RestClientChannelTests.swift
+++ b/Test/Tests/RestClientChannelTests.swift
@@ -1225,16 +1225,16 @@ class RestClientChannelTests: XCTestCase {
                     }
                     
                     let jsonData = AblyTests.msgpackToData(httpBody)
-                    var model: ExpectedModel
+                    var model: ExpectedModel? = nil
                     do {
                         model = try jsonUtility.decode(data: jsonData)
                     } catch {
                         XCTFail("\(error)")
                     }
-                    if let s = model.data, let data = try? JSONSerialization.jsonObject(with: s.data(using: .utf8)!) {
+                    if let s = model?.data, let data = try? JSONSerialization.jsonObject(with: s.data(using: .utf8)!) {
                         // Make sure the formatting is the same by parsing
                         // and reformatting in the same way as the test case.
-                        model.data = jsonUtility.toJSONString(data)
+                        model?.data = jsonUtility.toJSONString(data)
                     }
 
                     XCTAssertEqual(model, caseTest.expected)
@@ -1275,14 +1275,14 @@ class RestClientChannelTests: XCTestCase {
                         done(); return
                     }
                     
-                    var model: ExpectedModel
+                    var model: ExpectedModel? = nil
                     do {
                         model = try jsonUtility.decode(data: AblyTests.msgpackToData(httpBody))
                     } catch {
                         XCTFail("\(error)")
                     }
                     
-                    XCTAssertEqual(model.encoding, caseItem.expected.encoding)
+                    XCTAssertEqual(model?.encoding, caseItem.expected.encoding)
                     done()
                 })
             }

--- a/Test/Tests/RestClientChannelsTests.swift
+++ b/Test/Tests/RestClientChannelsTests.swift
@@ -1,5 +1,4 @@
 import Ably
-import Aspects
 import Nimble
 import XCTest
 


### PR DESCRIPTION
Aspects dependency is 9yrs old code and it won't compile with Xcode 14.3 because of it's low deployment target config.
We could fork this repo and change configuration, but this is just one file (and header) so I decided to integrate it into project codebase.