### PR TITLE
Upload all Fastlane test output as an artifact

### DIFF
--- a/.github/workflows/integration-test-iOS16_2.yaml
+++ b/.github/workflows/integration-test-iOS16_2.yaml
@@ -89,6 +89,13 @@ jobs:
           name: xcodebuild-logs
           path: ~/Library/Developer/Xcode/DerivedData/*/Logs
 
+      - name: Upload test output artifact
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-output
+          path: fastlane/test_output
+
       - name: Upload test results to observability server
         if: always()
         env:

--- a/.github/workflows/integration-test-macOS.yaml
+++ b/.github/workflows/integration-test-macOS.yaml
@@ -84,6 +84,13 @@ jobs:
           name: xcodebuild-logs
           path: ~/Library/Developer/Xcode/DerivedData/*/Logs
 
+      - name: Upload test output artifact
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-output
+          path: fastlane/test_output
+
       - name: Upload test results to observability server
         if: always()
         env:

--- a/.github/workflows/integration-test-tvOS16_1.yaml
+++ b/.github/workflows/integration-test-tvOS16_1.yaml
@@ -84,6 +84,13 @@ jobs:
           name: xcodebuild-logs
           path: ~/Library/Developer/Xcode/DerivedData/*/Logs
 
+      - name: Upload test output artifact
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-output
+          path: fastlane/test_output
+
       - name: Upload test results to observability server
         if: always()
         env:


### PR DESCRIPTION
This contains all of the test reports, including the `.xcresult` bundles which contain rich test-related data such as screenshots and crash reports. Useful for getting further test failure data that isn’t captured in the printed logs, or for debugging the behaviour of the observability server upload script.