### PR TITLE
Upload `.ips` crash reports to observability server

### DIFF
--- a/Scripts/upload_test_results.sh
+++ b/Scripts/upload_test_results.sh
@@ -167,11 +167,11 @@ cd ..
 
 xcparse_attachment_descriptors_file="${xcparse_output_directory}/xcparseAttachmentDescriptors.json"
 
-# 7. Filter the output of xcparse to find just the crash reports (files whose name ends in .crash).
+# 7. Filter the output of xcparse to find just the crash reports (files whose name ends in .crash or .ips).
 
 filtered_xcparse_attachment_descriptors_file=$(mktemp)
 
-jq 'map(select(.attachmentName | endswith(".crash")))' < "${xcparse_attachment_descriptors_file}" > "${filtered_xcparse_attachment_descriptors_file}"
+jq 'map(select(.attachmentName | (endswith(".crash") or endswith(".ips"))))' < "${xcparse_attachment_descriptors_file}" > "${filtered_xcparse_attachment_descriptors_file}"
 
 declare -i number_of_filtered_attachments
 number_of_filtered_attachments=$(jq '. | length' < "${filtered_xcparse_attachment_descriptors_file}")


### PR DESCRIPTION
This is a [new crash report format added in iOS 15](https://developer.apple.com/documentation/xcode/interpreting-the-json-format-of-a-crash-report).

https://github.com/ably/test-observability/pull/72 adds a link for downloading the crash report, which can then be viewed in macOS.

Resolves #1688.