### PR TITLE
Log observability server URL of created upload

### DIFF
--- a/Scripts/upload_test_results.sh
+++ b/Scripts/upload_test_results.sh
@@ -243,4 +243,12 @@ then
   upload_server_base_url="https://test-observability.herokuapp.com"
 fi
 
-curl -vvv --fail-with-body --data-binary "@${temp_request_body_file}" --header "Content-Type: application/json" --header "Test-Observability-Auth-Key: ${TEST_OBSERVABILITY_SERVER_AUTH_KEY}" "${upload_server_base_url}/uploads"
+temp_response_body_file=$(mktemp)
+curl -vvv --fail-with-body --data-binary "@${temp_request_body_file}" --header "Content-Type: application/json" --header "Test-Observability-Auth-Key: ${TEST_OBSERVABILITY_SERVER_AUTH_KEY}" "${upload_server_base_url}/uploads" | tee "${temp_response_body_file}"
+echo 2>&1 # Print a newline to separate the `curl` output from the next log line.
+
+# 10. Extract the ID of the created upload and log the web UI URL.
+
+upload_id=$(jq --exit-status --raw-output '.id' < "${temp_response_body_file}")
+web_ui_url="${upload_server_base_url}/repos/${GITHUB_REPOSITORY}/uploads/${upload_id}"
+echo "Test results uploaded successfully: ${web_ui_url}"


### PR DESCRIPTION
This is useful when you start on a GitHub action run page and want to find the corresponding upload in the observability server UI.