### PR TITLE
Add `xcparse` directory to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ Examples/Tests/Podfile.lock
 # Jazzy Docs
 Docs/jazzy
 
+# Tooling
+xcparse/


### PR DESCRIPTION
Normally this tool is used in CI, but we also need it checked out locally if using the `local_dev_upload_test_results.sh` script.