### PR TITLE
Tidy up fastlane config

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,12 +2,18 @@ default_platform(:ios)
 
 class LaneConfig < Struct.new(:name, :scheme, :devices)
   def args_for_run_tests
+    ably_env = ENV['ABLY_ENV']
+
+    unless ably_env && !ably_env.empty?
+      raise 'You must provide ABLY_ENV as an environment variable.'
+    end
+
     {
       scheme: scheme,
       derived_data_path: "derived_data",
       devices: devices,
       test_without_building: false,
-      xcargs: { ABLY_ENV: ENV['ABLY_ENV'], CLANG_ANALYZER_OUTPUT: 'plist-html' },
+      xcargs: { ABLY_ENV: ably_env, CLANG_ANALYZER_OUTPUT: 'plist-html' },
       output_directory: "fastlane/test_output/sdk/#{name}"
     }
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,36 +1,30 @@
 default_platform(:ios)
 
+class LaneConfig < Struct.new(:name, :scheme, :devices)
+  def args_for_run_tests
+    {
+      scheme: scheme,
+      derived_data_path: "derived_data",
+      devices: devices,
+      test_without_building: false,
+      xcargs: { ABLY_ENV: ENV['ABLY_ENV'], CLANG_ANALYZER_OUTPUT: 'plist-html' },
+      output_directory: "fastlane/test_output/sdk/#{name}"
+    }
+  end
+end
+
 platform :ios do
 
-  lane :test_iOS16_2 do
-    run_tests(
-      scheme: "Ably-iOS-Tests",
-      derived_data_path: "derived_data",
-      devices: ["iPhone 14 (16.2)"],
-      test_without_building: false,
-      xcargs: { ABLY_ENV: ENV['ABLY_ENV'], CLANG_ANALYZER_OUTPUT: 'plist-html' },
-      output_directory: "fastlane/test_output/sdk/test_iOS16_2"
-    )
-  end
+  LANE_CONFIGS = [
+    LaneConfig.new(:test_iOS16_2, "Ably-iOS-Tests", ["iPhone 14 (16.2)"]),
+    LaneConfig.new(:test_tvOS16_1, "Ably-tvOS-Tests", ["Apple TV 4K (2nd generation) (16.1)"]),
+    LaneConfig.new(:test_macOS, "Ably-macOS-Tests")
+  ]
 
-  lane :test_tvOS16_1 do
-    run_tests(
-      scheme: "Ably-tvOS-Tests",
-      derived_data_path: "derived_data",
-      devices: ["Apple TV 4K (2nd generation) (16.1)"],
-      xcargs: { ABLY_ENV: ENV['ABLY_ENV'], CLANG_ANALYZER_OUTPUT: 'plist-html' },
-      output_directory: "fastlane/test_output/sdk/test_tvOS16_1"
-    )
-  end
-
-  lane :test_macOS do
-    run_tests(
-      scheme: "Ably-macOS-Tests",
-      derived_data_path: "derived_data",
-      test_without_building: false,
-      xcargs: { ABLY_ENV: ENV['ABLY_ENV'], CLANG_ANALYZER_OUTPUT: 'plist-html' },
-      output_directory: "fastlane/test_output/sdk/test_macOS"
-    )
+  LANE_CONFIGS.each do |lane_config|
+    lane(lane_config.name) do
+      run_tests(**lane_config.args_for_run_tests)
+    end
   end
 
 end


### PR DESCRIPTION
I was getting an unhelpful error message when running fastlane without the `ABLY_ENV` environment variable set. This PR refactors the `Fastfile` a bit and then shows a more useful error message when this variable is missing.