### PR TITLE
Make testing target language and region fixed

### DIFF
--- a/Test/Ably-iOS.xctestplan
+++ b/Test/Ably-iOS.xctestplan
@@ -9,7 +9,9 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false
+    "codeCoverage" : false,
+    "language" : "en",
+    "region" : "US"
   },
   "testTargets" : [
     {

--- a/Test/Ably-macOS.xctestplan
+++ b/Test/Ably-macOS.xctestplan
@@ -9,7 +9,9 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false
+    "codeCoverage" : false,
+    "language" : "en",
+    "region" : "US"
   },
   "testTargets" : [
     {

--- a/Test/Ably-tvOS.xctestplan
+++ b/Test/Ably-tvOS.xctestplan
@@ -9,7 +9,9 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false
+    "codeCoverage" : false,
+    "language" : "en",
+    "region" : "US"
   },
   "testTargets" : [
     {


### PR DESCRIPTION
Som of the test depend or could depend on localized data (example below) 
![CleanShot 2023-04-27 at 12 28 27@2x](https://user-images.githubusercontent.com/130652619/235100844-cef14330-2aa0-4b13-bac3-028b4b76d1b6.png)

so the region and language for testing targets should be fixed. 
This change is fixing language to `EN` and region to `United States`