### PR TITLE
Fix/1626 handle reachability events

### DIFF
--- a/Source/ARTTestClientOptions.m
+++ b/Source/ARTTestClientOptions.m
@@ -21,6 +21,7 @@
     copied.realtimeRequestTimeout = self.realtimeRequestTimeout;
     copied.shuffleArray = self.shuffleArray;
     copied.transportFactory = self.transportFactory;
+    copied.reconnectionRealtimeHost = self.reconnectionRealtimeHost;
 
     return copied;
 }

--- a/Source/PrivateHeaders/Ably/ARTTestClientOptions.h
+++ b/Source/PrivateHeaders/Ably/ARTTestClientOptions.h
@@ -31,6 +31,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) id<ARTRealtimeTransportFactory> transportFactory;
 
+/**
+ RTN20c helper.
+ This property is used to provide a way for the test code to simulate the case where a reconnection attempt results in a different outcome to the original connection attempt. Initial value is `nil`.
+ */
+@property (readwrite, nonatomic) NSString *reconnectionRealtimeHost;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This is based on https://github.com/ably/ably-cocoa/pull/1691
Closes #1626

See commit comments for more details.