### PR TITLE
Remove some easily-avoidable use of `try!` in tests

### DIFF
--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -147,7 +147,7 @@ class AblyTests {
 
             let (responseData, _) = try SynchronousHTTPClient().perform(request)
 
-            app = try! JSONUtility.jsonObject(data: responseData)
+            app = try JSONUtility.jsonObject(data: responseData)
             testApplication = app
             
             if debug {
@@ -718,7 +718,12 @@ func extractBodyAsMsgPack(_ request: URLRequest?) -> Result<NSDictionary> {
     guard let bodyData = request.httpBody
         else { return Result(error: "No HTTPBody") }
 
-    let json = try! ARTMsgPackEncoder().decode(bodyData)
+    let json: Any
+    do {
+        json = try ARTMsgPackEncoder().decode(bodyData)
+    } catch {
+        return Result(error: error.localizedDescription)
+    }
 
     guard let httpBody = json as? NSDictionary
         else { return Result(error: "expected dictionary, got \(type(of: (json) as AnyObject)): \(json)") }
@@ -733,7 +738,12 @@ func extractBodyAsMessages(_ request: URLRequest?) -> Result<[NSDictionary]> {
     guard let bodyData = request.httpBody
         else { return Result(error: "No HTTPBody") }
 
-    let json = try! ARTMsgPackEncoder().decode(bodyData)
+    let json: Any
+    do {
+        json = try ARTMsgPackEncoder().decode(bodyData)
+    } catch {
+        return Result(error: error.localizedDescription)
+    }
 
     guard let httpBody = json as? NSArray
         else { return Result(error: "expected array, got \(type(of: (json) as AnyObject)): \(json)") }

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -3272,7 +3272,7 @@ class RealtimeClientChannelTests: XCTestCase {
         let channel = client.channels.get(uniqueChannelName(), options: channelOptions)
 
         let expectedMessage = ["key": 1]
-        let expectedData = try! JSONSerialization.data(withJSONObject: expectedMessage, options: JSONSerialization.WritingOptions(rawValue: 0))
+        let expectedData = try JSONSerialization.data(withJSONObject: expectedMessage, options: JSONSerialization.WritingOptions(rawValue: 0))
 
         let transport = client.internal.transport as! TestProxyTransport
 

--- a/Test/Tests/RestClientChannelTests.swift
+++ b/Test/Tests/RestClientChannelTests.swift
@@ -924,7 +924,7 @@ class RestClientChannelTests: XCTestCase {
         query.direction = .forwards
         query.limit = 2
 
-        try! channel.history(query) { result, error in
+        try channel.history(query) { result, error in
             guard let result = result else {
                 fail("Result is empty"); return
             }
@@ -1197,14 +1197,14 @@ class RestClientChannelTests: XCTestCase {
     // RSL4
 
     // RSL4a
-    func test__036__message_encoding__payloads_should_be_binary__strings__or_objects_capable_of_JSON_representation() {
+    func test__036__message_encoding__payloads_should_be_binary__strings__or_objects_capable_of_JSON_representation() throws {
         let validCases: [TestCase] = [
             TestCase(value: nil, expected: .with([:] as [String: Any])),
             TestCase(value: text, expected: .with(["data": text])),
             TestCase(value: integer, expected: .with(["data": integer])),
             TestCase(value: decimal, expected: .with(["data": decimal])),
-            TestCase(value: dictionary, expected: .with(["data": try! JSONUtility.toJSONString(dictionary), "encoding": "json"])),
-            TestCase(value: array, expected: .with(["data": try! JSONUtility.toJSONString(array), "encoding": "json"])),
+            TestCase(value: dictionary, expected: .with(["data": try JSONUtility.toJSONString(dictionary), "encoding": "json"])),
+            TestCase(value: array, expected: .with(["data": try JSONUtility.toJSONString(array), "encoding": "json"])),
             TestCase(value: binaryData, expected: .with(["data": binaryData.toBase64, "encoding": "base64"])),
         ]
         

--- a/Test/Tests/RestClientChannelsTests.swift
+++ b/Test/Tests/RestClientChannelsTests.swift
@@ -11,7 +11,7 @@ extension ARTRestChannels: Sequence {
 
 private func beAChannel(named expectedValue: String) -> Predicate<ARTChannel> {
     return Predicate.define("be a channel with name \"\(expectedValue)\"") { actualExpression, msg -> PredicateResult in
-        let actualValue = try! actualExpression.evaluate()
+        let actualValue = try actualExpression.evaluate()
         let m = msg.appended(details: "\"\(actualValue?.name ?? "nil")\" instead")
         return PredicateResult(status: PredicateStatus(bool: actualValue?.name == expectedValue), message: m)
     }

--- a/Test/Tests/RestClientTests.swift
+++ b/Test/Tests/RestClientTests.swift
@@ -1588,7 +1588,7 @@ class RestClientTests: XCTestCase {
         }
 
         let transport = realtime.internal.transport as! TestProxyTransport
-        let jsonArray: [[String: Any]] = transport.rawDataSent.map { try! JSONUtility.jsonObject(data: AblyTests.msgpackToData($0)) }
+        let jsonArray: [[String: Any]] = try transport.rawDataSent.map { try JSONUtility.jsonObject(data: AblyTests.msgpackToData($0)) }
         let messageJson = jsonArray.filter { item in (item["action"] as! Int) == 15 }.last!
         let messages = messageJson["messages"] as! [[String: Any]]
         XCTAssertEqual(messages[0]["data"] as? String, "message")
@@ -1625,7 +1625,7 @@ class RestClientTests: XCTestCase {
         }
 
         let transport = realtime.internal.transport as! TestProxyTransport
-        let object = try! JSONSerialization.jsonObject(with: transport.rawDataSent.first!, options: JSONSerialization.ReadingOptions(rawValue: 0))
+        let object = try JSONSerialization.jsonObject(with: transport.rawDataSent.first!, options: JSONSerialization.ReadingOptions(rawValue: 0))
         XCTAssertTrue(JSONSerialization.isValidJSONObject(object))
     }
 

--- a/Test/Tests/UtilitiesTests.swift
+++ b/Test/Tests/UtilitiesTests.swift
@@ -43,7 +43,7 @@ class UtilitiesTests: XCTestCase {
         jsonEncoder.delegate = ARTJsonEncoder()
     }
 
-    func test__001__Utilities__JSON_Encoder__should_decode_a_protocol_message_that_has_an_error_without_a_message() {
+    func test__001__Utilities__JSON_Encoder__should_decode_a_protocol_message_that_has_an_error_without_a_message() throws {
         beforeEach__Utilities__JSON_Encoder()
 
         let jsonObject: NSDictionary = [
@@ -53,7 +53,7 @@ class UtilitiesTests: XCTestCase {
                 "statusCode": "401",
             ],
         ]
-        let data = try! JSONSerialization.data(withJSONObject: jsonObject, options: [])
+        let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
         guard let protocolMessage = try? jsonEncoder.decodeProtocolMessage(data) else {
             fail("Decoder has failed"); return
         }


### PR DESCRIPTION
The one I particularly care about is the one in
`TestUtilities.commonAppSetup`, which has caused several crashes in CI when the sandbox is not behaving nicely.