### PR TITLE
Add ability to specify a factory for creating `ARTWebSocket` object

### DIFF
--- a/Ably-SoakTest-AppUITests/SoakTest.swift
+++ b/Ably-SoakTest-AppUITests/SoakTest.swift
@@ -20,7 +20,6 @@ class SoakTest: XCTestCase {
     }
 
     func testSoak() {
-        ARTWebSocketTransport.setWebSocketClass(SoakTestWebSocket.self)
         ARTHttp.setURLSessionClass(SoakTestURLSession.self)
         
         var shouldStop = DispatchQueue(label: "io.ably.soakTest.shouldStop").syncValue(false)
@@ -43,6 +42,7 @@ class SoakTest: XCTestCase {
                 options.logLevel = .error
                 options.dispatchQueue = queue
                 options.internalDispatchQueue = internalQueue
+                options.testOptions.transportFactory = SoakTestRealtimeTransportFactory()
                 let realtime = ARTRealtime(options: options)
                 realtime.internal.setReachabilityClass(SoakTestReachability.self)
 

--- a/Ably-SoakTest-AppUITests/SoakTestWebSocket.swift
+++ b/Ably-SoakTest-AppUITests/SoakTestWebSocket.swift
@@ -9,7 +9,7 @@ import Foundation
 import Ably.Private
 
 class SoakTestWebSocket: NSObject, ARTWebSocket {
-    var readyState: ARTSRReadyState
+    var readyState: ARTWebSocketReadyState
     var queue: DispatchQueue!
     var delegate: ARTWebSocketDelegate?
 

--- a/Ably-SoakTest-AppUITests/SoakTestWebSocket.swift
+++ b/Ably-SoakTest-AppUITests/SoakTestWebSocket.swift
@@ -17,7 +17,7 @@ class SoakTestWebSocket: NSObject, ARTWebSocket {
     let nextConnectionSerial: () -> Int64
 
     required init(urlRequest request: URLRequest) {
-        readyState = .CLOSED
+        readyState = .closed
         // TODO (maybe?): Extract connectionKey from params, resume conn state if
         // connectionStateTtl hasn't passed yet.
         nextConnectionSerial = serialSequence(label: "fakeConnection.\(id)", first: -1)
@@ -28,10 +28,10 @@ class SoakTestWebSocket: NSObject, ARTWebSocket {
     }
     
     func open() {
-        readyState = .CONNECTING
+        readyState = .connecting
         queue.afterSeconds(between: 0.1 ... ARTDefault.realtimeRequestTimeout() + 1.0) {
             if true.times(9, outOf: 10) {
-                self.readyState = .OPEN
+                self.readyState = .open
                 self.delegate?.webSocketDidOpen(self)
                 
                 self.doIfStillOpen(afterSecondsBetween: 0.1 ... 3.0) {
@@ -96,12 +96,12 @@ class SoakTestWebSocket: NSObject, ARTWebSocket {
     }
     
     func close(withCode code: Int, reason: String?) {
-        readyState = .CLOSING
+        readyState = .closing
         queue.afterSeconds(between: 0.1 ... 3.0) {
-            if self.readyState != .CLOSING {
+            if self.readyState != .closing {
                 return
             }
-            self.readyState = .CLOSED
+            self.readyState = .closed
         }
     }
     
@@ -317,7 +317,7 @@ class SoakTestWebSocket: NSObject, ARTWebSocket {
     
     func doIfStillOpen(afterSecondsBetween between: ClosedRange<TimeInterval>, execute: @escaping () -> Void) {
         queue.afterSeconds(between: between) {
-            if self.readyState != .OPEN {
+            if self.readyState != .open {
                 return
             }
             execute()

--- a/Ably-SoakTest-AppUITests/SoakTestWebSocket.swift
+++ b/Ably-SoakTest-AppUITests/SoakTestWebSocket.swift
@@ -8,9 +8,28 @@
 import Foundation
 import Ably.Private
 
+class SoakTestWebSocketFactory: WebSocketFactory {
+    func createWebSocket(with request: URLRequest, logger: InternalLog?) -> ARTWebSocket {
+        return SoakTestWebSocket(urlRequest: request)
+    }
+}
+
+class SoakTestRealtimeTransportFactory: RealtimeTransportFactory {
+    func transport(withRest rest: ARTRestInternal, options: ARTClientOptions, resumeKey: String?, connectionSerial: NSNumber?, logger: InternalLog) -> ARTRealtimeTransport {
+        return ARTWebSocketTransport(
+            rest: rest,
+            options: options,
+            resumeKey: resumeKey,
+            connectionSerial: connectionSerial,
+            logger: logger,
+            webSocketFactory: SoakTestWebSocketFactory()
+        )
+    }
+}
+
 class SoakTestWebSocket: NSObject, ARTWebSocket {
     var readyState: ARTWebSocketReadyState
-    var queue: DispatchQueue!
+    var delegateDispatchQueue: DispatchQueue?
     var delegate: ARTWebSocketDelegate?
 
     let id = nextGlobalSerial()
@@ -23,16 +42,12 @@ class SoakTestWebSocket: NSObject, ARTWebSocket {
         nextConnectionSerial = serialSequence(label: "fakeConnection.\(id)", first: -1)
     }
     
-    func setDelegateDispatchQueue(_ queue: DispatchQueue) {
-        self.queue = queue
-    }
-    
     func open() {
         readyState = .connecting
-        queue.afterSeconds(between: 0.1 ... ARTDefault.realtimeRequestTimeout() + 1.0) {
+        delegateDispatchQueue!.afterSeconds(between: 0.1 ... ARTDefault.realtimeRequestTimeout() + 1.0) {
             if true.times(9, outOf: 10) {
                 self.readyState = .open
-                self.delegate?.webSocketDidOpen(self)
+                self.delegate?.webSocketDidOpen?(self)
                 
                 self.doIfStillOpen(afterSecondsBetween: 0.1 ... 3.0) {
                     if true.times(9, outOf: 10) {
@@ -67,10 +82,10 @@ class SoakTestWebSocket: NSObject, ARTWebSocket {
                         (.codeMessageTooBig, true),
                         (.codeInternalError, true),
                     ].randomElement(using: &seededRandomNumberGenerator)!
-                    self.delegate?.webSocket(self, didCloseWithCode: code.rawValue, reason: "fake close", wasClean: clean)
+                    self.delegate?.webSocket?(self, didCloseWithCode: code.rawValue, reason: "fake close", wasClean: clean)
                 }
             } else {
-                self.delegate?.webSocket(self, didFailWithError: fakeError)
+                self.delegate?.webSocket?(self, didFailWithError: fakeError)
             }
         }
     }
@@ -92,12 +107,12 @@ class SoakTestWebSocket: NSObject, ARTWebSocket {
     
     func messageToClient(action: ARTProtocolMessageAction, setUp: (ARTProtocolMessage) -> Void = { _ in }) {
         let message = protocolMessage(action: action, setUp: setUp)
-        self.delegate?.webSocket(self, didReceiveMessage: message)
+        self.delegate?.webSocket?(self, didReceiveMessage: message)
     }
     
     func close(withCode code: Int, reason: String?) {
         readyState = .closing
-        queue.afterSeconds(between: 0.1 ... 3.0) {
+        delegateDispatchQueue!.afterSeconds(between: 0.1 ... 3.0) {
             if self.readyState != .closing {
                 return
             }
@@ -139,11 +154,11 @@ class SoakTestWebSocket: NSObject, ARTWebSocket {
             doIfStillOpen(afterSecondsBetween: 0.1 ... 3.0) {
                 self.messageToClient(action: .closed)
                 self.doIfStillOpen(afterSecondsBetween: 0.1 ... 0.5) {
-                    self.delegate?.webSocket(self, didCloseWithCode: 1000, reason: nil, wasClean: true)
+                    self.delegate?.webSocket?(self, didCloseWithCode: 1000, reason: nil, wasClean: true)
                 }
             }
         case .message:
-            queue.async {
+            delegateDispatchQueue!.async {
                 self.pendingSerials.append(message.msgSerial!)
             }
         case .attach:
@@ -316,7 +331,7 @@ class SoakTestWebSocket: NSObject, ARTWebSocket {
     }
     
     func doIfStillOpen(afterSecondsBetween between: ClosedRange<TimeInterval>, execute: @escaping () -> Void) {
-        queue.afterSeconds(between: between) {
+        delegateDispatchQueue!.afterSeconds(between: between) {
             if self.readyState != .open {
                 return
             }

--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -265,6 +265,12 @@
 		21881E7A283BD08300CFD9E2 /* GCDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A22171266F526600C87C42 /* GCDTests.swift */; };
 		21881E7B283BD0DF00CFD9E2 /* StringifiableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D520C4DD2680A1E3000012B2 /* StringifiableTests.swift */; };
 		21881E7C283BD0E100CFD9E2 /* StringifiableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D520C4DD2680A1E3000012B2 /* StringifiableTests.swift */; };
+		21E1C0E52A0DC47400A5DB65 /* ARTWebSocketFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 21E1C0E42A0DC47400A5DB65 /* ARTWebSocketFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		21E1C0E62A0DC47400A5DB65 /* ARTWebSocketFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 21E1C0E42A0DC47400A5DB65 /* ARTWebSocketFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		21E1C0E72A0DC47400A5DB65 /* ARTWebSocketFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 21E1C0E42A0DC47400A5DB65 /* ARTWebSocketFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		21E1C0E92A0DC5E600A5DB65 /* ARTWebSocketFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 21E1C0E82A0DC5E600A5DB65 /* ARTWebSocketFactory.m */; };
+		21E1C0EA2A0DC5E600A5DB65 /* ARTWebSocketFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 21E1C0E82A0DC5E600A5DB65 /* ARTWebSocketFactory.m */; };
+		21E1C0EB2A0DC5E600A5DB65 /* ARTWebSocketFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 21E1C0E82A0DC5E600A5DB65 /* ARTWebSocketFactory.m */; };
 		21FD9F272A015BE400216482 /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FD9F262A015BE400216482 /* Test.swift */; };
 		21FD9F282A015BE400216482 /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FD9F262A015BE400216482 /* Test.swift */; };
 		21FD9F292A015BE400216482 /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FD9F262A015BE400216482 /* Test.swift */; };
@@ -1218,6 +1224,8 @@
 		21DCDA8229F818630073A211 /* Ably-iOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Ably-iOS.xctestplan"; path = "Test/Ably-iOS.xctestplan"; sourceTree = SOURCE_ROOT; };
 		21DCDA8329F81B350073A211 /* Ably-macOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Ably-macOS.xctestplan"; sourceTree = "<group>"; };
 		21DCDA8429F81B550073A211 /* Ably-tvOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Ably-tvOS.xctestplan"; sourceTree = "<group>"; };
+		21E1C0E42A0DC47400A5DB65 /* ARTWebSocketFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTWebSocketFactory.h; path = PrivateHeaders/ARTWebSocketFactory.h; sourceTree = "<group>"; };
+		21E1C0E82A0DC5E600A5DB65 /* ARTWebSocketFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWebSocketFactory.m; sourceTree = "<group>"; };
 		21FD9F262A015BE400216482 /* Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test.swift; sourceTree = "<group>"; };
 		560579D824AF1BA900A4D03D /* ARTDefaultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARTDefaultTests.swift; sourceTree = "<group>"; };
 		56190953238C3D3200A862A6 /* CryptoTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CryptoTest.m; sourceTree = "<group>"; };
@@ -1952,6 +1960,8 @@
 				96E408461A3895E800087F77 /* ARTWebSocketTransport.m */,
 				EB20F8D61C653F1E00EF3978 /* ARTPresence+Private.h */,
 				EBB721C42376A948001C3550 /* ARTWebSocket.h */,
+				21E1C0E42A0DC47400A5DB65 /* ARTWebSocketFactory.h */,
+				21E1C0E82A0DC5E600A5DB65 /* ARTWebSocketFactory.m */,
 			);
 			name = Transport;
 			sourceTree = "<group>";
@@ -2347,6 +2357,7 @@
 				D75A3F1B1DDE5B62002A4AAD /* ARTGCD.h in Headers */,
 				D3AD0EBD215E2FB000312105 /* ARTNSString+ARTUtil.h in Headers */,
 				EB2D85011CD769C800F23CDA /* ARTOSReachability.h in Headers */,
+				21E1C0E52A0DC47400A5DB65 /* ARTWebSocketFactory.h in Headers */,
 				EB1B541522FB1CE1006A59AC /* ARTPushDeviceRegistrations+Private.h in Headers */,
 				D7D8F82B1BC2C706009718F2 /* ARTTokenRequest.h in Headers */,
 				2132C30929D5D18E000C4355 /* ARTConstantRetryDelayCalculator.h in Headers */,
@@ -2415,6 +2426,7 @@
 				D710D56C21949CB9008F54AD /* ARTPushChannelSubscriptions.h in Headers */,
 				D710D56721949CA1008F54AD /* ARTPushActivationStateMachine+Private.h in Headers */,
 				D798556123ECCDAF00946BE2 /* ARTVCDiffDecoder.h in Headers */,
+				21E1C0E62A0DC47400A5DB65 /* ARTWebSocketFactory.h in Headers */,
 				2132C32129D5FE74000C4355 /* ARTTypes+Private.h in Headers */,
 				D710D68D21949EED008F54AD /* ARTEventEmitter.h in Headers */,
 				D710D60C21949DDB008F54AD /* ARTHttp.h in Headers */,
@@ -2582,6 +2594,7 @@
 				EBB721CD2376B454001C3550 /* ARTURLSession.h in Headers */,
 				D710D4D021949BB3008F54AD /* ARTWebSocketTransport+Private.h in Headers */,
 				D710D57221949CBA008F54AD /* ARTPushChannelSubscriptions.h in Headers */,
+				21E1C0E72A0DC47400A5DB65 /* ARTWebSocketFactory.h in Headers */,
 				2132C32229D5FE74000C4355 /* ARTTypes+Private.h in Headers */,
 				D710D56921949CA2008F54AD /* ARTPushActivationStateMachine+Private.h in Headers */,
 				D798556223ECCDAF00946BE2 /* ARTVCDiffDecoder.h in Headers */,
@@ -3162,6 +3175,7 @@
 				D5BB211B26AA9AA700AA5F3E /* ARTNSMutableDictionary+ARTDictionaryUtil.m in Sources */,
 				2132C31529D5E50A000C4355 /* ARTBackoffRetryDelayCalculator.m in Sources */,
 				D768C6AD1E4B5B0200436011 /* ARTDevicePushDetails.m in Sources */,
+				21E1C0E92A0DC5E600A5DB65 /* ARTWebSocketFactory.m in Sources */,
 				1C6C18A41ADFDAB100AB79E4 /* ARTLog.m in Sources */,
 				D70EAAEE1BC3376200CD8B9E /* ARTRestChannel.m in Sources */,
 				EB1B540522F8DA05006A59AC /* ARTQueuedDealloc.m in Sources */,
@@ -3400,6 +3414,7 @@
 				D5BB211A26AA9AA600AA5F3E /* ARTNSMutableDictionary+ARTDictionaryUtil.m in Sources */,
 				2132C31629D5E50A000C4355 /* ARTBackoffRetryDelayCalculator.m in Sources */,
 				D710D63021949E03008F54AD /* ARTPaginatedResult.m in Sources */,
+				21E1C0EA2A0DC5E600A5DB65 /* ARTWebSocketFactory.m in Sources */,
 				D710D5E121949D78008F54AD /* ARTStatus.m in Sources */,
 				EB1B540622F8DA05006A59AC /* ARTQueuedDealloc.m in Sources */,
 				D710D53321949C54008F54AD /* ARTPushChannelSubscription.m in Sources */,
@@ -3524,6 +3539,7 @@
 				D710D64021949E04008F54AD /* ARTPaginatedResult.m in Sources */,
 				2132C31729D5E50A000C4355 /* ARTBackoffRetryDelayCalculator.m in Sources */,
 				D710D60721949D79008F54AD /* ARTStatus.m in Sources */,
+				21E1C0EB2A0DC5E600A5DB65 /* ARTWebSocketFactory.m in Sources */,
 				D5C0CB42268317B500C06521 /* NSURLQueryItem+Stringifiable.m in Sources */,
 				EB1B540722F8DA05006A59AC /* ARTQueuedDealloc.m in Sources */,
 				D710D54521949C55008F54AD /* ARTPushChannelSubscription.m in Sources */,

--- a/Source/ARTRealtimeTransportFactory.m
+++ b/Source/ARTRealtimeTransportFactory.m
@@ -1,14 +1,18 @@
 #import "ARTRealtimeTransportFactory.h"
 #import "ARTWebsocketTransport+Private.h"
+#import "ARTWebSocketFactory.h"
 
 @implementation ARTDefaultRealtimeTransportFactory
 
 - (id<ARTRealtimeTransport>)transportWithRest:(ARTRestInternal *)rest options:(ARTClientOptions *)options resumeKey:(NSString *)resumeKey connectionSerial:(NSNumber *)connectionSerial logger:(ARTInternalLog *)logger {
+    const id<ARTWebSocketFactory> webSocketFactory = [[ARTDefaultWebSocketFactory alloc] init];
+
     return [[ARTWebSocketTransport alloc] initWithRest:rest
                                                options:options
                                              resumeKey:resumeKey
                                       connectionSerial:connectionSerial
-                                                logger:logger];
+                                                logger:logger
+                                      webSocketFactory:webSocketFactory];
 }
 
 @end

--- a/Source/ARTWebSocketFactory.m
+++ b/Source/ARTWebSocketFactory.m
@@ -1,0 +1,10 @@
+#import "ARTWebSocketFactory.h"
+#import "ARTSRWebSocket.h"
+
+@implementation ARTDefaultWebSocketFactory
+
+- (id<ARTWebSocket>)createWebSocketWithURLRequest:(NSURLRequest *)request logger:(ARTInternalLog *)logger {
+    return [[ARTSRWebSocket alloc] initWithURLRequest:request logger:logger];
+}
+
+@end

--- a/Source/ARTWebSocketTransport.m
+++ b/Source/ARTWebSocketTransport.m
@@ -34,7 +34,7 @@ enum {
     ARTWsTlsError = 1015
 };
 
-NSString *WebSocketStateToStr(ARTSRReadyState state);
+NSString *WebSocketStateToStr(ARTWebSocketReadyState state);
 
 @interface ARTSRWebSocket () <ARTWebSocket>
 @end
@@ -371,7 +371,7 @@ Class configuredWebsocketClass = nil;
 
 @end
 
-NSString *WebSocketStateToStr(ARTSRReadyState state) {
+NSString *WebSocketStateToStr(ARTWebSocketReadyState state) {
     switch (state) {
         case ARTSR_CONNECTING:
             return @"Connecting"; //0

--- a/Source/ARTWebSocketTransport.m
+++ b/Source/ARTWebSocketTransport.m
@@ -83,7 +83,7 @@ Class configuredWebsocketClass = nil;
 }
 
 - (BOOL)send:(NSData *)data withSource:(id)decodedObject {
-    if (self.websocket.readyState == ARTSR_OPEN) {
+    if (self.websocket.readyState == ARTWebSocketReadyStateOpen) {
         [self.websocket send:data];
         return true;
     }
@@ -242,7 +242,7 @@ Class configuredWebsocketClass = nil;
 }
 
 - (ARTRealtimeTransportState)state {
-    if (self.websocket.readyState == ARTSR_OPEN) {
+    if (self.websocket.readyState == ARTWebSocketReadyStateOpen) {
         return ARTRealtimeTransportStateOpened;
     }
     return _state;
@@ -334,7 +334,7 @@ Class configuredWebsocketClass = nil;
 - (void)webSocket:(id<ARTWebSocket>)webSocket didReceiveMessage:(id)message {
     ARTLogVerbose(self.logger, @"R:%p WS:%p websocket did receive message", _delegate, self);
 
-    if (self.websocket.readyState == ARTSR_CLOSED) {
+    if (self.websocket.readyState == ARTWebSocketReadyStateClosed) {
         ARTLogDebug(self.logger, @"R:%p WS:%p websocket is closed, message has been ignored", _delegate, self);
         return;
     }
@@ -373,13 +373,13 @@ Class configuredWebsocketClass = nil;
 
 NSString *WebSocketStateToStr(ARTWebSocketReadyState state) {
     switch (state) {
-        case ARTSR_CONNECTING:
+        case ARTWebSocketReadyStateConnecting:
             return @"Connecting"; //0
-        case ARTSR_OPEN:
+        case ARTWebSocketReadyStateOpen:
             return @"Open"; //1
-        case ARTSR_CLOSING:
+        case ARTWebSocketReadyStateClosing:
             return @"Closing"; //2
-        case ARTSR_CLOSED:
+        case ARTWebSocketReadyStateClosed:
             return @"Closed"; //3
     }
 }

--- a/Source/ARTWebSocketTransport.m
+++ b/Source/ARTWebSocketTransport.m
@@ -36,9 +36,6 @@ enum {
 
 NSString *WebSocketStateToStr(ARTWebSocketReadyState state);
 
-@interface ARTSRWebSocket () <ARTWebSocket>
-@end
-
 Class configuredWebsocketClass = nil;
 
 @implementation ARTWebSocketTransport {
@@ -252,7 +249,7 @@ Class configuredWebsocketClass = nil;
     _state = state;
 }
 
-#pragma mark - ARTSRWebSocketDelegate
+#pragma mark - ARTWebSocketDelegate
 
 // All delegate methods from SocketRocket are called from rest's serial queue,
 // since we pass it as delegate queue on setupWebSocket. So we can safely

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -107,5 +107,6 @@ framework module Ably {
         header "ARTDataEncoder.h"
         header "ARTRealtimeTransportFactory.h"
         header "ARTContinuousClock.h"
+        header "ARTWebSocketFactory.h"
     }
 }

--- a/Source/PrivateHeaders/ARTWebSocketFactory.h
+++ b/Source/PrivateHeaders/ARTWebSocketFactory.h
@@ -1,0 +1,25 @@
+@import Foundation;
+
+@protocol ARTWebSocket;
+@class ARTInternalLog;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ A factory for creating an `ARTWebSocket` object.
+ */
+NS_SWIFT_NAME(WebSocketFactory)
+@protocol ARTWebSocketFactory
+
+- (id<ARTWebSocket>)createWebSocketWithURLRequest:(NSURLRequest *)request logger:(nullable ARTInternalLog *)logger;
+
+@end
+
+/**
+ The implementation of `ARTWebSocketFactory` that should be used in non-test code.
+ */
+NS_SWIFT_NAME(DefaultWebSocketFactory)
+@interface ARTDefaultWebSocketFactory: NSObject <ARTWebSocketFactory>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTWebSocket.h
+++ b/Source/PrivateHeaders/Ably/ARTWebSocket.h
@@ -31,12 +31,95 @@ typedef NS_ENUM(NSInteger, ARTWebSocketReadyState) {
 
 @end
 
+/**
+ The `ARTWebSocketDelegate` protocol describes the methods that `ARTWebSocket` objects
+ call on their delegates to handle status and messsage events.
+
+ This protocol was previously in the SocketRocket library and named ARTSRWebSocketDelegate; all documentation comments have been copied verbatim.
+ */
 @protocol ARTWebSocketDelegate <NSObject>
 
-- (void)webSocketDidOpen:(id<ARTWebSocket>)websocket;
-- (void)webSocket:(id<ARTWebSocket>)webSocket didCloseWithCode:(NSInteger)code reason:(NSString * _Nullable)reason wasClean:(BOOL)wasClean;
-- (void)webSocket:(id<ARTWebSocket>)webSocket didFailWithError:(NSError *)error;
+@optional
+
+#pragma mark Receive Messages
+
+/**
+ Called when any message was received from a web socket.
+ This method is suboptimal and might be deprecated in a future release.
+
+ @param webSocket An `ARTWebSocket` object that received a message.
+ @param message   Received message. Either a `String` or `NSData`.
+ */
 - (void)webSocket:(id<ARTWebSocket>)webSocket didReceiveMessage:(id)message;
+
+/**
+ Called when a frame was received from a web socket.
+
+ @param webSocket An `ARTWebSocket` object that received a message.
+ @param string    Received text in a form of UTF-8 `String`.
+ */
+- (void)webSocket:(id<ARTWebSocket>)webSocket didReceiveMessageWithString:(NSString *)string;
+
+/**
+ Called when a frame was received from a web socket.
+
+ @param webSocket An `ARTWebSocket` object that received a message.
+ @param data      Received data in a form of `NSData`.
+ */
+- (void)webSocket:(id<ARTWebSocket>)webSocket didReceiveMessageWithData:(NSData *)data;
+
+#pragma mark Status & Connection
+
+/**
+ Called when a given web socket was open and authenticated.
+
+ @param webSocket An `ARTWebSocket` object that was open.
+ */
+- (void)webSocketDidOpen:(id<ARTWebSocket>)webSocket;
+
+/**
+ Called when a given web socket encountered an error.
+
+ @param webSocket An `ARTWebSocket` object that failed with an error.
+ @param error     An instance of `NSError`.
+ */
+- (void)webSocket:(id<ARTWebSocket>)webSocket didFailWithError:(NSError *)error;
+
+/**
+ Called when a given web socket was closed.
+
+ @param webSocket An `ARTWebSocket` object that was closed.
+ @param code      Code reported by the server.
+ @param reason    Reason in a form of a String that was reported by the server or `nil`.
+ @param wasClean  Boolean value indicating whether a socket was closed in a clean state.
+ */
+- (void)webSocket:(id<ARTWebSocket>)webSocket didCloseWithCode:(NSInteger)code reason:(nullable NSString *)reason wasClean:(BOOL)wasClean;
+
+/**
+ Called on receive of a ping message from the server.
+
+ @param webSocket An `ARTWebSocket` object that received a ping frame.
+ @param data      Payload that was received or `nil` if there was no payload.
+ */
+- (void)webSocket:(id<ARTWebSocket>)webSocket didReceivePingWithData:(nullable NSData *)data;
+
+/**
+ Called when a pong data was received in response to ping.
+
+ @param webSocket An `ARTWebSocket` object that received a pong frame.
+ @param pongData  Payload that was received or `nil` if there was no payload.
+ */
+- (void)webSocket:(id<ARTWebSocket>)webSocket didReceivePong:(nullable NSData *)pongData;
+
+/**
+ Sent before reporting a text frame to be able to configure if it shuold be convert to a UTF-8 String or passed as `NSData`.
+ If the method is not implemented - it will always convert text frames to String.
+
+ @param webSocket An `ARTWebSocket` object that received a text frame.
+
+ @return `YES` if text frame should be converted to UTF-8 String, otherwise - `NO`. Default: `YES`.
+ */
+- (BOOL)webSocketShouldConvertTextFrameToString:(id<ARTWebSocket>)webSocket NS_SWIFT_NAME(webSocketShouldConvertTextFrameToString(_:));
 
 @end
 

--- a/Source/PrivateHeaders/Ably/ARTWebSocket.h
+++ b/Source/PrivateHeaders/Ably/ARTWebSocket.h
@@ -3,6 +3,14 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol ARTWebSocketDelegate;
+@class ARTInternalLog;
+
+typedef NS_ENUM(NSInteger, ARTWebSocketReadyState) {
+    ARTSR_CONNECTING   = 0,
+    ARTSR_OPEN         = 1,
+    ARTSR_CLOSING      = 2,
+    ARTSR_CLOSED       = 3,
+};
 
 /**
  This protocol has the subset of ARTSRWebSocket we actually use.
@@ -11,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak) id <ARTWebSocketDelegate> _Nullable delegate;
 @property (nullable, nonatomic) dispatch_queue_t delegateDispatchQueue;
-@property (atomic, readonly) ARTSRReadyState readyState;
+@property (atomic, readonly) ARTWebSocketReadyState readyState;
 
 - (instancetype)initWithURLRequest:(NSURLRequest *)request logger:(nullable ARTInternalLog *)logger;
 

--- a/Source/PrivateHeaders/Ably/ARTWebSocket.h
+++ b/Source/PrivateHeaders/Ably/ARTWebSocket.h
@@ -6,10 +6,10 @@ NS_ASSUME_NONNULL_BEGIN
 @class ARTInternalLog;
 
 typedef NS_ENUM(NSInteger, ARTWebSocketReadyState) {
-    ARTSR_CONNECTING   = 0,
-    ARTSR_OPEN         = 1,
-    ARTSR_CLOSING      = 2,
-    ARTSR_CLOSED       = 3,
+    ARTWebSocketReadyStateConnecting   = 0,
+    ARTWebSocketReadyStateOpen         = 1,
+    ARTWebSocketReadyStateClosing      = 2,
+    ARTWebSocketReadyStateClosed       = 3,
 };
 
 /**

--- a/Source/PrivateHeaders/Ably/ARTWebSocket.h
+++ b/Source/PrivateHeaders/Ably/ARTWebSocket.h
@@ -21,8 +21,6 @@ typedef NS_ENUM(NSInteger, ARTWebSocketReadyState) {
 @property (nullable, nonatomic) dispatch_queue_t delegateDispatchQueue;
 @property (atomic, readonly) ARTWebSocketReadyState readyState;
 
-- (instancetype)initWithURLRequest:(NSURLRequest *)request logger:(nullable ARTInternalLog *)logger;
-
 - (void)setDelegateDispatchQueue:(dispatch_queue_t)queue;
 
 - (void)open;

--- a/Source/PrivateHeaders/Ably/ARTWebSocketTransport+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTWebSocketTransport+Private.h
@@ -8,8 +8,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ARTWebSocketTransport () <ARTWebSocketDelegate>
 
-+ (void)setWebSocketClass:(Class)webSocketClass;
-
 // From RestClient
 @property (readwrite, nonatomic) id<ARTEncoder> encoder;
 @property (readonly, nonatomic) ARTInternalLog *logger;

--- a/Source/PrivateHeaders/Ably/ARTWebSocketTransport.h
+++ b/Source/PrivateHeaders/Ably/ARTWebSocketTransport.h
@@ -4,13 +4,14 @@
 
 @class ARTClientOptions;
 @class ARTRest;
+@protocol ARTWebSocketFactory;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ARTWebSocketTransport : NSObject <ARTRealtimeTransport>
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
-- (instancetype)initWithRest:(ARTRestInternal *)rest options:(ARTClientOptions *)options resumeKey:(nullable NSString *)resumeKey connectionSerial:(nullable NSNumber *)connectionSerial logger:(ARTInternalLog *)logger NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithRest:(ARTRestInternal *)rest options:(ARTClientOptions *)options resumeKey:(nullable NSString *)resumeKey connectionSerial:(nullable NSNumber *)connectionSerial logger:(ARTInternalLog *)logger webSocketFactory:(id<ARTWebSocketFactory>)webSocketFactory NS_DESIGNATED_INITIALIZER;
 
 @property (readonly, nonatomic) NSString *resumeKey;
 @property (readonly, nonatomic) NSNumber *connectionSerial;

--- a/Source/SocketRocket/ARTSRWebSocket.h
+++ b/Source/SocketRocket/ARTSRWebSocket.h
@@ -10,15 +10,9 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "ARTWebSocket.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
-typedef NS_ENUM(NSInteger, ARTSRReadyState) {
-    ARTSR_CONNECTING   = 0,
-    ARTSR_OPEN         = 1,
-    ARTSR_CLOSING      = 2,
-    ARTSR_CLOSED       = 3,
-};
 
 typedef NS_ENUM(NSInteger, ARTSRStatusCode) {
     // 0-999: Reserved and not used.
@@ -95,7 +89,7 @@ extern NSString *const ARTSRHTTPResponseErrorKey;
 
  This property is Key-Value Observable and fully thread-safe.
  */
-@property (atomic, readonly) ARTSRReadyState readyState;
+@property (atomic, readonly) ARTWebSocketReadyState readyState;
 
 /**
  An instance of `NSURL` that this socket connects to.

--- a/Source/SocketRocket/ARTSRWebSocket.h
+++ b/Source/SocketRocket/ARTSRWebSocket.h
@@ -85,7 +85,7 @@ extern NSString *const ARTSRHTTPResponseErrorKey;
 @property (nullable, nonatomic) NSOperationQueue *delegateOperationQueue;
 
 /**
- Current ready state of the socket. Default: `ARTSR_CONNECTING`.
+ Current ready state of the socket. Default: `ARTWebSocketReadyStateConnecting`.
 
  This property is Key-Value Observable and fully thread-safe.
  */

--- a/Source/SocketRocket/ARTSRWebSocket.h
+++ b/Source/SocketRocket/ARTSRWebSocket.h
@@ -52,7 +52,7 @@ extern NSString *const ARTSRWebSocketErrorDomain;
  */
 extern NSString *const ARTSRHTTPResponseErrorKey;
 
-@protocol ARTSRWebSocketDelegate;
+@protocol ARTWebSocketDelegate;
 
 ///--------------------------------------
 #pragma mark - ARTSRWebSocket
@@ -61,14 +61,14 @@ extern NSString *const ARTSRHTTPResponseErrorKey;
 /**
  A `ARTSRWebSocket` object lets you connect, send and receive data to a remote Web Socket.
  */
-@interface ARTSRWebSocket : NSObject <NSStreamDelegate>
+@interface ARTSRWebSocket : NSObject <ARTWebSocket, NSStreamDelegate>
 
 /**
  The delegate of the web socket.
 
  The web socket delegate is notified on all state changes that happen to the web socket.
  */
-@property (nonatomic, weak) id <ARTSRWebSocketDelegate> delegate;
+@property (nonatomic, weak) id <ARTWebSocketDelegate> delegate;
 
 /**
  A dispatch queue for scheduling the delegate calls. The queue doesn't need be a serial queue.
@@ -310,100 +310,6 @@ extern NSString *const ARTSRHTTPResponseErrorKey;
  @return `YES` if the string was scheduled to send, otherwise - `NO`.
  */
 - (BOOL)sendPing:(nullable NSData *)data error:(NSError **)error NS_SWIFT_NAME(sendPing(_:));
-
-@end
-
-///--------------------------------------
-#pragma mark - ARTSRWebSocketDelegate
-///--------------------------------------
-
-/**
- The `ARTSRWebSocketDelegate` protocol describes the methods that `ARTSRWebSocket` objects
- call on their delegates to handle status and messsage events.
- */
-@protocol ARTSRWebSocketDelegate <NSObject>
-
-@optional
-
-#pragma mark Receive Messages
-
-/**
- Called when any message was received from a web socket.
- This method is suboptimal and might be deprecated in a future release.
-
- @param webSocket An instance of `ARTSRWebSocket` that received a message.
- @param message   Received message. Either a `String` or `NSData`.
- */
-- (void)webSocket:(ARTSRWebSocket *)webSocket didReceiveMessage:(id)message;
-
-/**
- Called when a frame was received from a web socket.
-
- @param webSocket An instance of `ARTSRWebSocket` that received a message.
- @param string    Received text in a form of UTF-8 `String`.
- */
-- (void)webSocket:(ARTSRWebSocket *)webSocket didReceiveMessageWithString:(NSString *)string;
-
-/**
- Called when a frame was received from a web socket.
-
- @param webSocket An instance of `ARTSRWebSocket` that received a message.
- @param data      Received data in a form of `NSData`.
- */
-- (void)webSocket:(ARTSRWebSocket *)webSocket didReceiveMessageWithData:(NSData *)data;
-
-#pragma mark Status & Connection
-
-/**
- Called when a given web socket was open and authenticated.
-
- @param webSocket An instance of `ARTSRWebSocket` that was open.
- */
-- (void)webSocketDidOpen:(ARTSRWebSocket *)webSocket;
-
-/**
- Called when a given web socket encountered an error.
-
- @param webSocket An instance of `ARTSRWebSocket` that failed with an error.
- @param error     An instance of `NSError`.
- */
-- (void)webSocket:(ARTSRWebSocket *)webSocket didFailWithError:(NSError *)error;
-
-/**
- Called when a given web socket was closed.
-
- @param webSocket An instance of `ARTSRWebSocket` that was closed.
- @param code      Code reported by the server.
- @param reason    Reason in a form of a String that was reported by the server or `nil`.
- @param wasClean  Boolean value indicating whether a socket was closed in a clean state.
- */
-- (void)webSocket:(ARTSRWebSocket *)webSocket didCloseWithCode:(NSInteger)code reason:(nullable NSString *)reason wasClean:(BOOL)wasClean;
-
-/**
- Called on receive of a ping message from the server.
-
- @param webSocket An instance of `ARTSRWebSocket` that received a ping frame.
- @param data      Payload that was received or `nil` if there was no payload.
- */
-- (void)webSocket:(ARTSRWebSocket *)webSocket didReceivePingWithData:(nullable NSData *)data;
-
-/**
- Called when a pong data was received in response to ping.
-
- @param webSocket An instance of `ARTSRWebSocket` that received a pong frame.
- @param pongData  Payload that was received or `nil` if there was no payload.
- */
-- (void)webSocket:(ARTSRWebSocket *)webSocket didReceivePong:(nullable NSData *)pongData;
-
-/**
- Sent before reporting a text frame to be able to configure if it shuold be convert to a UTF-8 String or passed as `NSData`.
- If the method is not implemented - it will always convert text frames to String.
-
- @param webSocket An instance of `ARTSRWebSocket` that received a text frame.
-
- @return `YES` if text frame should be converted to UTF-8 String, otherwise - `NO`. Default: `YES`.
- */
-- (BOOL)webSocketShouldConvertTextFrameToString:(ARTSRWebSocket *)webSocket NS_SWIFT_NAME(webSocketShouldConvertTextFrameToString(_:));
 
 @end
 

--- a/Source/SocketRocket/ARTSRWebSocket.m
+++ b/Source/SocketRocket/ARTSRWebSocket.m
@@ -420,7 +420,7 @@ NSString *const ARTSRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
         [self _readFrameNew];
     }
 
-    [self.delegateController performDelegateBlock:^(id<ARTSRWebSocketDelegate>  _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods) {
+    [self.delegateController performDelegateBlock:^(id<ARTWebSocketDelegate>  _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods) {
         if (availableMethods.didOpen) {
             [delegate webSocketDidOpen:self];
         }
@@ -565,7 +565,7 @@ NSString *const ARTSRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
     dispatch_async(self->_workQueue, ^{
         if (self.readyState != ARTWebSocketReadyStateClosed) {
             self->_failed = YES;
-            [self.delegateController performDelegateBlock:^(id<ARTSRWebSocketDelegate>  _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods) {
+            [self.delegateController performDelegateBlock:^(id<ARTWebSocketDelegate>  _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods) {
                 if (availableMethods.didFailWithError) {
                     [delegate webSocket:self didFailWithError:error];
                 }
@@ -676,7 +676,7 @@ NSString *const ARTSRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
 - (void)_handlePingWithData:(nullable NSData *)data
 {
     // Need to pingpong this off _callbackQueue first to make sure messages happen in order
-    [self.delegateController performDelegateBlock:^(id<ARTSRWebSocketDelegate> _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods) {
+    [self.delegateController performDelegateBlock:^(id<ARTWebSocketDelegate> _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods) {
         if (availableMethods.didReceivePing) {
             [delegate webSocket:self didReceivePingWithData:data];
         }
@@ -689,7 +689,7 @@ NSString *const ARTSRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
 - (void)handlePong:(NSData *)pongData;
 {
     ARTSRDebugLog(self.logger, @"Received pong");
-    [self.delegateController performDelegateBlock:^(id<ARTSRWebSocketDelegate>  _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods) {
+    [self.delegateController performDelegateBlock:^(id<ARTWebSocketDelegate>  _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods) {
         if (availableMethods.didReceivePong) {
             [delegate webSocket:self didReceivePong:pongData];
         }
@@ -806,7 +806,7 @@ static inline BOOL closeCodeIsValid(int closeCode) {
                 return;
             }
             ARTSRDebugLog(self.logger, @"Received text message.");
-            [self.delegateController performDelegateBlock:^(id<ARTSRWebSocketDelegate>  _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods) {
+            [self.delegateController performDelegateBlock:^(id<ARTWebSocketDelegate>  _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods) {
                 // Don't convert into string - iff `delegate` tells us not to. Otherwise - create UTF8 string and handle that.
                 if (availableMethods.shouldConvertTextFrameToString && ![delegate webSocketShouldConvertTextFrameToString:self]) {
                     if (availableMethods.didReceiveMessage) {
@@ -828,7 +828,7 @@ static inline BOOL closeCodeIsValid(int closeCode) {
         }
         case ARTSROpCodeBinaryFrame: {
             ARTSRDebugLog(self.logger, @"Received data message.");
-            [self.delegateController performDelegateBlock:^(id<ARTSRWebSocketDelegate>  _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods) {
+            [self.delegateController performDelegateBlock:^(id<ARTWebSocketDelegate>  _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods) {
                 if (availableMethods.didReceiveMessage) {
                     [delegate webSocket:self didReceiveMessage:frameData];
                 }
@@ -1099,7 +1099,7 @@ static const uint8_t ARTSRPayloadLenMask   = 0x7F;
         }
 
         if (!_failed) {
-            [self.delegateController performDelegateBlock:^(id<ARTSRWebSocketDelegate>  _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods) {
+            [self.delegateController performDelegateBlock:^(id<ARTWebSocketDelegate>  _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods) {
                 if (availableMethods.didCloseWithCode) {
                     [delegate webSocket:self didCloseWithCode:self->_closeCode reason:self->_closeReason wasClean:YES];
                 }
@@ -1476,7 +1476,7 @@ static const size_t ARTSRFrameHeaderOverhead = 32;
                     if (!self->_sentClose && !self->_failed) {
                         self->_sentClose = YES;
                         // If we get closed in this state it's probably not clean because we should be sending this when we send messages
-                        [self.delegateController performDelegateBlock:^(id<ARTSRWebSocketDelegate>  _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods) {
+                        [self.delegateController performDelegateBlock:^(id<ARTWebSocketDelegate>  _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods) {
                             if (availableMethods.didCloseWithCode) {
                                 [delegate webSocket:self
                                    didCloseWithCode:ARTSRStatusCodeGoingAway
@@ -1530,12 +1530,12 @@ static const size_t ARTSRFrameHeaderOverhead = 32;
 #pragma mark - Delegate
 ///--------------------------------------
 
-- (id<ARTSRWebSocketDelegate> _Nullable)delegate
+- (id<ARTWebSocketDelegate> _Nullable)delegate
 {
     return self.delegateController.delegate;
 }
 
-- (void)setDelegate:(id<ARTSRWebSocketDelegate> _Nullable)delegate
+- (void)setDelegate:(id<ARTWebSocketDelegate> _Nullable)delegate
 {
     self.delegateController.delegate = delegate;
 }

--- a/Source/SocketRocket/ARTSRWebSocket.m
+++ b/Source/SocketRocket/ARTSRWebSocket.m
@@ -72,7 +72,7 @@ NSString *const ARTSRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
 
 @interface ARTSRWebSocket ()  <NSStreamDelegate>
 
-@property (atomic, readwrite) ARTSRReadyState readyState;
+@property (atomic, readwrite) ARTWebSocketReadyState readyState;
 
 // Specifies whether SSL trust chain should NOT be evaluated.
 // By default this flag is set to NO, meaning only secure SSL connections are allowed.
@@ -280,7 +280,7 @@ NSString *const ARTSRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
 
 #pragma mark readyState
 
-- (void)setReadyState:(ARTSRReadyState)readyState
+- (void)setReadyState:(ARTWebSocketReadyState)readyState
 {
     @try {
         ARTSRMutexLock(_kvoLock);
@@ -297,9 +297,9 @@ NSString *const ARTSRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
     }
 }
 
-- (ARTSRReadyState)readyState
+- (ARTWebSocketReadyState)readyState
 {
-    ARTSRReadyState state = 0;
+    ARTWebSocketReadyState state = 0;
     os_unfair_lock_lock(&_propertyLock);
     state = _readyState;
     os_unfair_lock_unlock(&_propertyLock);

--- a/Source/SocketRocket/Internal/Delegate/ARTSRDelegateController.h
+++ b/Source/SocketRocket/Internal/Delegate/ARTSRDelegateController.h
@@ -45,11 +45,11 @@ struct ARTSRDelegateAvailableMethods {
 
 typedef struct ARTSRDelegateAvailableMethods ARTSRDelegateAvailableMethods;
 
-typedef void(^ARTSRDelegateBlock)(id<ARTSRWebSocketDelegate> _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods);
+typedef void(^ARTSRDelegateBlock)(id<ARTWebSocketDelegate> _Nullable delegate, ARTSRDelegateAvailableMethods availableMethods);
 
 @interface ARTSRDelegateController : NSObject
 
-@property (nonatomic, weak) id<ARTSRWebSocketDelegate> delegate;
+@property (nonatomic, weak) id<ARTWebSocketDelegate> delegate;
 @property (atomic, readonly) ARTSRDelegateAvailableMethods availableDelegateMethods;
 
 @property (nullable, nonatomic) dispatch_queue_t dispatchQueue;

--- a/Source/SocketRocket/Internal/Delegate/ARTSRDelegateController.m
+++ b/Source/SocketRocket/Internal/Delegate/ARTSRDelegateController.m
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Accessors
 ///--------------------------------------
 
-- (void)setDelegate:(id<ARTSRWebSocketDelegate> _Nullable)delegate
+- (void)setDelegate:(id<ARTWebSocketDelegate> _Nullable)delegate
 {
     dispatch_barrier_async(self.accessQueue, ^{
         self->_delegate = delegate;
@@ -63,9 +63,9 @@ NS_ASSUME_NONNULL_BEGIN
     });
 }
 
-- (id<ARTSRWebSocketDelegate> _Nullable)delegate
+- (id<ARTWebSocketDelegate> _Nullable)delegate
 {
-    __block id<ARTSRWebSocketDelegate> delegate = nil;
+    __block id<ARTWebSocketDelegate> delegate = nil;
     dispatch_sync(self.accessQueue, ^{
         delegate = self->_delegate;
     });
@@ -112,7 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)performDelegateBlock:(ARTSRDelegateBlock)block
 {
-    __block __strong id<ARTSRWebSocketDelegate> delegate = nil;
+    __block __strong id<ARTWebSocketDelegate> delegate = nil;
     __block ARTSRDelegateAvailableMethods availableMethods = {};
     dispatch_sync(self.accessQueue, ^{
         delegate = self->_delegate; // Not `OK` to go through `self`, since queue sync.

--- a/Source/include/Ably.modulemap
+++ b/Source/include/Ably.modulemap
@@ -107,5 +107,6 @@ framework module Ably {
         header "Ably/ARTDataEncoder.h"
         header "Ably/ARTRealtimeTransportFactory.h"
         header "Ably/ARTContinuousClock.h"
+        header "Ably/ARTWebSocketFactory.h"
     }
 }

--- a/Test/Test Utilities/TestProxyTransportFactory.swift
+++ b/Test/Test Utilities/TestProxyTransportFactory.swift
@@ -8,13 +8,16 @@ class TestProxyTransportFactory: RealtimeTransportFactory {
     var networkConnectEvent: ((ARTRealtimeTransport, URL) -> Void)?
 
     func transport(withRest rest: ARTRestInternal, options: ARTClientOptions, resumeKey: String?, connectionSerial: NSNumber?, logger: InternalLog) -> ARTRealtimeTransport {
+        let webSocketFactory = DefaultWebSocketFactory()
+
         return TestProxyTransport(
             factory: self,
             rest: rest,
             options: options,
             resumeKey: resumeKey,
             connectionSerial: connectionSerial,
-            logger: logger
+            logger: logger,
+            webSocketFactory: webSocketFactory
         )
     }
 }

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -1101,9 +1101,9 @@ class TestProxyTransport: ARTWebSocketTransport {
         return _factory
     }
 
-    init(factory: TestProxyTransportFactory, rest: ARTRestInternal, options: ARTClientOptions, resumeKey: String?, connectionSerial: NSNumber?, logger: InternalLog) {
+    init(factory: TestProxyTransportFactory, rest: ARTRestInternal, options: ARTClientOptions, resumeKey: String?, connectionSerial: NSNumber?, logger: InternalLog, webSocketFactory: WebSocketFactory) {
         self._factory = factory
-        super.init(rest: rest, options: options, resumeKey: resumeKey, connectionSerial: connectionSerial, logger: logger)
+        super.init(rest: rest, options: options, resumeKey: resumeKey, connectionSerial: connectionSerial, logger: logger, webSocketFactory: webSocketFactory)
     }
 
     fileprivate(set) var lastUrl: URL?

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -1597,19 +1597,19 @@ extension ARTWebSocketTransport {
         let CLOSE_NORMAL = 1000
         self.setState(ARTRealtimeTransportState.closing)
         let webSocketDelegate = self as ARTWebSocketDelegate
-        webSocketDelegate.webSocket(self.websocket!, didCloseWithCode: CLOSE_NORMAL, reason: "", wasClean: true)
+        webSocketDelegate.webSocket?(self.websocket!, didCloseWithCode: CLOSE_NORMAL, reason: "", wasClean: true)
     }
 
     func simulateIncomingAbruptlyClose() {
         let CLOSE_ABNORMAL = 1006
         let webSocketDelegate = self as ARTWebSocketDelegate
-        webSocketDelegate.webSocket(self.websocket!, didCloseWithCode: CLOSE_ABNORMAL, reason: "connection was closed abnormally", wasClean: false)
+        webSocketDelegate.webSocket?(self.websocket!, didCloseWithCode: CLOSE_ABNORMAL, reason: "connection was closed abnormally", wasClean: false)
     }
 
     func simulateIncomingError() {
         let error = NSError(domain: ARTAblyErrorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey:"Fail test"])
         let webSocketDelegate = self as ARTWebSocketDelegate
-        webSocketDelegate.webSocket(self.websocket!, didFailWithError: error)
+        webSocketDelegate.webSocket?(self.websocket!, didFailWithError: error)
     }
 }
 


### PR DESCRIPTION
This refactor will give us more control over the created instance, which will be useful in tests. It removes `ARTWebSocketTransport`’s `webSocketClass` global state. See commit messages for more details.

Part of fixing #1695.