### PR TITLE
Remove use of global state for modifying `ARTWebSocket#open`

### DIFF
--- a/Test/Test Utilities/NSObject+TestSuite.swift
+++ b/Test/Test Utilities/NSObject+TestSuite.swift
@@ -8,12 +8,4 @@ extension NSObject {
         return try? self.aspect_hook(selector, with: AspectOptions(), usingBlock: unsafeBitCast(block, to: AnyObject.self))
     }
 
-    /// Replace identified class method with a block of code.
-    class func testSuite_replaceClassMethod(_ selector: Selector, code: @escaping ()->()) -> AspectToken? {
-        let block: @convention(block) (AspectInfo) -> Void = { _ in
-            code()
-        }
-        return try? self.aspect_hook(selector, with: .positionInstead, usingBlock: unsafeBitCast(block, to: AnyObject.self))
-    }
-
 }


### PR DESCRIPTION
This fixes an intermittent test failure in `RealtimeClientConnectionTests.test__100(...)`.

This failure was introduced by acc66fd. A side effect of the changes in that commit was that after completing execution of the preceding test case (`test__096`), we no longer reset the array-shuffling implementation used by this test. This (for reasons that I haven’t investigated) had the effect of causing the `ARTRealtime` instance created by that test (which for some reason the test decides not to tear down, with a commented justification that I’m not convinced by, but that’s a separate matter) to continue trying to connect even during the execution of `test__100`. In turn, this caused `test__100`’s override of `ARTWebSocket#open` to sometimes (depending on timing) be consumed by `test__096`’s `ARTRealtime` instance instead of that of `test__100`, leading to failure of the latter test.

To avoid this, we change things so that overrides of `ARTWebSocket#open` are local to each `TestProxyTransportFactory` instance, and hence to each test case.

Resolves #1695.

In removing the use of `testSuite_replaceClassMethod`, this also forms part of #1601.