### PR TITLE
Revert "Importing headers inside PrivateHeaders folder with module based import."

### DIFF
--- a/Source/PrivateHeaders/Ably/ARTAuth+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTAuth+Private.h
@@ -1,6 +1,6 @@
 #import <Ably/ARTAuth.h>
 #import <Ably/ARTEventEmitter.h>
-#import <Ably/ARTQueuedDealloc.h>
+#import "ARTQueuedDealloc.h"
 
 @class ARTRestInternal;
 @class ARTInternalLog;

--- a/Source/PrivateHeaders/Ably/ARTBackoffRetryDelayCalculator.h
+++ b/Source/PrivateHeaders/Ably/ARTBackoffRetryDelayCalculator.h
@@ -1,5 +1,5 @@
 @import Foundation;
-#import <Ably/ARTRetryDelayCalculator.h>
+#import "ARTRetryDelayCalculator.h"
 
 @protocol ARTJitterCoefficientGenerator;
 

--- a/Source/PrivateHeaders/Ably/ARTChannelStateChangeMetadata.h
+++ b/Source/PrivateHeaders/Ably/ARTChannelStateChangeMetadata.h
@@ -1,5 +1,5 @@
 @import Foundation;
-#import <Ably/ARTTypes.h>
+#import "ARTTypes.h"
 
 @class ARTErrorInfo;
 @class ARTRetryAttempt;

--- a/Source/PrivateHeaders/Ably/ARTConnection+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTConnection+Private.h
@@ -1,7 +1,7 @@
 #import <Ably/ARTConnection.h>
 #import <Ably/ARTEventEmitter.h>
 #import <Ably/ARTTypes.h>
-#import <Ably/ARTQueuedDealloc.h>
+#import "ARTQueuedDealloc.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/PrivateHeaders/Ably/ARTConstantRetryDelayCalculator.h
+++ b/Source/PrivateHeaders/Ably/ARTConstantRetryDelayCalculator.h
@@ -1,5 +1,5 @@
 @import Foundation;
-#import <Ably/ARTRetryDelayCalculator.h>
+#import "ARTRetryDelayCalculator.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/PrivateHeaders/Ably/ARTHttp+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTHttp+Private.h
@@ -1,4 +1,4 @@
-#import <Ably/ARTHttp.h>
+#import "ARTHttp.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/PrivateHeaders/Ably/ARTInternalLogCore+Testing.h
+++ b/Source/PrivateHeaders/Ably/ARTInternalLogCore+Testing.h
@@ -1,5 +1,5 @@
 @import Foundation;
-#import <Ably/ARTInternalLog.h>
+#import "ARTInternalLog.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/PrivateHeaders/Ably/ARTLogAdapter+Testing.h
+++ b/Source/PrivateHeaders/Ably/ARTLogAdapter+Testing.h
@@ -1,5 +1,5 @@
 @import Foundation;
-#import <Ably/ARTLogAdapter.h>
+#import "ARTLogAdapter.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/PrivateHeaders/Ably/ARTLogAdapter.h
+++ b/Source/PrivateHeaders/Ably/ARTLogAdapter.h
@@ -1,6 +1,6 @@
 @import Foundation;
 
-#import <Ably/ARTVersion2Log.h>
+#import "ARTVersion2Log.h"
 
 @class ARTLog;
 

--- a/Source/PrivateHeaders/Ably/ARTPaginatedResult+Subclass.h
+++ b/Source/PrivateHeaders/Ably/ARTPaginatedResult+Subclass.h
@@ -1,5 +1,5 @@
 @import Foundation;
-#import <Ably/ARTPaginatedResult.h>
+#import "ARTPaginatedResult.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/PrivateHeaders/Ably/ARTPresenceMap.h
+++ b/Source/PrivateHeaders/Ably/ARTPresenceMap.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import <Ably/ARTTypes.h>
+#import "ARTTypes.h"
 
 @class ARTPresenceMap;
 @class ARTPresenceMessage;

--- a/Source/PrivateHeaders/Ably/ARTPush+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPush+Private.h
@@ -1,6 +1,6 @@
 #import <Ably/ARTPush.h>
 #import <Ably/ARTPushAdmin+Private.h>
-#import <Ably/ARTQueuedDealloc.h>
+#import "ARTQueuedDealloc.h"
 
 @class ARTPushActivationStateMachine;
 @class ARTRestInternal;

--- a/Source/PrivateHeaders/Ably/ARTPushAdmin+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPushAdmin+Private.h
@@ -1,7 +1,7 @@
 #import <Ably/ARTPushAdmin.h>
 #import <Ably/ARTPushDeviceRegistrations+Private.h>
 #import <Ably/ARTPushChannelSubscriptions+Private.h>
-#import <Ably/ARTQueuedDealloc.h>
+#import "ARTQueuedDealloc.h"
 
 @class ARTRestInternal;
 

--- a/Source/PrivateHeaders/Ably/ARTPushChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPushChannel+Private.h
@@ -1,5 +1,5 @@
 #import <Ably/ARTPushChannel.h>
-#import <Ably/ARTQueuedDealloc.h>
+#import "ARTQueuedDealloc.h"
 
 @class ARTRestInternal;
 @class ARTInternalLog;

--- a/Source/PrivateHeaders/Ably/ARTPushChannelSubscriptions+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPushChannelSubscriptions+Private.h
@@ -1,5 +1,5 @@
 #import <Ably/ARTPushChannelSubscriptions.h>
-#import <Ably/ARTQueuedDealloc.h>
+#import "ARTQueuedDealloc.h"
 
 @class ARTRestInternal;
 @class ARTInternalLog;

--- a/Source/PrivateHeaders/Ably/ARTPushDeviceRegistrations+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPushDeviceRegistrations+Private.h
@@ -1,5 +1,5 @@
 #import <Ably/ARTPushDeviceRegistrations.h>
-#import <Ably/ARTQueuedDealloc.h>
+#import "ARTQueuedDealloc.h"
 
 @class ARTRestInternal;
 @class ARTInternalLog;

--- a/Source/PrivateHeaders/Ably/ARTRealtimeChannels+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeChannels+Private.h
@@ -5,7 +5,7 @@
 
 #import <Ably/ARTRealtimeChannels.h>
 #import <Ably/ARTRealtime+Private.h>
-#import <Ably/ARTQueuedDealloc.h>
+#import "ARTQueuedDealloc.h"
 
 @class ARTRealtimeChannelInternal;
 

--- a/Source/PrivateHeaders/Ably/ARTRest+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRest+Private.h
@@ -1,7 +1,7 @@
 #import <Ably/ARTRest.h>
 #import <Ably/ARTHttp.h>
-#import <Ably/ARTRestChannels+Private.h>
-#import <Ably/ARTPush+Private.h>
+#import "ARTRestChannels+Private.h"
+#import "ARTPush+Private.h"
 
 @protocol ARTEncoder;
 @protocol ARTHTTPExecutor;

--- a/Source/PrivateHeaders/Ably/ARTRestChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRestChannel+Private.h
@@ -6,7 +6,7 @@
 #import <Ably/ARTRestChannel.h>
 #import <Ably/ARTRestPresence+Private.h>
 #import <Ably/ARTPushChannel+Private.h>
-#import <Ably/ARTQueuedDealloc.h>
+#import "ARTQueuedDealloc.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/PrivateHeaders/Ably/ARTRestChannels+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRestChannels+Private.h
@@ -1,6 +1,6 @@
 #import <Ably/ARTRestChannels.h>
-#import <Ably/ARTQueuedDealloc.h>
-#import <Ably/ARTRestChannel+Private.h>
+#import "ARTQueuedDealloc.h"
+#import "ARTRestChannel+Private.h"
 
 @class ARTRestChannel;
 @class ARTRestInternal;

--- a/Source/PrivateHeaders/Ably/ARTRestPresence+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRestPresence+Private.h
@@ -1,5 +1,5 @@
 #import <Ably/ARTRestPresence.h>
-#import <Ably/ARTQueuedDealloc.h>
+#import "ARTQueuedDealloc.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/PrivateHeaders/Ably/ARTTypes+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTTypes+Private.h
@@ -1,5 +1,5 @@
 @import Foundation;
-#import <Ably/ARTTypes.h>
+#import "ARTTypes.h"
 
 @class ARTRetryAttempt;
 @class ARTInternalLog;


### PR DESCRIPTION
Reverts ably/ably-cocoa#1756

Reverting, because compilation errors for Xcode 14.2/14.3 should be addressed instead, see https://github.com/ably/ably-cocoa/issues/1764