### PR TITLE
Fix parameter in log message

### DIFF
--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -619,7 +619,7 @@ dispatch_sync(_queue, ^{
             ARTLogDebug(self.logger, @"RT:%p C:%p Created attach retry sequence %@", _realtime, self, self.attachRetrySequence);
 
             ARTRetryAttempt *const retryAttempt = [self.attachRetrySequence addRetryAttempt];
-            ARTLogDebug(self.logger, @"RT:%p C:%p Adding attach retry attempt to %@ gave %@", retryAttempt, self, self.attachRetrySequence.id, retryAttempt);
+            ARTLogDebug(self.logger, @"RT:%p C:%p Adding attach retry attempt to %@ gave %@", _realtime, self, self.attachRetrySequence.id, retryAttempt);
 
             [_attachedEventEmitter emit:nil with:metadata.errorInfo];
             if (self.realtime.shouldSendEvents) {


### PR DESCRIPTION
This was a mistake in 47e3a59.