### PR TITLE
[SDK-3814] Refactoring for "test__023__Presence__Channel_state_change_side_effects…"

### DIFF
--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -1585,6 +1585,10 @@ extension String {
 
 extension ARTRealtime {
 
+    var transportFactory: TestProxyTransportFactory? {
+        self.internal.options.testOptions.transportFactory as? TestProxyTransportFactory
+    }
+    
     func simulateLostConnectionAndState() {
         //1. Abruptly disconnect
         //2. Change the `Connection#id` and `Connection#key` before the client
@@ -1614,6 +1618,16 @@ extension ARTRealtime {
             reachability.simulate(false)
         }
     }
+    
+    func simulateNoInternetConnection(during timeout: TimeInterval? = nil) {
+        guard let transportFactory = self.transportFactory else {
+            fatalError("Expected test TestProxyTransportFactory")
+        }
+        simulateNoInternetConnection(transportFactory: transportFactory)
+        if let timeout {
+            simulateRestoreInternetConnection(after: timeout, transportFactory: transportFactory)
+        }
+    }
 
     func simulateRestoreInternetConnection(after seconds: TimeInterval? = nil, transportFactory: TestProxyTransportFactory) {
         guard let reachability = self.internal.reachability as? TestReachability else {
@@ -1624,6 +1638,13 @@ extension ARTRealtime {
             transportFactory.fakeNetworkResponse = nil
             reachability.simulate(true)
         }
+    }
+
+    func simulateRestoreInternetConnection(after seconds: TimeInterval? = nil) {
+        guard let transportFactory = self.transportFactory else {
+            fatalError("Expected test TestProxyTransportFactory")
+        }
+        simulateRestoreInternetConnection(after: seconds, transportFactory: transportFactory)
     }
 
     func overrideConnectionStateTTL(_ ttl: TimeInterval) -> HookToken {

--- a/Test/Tests/RealtimeClientPresenceTests.swift
+++ b/Test/Tests/RealtimeClientPresenceTests.swift
@@ -829,6 +829,7 @@ class RealtimeClientPresenceTests: XCTestCase {
                 }
                 leavesChannel.presence.leave(nil) { error in
                     XCTAssertNil(error)
+                    XCTAssertEqual(mainChannel.state, .suspended)
                     partialDone()
                 }
                 partialDone()

--- a/Test/Tests/RealtimeClientPresenceTests.swift
+++ b/Test/Tests/RealtimeClientPresenceTests.swift
@@ -780,11 +780,11 @@ class RealtimeClientPresenceTests: XCTestCase {
             let partialDone = AblyTests.splitDone(4, done: done)
             mainChannel.presence.subscribe { message in
                 if message.clientId == "main" {
-                    XCTAssertEqual(message.action, ARTPresenceAction.enter)
+                    XCTAssertTrue(message.action == ARTPresenceAction.enter || message.action == ARTPresenceAction.present)
                     partialDone()
                 }
                 else if message.clientId == "leaves" {
-                    XCTAssertEqual(message.action, ARTPresenceAction.present) // .enter was replaced by .present (RTP2d)
+                    XCTAssertTrue(message.action == ARTPresenceAction.enter || message.action == ARTPresenceAction.present)
                     partialDone()
                 }
             }

--- a/Test/Tests/RealtimeClientPresenceTests.swift
+++ b/Test/Tests/RealtimeClientPresenceTests.swift
@@ -756,86 +756,106 @@ class RealtimeClientPresenceTests: XCTestCase {
         }
     }
 
-    func test__023__Presence__Channel_state_change_side_effects__channel_enters_the_SUSPENDED_state__should_maintain_the_PresenceMap_and_any_members_present_before_and_after_the_sync_should_not_emit_presence_events() throws {
+    func test__023__Presence__Channel_state_change_side_effects__channel_enters_the_SUSPENDED_state__members_map_is_preserved_and_only_members_that_changed_between_ATTACHED_states_should_result_in_presence_events() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let channelName = test.uniqueChannelName()
 
-        var clientMembers: ARTRealtime?
-        clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 3, options: options)
-        defer { clientMembers?.dispose(); clientMembers?.close() }
-
-        options.clientId = "tester"
+        let clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 2, options: options)
+        defer { clientMembers.dispose(); clientMembers.close() }
+        
+        options.clientId = "leaves"
+        let leavesClient = AblyTests.newRealtime(options).client
+        defer { leavesClient.dispose(); leavesClient.close() }
+        
+        options.clientId = "main"
         options.tokenDetails = try getTestTokenDetails(for: test, key: options.key!, clientId: options.clientId, ttl: 5.0)
-        let client = AblyTests.newRealtime(options).client
-        defer { client.dispose(); client.close() }
-        let channel = client.channels.get(channelName)
+        let mainClient = AblyTests.newRealtime(options).client
+        defer { mainClient.dispose(); mainClient.close() }
+        
+        let leavesChannel = leavesClient.channels.get(channelName)
+        let mainChannel = mainClient.channels.get(channelName)
+        
         waitUntil(timeout: testTimeout) { done in
-            let partialDone = AblyTests.splitDone(3, done: done)
-            channel.presence.enter(nil) { error in
+            let partialDone = AblyTests.splitDone(5, done: done)
+            mainChannel.presence.enter(nil) { error in
                 XCTAssertNil(error)
                 partialDone()
             }
-            channel.presence.get { members, error in
+            leavesChannel.presence.enter(nil) { error in
+                XCTAssertNil(error)
+                partialDone()
+            }
+            mainChannel.presence.get { members, error in
                 XCTAssertNil(error)
                 if let members {
-                    XCTAssertEqual(members.count, 3)
+                    XCTAssertEqual(members.count, 3) // "user1", "user2", "leaves"
                 } else {
                     XCTFail("Expected members to be non-nil")
                 }
                 partialDone()
             }
-            channel.presence.subscribe(.enter) { message in
-                if message.clientId == "tester" {
-                    channel.presence.unsubscribe()
+            mainChannel.presence.subscribe { message in
+                if message.clientId == "main" {
+                    XCTAssertEqual(message.action, ARTPresenceAction.enter)
+                    mainChannel.presence.unsubscribe()
+                    partialDone()
+                }
+                else if message.clientId == "leaves" {
+                    XCTAssertEqual(message.action, ARTPresenceAction.present) // .enter was replaced by .present (RTP2d)
                     partialDone()
                 }
             }
         }
 
+        var presenceEvents = [ARTPresenceMessage]()
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(4, done: done)
-            channel.presence.subscribe { presence in
-                XCTAssertEqual(presence.action, ARTPresenceAction.leave)
-                XCTAssertEqual(presence.clientId, "tester")
-                partialDone()
-            }
-            channel.once(.suspended) { _ in
-                channel.internalSync { _internal in
-                    XCTAssertEqual(_internal.presenceMap.members.count, 4)
-                    XCTAssertEqual(_internal.presenceMap.localMembers.count, 1)
+            mainChannel.presence.subscribe { presence in
+                presenceEvents += [presence]
+                delay(1) {
+                    partialDone() // Wait a bit to make sure we don't receive any other presence messages
                 }
-                partialDone()
             }
-            channel.once(.attached) { stateChange in
-                XCTAssertNil(stateChange.reason)
-                channel.presence.leave(nil) { error in
+            mainChannel.once(.suspended) { _ in
+                mainChannel.internalSync { _internal in
+                    XCTAssertEqual(_internal.presenceMap.members.count, 4) // "main", "user1", "user2", "leaves"
+                    XCTAssertEqual(_internal.presenceMap.localMembers.count, 1) // "main"
+                }
+                leavesChannel.presence.leave(nil) { error in
                     XCTAssertNil(error)
                     partialDone()
                 }
                 partialDone()
             }
-            channel.internalAsync { _internal in
+            mainChannel.once(.attached) { stateChange in
+                XCTAssertNil(stateChange.reason)
+                partialDone()
+            }
+            mainChannel.internalAsync { _internal in
                 _internal.setSuspended(.init(state: .ok))
             }
         }
+        XCTAssertEqual(presenceEvents.count, 1)
+        XCTAssertEqual(presenceEvents[0].action, ARTPresenceAction.leave)
+        XCTAssertEqual(presenceEvents[0].clientId, "leaves")
 
-        channel.presence.unsubscribe()
+        mainChannel.presence.unsubscribe()
         waitUntil(timeout: testTimeout) { done in
-            channel.presence.get { members, error in
+            mainChannel.presence.get { members, error in
                 XCTAssertNil(error)
                 guard let members = members else {
                     fail("Members is nil"); done(); return
                 }
-                XCTAssertEqual(members.count, 3)
+                XCTAssertEqual(members.count, 3) // "main", "user1", "user2"
                 expect(members).to(allPass { (member: ARTPresenceMessage?) in member!.action != .absent })
                 done()
             }
         }
 
-        channel.internalSync { _internal in
-            XCTAssertEqual(_internal.presenceMap.members.count, 3)
-            expect(_internal.presenceMap.localMembers).to(beEmpty())
+        mainChannel.internalSync { _internal in
+            XCTAssertEqual(_internal.presenceMap.members.count, 3) // "main", "user1", "user2"
+            XCTAssertEqual(_internal.presenceMap.localMembers.count, 1) // "main"
         }
     }
 


### PR DESCRIPTION
Closes #1792

Now a separate client is created for the member that will leave during SUSPENDED and ensure that a leave event for this member will be generated upon new attach.