### PR TITLE
[Experimental] Transition to macos 13 and Xcode 14.3

### DIFF
--- a/.github/workflows/check-pod.yaml
+++ b/.github/workflows/check-pod.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/check-pod.yaml
+++ b/.github/workflows/check-pod.yaml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Select Specific Xcode Version (13.4.1)
+      - name: Select Specific Xcode Version (14.3)
         run: |
-          sudo xcode-select -s /Applications/Xcode_13.4.1.app
+          sudo xcode-select -s /Applications/Xcode_14.3.app
           echo "Selected Xcode version:"
           xcodebuild -version
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
     
     permissions:
       deployments: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Select Specific Xcode Version
+      - name: Select Specific Xcode Version (14.3)
         run: |
-          sudo xcode-select -s /Applications/Xcode_13.2.app
+          sudo xcode-select -s /Applications/Xcode_14.3.app
           echo "Selected Xcode version:"
           xcodebuild -version
 

--- a/.github/workflows/integration-test-iOS16_4.yaml
+++ b/.github/workflows/integration-test-iOS16_4.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check:
-    runs-on: macos-latest
+    runs-on: macos-13
 
     env:
       LC_CTYPE: en_US.UTF-8

--- a/.github/workflows/integration-test-iOS16_4.yaml
+++ b/.github/workflows/integration-test-iOS16_4.yaml
@@ -1,4 +1,4 @@
-name: "Integration Test: tvOS 16.1"
+name: "Integration Test: iOS 16.4"
 
 on:
   pull_request:
@@ -22,6 +22,12 @@ jobs:
     steps:
       - name: Check out SDK repo
         uses: actions/checkout@v2
+        
+      - name: Select Specific Xcode Version (14.3)
+        run: |
+          sudo xcode-select -s /Applications/Xcode_14.3.app
+          echo "Selected Xcode version:"
+          xcodebuild -version
 
       - name: Log environment information
         run: ./Scripts/log-environment-information.sh
@@ -53,8 +59,8 @@ jobs:
           brew install xcbeautify
           make submodules
           bundle install
-          make update_carthage_dependencies_tvos
-          bundle exec fastlane test_tvOS16_1
+          make update_carthage_dependencies_ios
+          bundle exec fastlane test_iOS16_4
 
       - name: Check Static Analyzer Output
         id: analyzer-output
@@ -70,7 +76,7 @@ jobs:
         if: ${{ failure() && steps.analyzer-output.outcome == 'failure' }}
         uses: actions/upload-artifact@v2
         with:
-          name: static-analyzer-reports-test_tvOS16_1
+          name: static-analyzer-reports-test_iOS16_4
           path: ./derived_data/**/report-*.html
 
       - name: Run Examples Tests
@@ -78,7 +84,12 @@ jobs:
         run: |
           pod repo update
           pod install
-          bundle exec fastlane scan -s Tests --output-directory "fastlane/test_output/examples/test_tvOS_16_1"
+          bundle exec fastlane scan -s Tests --output-directory "fastlane/test_output/examples/test_iOS16_4"
+
+      - name: Build APNS Example Project
+        working-directory: ./Examples/AblyPush
+        run: |
+          xcodebuild build -scheme "AblyPushExample" -destination "platform=iOS Simulator,name=iPhone 14" -configuration "Debug"
       
       - name: Xcodebuild Logs Artifact
         if: always()

--- a/.github/workflows/integration-test-macOS.yaml
+++ b/.github/workflows/integration-test-macOS.yaml
@@ -1,4 +1,4 @@
-name: "Integration Test: macOS Latest"
+name: "Integration Test: macOS 13"
 
 on:
   pull_request:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check:
-    runs-on: macos-latest
+    runs-on: macos-13
 
     env:
       LC_CTYPE: en_US.UTF-8

--- a/.github/workflows/integration-test-macOS.yaml
+++ b/.github/workflows/integration-test-macOS.yaml
@@ -22,6 +22,12 @@ jobs:
     steps:
       - name: Check out SDK repo
         uses: actions/checkout@v2
+        
+      - name: Select Specific Xcode Version (14.3)
+        run: |
+          sudo xcode-select -s /Applications/Xcode_14.3.app
+          echo "Selected Xcode version:"
+          xcodebuild -version
 
       - name: Log environment information
         run: ./Scripts/log-environment-information.sh

--- a/.github/workflows/integration-test-tvOS16_4.yaml
+++ b/.github/workflows/integration-test-tvOS16_4.yaml
@@ -1,4 +1,4 @@
-name: "Integration Test: iOS 16.2"
+name: "Integration Test: tvOS 16.4"
 
 on:
   pull_request:
@@ -22,6 +22,12 @@ jobs:
     steps:
       - name: Check out SDK repo
         uses: actions/checkout@v2
+        
+      - name: Select Specific Xcode Version (14.3)
+        run: |
+          sudo xcode-select -s /Applications/Xcode_14.3.app
+          echo "Selected Xcode version:"
+          xcodebuild -version
 
       - name: Log environment information
         run: ./Scripts/log-environment-information.sh
@@ -53,8 +59,8 @@ jobs:
           brew install xcbeautify
           make submodules
           bundle install
-          make update_carthage_dependencies_ios
-          bundle exec fastlane test_iOS16_2
+          make update_carthage_dependencies_tvos
+          bundle exec fastlane test_tvOS16_4
 
       - name: Check Static Analyzer Output
         id: analyzer-output
@@ -70,7 +76,7 @@ jobs:
         if: ${{ failure() && steps.analyzer-output.outcome == 'failure' }}
         uses: actions/upload-artifact@v2
         with:
-          name: static-analyzer-reports-test_iOS16_2
+          name: static-analyzer-reports-test_tvOS16_4
           path: ./derived_data/**/report-*.html
 
       - name: Run Examples Tests
@@ -78,12 +84,7 @@ jobs:
         run: |
           pod repo update
           pod install
-          bundle exec fastlane scan -s Tests --output-directory "fastlane/test_output/examples/test_iOS16_2"
-
-      - name: Build APNS Example Project
-        working-directory: ./Examples/AblyPush
-        run: |
-          xcodebuild build -scheme "AblyPushExample" -destination "platform=iOS Simulator,name=iPhone 14" -configuration "Debug"
+          bundle exec fastlane scan -s Tests --output-directory "fastlane/test_output/examples/test_tvOS_16_4"
       
       - name: Xcodebuild Logs Artifact
         if: always()

--- a/.github/workflows/integration-test-tvOS16_4.yaml
+++ b/.github/workflows/integration-test-tvOS16_4.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check:
-    runs-on: macos-latest
+    runs-on: macos-13
 
     env:
       LC_CTYPE: en_US.UTF-8

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,1 @@
-github "Quick/Nimble" == 9.2.1
+github "Quick/Nimble" == 11.2.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v9.2.1"
+github "Quick/Nimble" "v11.2.2"
 github "ably/delta-codec-cocoa" "1.3.3"
 github "rvi/msgpack-objective-C" "0.4.0"

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ carthage_package:
 
 	# https://github.com/Carthage/Carthage#archive-prebuilt-frameworks-into-one-zip-file
 	# From `carthage help build` we are told that `--archive` implies `--no-skip-current`.
-	./Scripts/carthage-with-workaround-for-issue-3019.sh build --archive --no-use-binaries
+	./Scripts/carthage-with-workaround-for-issue-3019.sh build --archive --no-use-binaries --platform iOS,macOS,tvOS
 	# Add LICENSE files (ours and SocketRocket’s).
 	./Scripts/add-licenses-to-carthage-output.sh
 
@@ -105,7 +105,7 @@ carthage_clean:
 update_carthage_dependencies:
 	$(info Updating Carthage dependencies for all platforms…)
 
-	carthage update --use-xcframeworks --no-use-binaries
+	carthage update --use-xcframeworks --platform iOS,macOS,tvOS --no-use-binaries
 
 ## [Carthage] Update dependencies for just iOS
 update_carthage_dependencies_ios:

--- a/Scripts/carthage-with-workaround-for-issue-3019.sh
+++ b/Scripts/carthage-with-workaround-for-issue-3019.sh
@@ -10,8 +10,8 @@ trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
 
 # For Xcode 13 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
 # the build will fail on lipo due to duplicate architectures.
-echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1300 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
-echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_arm64__XCODE_1300 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1400 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_arm64__XCODE_1400 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
 echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
 
 export XCODE_XCCONFIG_FILE="$xcconfig"

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -3740,7 +3740,7 @@ class AuthTests: XCTestCase {
             realtime.auth.authorize(callback)
         }
 
-        expect(didCancelAuthorization).to(be(true))
+        XCTAssertTrue(didCancelAuthorization)
         XCTAssertTrue(realtime.auth.tokenDetails === tokenDetailsLast)
         XCTAssertEqual(realtime.auth.tokenDetails?.token, tokenDetailsLast?.token)
 

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -2449,6 +2449,23 @@ class RealtimeClientChannelTests: XCTestCase {
         let test = Test()
         try beforeEach__Channel__publish__Connection_state_conditions__the_message(for: test, channelName: test.uniqueChannelName())
 
+        rtl6c2TestsClient.connect()
+        expect(rtl6c2TestsClient.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
+        expect(rtl6c2TestsChannel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        waitUntil(timeout: testTimeout) { done in
+            rtl16c2TestsPublish(done)
+            XCTAssertEqual(rtl6c2TestsClient.internal.queuedMessages.count, 0)
+            XCTAssertEqual((rtl6c2TestsClient.internal.transport as! TestProxyTransport).protocolMessagesSent.filter { $0.action == .message }.count, 1)
+        }
+
+        afterEach__Channel__publish__Connection_state_conditions__the_message()
+    }
+    
+    func skip_test__081__Channel__publish__Connection_state_conditions__the_message__should_NOT_be_queued_instead_it_should_be_published_if_the_channel_is__ATTACHED() throws {
+        let test = Test()
+        try beforeEach__Channel__publish__Connection_state_conditions__the_message(for: test, channelName: test.uniqueChannelName())
+
         waitUntil(timeout: testTimeout) { done in
             rtl6c2TestsChannel.attach { error in
                 XCTAssertNil(error)

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -213,11 +213,11 @@ class RealtimeClientChannelTests: XCTestCase {
         }
 
         expect(channel1.internal.presenceMap.members).toEventually(haveCount(2), timeout: testTimeout)
-        expect(channel1.internal.presenceMap.members.keys).to(allPass { $0!.hasPrefix("\(channel1.internal.connectionId):Client") || $0!.hasPrefix("\(channel2.internal.connectionId):Client") })
-        expect(channel1.internal.presenceMap.members.values).to(allPass { $0!.action == .present })
+        expect(channel1.internal.presenceMap.members.keys).to(allPass { $0.hasPrefix("\(channel1.internal.connectionId):Client") || $0.hasPrefix("\(channel2.internal.connectionId):Client") })
+        expect(channel1.internal.presenceMap.members.values).to(allPass { $0.action == .present })
 
         expect(channel2.internal.presenceMap.members).toEventually(haveCount(2), timeout: testTimeout)
-        expect(channel2.internal.presenceMap.members.keys).to(allPass { $0!.hasPrefix("\(channel1.internal.connectionId):Client") || $0!.hasPrefix("\(channel2.internal.connectionId):Client") })
+        expect(channel2.internal.presenceMap.members.keys).to(allPass { $0.hasPrefix("\(channel1.internal.connectionId):Client") || $0.hasPrefix("\(channel2.internal.connectionId):Client") })
         XCTAssertEqual(channel2.internal.presenceMap.members["\(channel1.internal.connectionId):Client 1"]!.action, ARTPresenceAction.present)
         XCTAssertEqual(channel2.internal.presenceMap.members["\(channel2.internal.connectionId):Client 2"]!.action, ARTPresenceAction.present)
     }

--- a/Test/Tests/RealtimeClientPresenceTests.swift
+++ b/Test/Tests/RealtimeClientPresenceTests.swift
@@ -3296,8 +3296,8 @@ class RealtimeClientPresenceTests: XCTestCase {
                 }
                 expect(members!.first).to(beAnInstanceOf(ARTPresenceMessage.self))
                 expect(members).to(allPass { member in
-                    NSRegularExpression.match(member!.clientId, pattern: "^user(\\d+)$")
-                        && (member!.data as? String) == expectedData
+                    NSRegularExpression.match(member.clientId, pattern: "^user(\\d+)$")
+                        && (member.data as? String) == expectedData
                 })
                 done()
             }
@@ -3812,8 +3812,8 @@ class RealtimeClientPresenceTests: XCTestCase {
 
                 let members = membersPage.items
                 expect(members).to(allPass { member in
-                    NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                        && (member!.data as! [String]) == expectedData
+                    NSRegularExpression.match(member.clientId, pattern: expectedPattern)
+                        && (member.data as! [String]) == expectedData
                 })
 
                 XCTAssertTrue(membersPage.hasNext)
@@ -3829,8 +3829,8 @@ class RealtimeClientPresenceTests: XCTestCase {
 
                     let members = nextPage.items
                     expect(members).to(allPass { member in
-                        NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                            && (member!.data as! [String]) == expectedData
+                        NSRegularExpression.match(member.clientId, pattern: expectedPattern)
+                            && (member.data as! [String]) == expectedData
                     })
 
                     XCTAssertFalse(nextPage.hasNext)

--- a/Test/Tests/RealtimeClientTests.swift
+++ b/Test/Tests/RealtimeClientTests.swift
@@ -225,7 +225,7 @@ class RealtimeClientTests: XCTestCase {
                     /**
                      Test that replacing query string default values in ARTClientOptions works properly
                      */
-                    expect(absoluteString.components(separatedBy: "v=").count).to(be(2))
+                    XCTAssertEqual(absoluteString.components(separatedBy: "v=").count, 2)
                 } else {
                     XCTFail("Expected webSocketTransport.websocketURL?.absoluteString to be non-nil")
                 }

--- a/Test/Tests/RestClientPresenceTests.swift
+++ b/Test/Tests/RestClientPresenceTests.swift
@@ -37,8 +37,8 @@ class RestClientPresenceTests: XCTestCase {
 
                 let members = membersPage.items
                 expect(members).to(allPass { member in
-                    NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                        && (member!.data as? String) == expectedData
+                    NSRegularExpression.match(member.clientId, pattern: expectedPattern)
+                        && (member.data as? String) == expectedData
                 })
 
                 XCTAssertTrue(membersPage.hasNext)
@@ -52,8 +52,8 @@ class RestClientPresenceTests: XCTestCase {
 
                     let members = nextPage.items
                     expect(members).to(allPass { member in
-                        NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                            && (member!.data as? String) == expectedData
+                        NSRegularExpression.match(member.clientId, pattern: expectedPattern)
+                            && (member.data as? String) == expectedData
                     })
 
                     XCTAssertFalse(nextPage.hasNext)
@@ -151,7 +151,6 @@ class RestClientPresenceTests: XCTestCase {
                     XCTAssertFalse(membersPage!.hasNext)
                     XCTAssertTrue(membersPage!.isLast)
                     expect(membersPage!.items).to(allPass { member in
-                        let member = member!
                         return NSRegularExpression.match(member.clientId, pattern: "^user(7|8|9)")
                     })
                     done()
@@ -189,8 +188,8 @@ class RestClientPresenceTests: XCTestCase {
 
                 let members = membersPage.items
                 expect(members).to(allPass { member in
-                    NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                        && (member!.data as? String) == expectedData
+                    NSRegularExpression.match(member.clientId, pattern: expectedPattern)
+                        && (member.data as? String) == expectedData
                 })
 
                 XCTAssertTrue(membersPage.hasNext)
@@ -206,8 +205,8 @@ class RestClientPresenceTests: XCTestCase {
 
                     let members = nextPage.items
                     expect(members).to(allPass { member in
-                        NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                            && (member!.data as? String) == expectedData
+                        NSRegularExpression.match(member.clientId, pattern: expectedPattern)
+                            && (member.data as? String) == expectedData
                     })
 
                     XCTAssertFalse(nextPage.hasNext)
@@ -350,8 +349,7 @@ class RestClientPresenceTests: XCTestCase {
                     XCTAssertFalse(membersPage!.hasNext)
                     XCTAssertTrue(membersPage!.isLast)
                     expect(membersPage!.items).to(allPass { member in
-                        let member = member
-                        return NSRegularExpression.match(member!.clientId, pattern: "^user(7|8|9)")
+                        return NSRegularExpression.match(member.clientId, pattern: "^user(7|8|9)")
                     })
                     done()
                 }

--- a/Test/Tests/RestClientTests.swift
+++ b/Test/Tests/RestClientTests.swift
@@ -1507,7 +1507,7 @@ class RestClientTests: XCTestCase {
             $0.allHTTPHeaderFields!["Host"] == $0.url?.host
         }
 
-        expect(fallbackRequests.count).to(be(fallbackRequestsWithHostHeader.count))
+        XCTAssertEqual(fallbackRequests.count, fallbackRequestsWithHostHeader.count)
     }
 
     func test__073__RestClient__Host_Fallback__retry_hosts_in_random_order__if_an_empty_array_of_fallback_hosts_is_provided__then_fallback_host_functionality_is_disabled() {
@@ -2144,7 +2144,7 @@ class RestClientTests: XCTestCase {
         }
 
         expect(fallbackRequests).toNot(beEmpty())
-        expect(fallbackRequests).to(allPass { extractURLQueryValue($0?.url, key: "request_id") == requestId })
+        expect(fallbackRequests).to(allPass { extractURLQueryValue($0.url, key: "request_id") == requestId })
     }
 
     func test__097__RestClient__request_IDs__ErrorInfo_should_have__requestId__property() {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,8 +22,8 @@ end
 platform :ios do
 
   LANE_CONFIGS = [
-    LaneConfig.new(:test_iOS16_2, "Ably-iOS", ["iPhone 14 (16.2)"]),
-    LaneConfig.new(:test_tvOS16_1, "Ably-tvOS", ["Apple TV 4K (2nd generation) (16.1)"]),
+    LaneConfig.new(:test_iOS16_4, "Ably-iOS", ["iPhone 14 (16.4)"]),
+    LaneConfig.new(:test_tvOS16_4, "Ably-tvOS", ["Apple TV 4K (3rd generation) (16.4)"]),
     LaneConfig.new(:test_macOS, "Ably-macOS")
   ]
 


### PR DESCRIPTION
See #1801

Contains work from https://github.com/ably/ably-cocoa/pull/1783

The reason why tests stop failing after `ttl` time has been increased in #1783 remains unknown, but I think it's due to different hardware Github uses for its beta servers where low performance can affect how test executes with smaller timeout values. So I would run those workflows again when macOS 13 (by reverting explicit switch to macos 13 3bb354db67ef476603ff0a75b03c3f856a1f3b93) will become the latest available os and see how tests will behave there.

The test "test__81..." was modified to reflect what it says in the title and to be similar to the "test__80..." which has similar title and conditions. But I left the previous version of the "test__80..." with the "skip" prefix and created an [issue](https://github.com/ably/ably-cocoa/issues/1798) for dealing with it later, since I think that behavior of this test is rather confusing and is in contradiction to its own title.