### PR TITLE
[SDK-3644] Preparation for macOS 13

### DIFF
--- a/.github/workflows/check-pod.yaml
+++ b/.github/workflows/check-pod.yaml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Select Specific Xcode Version (13.4.1)
+      - name: Select Specific Xcode Version (14.2)
         run: |
-          sudo xcode-select -s /Applications/Xcode_13.4.1.app
+          sudo xcode-select -s /Applications/Xcode_14.2.app
           echo "Selected Xcode version:"
           xcodebuild -version
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Select Specific Xcode Version
+      - name: Select Specific Xcode Version (14.2)
         run: |
-          sudo xcode-select -s /Applications/Xcode_13.2.app
+          sudo xcode-select -s /Applications/Xcode_14.2.app
           echo "Selected Xcode version:"
           xcodebuild -version
 

--- a/.github/workflows/integration-test-iOS16_2.yaml
+++ b/.github/workflows/integration-test-iOS16_2.yaml
@@ -22,6 +22,12 @@ jobs:
     steps:
       - name: Check out SDK repo
         uses: actions/checkout@v2
+        
+      - name: Select Specific Xcode Version (14.2)
+        run: |
+          sudo xcode-select -s /Applications/Xcode_14.2.app
+          echo "Selected Xcode version:"
+          xcodebuild -version
 
       - name: Log environment information
         run: ./Scripts/log-environment-information.sh

--- a/.github/workflows/integration-test-macOS.yaml
+++ b/.github/workflows/integration-test-macOS.yaml
@@ -22,6 +22,12 @@ jobs:
     steps:
       - name: Check out SDK repo
         uses: actions/checkout@v2
+        
+      - name: Select Specific Xcode Version (14.2)
+        run: |
+          sudo xcode-select -s /Applications/Xcode_14.2.app
+          echo "Selected Xcode version:"
+          xcodebuild -version
 
       - name: Log environment information
         run: ./Scripts/log-environment-information.sh

--- a/.github/workflows/integration-test-tvOS16_1.yaml
+++ b/.github/workflows/integration-test-tvOS16_1.yaml
@@ -22,6 +22,12 @@ jobs:
     steps:
       - name: Check out SDK repo
         uses: actions/checkout@v2
+        
+      - name: Select Specific Xcode Version (14.2)
+        run: |
+          sudo xcode-select -s /Applications/Xcode_14.2.app
+          echo "Selected Xcode version:"
+          xcodebuild -version
 
       - name: Log environment information
         run: ./Scripts/log-environment-information.sh

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,1 @@
-github "Quick/Nimble" == 9.2.1
+github "Quick/Nimble" == 11.2.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v9.2.1"
+github "Quick/Nimble" "v11.2.2"
 github "ably/delta-codec-cocoa" "1.3.3"
 github "rvi/msgpack-objective-C" "0.4.0"

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ carthage_package:
 
 	# https://github.com/Carthage/Carthage#archive-prebuilt-frameworks-into-one-zip-file
 	# From `carthage help build` we are told that `--archive` implies `--no-skip-current`.
-	./Scripts/carthage-with-workaround-for-issue-3019.sh build --archive --no-use-binaries
+	./Scripts/carthage-with-workaround-for-issue-3019.sh build --archive --no-use-binaries --platform iOS,macOS,tvOS
 	# Add LICENSE files (ours and SocketRocket’s).
 	./Scripts/add-licenses-to-carthage-output.sh
 
@@ -105,7 +105,7 @@ carthage_clean:
 update_carthage_dependencies:
 	$(info Updating Carthage dependencies for all platforms…)
 
-	carthage update --use-xcframeworks --no-use-binaries
+	carthage update --use-xcframeworks --platform iOS,macOS,tvOS --no-use-binaries
 
 ## [Carthage] Update dependencies for just iOS
 update_carthage_dependencies_ios:

--- a/Scripts/carthage-with-workaround-for-issue-3019.sh
+++ b/Scripts/carthage-with-workaround-for-issue-3019.sh
@@ -10,8 +10,8 @@ trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
 
 # For Xcode 13 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
 # the build will fail on lipo due to duplicate architectures.
-echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1300 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
-echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_arm64__XCODE_1300 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1400 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_arm64__XCODE_1400 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
 echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
 
 export XCODE_XCCONFIG_FILE="$xcconfig"

--- a/Source/ARTRealtimePresence.m
+++ b/Source/ARTRealtimePresence.m
@@ -234,15 +234,7 @@ dispatch_async(_queue, ^{
 
 - (BOOL)history:(ARTRealtimeHistoryQuery *)query callback:(ARTPaginatedPresenceCallback)callback error:(NSError **)errorPtr {
     query.realtimeChannel = _channel;
-    @try {
-        return [_channel.restChannel.presence history:query callback:callback error:errorPtr];
-    }
-    @catch (NSError *error) {
-        if (errorPtr) {
-            *errorPtr = error;
-        }
-        return false;
-    }
+    return [_channel.restChannel.presence history:query callback:callback error:errorPtr];
 }
 
 - (void)enter:(id)data {

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -1744,7 +1744,7 @@ extension ARTPresenceAction : CustomStringConvertible {
 // MARK: - Custom Nimble Matchers
 
 /// A Nimble matcher that succeeds when two dates are quite the same.
-public func beCloseTo(_ expectedValue: Date) -> Predicate<Date> {
+public func beCloseTo(_ expectedValue: Date) -> Nimble.Predicate<Date> {
     let errorMessage = "be close to <\(expectedValue)> (within 0.5)"
     return Predicate.simple(errorMessage) { actualExpression in
         guard let actualValue = try actualExpression.evaluate() else {
@@ -1758,7 +1758,7 @@ public func beCloseTo(_ expectedValue: Date) -> Predicate<Date> {
 }
 
 /// A Nimble matcher that succeeds when a param exists.
-public func haveParam(_ key: String, withValue expectedValue: String? = nil) -> Predicate<String> {
+public func haveParam(_ key: String, withValue expectedValue: String? = nil) -> Nimble.Predicate<String> {
     let errorMessage = "param <\(key)=\(expectedValue ?? "nil")> exists"
     return Predicate.simple(errorMessage) { actualExpression in
         guard let actualValue = try actualExpression.evaluate() else {
@@ -1776,7 +1776,7 @@ public func haveParam(_ key: String, withValue expectedValue: String? = nil) -> 
 }
 
 /// A Nimble matcher that succeeds when a param value starts with a particular string.
-public func haveParam(_ key: String, hasPrefix expectedValue: String) -> Predicate<String> {
+public func haveParam(_ key: String, hasPrefix expectedValue: String) -> Nimble.Predicate<String> {
     let errorMessage = "param <\(key)> has prefix \(expectedValue)"
     return Predicate.simple(errorMessage) { actualExpression in
         guard let actualValue = try actualExpression.evaluate() else {

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -3740,7 +3740,7 @@ class AuthTests: XCTestCase {
             realtime.auth.authorize(callback)
         }
 
-        expect(didCancelAuthorization).to(be(true))
+        XCTAssertTrue(didCancelAuthorization)
         XCTAssertTrue(realtime.auth.tokenDetails === tokenDetailsLast)
         XCTAssertEqual(realtime.auth.tokenDetails?.token, tokenDetailsLast?.token)
 

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -213,11 +213,11 @@ class RealtimeClientChannelTests: XCTestCase {
         }
 
         expect(channel1.internal.presenceMap.members).toEventually(haveCount(2), timeout: testTimeout)
-        expect(channel1.internal.presenceMap.members.keys).to(allPass { $0!.hasPrefix("\(channel1.internal.connectionId):Client") || $0!.hasPrefix("\(channel2.internal.connectionId):Client") })
-        expect(channel1.internal.presenceMap.members.values).to(allPass { $0!.action == .present })
+        expect(channel1.internal.presenceMap.members.keys).to(allPass { $0.hasPrefix("\(channel1.internal.connectionId):Client") || $0.hasPrefix("\(channel2.internal.connectionId):Client") })
+        expect(channel1.internal.presenceMap.members.values).to(allPass { $0.action == .present })
 
         expect(channel2.internal.presenceMap.members).toEventually(haveCount(2), timeout: testTimeout)
-        expect(channel2.internal.presenceMap.members.keys).to(allPass { $0!.hasPrefix("\(channel1.internal.connectionId):Client") || $0!.hasPrefix("\(channel2.internal.connectionId):Client") })
+        expect(channel2.internal.presenceMap.members.keys).to(allPass { $0.hasPrefix("\(channel1.internal.connectionId):Client") || $0.hasPrefix("\(channel2.internal.connectionId):Client") })
         XCTAssertEqual(channel2.internal.presenceMap.members["\(channel1.internal.connectionId):Client 1"]!.action, ARTPresenceAction.present)
         XCTAssertEqual(channel2.internal.presenceMap.members["\(channel2.internal.connectionId):Client 2"]!.action, ARTPresenceAction.present)
     }

--- a/Test/Tests/RealtimeClientPresenceTests.swift
+++ b/Test/Tests/RealtimeClientPresenceTests.swift
@@ -3296,8 +3296,8 @@ class RealtimeClientPresenceTests: XCTestCase {
                 }
                 expect(members!.first).to(beAnInstanceOf(ARTPresenceMessage.self))
                 expect(members).to(allPass { member in
-                    NSRegularExpression.match(member!.clientId, pattern: "^user(\\d+)$")
-                        && (member!.data as? String) == expectedData
+                    NSRegularExpression.match(member.clientId, pattern: "^user(\\d+)$")
+                        && (member.data as? String) == expectedData
                 })
                 done()
             }
@@ -3812,8 +3812,8 @@ class RealtimeClientPresenceTests: XCTestCase {
 
                 let members = membersPage.items
                 expect(members).to(allPass { member in
-                    NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                        && (member!.data as! [String]) == expectedData
+                    NSRegularExpression.match(member.clientId, pattern: expectedPattern)
+                        && (member.data as! [String]) == expectedData
                 })
 
                 XCTAssertTrue(membersPage.hasNext)
@@ -3829,8 +3829,8 @@ class RealtimeClientPresenceTests: XCTestCase {
 
                     let members = nextPage.items
                     expect(members).to(allPass { member in
-                        NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                            && (member!.data as! [String]) == expectedData
+                        NSRegularExpression.match(member.clientId, pattern: expectedPattern)
+                            && (member.data as! [String]) == expectedData
                     })
 
                     XCTAssertFalse(nextPage.hasNext)

--- a/Test/Tests/RealtimeClientTests.swift
+++ b/Test/Tests/RealtimeClientTests.swift
@@ -225,7 +225,7 @@ class RealtimeClientTests: XCTestCase {
                     /**
                      Test that replacing query string default values in ARTClientOptions works properly
                      */
-                    expect(absoluteString.components(separatedBy: "v=").count).to(be(2))
+                    XCTAssertEqual(absoluteString.components(separatedBy: "v=").count, 2)
                 } else {
                     XCTFail("Expected webSocketTransport.websocketURL?.absoluteString to be non-nil")
                 }

--- a/Test/Tests/RestClientChannelsTests.swift
+++ b/Test/Tests/RestClientChannelsTests.swift
@@ -9,7 +9,7 @@ extension ARTRestChannels: Sequence {
     }
 }
 
-private func beAChannel(named expectedValue: String) -> Predicate<ARTChannel> {
+private func beAChannel(named expectedValue: String) -> Nimble.Predicate<ARTChannel> {
     return Predicate.define("be a channel with name \"\(expectedValue)\"") { actualExpression, msg -> PredicateResult in
         let actualValue = try actualExpression.evaluate()
         let m = msg.appended(details: "\"\(actualValue?.name ?? "nil")\" instead")

--- a/Test/Tests/RestClientPresenceTests.swift
+++ b/Test/Tests/RestClientPresenceTests.swift
@@ -37,8 +37,8 @@ class RestClientPresenceTests: XCTestCase {
 
                 let members = membersPage.items
                 expect(members).to(allPass { member in
-                    NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                        && (member!.data as? String) == expectedData
+                    NSRegularExpression.match(member.clientId, pattern: expectedPattern)
+                        && (member.data as? String) == expectedData
                 })
 
                 XCTAssertTrue(membersPage.hasNext)
@@ -52,8 +52,8 @@ class RestClientPresenceTests: XCTestCase {
 
                     let members = nextPage.items
                     expect(members).to(allPass { member in
-                        NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                            && (member!.data as? String) == expectedData
+                        NSRegularExpression.match(member.clientId, pattern: expectedPattern)
+                            && (member.data as? String) == expectedData
                     })
 
                     XCTAssertFalse(nextPage.hasNext)
@@ -151,7 +151,6 @@ class RestClientPresenceTests: XCTestCase {
                     XCTAssertFalse(membersPage!.hasNext)
                     XCTAssertTrue(membersPage!.isLast)
                     expect(membersPage!.items).to(allPass { member in
-                        let member = member!
                         return NSRegularExpression.match(member.clientId, pattern: "^user(7|8|9)")
                     })
                     done()
@@ -189,8 +188,8 @@ class RestClientPresenceTests: XCTestCase {
 
                 let members = membersPage.items
                 expect(members).to(allPass { member in
-                    NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                        && (member!.data as? String) == expectedData
+                    NSRegularExpression.match(member.clientId, pattern: expectedPattern)
+                        && (member.data as? String) == expectedData
                 })
 
                 XCTAssertTrue(membersPage.hasNext)
@@ -206,8 +205,8 @@ class RestClientPresenceTests: XCTestCase {
 
                     let members = nextPage.items
                     expect(members).to(allPass { member in
-                        NSRegularExpression.match(member!.clientId, pattern: expectedPattern)
-                            && (member!.data as? String) == expectedData
+                        NSRegularExpression.match(member.clientId, pattern: expectedPattern)
+                            && (member.data as? String) == expectedData
                     })
 
                     XCTAssertFalse(nextPage.hasNext)
@@ -350,8 +349,7 @@ class RestClientPresenceTests: XCTestCase {
                     XCTAssertFalse(membersPage!.hasNext)
                     XCTAssertTrue(membersPage!.isLast)
                     expect(membersPage!.items).to(allPass { member in
-                        let member = member
-                        return NSRegularExpression.match(member!.clientId, pattern: "^user(7|8|9)")
+                        return NSRegularExpression.match(member.clientId, pattern: "^user(7|8|9)")
                     })
                     done()
                 }

--- a/Test/Tests/RestClientTests.swift
+++ b/Test/Tests/RestClientTests.swift
@@ -1507,7 +1507,7 @@ class RestClientTests: XCTestCase {
             $0.allHTTPHeaderFields!["Host"] == $0.url?.host
         }
 
-        expect(fallbackRequests.count).to(be(fallbackRequestsWithHostHeader.count))
+        XCTAssertEqual(fallbackRequests.count, fallbackRequestsWithHostHeader.count)
     }
 
     func test__073__RestClient__Host_Fallback__retry_hosts_in_random_order__if_an_empty_array_of_fallback_hosts_is_provided__then_fallback_host_functionality_is_disabled() {
@@ -2144,7 +2144,7 @@ class RestClientTests: XCTestCase {
         }
 
         expect(fallbackRequests).toNot(beEmpty())
-        expect(fallbackRequests).to(allPass { extractURLQueryValue($0?.url, key: "request_id") == requestId })
+        expect(fallbackRequests).to(allPass { extractURLQueryValue($0.url, key: "request_id") == requestId })
     }
 
     func test__097__RestClient__request_IDs__ErrorInfo_should_have__requestId__property() {


### PR DESCRIPTION
Closes #1765, #1766

This contains changes required by Xcode 14.3 (and 15 by the means of https://github.com/ably/ably-cocoa/pull/1801/commits/64967fe59da53e41c45564297167e894e247f683 and https://github.com/ably/ably-cocoa/pull/1801/commits/62fb2335c37dee19b1b3fa8ef70e75ed26a427ff), but not actually switching to macOS 13 for it (Xcode 14.2 accepts those changes just fine).

By switching to macOS 13 explicitly, [known set of tests](https://github.com/ably/ably-cocoa/pull/1760#issuecomment-1606290881) begins to fail on CI, until `ttl` timeout for those tests [increase](https://github.com/ably/ably-cocoa/pull/1799/commits/a1e270a235abd6171dc5804ddd0a0197870874b7) (https://github.com/ably/ably-cocoa/pull/1783, [run](https://github.com/ably/ably-cocoa/actions/runs/6178325306/job/16796412215?pr=1799)). On iOS 17 they at least [failed once](https://github.com/ably/ably-cocoa/actions/runs/6178325306/job/16791883533?pr=1799) even with increased timeout. Those tests succeed when run locally (on Xcode 14.3/15).

See also [PR](https://github.com/ably/ably-cocoa/pull/1802) for adding iOS 17 Ci job.

Other experiments on transition to macOS 13: https://github.com/ably/ably-cocoa/pull/1783, https://github.com/ably/ably-cocoa/pull/1797, https://github.com/ably/ably-cocoa/pull/1799, https://github.com/ably/ably-cocoa/pull/1800
