### PR TITLE
[SDK-3926] Treat all transport errors as recoverable

### DIFF
--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -1629,21 +1629,10 @@ const NSTimeInterval _reachabilityReconnectionAttemptThreshold = 0.1;
             return;
         }
     }
-    
-    switch (transportError.type) {
-        case ARTRealtimeTransportErrorTypeBadResponse:
-        case ARTRealtimeTransportErrorTypeOther: {
-            ARTErrorInfo *const errorInfo = [ARTErrorInfo createFromNSError:transportError.error];
-            ARTConnectionStateChangeMetadata *const metadata = [[ARTConnectionStateChangeMetadata alloc] initWithErrorInfo:errorInfo];
-            [self transition:ARTRealtimeFailed withMetadata:metadata];
-            break;
-        }
-        default: {
-            ARTErrorInfo *error = [ARTErrorInfo createFromNSError:transportError.error];
-            ARTConnectionStateChangeMetadata *const metadata = [[ARTConnectionStateChangeMetadata alloc] initWithErrorInfo:error];
-            [self transitionToDisconnectedOrSuspendedWithMetadata:metadata];
-        }
-    }
+
+    ARTErrorInfo *const errorInfo = [ARTErrorInfo createFromNSError:transportError.error];
+    ARTConnectionStateChangeMetadata *const metadata = [[ARTConnectionStateChangeMetadata alloc] initWithErrorInfo:errorInfo];
+    [self transitionToDisconnectedOrSuspendedWithMetadata:metadata];
 }
 
 - (void)realtimeTransportNeverConnected:(id<ARTRealtimeTransport>)transport {
@@ -1654,7 +1643,7 @@ const NSTimeInterval _reachabilityReconnectionAttemptThreshold = 0.1;
     
     ARTErrorInfo *const errorInfo = [ARTErrorInfo createWithCode:ARTClientCodeErrorTransport message:@"Transport never connected"];
     ARTConnectionStateChangeMetadata *const metadata = [[ARTConnectionStateChangeMetadata alloc] initWithErrorInfo:errorInfo];
-    [self transition:ARTRealtimeFailed withMetadata:metadata];
+    [self transitionToDisconnectedOrSuspendedWithMetadata:metadata];
 }
 
 - (void)realtimeTransportRefused:(id<ARTRealtimeTransport>)transport withError:(ARTRealtimeTransportError *)error {
@@ -1666,15 +1655,16 @@ const NSTimeInterval _reachabilityReconnectionAttemptThreshold = 0.1;
     if (error && error.type == ARTRealtimeTransportErrorTypeRefused) {
         ARTErrorInfo *const errorInfo = [ARTErrorInfo createWithCode:ARTClientCodeErrorTransport message:[NSString stringWithFormat:@"Connection refused using %@", error.url]];
         ARTConnectionStateChangeMetadata *const metadata = [[ARTConnectionStateChangeMetadata alloc] initWithErrorInfo:errorInfo];
-        [self transition:ARTRealtimeFailed withMetadata:metadata];
+        [self transitionToDisconnectedOrSuspendedWithMetadata:metadata];
     }
     else if (error) {
         ARTErrorInfo *const errorInfo = [ARTErrorInfo createFromNSError:error.error];
         ARTConnectionStateChangeMetadata *const metadata = [[ARTConnectionStateChangeMetadata alloc] initWithErrorInfo:errorInfo];
-        [self transition:ARTRealtimeFailed withMetadata:metadata];
+        [self transitionToDisconnectedOrSuspendedWithMetadata:metadata];
     }
     else {
-        [self transition:ARTRealtimeFailed withMetadata:[[ARTConnectionStateChangeMetadata alloc] init]];
+        ARTConnectionStateChangeMetadata *const metadata = [[ARTConnectionStateChangeMetadata alloc] init];
+        [self transitionToDisconnectedOrSuspendedWithMetadata:metadata];
     }
 }
 
@@ -1686,7 +1676,7 @@ const NSTimeInterval _reachabilityReconnectionAttemptThreshold = 0.1;
 
     ARTErrorInfo *const errorInfo = [ARTErrorInfo createWithCode:ARTClientCodeErrorTransport message:@"Transport too big"];
     ARTConnectionStateChangeMetadata *const metadata = [[ARTConnectionStateChangeMetadata alloc] initWithErrorInfo:errorInfo];
-    [self transition:ARTRealtimeFailed withMetadata:metadata];
+    [self transitionToDisconnectedOrSuspendedWithMetadata:metadata];
 }
 
 - (void)realtimeTransportSetMsgSerial:(id<ARTRealtimeTransport>)transport msgSerial:(int64_t)msgSerial {

--- a/Source/ARTWebSocketTransport.m
+++ b/Source/ARTWebSocketTransport.m
@@ -282,9 +282,14 @@ NS_ASSUME_NONNULL_END
         [_delegate realtimeTransportDisconnected:self withError:nil];
         break;
     case ARTWsRefuse:
-    case ARTWsPolicyValidation:
-        [_delegate realtimeTransportRefused:self withError:[[ARTRealtimeTransportError alloc] initWithError:[ARTErrorInfo createWithCode:code message:reason] type:ARTRealtimeTransportErrorTypeRefused url:self.websocketURL]];
+    case ARTWsPolicyValidation: {
+        ARTErrorInfo *const errorInfo = [ARTErrorInfo createWithCode:code message:reason];
+        ARTRealtimeTransportError *const error = [[ARTRealtimeTransportError alloc] initWithError:errorInfo
+                                                                                             type:ARTRealtimeTransportErrorTypeRefused
+                                                                                              url:self.websocketURL];
+        [_delegate realtimeTransportRefused:self withError:error];
         break;
+    }
     case ARTWsTooBig:
         [_delegate realtimeTransportTooBig:self];
         break;
@@ -292,10 +297,15 @@ NS_ASSUME_NONNULL_END
     case ARTWsCloseProtocolError:
     case ARTWsUnexpectedCondition:
     case ARTWsExtension:
-    case ARTWsTlsError:
+    case ARTWsTlsError: {
         // Failed
-        [_delegate realtimeTransportFailed:self withError:[[ARTRealtimeTransportError alloc] initWithError:[ARTErrorInfo createWithCode:code message:reason] type:ARTRealtimeTransportErrorTypeOther url:self.websocketURL]];
+        ARTErrorInfo *const errorInfo = [ARTErrorInfo createWithCode:code message:reason];
+        ARTRealtimeTransportError *const error = [[ARTRealtimeTransportError alloc] initWithError:errorInfo
+                                                                                             type:ARTRealtimeTransportErrorTypeOther
+                                                                                              url:self.websocketURL];
+        [_delegate realtimeTransportFailed:self withError:error];
         break;
+    }
     default:
         NSAssert(true, @"WebSocket close: unknown code");
         break;

--- a/Source/PrivateHeaders/Ably/ARTRealtimeTransport.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeTransport.h
@@ -32,6 +32,9 @@ typedef NS_ENUM(NSUInteger, ARTRealtimeTransportState) {
 
 @property (nonatomic) NSError *error;
 @property (nonatomic) ARTRealtimeTransportErrorType type;
+/**
+ This meaning of this property is only defined if the error is of type `ARTRealtimeTransportErrorTypeBadResponse`.
+ */
 @property (nonatomic) NSInteger badResponseCode;
 @property (nonatomic) NSURL *url;
 

--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -751,6 +751,7 @@ enum FakeNetworkResponse {
     case requestTimeout(timeout: TimeInterval)
     case hostInternalError(code: Int)
     case host400BadRequest
+    case arbitraryError
 
     var error: NSError {
         switch self {
@@ -764,6 +765,8 @@ enum FakeNetworkResponse {
             return NSError(domain: AblyTestsErrorDomain, code: code, userInfo: [NSLocalizedDescriptionKey: "internal error", NSLocalizedFailureReasonErrorKey: AblyTestsErrorDomain + ".FakeNetworkResponse"])
         case .host400BadRequest:
             return NSError(domain: AblyTestsErrorDomain, code: 400, userInfo: [NSLocalizedDescriptionKey: "bad request", NSLocalizedFailureReasonErrorKey: AblyTestsErrorDomain + ".FakeNetworkResponse"])
+        case .arbitraryError:
+            return NSError(domain: AblyTestsErrorDomain, code: 1, userInfo: [NSLocalizedDescriptionKey: "error from FakeNetworkResponse.arbitraryError"])
         }
     }
 
@@ -779,6 +782,8 @@ enum FakeNetworkResponse {
             return ARTRealtimeTransportError(error: error, badResponseCode: code, url: url)
         case .host400BadRequest:
             return ARTRealtimeTransportError(error: error, badResponseCode: 400, url: url)
+        case .arbitraryError:
+            return ARTRealtimeTransportError(error: error, type: .other, url: url)
         }
     }
 }
@@ -864,6 +869,8 @@ class MockHTTP: ARTHttp {
             requestCallback?(HTTPURLResponse(url: URL(string: "http://cocoa.test.suite")!, statusCode: code, httpVersion: nil, headerFields: nil), nil, nil)
         case .host400BadRequest:
             requestCallback?(HTTPURLResponse(url: URL(string: "http://cocoa.test.suite")!, statusCode: 400, httpVersion: nil, headerFields: nil), nil, nil)
+        case .arbitraryError:
+            requestCallback?(nil, nil, NSError(domain: AblyTestsErrorDomain, code: 1, userInfo: [NSLocalizedDescriptionKey: "error from FakeNetworkResponse.arbitraryError"]))
         }
     }
 
@@ -1289,7 +1296,8 @@ class TestProxyTransport: ARTWebSocketTransport {
             case .noInternet,
                  .hostUnreachable,
                  .hostInternalError,
-                 .host400BadRequest:
+                 .host400BadRequest,
+                 .arbitraryError:
                 performFakeConnectionError(0.1, error: networkResponse.transportError(for: url))
             case .requestTimeout(let timeout):
                 performFakeConnectionError(0.1 + timeout, error: networkResponse.transportError(for: url))
@@ -1658,9 +1666,11 @@ extension ARTWebSocketTransport {
     }
 
     func simulateIncomingError() {
-        let error = NSError(domain: ARTAblyErrorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey:"Fail test"])
-        let webSocketDelegate = self as ARTWebSocketDelegate
-        webSocketDelegate.webSocket?(self.websocket!, didFailWithError: error)
+        // Simulate receiving an ERROR ProtocolMessage, which should put a client into the FAILED state (per RTN15i)
+        let protocolMessage = ARTProtocolMessage()
+        protocolMessage.action = .error
+        protocolMessage.error = ARTErrorInfo.create(withCode: 50000 /* arbitrarily chosen */, message: "Fail test")
+        receive(protocolMessage)
     }
 }
 

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -2262,7 +2262,6 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__059__Connection__connection_request_fails__connection_attempt_fails_for_any_recoverable_reason() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
-        options.realtimeHost = "10.255.255.1" // non-routable IP address
         options.disconnectedRetryTimeout = 1.0
         options.autoConnect = false
         options.testOptions.realtimeRequestTimeout = 0.1


### PR DESCRIPTION
This treats all transport errors as recoverable from the point of view of [RTN14d](https://sdk.ably.com/builds/ably/specification/main/features/#RTN14d).

The immediate reason for doing this is so that an error of OSStatus 9806 (`errSSLClosedAbort`) doesn't cause the client to transition to the `FAILED` state. But, as described in the commit message, this also reflects the broader approach that @paddybyers wants us to take for handling transport errors.

Resolves #1817.