### PR TITLE
Clear clientId after deregistration

### DIFF
--- a/Source/ARTLocalDevice.m
+++ b/Source/ARTLocalDevice.m
@@ -153,4 +153,9 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
     return _identityTokenDetails != nil;
 }
 
+- (void)clearIdentityTokenDetailsAndClientId {
+    [self setAndPersistIdentityTokenDetails:nil];
+    self.clientId = nil;
+}
+
 @end

--- a/Source/ARTPushActivationState.m
+++ b/Source/ARTPushActivationState.m
@@ -275,7 +275,7 @@ ARTPushActivationState *validateAndSync(ARTPushActivationStateMachine *machine, 
     else if ([event isKindOfClass:[ARTPushActivationEventDeregistered class]]) {
         #if TARGET_OS_IOS
         ARTLocalDevice *local = self.machine.rest.device_nosync;
-        [local setAndPersistIdentityTokenDetails:nil];
+        [local clearIdentityTokenDetailsAndClientId];
         #endif
         [self.machine callDeactivatedCallback:nil];
         return [ARTPushActivationStateNotActivated newWithMachine:self.machine logger:self.logger];

--- a/Source/PrivateHeaders/Ably/ARTLocalDevice+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTLocalDevice+Private.h
@@ -25,6 +25,7 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString * _Nullable tokenType);
 - (void)setAndPersistAPNSDeviceToken:(nullable NSString *)deviceToken;
 - (void)setAndPersistIdentityTokenDetails:(nullable ARTDeviceIdentityTokenDetails *)tokenDetails;
 - (BOOL)isRegistered;
+- (void)clearIdentityTokenDetailsAndClientId;
 
 + (NSString *)generateId;
 + (NSString *)generateSecret;


### PR DESCRIPTION
This partially fixes issue #1177 (deregistration does not clear device details) and only resets clientId, since it affects push device registration with a different clientId (after deregistration with previous clientId). This only affects clients that do not restart their apps after deregistration, since clientId is loaded into device once per app launch.