### PR TITLE
Try to reduce failures in some tests that exercise token expiry

### DIFF
--- a/Test/Test Utilities/TestUtilities.swift
+++ b/Test/Test Utilities/TestUtilities.swift
@@ -346,6 +346,11 @@ class AblyTests {
 
         return .init(sequence)
     }
+
+    /**
+     Tests that wait for the Ably service to consider a token as having expired by waiting for its `ttl` to elapse should wait this additional tolerance (arbitarily chosen) to compensate for clock differences between different Ably servers.
+     */
+    static let tokenExpiryTolerance: TimeInterval = 2
 }
 
 /// A helper class for performing HTTP requests synchronously in tests.

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -262,13 +262,14 @@ class AuthTests: XCTestCase {
     func test__021__Token__authentication_method__should_transition_the_connection_to_the_FAILED_state_when_the_server_responds_with_a_token_error_and_there_is_no_way_to_renew_the_token() throws {
         let test = Test()
         let options = try AblyTests.clientOptions(for: test)
-        options.tokenDetails = try getTestTokenDetails(for: test, ttl: 0.1)
+        let tokenTtl = 0.1
+        options.tokenDetails = try getTestTokenDetails(for: test, ttl: tokenTtl)
         options.autoConnect = false
         options.testOptions.transportFactory = TestProxyTransportFactory()
 
         // Token will expire, expecting 40142
         waitUntil(timeout: testTimeout) { done in
-            delay(0.2) { done() }
+            delay(tokenTtl + AblyTests.tokenExpiryTolerance) { done() }
         }
 
         let realtime = ARTRealtime(options: options)

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -2184,7 +2184,7 @@ class RealtimeClientConnectionTests: XCTestCase {
 
         // Let the token expire
         waitUntil(timeout: testTimeout) { done in
-            delay(tokenTtl) {
+            delay(tokenTtl + AblyTests.tokenExpiryTolerance) {
                 done()
             }
         }

--- a/Test/Tests/RestClientTests.swift
+++ b/Test/Tests/RestClientTests.swift
@@ -689,7 +689,8 @@ class RestClientTests: XCTestCase {
         let auth = client.auth
 
         let tokenParams = ARTTokenParams()
-        tokenParams.ttl = 3.0 // Seconds
+        let tokenTtl = 3.0
+        tokenParams.ttl = NSNumber(value: tokenTtl) // Seconds
 
         let options: ARTClientOptions = try AblyTests.waitFor(timeout: testTimeout) { value in
             auth.requestToken(tokenParams, with: nil) { tokenDetails, error in
@@ -735,7 +736,7 @@ class RestClientTests: XCTestCase {
 
         waitUntil(timeout: testTimeout) { done in
             // Delay for token expiration
-            delay(TimeInterval(truncating: tokenParams.ttl!)) {
+            delay(tokenTtl + AblyTests.tokenExpiryTolerance) {
                 // [40140, 40150) - token expired and will not recover because authUrl is invalid
                 publishTestMessage(rest, channelName: test.uniqueChannelName()) { error in
                     guard let errorCode = testHTTPExecutor.responses.first?.value(forHTTPHeaderField: "X-Ably-Errorcode") else {
@@ -758,7 +759,8 @@ class RestClientTests: XCTestCase {
         let auth = client.auth
 
         let tokenParams = ARTTokenParams()
-        tokenParams.ttl = 3.0 // Seconds
+        let tokenTtl = 3.0
+        tokenParams.ttl = NSNumber(value: tokenTtl) // Seconds
 
         waitUntil(timeout: testTimeout) { done in
             auth.requestToken(tokenParams, with: nil) { tokenDetails, error in
@@ -798,7 +800,7 @@ class RestClientTests: XCTestCase {
                 rest.internal.httpExecutor = testHTTPExecutor
 
                 // Delay for token expiration
-                delay(TimeInterval(truncating: tokenParams.ttl!)) {
+                delay(tokenTtl + AblyTests.tokenExpiryTolerance) {
                     // [40140, 40150) - token expired and will not recover because authUrl is invalid
                     publishTestMessage(rest, channelName: test.uniqueChannelName()) { error in
                         guard let errorCode = testHTTPExecutor.responses.first?.value(forHTTPHeaderField: "X-Ably-Errorcode") else {
@@ -1744,10 +1746,11 @@ class RestClientTests: XCTestCase {
     func test__012__RestClient__should_indicate_an_error_if_there_is_no_way_to_renew_the_token() throws {
         let test = Test()
         let options = try AblyTests.clientOptions(for: test)
-        options.token = try getTestToken(for: test, ttl: 0.1)
+        let tokenTtl = 0.1
+        options.token = try getTestToken(for: test, ttl: tokenTtl)
         let client = ARTRest(options: options)
         waitUntil(timeout: testTimeout) { done in
-            delay(0.1) {
+            delay(tokenTtl + AblyTests.tokenExpiryTolerance) {
                 client.channels.get(test.uniqueChannelName()).publish(nil, data: "message") { error in
                     guard let error = error else {
                         fail("Error is empty"); done()


### PR DESCRIPTION
I’ve noticed these tests intermittently failing on CI. They all wait for the Ably service to consider a token as having expired by waiting for its `ttl` to elapse. However, clock discrepancies between Ably servers might mean that this doesn’t always work. So let’s try adding a bit of a tolerance to the wait and see if it helps.

There are probably other tests that are affected similarly; these are just the ones that caught my eye.