### PR TITLE
Fix for "test__090__RestClient__request_…"

### DIFF
--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -591,6 +591,8 @@ NS_ASSUME_NONNULL_END
     }
 
     NSURL *url = [NSURL URLWithString:path relativeToURL:self.baseUrl];
+    // Should not happen in iOS 17 and above. See explanation in the "Important" section here:
+    // https://developer.apple.com/documentation/foundation/nsurl/1572047-urlwithstring
     if (!url) {
         if (errorPtr) {
             *errorPtr = [NSError errorWithDomain:ARTAblyErrorDomain

--- a/Test/Tests/RestClientTests.swift
+++ b/Test/Tests/RestClientTests.swift
@@ -1912,15 +1912,6 @@ class RestClientTests: XCTestCase {
         rest.internal.httpExecutor = mockHTTPExecutor
 
         do {
-            try rest.request("get", path: "new feature", params: nil, body: nil, headers: nil) { _, _ in
-                fail("Completion closure should not be called")
-            }
-        } catch let error as NSError {
-            XCTAssertEqual(error.code, ARTCustomRequestError.invalidPath.rawValue)
-            expect(error.localizedDescription).to(contain("Path isn't valid"))
-        }
-
-        do {
             try rest.request("get", path: "", params: nil, body: nil, headers: nil) { _, _ in
                 fail("Completion closure should not be called")
             }


### PR DESCRIPTION
Partially addresses #1796 

In a test suite this failure goes as `test__092__RestClient__request__method_signature_and_arguments__should_do_a_request_and_receive_a_valid_response`, i.e. the test which is being executed at the moment when `fail("Completion closure should not be called")` is called [within](https://github.com/ably/ably-cocoa/blob/ca4ffa1f582714945b9f323a1dc86b1da57c974f/Test/Tests/RestClientTests.swift#L1916) `test__090__RestClient__...` test.

Test passes frequently on CI because I assume tests failures after execution not always tracked by XCTest framework. Locally it crashes with this:
```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Attempted to report a test failure to XCTest while no test case was running. The failure was:
"Completion closure should not be called".
```

The path "new feature" is not an invalid path, since it's being replaced with "new%20feature" in Foundation. Also [this check](https://github.com/ably/ably-cocoa/blob/ca4ffa1f582714945b9f323a1dc86b1da57c974f/Source/ARTRest.m#L584C28-L584C28) has nothing to do with a whitespace in the middle. So I'm removing this expectation.

I've noticed that this test fails frequently when other well known [set of tests](https://test-observability.herokuapp.com/repos/ably/ably-cocoa/uploads/554d09f1-71e2-4e79-b641-9f33a8382220) don't fail. So when I've fixed it in this experimental [PR](https://github.com/ably/ably-cocoa/pull/1799), iOS 17 job finally [could pass](https://github.com/ably/ably-cocoa/actions/runs/6908384330) (after a few attemts).