### PR TITLE
[SDK-1181] Setting clientId again.

### DIFF
--- a/Source/ARTLocalDevice.m
+++ b/Source/ARTLocalDevice.m
@@ -153,9 +153,4 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
     return _identityTokenDetails != nil;
 }
 
-- (void)clearIdentityTokenDetailsAndClientId {
-    [self setAndPersistIdentityTokenDetails:nil];
-    self.clientId = nil;
-}
-
 @end

--- a/Source/ARTPushActivationState.m
+++ b/Source/ARTPushActivationState.m
@@ -282,7 +282,7 @@ ARTPushActivationState *validateAndSync(ARTPushActivationStateMachine *machine, 
     else if ([event isKindOfClass:[ARTPushActivationEventDeregistered class]]) {
         #if TARGET_OS_IOS
         ARTLocalDevice *local = self.machine.rest.device_nosync;
-        [local clearIdentityTokenDetailsAndClientId];
+        [local setAndPersistIdentityTokenDetails:nil];
         #endif
         [self.machine callDeactivatedCallback:nil];
         return [ARTPushActivationStateNotActivated newWithMachine:self.machine logger:self.logger];

--- a/Source/ARTPushActivationState.m
+++ b/Source/ARTPushActivationState.m
@@ -9,6 +9,7 @@
 #import "ARTAuth+Private.h"
 #import "ARTHttp.h"
 #import "ARTTypes+Private.h"
+#import "ARTClientOptions.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -117,6 +118,12 @@ ARTPushActivationState *validateAndSync(ARTPushActivationStateMachine *machine, 
     }
     else if ([event isKindOfClass:[ARTPushActivationEventCalledActivate class]]) {
         [self.machine registerForAPNS];
+#if TARGET_OS_IOS
+        ARTLocalDevice *const local = self.machine.rest.device_nosync;
+        if ([local clientId] == nil) {
+            [local setClientId:self.machine.rest.options.clientId];
+        }
+#endif
         return validateAndSync(self.machine, event, self.logger);
     }
     return nil;

--- a/Source/ARTPushActivationState.m
+++ b/Source/ARTPushActivationState.m
@@ -120,9 +120,7 @@ ARTPushActivationState *validateAndSync(ARTPushActivationStateMachine *machine, 
         [self.machine registerForAPNS];
 #if TARGET_OS_IOS
         ARTLocalDevice *const local = self.machine.rest.device_nosync;
-        if ([local clientId] == nil) {
-            [local setClientId:self.machine.rest.options.clientId];
-        }
+        [local setClientId:self.machine.rest.options.clientId];
 #endif
         return validateAndSync(self.machine, event, self.logger);
     }

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -777,9 +777,6 @@ static BOOL sharedDeviceNeedsLoading_onlyAccessOnDeviceAccessQueue = YES;
         device = [ARTLocalDevice load:clientId storage:self.storage logger:self.logger];
         sharedDeviceNeedsLoading_onlyAccessOnDeviceAccessQueue = NO;
     }
-    else if ([device clientId] == nil) {
-        [device setClientId:clientId];
-    }
     return device;
 }
 

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -777,6 +777,9 @@ static BOOL sharedDeviceNeedsLoading_onlyAccessOnDeviceAccessQueue = YES;
         device = [ARTLocalDevice load:clientId storage:self.storage logger:self.logger];
         sharedDeviceNeedsLoading_onlyAccessOnDeviceAccessQueue = NO;
     }
+    else if ([device clientId] == nil) {
+        [device setClientId:clientId];
+    }
     return device;
 }
 

--- a/Source/PrivateHeaders/Ably/ARTLocalDevice+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTLocalDevice+Private.h
@@ -25,7 +25,6 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString * _Nullable tokenType);
 - (void)setAndPersistAPNSDeviceToken:(nullable NSString *)deviceToken;
 - (void)setAndPersistIdentityTokenDetails:(nullable ARTDeviceIdentityTokenDetails *)tokenDetails;
 - (BOOL)isRegistered;
-- (void)clearIdentityTokenDetailsAndClientId;
 
 + (NSString *)generateId;
 + (NSString *)generateSecret;

--- a/Test/Tests/PushActivationStateMachineTests.swift
+++ b/Test/Tests/PushActivationStateMachineTests.swift
@@ -858,35 +858,26 @@ class PushActivationStateMachineTests: XCTestCase {
 
     // RSH3g2
     func test__054__Activation_state_machine__State_WaitingForDeregistration__on_Event_Deregistered() {
-        storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForDeregistration(machine: initialStateMachine, logger: .init(core: MockInternalLogCore())))
-        
-        let options = ARTClientOptions(key: "xxxx:xxxx")
-        options.clientId = "client1"
-        let rest = ARTRest(options: options)
-        rest.internal.storage = storage
-        stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate(), logger: .init(core: MockInternalLogCore()))
-        
-        XCTAssertEqual(stateMachine.rest.device.clientId, "client1")
-        
+        beforeEach__Activation_state_machine__State_WaitingForDeregistration()
+
         var deactivatedCallbackCalled = false
         let hook = stateMachine.testSuite_injectIntoMethod(after: NSSelectorFromString("callDeactivatedCallback:")) {
             deactivatedCallbackCalled = true
         }
         defer { hook.remove() }
 
-        var clearIdentityTokenDetailsAndClientIdCalled = false
-        let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("clearIdentityTokenDetailsAndClientId")) {
-            clearIdentityTokenDetailsAndClientIdCalled = true
+        var setAndPersistIdentityTokenDetailsCalled = false
+        let hookDevice = stateMachine.rest.device.testSuite_injectIntoMethod(after: NSSelectorFromString("setAndPersistIdentityTokenDetails:")) {
+            setAndPersistIdentityTokenDetailsCalled = true
         }
         defer { hookDevice.remove() }
 
         stateMachine.send(ARTPushActivationEventDeregistered())
         expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
         XCTAssertTrue(deactivatedCallbackCalled)
-        XCTAssertTrue(clearIdentityTokenDetailsAndClientIdCalled)
+        XCTAssertTrue(setAndPersistIdentityTokenDetailsCalled)
         // RSH3g2a
         XCTAssertNil(stateMachine.rest.device.identityTokenDetails)
-        XCTAssertNil(stateMachine.rest.device.clientId)
     }
 
     // RSH3g3


### PR DESCRIPTION
After clientId has been reset on `deactivate`, it will be `nil` during further calls to `activate` until app relaunch or re-auth to Ably. Fixing it by setting clientId from options again on device activation.