### PR TITLE
Added ARTPrint macros for easier debug.

### DIFF
--- a/Source/PrivateHeaders/Ably/ARTInternalLog.h
+++ b/Source/PrivateHeaders/Ably/ARTInternalLog.h
@@ -20,6 +20,7 @@
 #define ARTLogInfo(logger, format, ...) ARTLog(logger, ARTLogLevelInfo, format, ##__VA_ARGS__)
 #define ARTLogWarn(logger, format, ...) ARTLog(logger, ARTLogLevelWarn, format, ##__VA_ARGS__)
 #define ARTLogError(logger, format, ...) ARTLog(logger, ARTLogLevelError, format, ##__VA_ARGS__)
+#define ARTPrint(logger, format, ...) ARTLog(logger, ARTLogLevelNone, format, ##__VA_ARGS__)
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/PrivateHeaders/Ably/ARTInternalLog.h
+++ b/Source/PrivateHeaders/Ably/ARTInternalLog.h
@@ -20,6 +20,9 @@
 #define ARTLogInfo(logger, format, ...) ARTLog(logger, ARTLogLevelInfo, format, ##__VA_ARGS__)
 #define ARTLogWarn(logger, format, ...) ARTLog(logger, ARTLogLevelWarn, format, ##__VA_ARGS__)
 #define ARTLogError(logger, format, ...) ARTLog(logger, ARTLogLevelError, format, ##__VA_ARGS__)
+/**
+ This one is for local debugging only. You can replace other log macroses with it when needed and immidiatly print its message into the console without changing logLevel. Do not commit such changes.
+ */
 #define ARTPrint(logger, format, ...) ARTLog(logger, ARTLogLevelNone, format, ##__VA_ARGS__)
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
Sometimes just one place with `ARTLog*` macros call is needed, so instead of changing `logLevel` you can just make a quick replace with `ARTPrint` and it will be printed into the console regardless of `logLevel` value.