### PR TITLE
Use `name` property to find current job in GitHub API response

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -115,5 +115,5 @@ jobs:
           TEST_OBSERVABILITY_SERVER_AUTH_KEY: ${{ secrets.TEST_OBSERVABILITY_SERVER_AUTH_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-           Scripts/upload_test_results.sh --job-index ${{ strategy.job-index }}
+           Scripts/upload_test_results.sh --job-name "check (${{ matrix.platform }}, ${{ matrix.lane }})"
 


### PR DESCRIPTION
This updates the change made in d7e7736. Copied from test-observability-action commit 518bc5e. Motivation as described in that commit:

> I originally tried implementing this by passing a job-index input, whose
> value was the index to which the current job corresponds in the response
> from the "list jobs for a workflow run attempt" GitHub API. However,
> some experimentation then showed that that the order in which the jobs
> are listed in the action YAML file doesn’t necessarily match that in
> which they are returned from the API, so there was no way to calculate
> the value to pass for job-index. Hence, switched to using the job’s
> `name` instead.