### PR TITLE
[SDK-4018] Renamed channel's `serial` to `channelSerial`.

### DIFF
--- a/Source/ARTConnection.m
+++ b/Source/ARTConnection.m
@@ -271,7 +271,7 @@ dispatch_sync(_queue, ^{
     NSMutableDictionary<NSString *, NSString *> *channelSerials = [NSMutableDictionary new];
     for (ARTRealtimeChannelInternal *const channel in _realtime.channels.nosyncIterable) {
         if (channel.state_nosync == ARTRealtimeChannelAttached) {
-            channelSerials[channel.name] = channel.serial;
+            channelSerials[channel.name] = channel.channelSerial;
         }
     }
     

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -253,7 +253,7 @@ const NSTimeInterval _reachabilityReconnectionAttemptThreshold = 0.1;
                 _msgSerial = recoveryKey.msgSerial; // RTN16f
                 for (NSString *const channelName in recoveryKey.channelSerials) {
                     ARTRealtimeChannelInternal *const channel = [_channels get:channelName];
-                    channel.serial = recoveryKey.channelSerials[channelName]; // RTN16j
+                    channel.channelSerial = recoveryKey.channelSerials[channelName]; // RTN16j
                 }
             }
         }

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -560,7 +560,7 @@ dispatch_sync(_queue, ^{
             self.attachResume = true;
             break;
         case ARTRealtimeChannelSuspended: {
-            self.serial = nil; // RTP5a1
+            self.channelSerial = nil; // RTP5a1
             ARTRetryAttempt *const retryAttempt = [self.attachRetryState addRetryAttempt];
 
             [_attachedEventEmitter emit:nil with:params.errorInfo];
@@ -577,11 +577,11 @@ dispatch_sync(_queue, ^{
             self.attachResume = false;
             break;
         case ARTRealtimeChannelDetached:
-            self.serial = nil; // RTP5a1
+            self.channelSerial = nil; // RTP5a1
             [self.presence failsSync:params.errorInfo];
             break;
         case ARTRealtimeChannelFailed:
-            self.serial = nil; // RTP5a1
+            self.channelSerial = nil; // RTP5a1
             self.attachResume = false;
             [_attachedEventEmitter emit:nil with:params.errorInfo];
             [_detachedEventEmitter emit:nil with:params.errorInfo];
@@ -671,7 +671,7 @@ dispatch_sync(_queue, ^{
     self.attachSerial = message.channelSerial;
     // RTL15b
     if (message.channelSerial) {
-        self.serial = message.channelSerial;
+        self.channelSerial = message.channelSerial;
     }
 
     if (state == ARTRealtimeChannelAttached) {
@@ -813,7 +813,7 @@ dispatch_sync(_queue, ^{
     
     // RTL15b
     if (pm.channelSerial) {
-        self.serial = pm.channelSerial;
+        self.channelSerial = pm.channelSerial;
     }
 }
 
@@ -821,7 +821,7 @@ dispatch_sync(_queue, ^{
     ARTLogDebug(self.logger, @"RT:%p C:%p (%@) handle PRESENCE message", _realtime, self, self.name);
     // RTL15b
     if (message.channelSerial) {
-        self.serial = message.channelSerial;
+        self.channelSerial = message.channelSerial;
     }
     [self.presence onMessage:message];
 }
@@ -914,7 +914,7 @@ dispatch_sync(_queue, ^{
     ARTProtocolMessage *attachMessage = [[ARTProtocolMessage alloc] init];
     attachMessage.action = ARTProtocolMessageAttach;
     attachMessage.channel = self.name;
-    attachMessage.channelSerial = self.serial; // RTL4c1
+    attachMessage.channelSerial = self.channelSerial; // RTL4c1
     attachMessage.params = self.options_nosync.params;
     attachMessage.flags = self.options_nosync.modes;
 

--- a/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, weak, nonatomic) ARTRealtimeInternal *realtime; // weak because realtime owns self
 @property (readonly, nonatomic) ARTRestChannelInternal *restChannel;
 @property (readwrite, nonatomic, nullable) NSString *attachSerial;
-@property (readwrite, nonatomic, nullable) NSString *serial; // CP2b
+@property (readwrite, nonatomic, nullable) NSString *channelSerial; // CP2b
 @property (readonly, nullable, getter=getClientId) NSString *clientId;
 @property (readonly, nonatomic) ARTEventEmitter<ARTEvent *, ARTChannelStateChange *> *internalEventEmitter;
 @property (readonly, nonatomic) ARTEventEmitter<ARTEvent *, ARTChannelStateChange *> *statesEventEmitter;

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -1240,7 +1240,7 @@ class RealtimeClientChannelTests: XCTestCase {
                 partialDone()
             }
         }
-        expect(channel.internal.serial).toEventuallyNot(beNil())
+        expect(channel.internal.channelSerial).toEventuallyNot(beNil())
         
         client.simulateNoInternetConnection(transportFactory: transportFactory)
         client.simulateRestoreInternetConnection(after: 0.1, transportFactory: transportFactory)
@@ -1250,7 +1250,7 @@ class RealtimeClientChannelTests: XCTestCase {
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
         
         let secondProtocolAttachMessage = try latestAttachProtocolMessage()
-        expect(secondProtocolAttachMessage.channelSerial).to(equal(channel.internal.serial))
+        expect(secondProtocolAttachMessage.channelSerial).to(equal(channel.internal.channelSerial))
     }
 
     // RTL4e
@@ -4232,14 +4232,14 @@ class RealtimeClientChannelTests: XCTestCase {
                 expect(error).to(beNil())
                 let attachMessage = transport.protocolMessagesReceived.filter { $0.action == .attached }[0]
                 if attachMessage.channelSerial != nil {
-                    expect(attachMessage.channelSerial).to(equal(channel.internal.serial))
+                    expect(attachMessage.channelSerial).to(equal(channel.internal.channelSerial))
                 }
                 partialDone()
                 
                 channel.subscribe { message in
                     let messageMessage = transport.protocolMessagesReceived.filter { $0.action == .message }[0]
                     if messageMessage.channelSerial != nil {
-                        expect(messageMessage.channelSerial).to(equal(channel.internal.serial))
+                        expect(messageMessage.channelSerial).to(equal(channel.internal.channelSerial))
                     }
                     channel.presence.enterClient("client1", data: "Hey")
                     partialDone()
@@ -4247,7 +4247,7 @@ class RealtimeClientChannelTests: XCTestCase {
                 channel.presence.subscribe { presenceMessage in
                     let presenceMessage = transport.protocolMessagesReceived.filter { $0.action == .presence }[0]
                     if presenceMessage.channelSerial != nil {
-                        expect(presenceMessage.channelSerial).to(equal(channel.internal.serial))
+                        expect(presenceMessage.channelSerial).to(equal(channel.internal.channelSerial))
                     }
                     partialDone()
                 }
@@ -4269,29 +4269,29 @@ class RealtimeClientChannelTests: XCTestCase {
         // Case for detached
         channel.attach()
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-        expect(channel.internal.serial).toNot(beNil())
+        expect(channel.internal.channelSerial).toNot(beNil())
         
         channel.detach()
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
-        expect(channel.internal.serial).to(beNil())
+        expect(channel.internal.channelSerial).to(beNil())
         
         // Case for suspended
         channel.attach()
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-        expect(channel.internal.serial).toNot(beNil())
+        expect(channel.internal.channelSerial).toNot(beNil())
         
         channel.internal.setSuspended(.init(state: .ok))
         expect(channel.state).to(equal(ARTRealtimeChannelState.suspended))
-        expect(channel.internal.serial).to(beNil())
+        expect(channel.internal.channelSerial).to(beNil())
         
         // Case for failed
         channel.attach()
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-        expect(channel.internal.serial).toNot(beNil())
+        expect(channel.internal.channelSerial).toNot(beNil())
         
         channel.internal.setFailed(.init(state: .ok))
         expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
-        expect(channel.internal.serial).to(beNil())
+        expect(channel.internal.channelSerial).to(beNil())
     }
 
     // RTL16

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -3331,12 +3331,12 @@ class RealtimeClientConnectionTests: XCTestCase {
             client.connection.once(.connected) { stateChange in
                 let firstChannel = client.channels.get(firstChannelName)
                 firstChannel.on(.attached) {_ in
-                    firstChannelSerial = firstChannel.internal.serial
+                    firstChannelSerial = firstChannel.internal.channelSerial
                     partialDone()
                 }
                 let secondChannel = client.channels.get(secondChannelName)
                 secondChannel.on(.attached) {_ in
-                    secondChannelSerial = secondChannel.internal.serial
+                    secondChannelSerial = secondChannel.internal.channelSerial
                     secondChannel.publish(nil, data: "message") { error in
                         expect(error).to(beNil())
                         partialDone()
@@ -3345,7 +3345,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                 }
                 let thirdChannel = client.channels.get(thirdChannelName)
                 thirdChannel.on(.attached) {_ in
-                    thirdChannelSerial = thirdChannel.internal.serial
+                    thirdChannelSerial = thirdChannel.internal.channelSerial
                     partialDone()
                 }
                 firstChannel.attach()
@@ -3399,12 +3399,12 @@ class RealtimeClientConnectionTests: XCTestCase {
             client.connection.once(.connected) { stateChange in
                 let firstChannel = client.channels.get(sanskritChannelName)
                 firstChannel.on(.attached) {_ in
-                    firstChannelSerial = firstChannel.internal.serial
+                    firstChannelSerial = firstChannel.internal.channelSerial
                     partialDone()
                 }
                 let secondChannel = client.channels.get(koreanChannelName)
                 secondChannel.on(.attached) {_ in
-                    secondChannelSerial = secondChannel.internal.serial
+                    secondChannelSerial = secondChannel.internal.channelSerial
                     
                     secondChannel.publish(nil, data: "message") { error in
                         expect(error).to(beNil())
@@ -3539,7 +3539,7 @@ class RealtimeClientConnectionTests: XCTestCase {
             client.connection.once(.connected) { stateChange in
                 let channel = client.channels.get(channelName)
                 channel.on(.attached) { _ in
-                    expectedChannelSerial = channel.internal.serial
+                    expectedChannelSerial = channel.internal.channelSerial
                     partialDone()
                 }
                 channel.attach()
@@ -3556,7 +3556,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         
         XCTAssertTrue(recoveredClient.channels.exists(channelName))
         let recoveredChannel = recoveredClient.channels.get(channelName)
-        expect(recoveredChannel.internal.serial).to(equal(expectedChannelSerial))
+        expect(recoveredChannel.internal.channelSerial).to(equal(expectedChannelSerial))
     }
   
     // RTN16k


### PR DESCRIPTION
Closes #1852 