### PR TITLE
[SDK-4015] Renamed presence map's `localMembers` to `internalMembers`

### DIFF
--- a/Source/PrivateHeaders/Ably/ARTRealtimePresence+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimePresence+Private.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// List of internal members.
 /// The key is the clientId and the value is the latest relevant ARTPresenceMessage for that clientId.
-@property (readonly, atomic) NSMutableDictionary<NSString *, ARTPresenceMessage *> *localMembers;
+@property (readonly, atomic) NSMutableDictionary<NSString *, ARTPresenceMessage *> *internalMembers;
 
 @property (readonly, nonatomic) NSUInteger syncSessionId;
 @property (readonly, nonatomic) BOOL syncComplete;


### PR DESCRIPTION
Closes #1849 