### PR TITLE
[SDK-4076] Removed unnecessary checks for RTP1.

### DIFF
--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -731,13 +731,11 @@ dispatch_sync(_queue, ^{
     if (message.hasPresence) {
         [self.presenceMap startSync];
     }
-    else if ([self.presenceMap.members count] > 0 || [self.presenceMap.localMembers count] > 0) {
-        if (!message.resumed) {
-            // When an ATTACHED message is received without a HAS_PRESENCE flag and PresenceMap has existing members
-            [self.presenceMap startSync];
-            [self.presenceMap endSync];
-            ARTLogDebug(self.logger, @"R:%p C:%p (%@) PresenceMap has been reset", _realtime, self, self.name);
-        }
+    else {
+        // RTP1 - when an ATTACHED message is received without a HAS_PRESENCE flag, reset PresenceMap
+        [self.presenceMap startSync];
+        [self.presenceMap endSync];
+        ARTLogDebug(self.logger, @"R:%p C:%p (%@) PresenceMap has been reset", _realtime, self, self.name);
     }
 
     if (self.state_nosync == ARTRealtimeChannelAttached) {


### PR DESCRIPTION
Closes #1868

based on [RTP1](https://sdk.ably.com/builds/ably/specification/main/features/#RTP1) we shouldn't check on message's `resume` flag when resetting presence map. Also members count check is not necessary either. 