### PR TITLE
[ECO-4715] Addresses push notification edge cases

### DIFF
--- a/Source/ARTPushActivationState.m
+++ b/Source/ARTPushActivationState.m
@@ -114,8 +114,19 @@ ARTPushActivationState *validateAndSync(ARTPushActivationStateMachine *machine, 
 - (ARTPushActivationState *)transition:(ARTPushActivationEvent *)event {
     [self logEventTransition:event file:__FILE__ line:__LINE__];
     if ([event isKindOfClass:[ARTPushActivationEventCalledDeactivate class]]) {
-        [self.machine callDeactivatedCallback:nil];
-        return self;
+        // RSH3a1c
+        ARTLocalDevice *device = self.machine.rest.device_nosync;
+        if (device.isRegistered) {
+            [self.machine deviceUnregistration:nil];
+            return [ARTPushActivationStateWaitingForDeregistration newWithMachine:self.machine logger:self.logger];
+        // RSH3a1d
+        } else {
+            #if TARGET_OS_IOS
+            [self.machine.rest resetLocalDevice_nosync];
+            #endif
+            [self.machine callDeactivatedCallback:nil];
+            return self;
+        }
     }
     else if ([event isKindOfClass:[ARTPushActivationEventCalledActivate class]]) {
         return validateAndSync(self.machine, event, self.logger);

--- a/Source/ARTPushActivationState.m
+++ b/Source/ARTPushActivationState.m
@@ -114,8 +114,12 @@ ARTPushActivationState *validateAndSync(ARTPushActivationStateMachine *machine, 
 - (ARTPushActivationState *)transition:(ARTPushActivationEvent *)event {
     [self logEventTransition:event file:__FILE__ line:__LINE__];
     if ([event isKindOfClass:[ARTPushActivationEventCalledDeactivate class]]) {
-        // RSH3a1c
+        #if TARGET_OS_IOS
         ARTLocalDevice *device = self.machine.rest.device_nosync;
+        #else
+        ARTLocalDevice *device = nil;
+        #endif
+        // RSH3a1c
         if (device.isRegistered) {
             [self.machine deviceUnregistration:nil];
             return [ARTPushActivationStateWaitingForDeregistration newWithMachine:self.machine logger:self.logger];

--- a/Source/ARTPushActivationStateMachine.m
+++ b/Source/ARTPushActivationStateMachine.m
@@ -333,8 +333,12 @@ dispatch_async(_queue, ^{
         dispatch_async(_userQueue, ^{
             [delegate ablyPushCustomDeregister:error deviceId:local.id callback:^(ARTErrorInfo *error) {
                 if (error) {
-                    // Failed
-                    [self sendEvent:[ARTPushActivationEventDeregistrationFailed newWithError:error]];
+                    // RSH3d2c1: ignore unauthorized or invalid credentials errors
+                    if (error.code == 401 || error.code == 40005) {
+                        [self sendEvent:[ARTPushActivationEventDeregistered new]];
+                    } else {
+                        [self sendEvent:[ARTPushActivationEventDeregistrationFailed newWithError:error]];
+                    }
                 }
                 else {
                     // Success
@@ -353,8 +357,14 @@ dispatch_async(_queue, ^{
     ARTLogDebug(_logger, @"%@: device deregistration with request %@", NSStringFromClass(self.class), request);
     [_rest executeRequest:request withAuthOption:ARTAuthenticationOn completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
-            ARTLogError(self->_logger, @"%@: device deregistration failed (%@)", NSStringFromClass(self.class), error.localizedDescription);
-            [self sendEvent:[ARTPushActivationEventDeregistrationFailed newWithError:[ARTErrorInfo createFromNSError:error]]];
+            // RSH3d2c1: ignore unauthorized or invalid credentials errors
+            if (error.code == 401 || error.code == 40005) {
+                ARTLogError(self->_logger, @"%@: unauthorized error during deregistration (%@)", NSStringFromClass(self.class), error.localizedDescription);
+                [self sendEvent:[ARTPushActivationEventDeregistered new]];
+            } else {
+                ARTLogError(self->_logger, @"%@: device deregistration failed (%@)", NSStringFromClass(self.class), error.localizedDescription);
+                [self sendEvent:[ARTPushActivationEventDeregistrationFailed newWithError:[ARTErrorInfo createFromNSError:error]]];
+            }
             return;
         }
         ARTLogDebug(self->_logger, @"successfully deactivate device");


### PR DESCRIPTION
- clear partial state when CalledDeactivate come to NotActive state (RSH3a1c & RSH3a1d)
- ignore errors with 401 status code and 40005 code (invalid credentials) - (RSH3d2c1)

Will implement RSH3d2b (use `deviceIdentityToken` to perform request) later. The issue for Bank Jago is fixed with the implementation of the spec items above. RSH3d2b just ensures there are no stale/out of sync states between client and server, but the actual push activation/deactivation states are not affected. 