### PR TITLE
[ECO-4723] Adds privacy manifest to podspec and Package.swift

### DIFF
--- a/Ably.podspec
+++ b/Ably.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   s.requires_arc            = true
   s.swift_version           = '5.0'
   s.source_files            = 'Source/**/*.{h,m,swift}'
+  s.resource_bundles        = {'Ably' => ['Source/PrivacyInfo.xcprivacy']}
   s.private_header_files    = 'Source/PrivateHeaders/**/*.h', 'Source/SocketRocket/**/*.h'
   s.module_map              = 'Source/Ably.modulemap'
   s.dependency 'msgpack', '0.4.0'

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,8 @@ let package = Package(
                 .headerSearchPath("SocketRocket/Internal/RunLoop"),
                 .headerSearchPath("SocketRocket/Internal/Delegate"),
                 .headerSearchPath("SocketRocket/Internal/IOConsumer"),
-            ]
+            ],
+            resources: [.copy("PrivacyInfo.xcprivacy")]
         )
     ]
 )


### PR DESCRIPTION
- Adds privacy manifest to podspec and Package.swift

Follows guidance [here](https://apnspush.com/add-privacy-manifest-sdk) to ensure the privacy manifest is included in different installation types as expected 