### PR TITLE
[ECO-4814] `realtimeRequestTimeout` should be longer

### DIFF
--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -3916,7 +3916,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         let test = Test()
         let options = ARTClientOptions(key: "xxxx:xxxx")
         options.autoConnect = false
-        options.testOptions.realtimeRequestTimeout = 1.0
+        options.testOptions.realtimeRequestTimeout = 2.0 // this timeout should be longer than `internetIsUp` + `performFakeConnectionError` timeouts
         let transportFactory = TestProxyTransportFactory()
         options.testOptions.transportFactory = transportFactory
         let client = ARTRealtime(options: options)


### PR DESCRIPTION
`realtimeRequestTimeout` should be longer than sum of `internetIsUp` execution time and `performFakeConnectionError` timeout, otherwise the test will fail, which happens a lot when `internetIsUp` takes longer because of network conditions during some hours (I beleive so).

Closes #1924 