### PR TITLE
[ECO-4818] Introducing `syncInProgress`/`syncInProgress_nosync` pair

### DIFF
--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -899,10 +899,10 @@ dispatch_sync(_queue, ^{
     const ARTState state = params.reason ? ARTStateError : ARTStateOk;
     ARTChannelStateChangeParams *const stateChangeParams = [[ARTChannelStateChangeParams alloc] initWithState:state errorInfo:params.reason storeErrorInfo:NO retryAttempt:params.retryAttempt];
     [self performTransitionToState:ARTRealtimeChannelAttaching withParams:stateChangeParams];
-    [self attachAfterChecks:callback];
+    [self attachAfterChecks];
 }
 
-- (void)attachAfterChecks:(ARTCallback)callback {
+- (void)attachAfterChecks {
     ARTProtocolMessage *attachMessage = [[ARTProtocolMessage alloc] init];
     attachMessage.action = ARTProtocolMessageAttach;
     attachMessage.channel = self.name;

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -1026,7 +1026,7 @@ dispatch_sync(_queue, ^{
         }];
     }
 
-    if (self.presence.syncInProgress) {
+    if (self.presence.syncInProgress_nosync) {
         [self.presence failsSync:[ARTErrorInfo createWithCode:ARTErrorChannelOperationFailed message:@"channel is being DETACHED"]];
     }
 }

--- a/Source/PrivateHeaders/Ably/ARTRealtimePresence+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimePresence+Private.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithChannel:(ARTRealtimeChannelInternal *)channel logger:(ARTInternalLog *)logger;
 - (void)_unsubscribe;
 - (BOOL)syncComplete_nosync;
+- (BOOL)syncInProgress_nosync;
 
 - (void)failPendingPresence:(ARTStatus *)status;
 - (void)broadcast:(ARTPresenceMessage *)pm;

--- a/Test/Tests/RealtimeClientPresenceTests.swift
+++ b/Test/Tests/RealtimeClientPresenceTests.swift
@@ -1698,7 +1698,7 @@ class RealtimeClientPresenceTests: XCTestCase {
                 return protocolMessage
             }
             channel.internal.presence.testSuite_injectIntoMethod(after: #selector(ARTRealtimePresenceInternal.endSync)) {
-                XCTAssertFalse(channel.internal.presence.syncInProgress)
+                XCTAssertFalse(channel.internal.presence.syncInProgress_nosync())
                 XCTAssertEqual(channel.internal.presence.members.count, 19)
                 XCTAssertEqual(channel.internal.presence.members.filter { _, presence in presence.clientId == "user10" && presence.action == .present }.count, 1) // LEAVE for user10 is ignored, because it's timestamped before SYNC
                 XCTAssertEqual(channel.internal.presence.members.filter { _, presence in presence.clientId == "user12" && presence.action == .present }.count, 0) // LEAVE for user12 is not ignored, because it's timestamped after SYNC
@@ -1757,7 +1757,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(2, done: done)
             channel.internal.presence.testSuite_injectIntoMethod(after: #selector(ARTRealtimePresenceInternal.endSync)) {
-                XCTAssertFalse(channel.internal.presence.syncInProgress)
+                XCTAssertFalse(channel.internal.presence.syncInProgress_nosync())
                 partialDone()
             }
             channel.attach { error in


### PR DESCRIPTION
Closes #1929 

Introducing `syncInProgress`/`syncInProgress_nosync` pair to properly update call sites for `syncInProgress`.