### PR TITLE
[ECO-4858] TO3g compliance

### DIFF
--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -743,9 +743,8 @@ const NSTimeInterval _immediateReconnectionDelay = 0.1;
     
     if ([self shouldSendEvents]) {
         for (ARTRealtimeChannelInternal *channel in channels) {
-            // Reattach channel regardless resume success - RTN15c6, RTN15c7
             ARTAttachRequestParams *const params = [[ARTAttachRequestParams alloc] initWithReason:stateChange.reason];
-            [channel reattachWithParams:params];
+            [channel proceedAttachDetachWithParams:params];
         }
         [self sendQueuedMessages];
     }

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -742,13 +742,12 @@ const NSTimeInterval _immediateReconnectionDelay = 0.1;
     }
     
     if ([self shouldSendEvents]) {
-        [self sendQueuedMessages];
-        
         for (ARTRealtimeChannelInternal *channel in channels) {
             // Reattach channel regardless resume success - RTN15c6, RTN15c7
             ARTAttachRequestParams *const params = [[ARTAttachRequestParams alloc] initWithReason:stateChange.reason];
             [channel reattachWithParams:params];
         }
+        [self sendQueuedMessages];
     }
     else if (![self shouldQueueEvents]) {
         if (!channelStateChangeParams) {

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -905,9 +905,11 @@ dispatch_sync(_queue, ^{
 
     if (callback) [_attachedEventEmitter once:callback];
     // Set state: Attaching
-    const ARTState state = params.reason ? ARTStateError : ARTStateOk;
-    ARTChannelStateChangeParams *const stateChangeParams = [[ARTChannelStateChangeParams alloc] initWithState:state errorInfo:params.reason storeErrorInfo:NO retryAttempt:params.retryAttempt];
-    [self performTransitionToState:ARTRealtimeChannelAttaching withParams:stateChangeParams];
+    if (self.state_nosync != ARTRealtimeChannelAttaching) {
+        const ARTState state = params.reason ? ARTStateError : ARTStateOk;
+        ARTChannelStateChangeParams *const stateChangeParams = [[ARTChannelStateChangeParams alloc] initWithState:state errorInfo:params.reason storeErrorInfo:NO retryAttempt:params.retryAttempt];
+        [self performTransitionToState:ARTRealtimeChannelAttaching withParams:stateChangeParams];
+    }
     [self attachAfterChecks];
 }
 

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -1015,10 +1015,10 @@ dispatch_sync(_queue, ^{
     ARTChannelStateChangeParams *const params = [[ARTChannelStateChangeParams alloc] initWithState:ARTStateOk];
     [self performTransitionToState:ARTRealtimeChannelDetaching withParams:params];
 
-    [self detachAfterChecks:callback];
+    [self detachAfterChecks];
 }
 
-- (void)detachAfterChecks:(ARTCallback)callback {
+- (void)detachAfterChecks {
     ARTProtocolMessage *detachMessage = [[ARTProtocolMessage alloc] init];
     detachMessage.action = ARTProtocolMessageDetach;
     detachMessage.channel = self.name;

--- a/Source/PrivateHeaders/Ably/ARTRealtime+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtime+Private.h
@@ -51,7 +51,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 // State properties
 - (BOOL)shouldSendEvents;
-- (BOOL)shouldQueueEvents;
 
 // Message sending
 - (void)sendQueuedMessages;

--- a/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithRealtime:(ARTRealtimeInternal *)realtime andName:(NSString *)name withOptions:(ARTRealtimeChannelOptions *)options logger:(ARTInternalLog *)logger;
 
-- (void)reattachWithParams:(ARTAttachRequestParams *)params;
+- (void)proceedAttachDetachWithParams:(ARTAttachRequestParams *)params;
 
 - (void)_attach:(nullable ARTCallback)callback;
 - (void)_detach:(nullable ARTCallback)callback;

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -2565,7 +2565,8 @@ class RealtimeClientConnectionTests: XCTestCase {
         let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(test.uniqueChannelName())
-
+        channel.attach()
+        
         XCTAssertTrue(client.waitUntilConnected())
         let expectedConnectionId = client.connection.id
 
@@ -2601,7 +2602,9 @@ class RealtimeClientConnectionTests: XCTestCase {
         defer { client.dispose(); client.close() }
         let channel1 = client.channels.get(test.uniqueChannelName())
         let channel2 = client.channels.get(test.uniqueChannelName(prefix: "second_"))
-
+        channel1.attach()
+        channel2.attach()
+        
         XCTAssertTrue(client.waitUntilConnected())
         expect(channel1.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
         expect(channel2.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
@@ -2642,7 +2645,8 @@ class RealtimeClientConnectionTests: XCTestCase {
         let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(test.uniqueChannelName())
-
+        channel.attach()
+        
         XCTAssertTrue(client.waitUntilConnected())
         let expectedConnectionId = client.connection.id
 

--- a/Test/Tests/RestClientChannelTests.swift
+++ b/Test/Tests/RestClientChannelTests.swift
@@ -391,6 +391,7 @@ class RestClientChannelTests: XCTestCase {
         let chanelName = test.uniqueChannelName(prefix: "ch1")
         
         let subscriber = realtime.channels.get(chanelName)
+        subscriber.attach()
         waitUntil(timeout: testTimeout) { done in
             subscriber.once(.attached) { _ in
                 done()
@@ -423,6 +424,7 @@ class RestClientChannelTests: XCTestCase {
         let chanelName = test.uniqueChannelName(prefix: "ch1")
         
         let subscriber = realtime.channels.get(chanelName)
+        subscriber.attach()
         waitUntil(timeout: testTimeout) { done in
             subscriber.once(.attached) { _ in
                 done()
@@ -453,6 +455,7 @@ class RestClientChannelTests: XCTestCase {
         let chanelName = test.uniqueChannelName(prefix: "ch1")
         
         let subscriber = realtime.channels.get(chanelName)
+        subscriber.attach()
         waitUntil(timeout: testTimeout) { done in
             subscriber.once(.attached) { _ in
                 done()
@@ -484,6 +487,7 @@ class RestClientChannelTests: XCTestCase {
         let chanelName = test.uniqueChannelName(prefix: "ch1")
         
         let subscriber = realtime.channels.get(chanelName)
+        subscriber.attach()
         waitUntil(timeout: testTimeout) { done in
             subscriber.once(.attached) { _ in
                 done()


### PR DESCRIPTION
Closes #1936, #1938 and #1940

These three bugs were cancelling each other, so it's impossible to address them in different PRs since to fix all the tests failures you need to fix other two bugs. Please see commit messages and review per commit basis.

See also https://github.com/ably/specification/pull/194

Some additional info for commits messages.

d60269af "Proceeding with detach on `CONNECTED`":

What happens here is that in addition to re-attach we need re-detach as well to continue the process after connection becomes `CONNECTED`. But in oppose to `attach` there were no internal method for doing so, that's why I've splitted  `_detach` into `internalDetach:` which doesn't do state check before proceeding with detaching. Also because detach message shouldn't be queued I've removed `shouldQueueEvents` check from the `detachAfterChecks`.

305d8db3 "Sending queued messages should be after reattach":

If you send message before sending `ATTACH`, realtime won't respond and tests will timeout. You can check it with `test__065__Channel__publish__Message_connectionId_should_match_the_current_Connection_id_for_all_published_messages` test.

16b38064 "Only queue publish and presence messages":

The check `else if (msg.ackRequired)` you should read as "if message can be queued", since `ACK` required with the same condition as queuing - message is either `MESSAGE` or `PRESENCE`. Also I've added log line if message sending was ignored.