### PR TITLE
[ECO-4873] Max message size fix

### DIFF
--- a/Source/ARTConnection.m
+++ b/Source/ARTConnection.m
@@ -1,10 +1,12 @@
 #import "ARTConnection+Private.h"
-
+#import "ARTDefault.h"
 #import "ARTRealtime+Private.h"
 #import "ARTEventEmitter+Private.h"
 #import "ARTQueuedDealloc.h"
 #import "ARTRealtimeChannels+Private.h"
 #import "ARTRealtimeChannel+Private.h"
+#import "ARTDefault+Private.h"
+#import "ARTClientOptions+Private.h"
 
 #define IsInactiveConnectionState(state) (state == ARTRealtimeClosing || state == ARTRealtimeClosed || state == ARTRealtimeFailed || state == ARTRealtimeSuspended)
 
@@ -192,6 +194,12 @@ dispatch_sync(_queue, ^{
 - (NSString *)key_nosync {
     return _key;
 } 
+
+- (NSInteger)maxMessageSize {
+    if (_maxMessageSize)
+        return _maxMessageSize;
+    return _realtime.options.isProductionEnvironment ? [ARTDefault maxProductionMessageSize] : [ARTDefault maxSandboxMessageSize];
+}
 
 - (ARTRealtimeConnectionState)state_nosync {
     return _state;

--- a/Source/ARTDefault.m
+++ b/Source/ARTDefault.m
@@ -11,7 +11,9 @@ static NSString *const ARTDefault_restHost = @"rest.ably.io";
 static NSString *const ARTDefault_realtimeHost = @"realtime.ably.io";
 
 static NSTimeInterval _connectionStateTtl = 60.0;
-static NSInteger _maxMessageSize = 65536;
+static NSInteger _maxMessageSize = 0;
+static NSInteger _maxProductionMessageSize = 65536;
+static NSInteger _maxSandboxMessageSize = 16384;
 
 @implementation ARTDefault
 
@@ -70,7 +72,21 @@ static NSInteger _maxMessageSize = 65536;
 }
 
 + (NSInteger)maxMessageSize {
-    return _maxMessageSize;
+    if (_maxMessageSize)
+        return _maxMessageSize;
+#if DEBUG
+    return _maxSandboxMessageSize;
+#else
+    return _maxProductionMessageSize;
+#endif
+}
+
++ (NSInteger)maxSandboxMessageSize {
+    return _maxSandboxMessageSize;
+}
+
++ (NSInteger)maxProductionMessageSize {
+    return _maxProductionMessageSize;
 }
 
 + (void)setConnectionStateTtl:(NSTimeInterval)value {
@@ -82,6 +98,18 @@ static NSInteger _maxMessageSize = 65536;
 + (void)setMaxMessageSize:(NSInteger)value {
     @synchronized (self) {
         _maxMessageSize = value;
+    }
+}
+
++ (void)setMaxProductionMessageSize:(NSInteger)value {
+    @synchronized (self) {
+        _maxProductionMessageSize = value;
+    }
+}
+
++ (void)setMaxSandboxMessageSize:(NSInteger)value {
+    @synchronized (self) {
+        _maxSandboxMessageSize = value;
     }
 }
 

--- a/Source/ARTProtocolMessage.m
+++ b/Source/ARTProtocolMessage.m
@@ -77,12 +77,12 @@
     return pm;
 }
 
- - (BOOL)mergeFrom:(ARTProtocolMessage *)src {
+- (BOOL)mergeFrom:(ARTProtocolMessage *)src maxSize:(NSInteger)maxSize {
      if (![src.channel isEqualToString:self.channel] || src.action != self.action) {
          // RTL6d3
          return NO;
      }
-     if ([self mergeWouldExceedMaxSize:src.messages]) {
+     if ([self mergeWithMessages:src.messages wouldExceedMaxSize:maxSize]) {
          // RTL6d1
          return NO;
      }
@@ -142,7 +142,7 @@
     }
 }
 
-- (BOOL)mergeWouldExceedMaxSize:(NSArray<ARTMessage*>*)messages {
+- (BOOL)mergeWithMessages:(NSArray<ARTMessage*>*)messages wouldExceedMaxSize:(NSInteger)maxSize {
     NSInteger queuedMessagesSize = 0;
     for (ARTMessage *message in self.messages) {
         queuedMessagesSize += [message messageSize];
@@ -152,10 +152,6 @@
         messagesSize += [message messageSize];
     }
     NSInteger totalSize = queuedMessagesSize + messagesSize;
-    NSInteger maxSize = [ARTDefault maxMessageSize];
-    if (_connectionDetails.maxMessageSize) {
-        maxSize = _connectionDetails.maxMessageSize;
-    }
     return totalSize > maxSize;
 }
 

--- a/Source/ARTQueuedMessage.m
+++ b/Source/ARTQueuedMessage.m
@@ -25,8 +25,8 @@
     return [self.msg description];
 }
 
-- (BOOL)mergeFrom:(ARTProtocolMessage *)msg sentCallback:(ARTCallback)sentCallback ackCallback:(ARTStatusCallback)ackCallback {
-    if ([self.msg mergeFrom:msg]) {
+- (BOOL)mergeFrom:(ARTProtocolMessage *)msg maxSize:(NSInteger)maxSize sentCallback:(ARTCallback)sentCallback ackCallback:(ARTStatusCallback)ackCallback {
+    if ([self.msg mergeFrom:msg maxSize:maxSize]) {
         if (sentCallback) {
             [self.sentCallbacks addObject:sentCallback];
         }

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -1273,7 +1273,8 @@ const NSTimeInterval _immediateReconnectionDelay = 0.1;
     else if (msg.ackRequired) {
         if (self.isActive && self.options.queueMessages) {
             ARTQueuedMessage *lastQueuedMessage = self.queuedMessages.lastObject; //RTL6d5
-            BOOL merged = [lastQueuedMessage mergeFrom:msg sentCallback:nil ackCallback:ackCallback];
+            NSInteger maxSize = _connection.maxMessageSize;
+            BOOL merged = [lastQueuedMessage mergeFrom:msg maxSize:maxSize sentCallback:nil ackCallback:ackCallback];
             if (!merged) {
                 ARTQueuedMessage *qm = [[ARTQueuedMessage alloc] initWithProtocolMessage:msg sentCallback:sentCallback ackCallback:ackCallback];
                 [self.queuedMessages addObject:qm];

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -1066,10 +1066,7 @@ dispatch_sync(_queue, ^{
     for (ARTMessage *message in messages) {
         size += [message messageSize];
     }
-    NSInteger maxSize = [ARTDefault maxMessageSize];
-    if (self.realtime.connection.maxMessageSize) {
-        maxSize = self.realtime.connection.maxMessageSize;
-    }
+    NSInteger maxSize = _realtime.connection.maxMessageSize;
     return size > maxSize;
 }
 

--- a/Source/PrivateHeaders/Ably/ARTDefault+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTDefault+Private.h
@@ -7,4 +7,7 @@ extern NSString *const ARTDefaultProduction;
 + (void)setConnectionStateTtl:(NSTimeInterval)value;
 + (void)setMaxMessageSize:(NSInteger)value;
 
++ (NSInteger)maxSandboxMessageSize;
++ (NSInteger)maxProductionMessageSize;
+
 @end

--- a/Source/PrivateHeaders/Ably/ARTProtocolMessage+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTProtocolMessage+Private.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic) BOOL hasBacklog;
 @property (readonly, nonatomic) BOOL resumed;
 
-- (BOOL)mergeFrom:(ARTProtocolMessage *)msg;
+- (BOOL)mergeFrom:(ARTProtocolMessage *)msg maxSize:(NSInteger)maxSize;
 
 @end
 

--- a/Source/include/Ably/ARTQueuedMessage.h
+++ b/Source/include/Ably/ARTQueuedMessage.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithProtocolMessage:(ARTProtocolMessage *)msg sentCallback:(nullable ARTCallback)sentCallback ackCallback:(nullable ARTStatusCallback)ackCallback;
 
-- (BOOL)mergeFrom:(ARTProtocolMessage *)msg sentCallback:(nullable ARTCallback)sentCallback ackCallback:(nullable ARTStatusCallback)ackCallback;
+- (BOOL)mergeFrom:(ARTProtocolMessage *)msg maxSize:(NSInteger)maxSize sentCallback:(nullable ARTCallback)sentCallback ackCallback:(nullable ARTStatusCallback)ackCallback;
 
 - (ARTCallback)sentCallback;
 - (ARTStatusCallback)ackCallback;

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -1914,7 +1914,7 @@ class AuthTests: XCTestCase {
                 guard let error = error else {
                     fail("Error is nil"); done(); return
                 }
-                expect(error.message).to(contain("mismatched clientId"))
+                expect(error.message).to(contain("invalid clientId"))
                 done()
             }
         }


### PR DESCRIPTION
Closes #1945 and #1946

`maxMessageSize` wasn't properly respected across the codebase. This fix adds different default values for production/sandbox and properly propogates appropriate value to calculation sites.