### PR TITLE
[ECO-4365] Unskip all tests

### DIFF
--- a/Source/ARTDefault.m
+++ b/Source/ARTDefault.m
@@ -11,7 +11,6 @@ static NSString *const ARTDefault_restHost = @"rest.ably.io";
 static NSString *const ARTDefault_realtimeHost = @"realtime.ably.io";
 
 static NSTimeInterval _connectionStateTtl = 60.0;
-static NSInteger _maxMessageSize = 0;
 static NSInteger _maxProductionMessageSize = 65536;
 static NSInteger _maxSandboxMessageSize = 16384;
 
@@ -72,8 +71,6 @@ static NSInteger _maxSandboxMessageSize = 16384;
 }
 
 + (NSInteger)maxMessageSize {
-    if (_maxMessageSize)
-        return _maxMessageSize;
 #if DEBUG
     return _maxSandboxMessageSize;
 #else
@@ -97,7 +94,11 @@ static NSInteger _maxSandboxMessageSize = 16384;
 
 + (void)setMaxMessageSize:(NSInteger)value {
     @synchronized (self) {
-        _maxMessageSize = value;
+#if DEBUG
+        _maxSandboxMessageSize = value;
+#else
+        _maxProductionMessageSize = value;
+#endif
     }
 }
 

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -3430,7 +3430,7 @@ class AuthTests: XCTestCase {
 
     // RSA10k
 
-    func skipped__test__115__authorize__server_time_offset__should_obtain_server_time_once_and_persist_the_offset_from_the_local_clock() throws {
+    func test__FLAKY__115__authorize__server_time_offset__should_obtain_server_time_once_and_persist_the_offset_from_the_local_clock() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let rest = ARTRest(options: options)
@@ -4058,7 +4058,7 @@ class AuthTests: XCTestCase {
         expect { try ARTTokenDetails.fromJson("[]" as ARTJsonCompatible) }.to(throwError())
     }
 
-    func skipped__test__140__JWT_and_realtime__client_initialized_with_a_JWT_token_in_ClientOptions__with_valid_credentials__pulls_stats_successfully() throws {
+    func test__FLAKY__140__JWT_and_realtime__client_initialized_with_a_JWT_token_in_ClientOptions__with_valid_credentials__pulls_stats_successfully() throws {
         let test = Test()
         let options = try AblyTests.clientOptions(for: test)
         options.token = try getJWTToken(for: test)
@@ -4210,7 +4210,7 @@ class AuthTests: XCTestCase {
 
     // RSA8g
 
-    func skipped__test__146__JWT_and_realtime__when_using_authCallback__with_valid_credentials__pulls_stats_successfully() throws {
+    func test__FLAKY__146__JWT_and_realtime__when_using_authCallback__with_valid_credentials__pulls_stats_successfully() throws {
         let test = Test()
         let options = try AblyTests.clientOptions(for: test)
         options.authCallback = { _, completion in

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -3430,7 +3430,7 @@ class AuthTests: XCTestCase {
 
     // RSA10k
 
-    func test__FLAKY__115__authorize__server_time_offset__should_obtain_server_time_once_and_persist_the_offset_from_the_local_clock() throws {
+    func test__115__authorize__server_time_offset__should_obtain_server_time_once_and_persist_the_offset_from_the_local_clock() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let rest = ARTRest(options: options)
@@ -4058,7 +4058,7 @@ class AuthTests: XCTestCase {
         expect { try ARTTokenDetails.fromJson("[]" as ARTJsonCompatible) }.to(throwError())
     }
 
-    func test__FLAKY__140__JWT_and_realtime__client_initialized_with_a_JWT_token_in_ClientOptions__with_valid_credentials__pulls_stats_successfully() throws {
+    func test__140__JWT_and_realtime__client_initialized_with_a_JWT_token_in_ClientOptions__with_valid_credentials__pulls_stats_successfully() throws {
         let test = Test()
         let options = try AblyTests.clientOptions(for: test)
         options.token = try getJWTToken(for: test)
@@ -4210,7 +4210,7 @@ class AuthTests: XCTestCase {
 
     // RSA8g
 
-    func test__FLAKY__146__JWT_and_realtime__when_using_authCallback__with_valid_credentials__pulls_stats_successfully() throws {
+    func test__146__JWT_and_realtime__when_using_authCallback__with_valid_credentials__pulls_stats_successfully() throws {
         let test = Test()
         let options = try AblyTests.clientOptions(for: test)
         options.authCallback = { _, completion in

--- a/Test/Tests/PushAdminTests.swift
+++ b/Test/Tests/PushAdminTests.swift
@@ -223,7 +223,7 @@ class PushAdminTests: XCTestCase {
         }
     }
 
-    func skipped__test__002__publish__should_publish_successfully() throws {
+    func test__FLAKY__002__publish__should_publish_successfully() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let realtime = ARTRealtime(options: options)
@@ -257,7 +257,7 @@ class PushAdminTests: XCTestCase {
         }
     }
 
-    func skipped__test__003__publish__should_fail_with_a_bad_recipient() throws {
+    func test__FLAKY__003__publish__should_fail_with_a_bad_recipient() throws {
         let test = Test()
         let realtime = ARTRealtime(options: try AblyTests.commonAppSetup(for: test))
         defer { realtime.dispose(); realtime.close() }
@@ -285,7 +285,7 @@ class PushAdminTests: XCTestCase {
         }
     }
 
-    func skipped__test__004__publish__should_fail_with_an_empty_recipient() throws {
+    func test__FLAKY__004__publish__should_fail_with_an_empty_recipient() throws {
         let test = Test()
         let realtime = ARTRealtime(options: try AblyTests.commonAppSetup(for: test))
         defer { realtime.dispose(); realtime.close() }

--- a/Test/Tests/PushAdminTests.swift
+++ b/Test/Tests/PushAdminTests.swift
@@ -223,7 +223,7 @@ class PushAdminTests: XCTestCase {
         }
     }
 
-    func test__FLAKY__002__publish__should_publish_successfully() throws {
+    func test__002__publish__should_publish_successfully() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let realtime = ARTRealtime(options: options)
@@ -257,7 +257,7 @@ class PushAdminTests: XCTestCase {
         }
     }
 
-    func test__FLAKY__003__publish__should_fail_with_a_bad_recipient() throws {
+    func test__003__publish__should_fail_with_a_bad_recipient() throws {
         let test = Test()
         let realtime = ARTRealtime(options: try AblyTests.commonAppSetup(for: test))
         defer { realtime.dispose(); realtime.close() }
@@ -285,7 +285,7 @@ class PushAdminTests: XCTestCase {
         }
     }
 
-    func test__FLAKY__004__publish__should_fail_with_an_empty_recipient() throws {
+    func test__004__publish__should_fail_with_an_empty_recipient() throws {
         let test = Test()
         let realtime = ARTRealtime(options: try AblyTests.commonAppSetup(for: test))
         defer { realtime.dispose(); realtime.close() }

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -2776,8 +2776,7 @@ class RealtimeClientChannelTests: XCTestCase {
         XCTAssertEqual(protocolMessages.count, 1)
     }
 
-    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
-    func skipped__test__090__Channel__publish__message_bundling__should_only_bundle_messages_when_it_respects_all_of_the_constraints() throws {
+    func test__090__Channel__publish__message_bundling__should_only_bundle_messages_when_it_respects_all_of_the_constraints() throws {
         let test = Test()
         let defaultMaxMessageSize = ARTDefault.maxMessageSize()
         ARTDefault.setMaxMessageSize(256)

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -155,7 +155,7 @@ class RealtimeClientChannelTests: XCTestCase {
     }
 
     // RTL1
-    func skipped__test__001__Channel__should_process_all_incoming_messages_and_presence_messages_as_soon_as_a_Channel_becomes_attached() throws {
+    func test__FLAKY__001__Channel__should_process_all_incoming_messages_and_presence_messages_as_soon_as_a_Channel_becomes_attached() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client1 = AblyTests.newRealtime(options).client
@@ -1236,7 +1236,7 @@ class RealtimeClientChannelTests: XCTestCase {
         }
     }
 
-    func skipped__test__045__Channel__attach__happens_when_connection_is_CONNECTED_if_it_s_currently__DISCONNECTED() throws {
+    func test__FLAKY__045__Channel__attach__happens_when_connection_is_CONNECTED_if_it_s_currently__DISCONNECTED() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRealtime(options: options)

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -155,7 +155,7 @@ class RealtimeClientChannelTests: XCTestCase {
     }
 
     // RTL1
-    func test__FLAKY__001__Channel__should_process_all_incoming_messages_and_presence_messages_as_soon_as_a_Channel_becomes_attached() throws {
+    func test__001__Channel__should_process_all_incoming_messages_and_presence_messages_as_soon_as_a_Channel_becomes_attached() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client1 = AblyTests.newRealtime(options).client
@@ -1236,7 +1236,7 @@ class RealtimeClientChannelTests: XCTestCase {
         }
     }
 
-    func test__FLAKY__045__Channel__attach__happens_when_connection_is_CONNECTED_if_it_s_currently__DISCONNECTED() throws {
+    func test__045__Channel__attach__happens_when_connection_is_CONNECTED_if_it_s_currently__DISCONNECTED() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRealtime(options: options)

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -2770,7 +2770,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         XCTAssertTrue(channel.errorReason === protocolError.error)
     }
 
-    func skipped__test__072__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__should_resume_the_connection_after_an_auth_renewal() throws {
+    func test__FLAKY__072__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__should_resume_the_connection_after_an_auth_renewal() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         options.tokenDetails = try getTestTokenDetails(for: test, ttl: 5.0)
@@ -2847,10 +2847,9 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
         }
     }
-
-    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    
     // RTN15d
-    func skipped__test__065__Connection__connection_failures_once_CONNECTED__should_recover_from_disconnection_and_messages_should_be_delivered_once_the_connection_is_resumed() throws {
+    func test__FLAKY__065__Connection__connection_failures_once_CONNECTED__should_recover_from_disconnection_and_messages_should_be_delivered_once_the_connection_is_resumed() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
 
@@ -2992,7 +2991,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     }
 
     // RTN15g RTN15g1
-    func skipped__test__074__Connection__connection_failures_once_CONNECTED__when_connection__ttl_plus_idle_interval__period_has_passed_since_last_activity__uses_a_new_connection() throws {
+    func test__FLAKY__074__Connection__connection_failures_once_CONNECTED__when_connection__ttl_plus_idle_interval__period_has_passed_since_last_activity__uses_a_new_connection() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         // We want this to be > than the sum of customTtlInterval and customIdleInterval
@@ -3095,7 +3094,7 @@ class RealtimeClientConnectionTests: XCTestCase {
 
     // RTN15h
 
-    func skipped__test__077__Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__if_the_token_is_renewable_then_error_should_not_be_emitted() throws {
+    func test__FLAKY__077__Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__if_the_token_is_renewable_then_error_should_not_be_emitted() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         options.autoConnect = false
@@ -3173,7 +3172,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     }
 
     // RTN15h2
-    func skipped__test__079__Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__should_transition_to_disconnected_when_the_token_renewal_fails_and_the_error_should_be_emitted() throws {
+    func test__FLAKY__079__Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__should_transition_to_disconnected_when_the_token_renewal_fails_and_the_error_should_be_emitted() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         options.autoConnect = false
@@ -3293,25 +3292,6 @@ class RealtimeClientConnectionTests: XCTestCase {
                 XCTAssertEqual(clientRecover.connection.id, expectedConnectionId)
                 XCTAssertEqual(clientRecover.connection.key, firstConnectionDetails!.connectionKey)
                 done()
-            }
-        }
-    }
-
-    // RTN16c
-    func skipped__test__083__Connection__Connection_recovery__Connection_recoveryKey_should_become_becomes_null_when_a_connection_is_explicitly_CLOSED_or_CLOSED() throws {
-        let test = Test()
-        let options = try AblyTests.commonAppSetup(for: test)
-        let client = ARTRealtime(options: options)
-        defer { client.dispose(); client.close() }
-        waitUntil(timeout: testTimeout) { done in
-            client.connection.once(.connected) { _ in
-                client.connection.once(.closed) { _ in
-                    XCTAssertNil(client.connection.createRecoveryKey())
-                    XCTAssertNil(client.connection.key)
-                    XCTAssertNil(client.connection.id)
-                    done()
-                }
-                client.close()
             }
         }
     }
@@ -4006,17 +3986,17 @@ class RealtimeClientConnectionTests: XCTestCase {
 
     // RTN17d
 
-    func skipped__test__097__Connection__Host_Fallback__should_use_an_alternative_host_when___hostUnreachable() {
+    func test__FLAKY__097__Connection__Host_Fallback__should_use_an_alternative_host_when___hostUnreachable() {
         let test = Test()
         testUsesAlternativeHostOnResponse(.hostUnreachable, channelName: test.uniqueChannelName())
     }
 
-    func skipped__test__098__Connection__Host_Fallback__should_use_an_alternative_host_when___requestTimeout_timeout__0_1_() {
+    func test__FLAKY__098__Connection__Host_Fallback__should_use_an_alternative_host_when___requestTimeout_timeout__0_1_() {
         let test = Test()
         testUsesAlternativeHostOnResponse(.requestTimeout(timeout: 0.1), channelName: test.uniqueChannelName())
     }
 
-    func skipped__test__099__Connection__Host_Fallback__should_use_an_alternative_host_when___hostInternalError_code__501_() {
+    func test__FLAKY__099__Connection__Host_Fallback__should_use_an_alternative_host_when___hostInternalError_code__501_() {
         let test = Test()
         testUsesAlternativeHostOnResponse(.hostInternalError(code: 501), channelName: test.uniqueChannelName())
     }
@@ -4612,7 +4592,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     }
 
     // RTN19b
-    func skipped__test__104__Connection__Transport_disconnected_side_effects__should_resend_the_ATTACH_message_if_there_are_any_pending_channels() throws {
+    func test__FLAKY__104__Connection__Transport_disconnected_side_effects__should_resend_the_ATTACH_message_if_there_are_any_pending_channels() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = AblyTests.newRealtime(options).client
@@ -5332,7 +5312,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
     }
 
-    func skipped__test__113__Connection__with_fixture_messages__should_send_messages_through_MsgPack_and_JSON_and_retrieve_equal_messages_through_raw_JSON_GET() throws {
+    func test__FLAKY__113__Connection__with_fixture_messages__should_send_messages_through_MsgPack_and_JSON_and_retrieve_equal_messages_through_raw_JSON_GET() throws {
         let test = Test()
         try setupDependencies(for: test)
         let restPublishClientMsgPack = ARTRest(options: msgpackOptions)

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -2773,7 +2773,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         XCTAssertTrue(channel.errorReason === protocolError.error)
     }
 
-    func test__FLAKY__072__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__should_resume_the_connection_after_an_auth_renewal() throws {
+    func test__072__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__should_resume_the_connection_after_an_auth_renewal() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         options.tokenDetails = try getTestTokenDetails(for: test, ttl: 5.0)
@@ -2852,7 +2852,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     }
     
     // RTN15d
-    func test__FLAKY__065__Connection__connection_failures_once_CONNECTED__should_recover_from_disconnection_and_messages_should_be_delivered_once_the_connection_is_resumed() throws {
+    func test__065__Connection__connection_failures_once_CONNECTED__should_recover_from_disconnection_and_messages_should_be_delivered_once_the_connection_is_resumed() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
 
@@ -2994,7 +2994,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     }
 
     // RTN15g RTN15g1
-    func test__FLAKY__074__Connection__connection_failures_once_CONNECTED__when_connection__ttl_plus_idle_interval__period_has_passed_since_last_activity__uses_a_new_connection() throws {
+    func test__074__Connection__connection_failures_once_CONNECTED__when_connection__ttl_plus_idle_interval__period_has_passed_since_last_activity__uses_a_new_connection() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         // We want this to be > than the sum of customTtlInterval and customIdleInterval
@@ -3097,7 +3097,7 @@ class RealtimeClientConnectionTests: XCTestCase {
 
     // RTN15h
 
-    func test__FLAKY__077__Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__if_the_token_is_renewable_then_error_should_not_be_emitted() throws {
+    func test__077__Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__if_the_token_is_renewable_then_error_should_not_be_emitted() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         options.autoConnect = false
@@ -3175,7 +3175,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     }
 
     // RTN15h2
-    func test__FLAKY__079__Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__should_transition_to_disconnected_when_the_token_renewal_fails_and_the_error_should_be_emitted() throws {
+    func test__079__Connection__connection_failures_once_CONNECTED__DISCONNECTED_message_contains_a_token_error__should_transition_to_disconnected_when_the_token_renewal_fails_and_the_error_should_be_emitted() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         options.autoConnect = false
@@ -3989,17 +3989,17 @@ class RealtimeClientConnectionTests: XCTestCase {
 
     // RTN17d
 
-    func test__FLAKY__097__Connection__Host_Fallback__should_use_an_alternative_host_when___hostUnreachable() {
+    func test__097__Connection__Host_Fallback__should_use_an_alternative_host_when___hostUnreachable() {
         let test = Test()
         testUsesAlternativeHostOnResponse(.hostUnreachable, channelName: test.uniqueChannelName())
     }
 
-    func test__FLAKY__098__Connection__Host_Fallback__should_use_an_alternative_host_when___requestTimeout_timeout__0_1_() {
+    func test__098__Connection__Host_Fallback__should_use_an_alternative_host_when___requestTimeout_timeout__0_1_() {
         let test = Test()
         testUsesAlternativeHostOnResponse(.requestTimeout(timeout: 0.1), channelName: test.uniqueChannelName())
     }
 
-    func test__FLAKY__099__Connection__Host_Fallback__should_use_an_alternative_host_when___hostInternalError_code__501_() {
+    func test__099__Connection__Host_Fallback__should_use_an_alternative_host_when___hostInternalError_code__501_() {
         let test = Test()
         testUsesAlternativeHostOnResponse(.hostInternalError(code: 501), channelName: test.uniqueChannelName())
     }
@@ -4595,7 +4595,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     }
 
     // RTN19b
-    func test__FLAKY__104__Connection__Transport_disconnected_side_effects__should_resend_the_ATTACH_message_if_there_are_any_pending_channels() throws {
+    func test__104__Connection__Transport_disconnected_side_effects__should_resend_the_ATTACH_message_if_there_are_any_pending_channels() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = AblyTests.newRealtime(options).client
@@ -5315,7 +5315,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
     }
 
-    func test__FLAKY__113__Connection__with_fixture_messages__should_send_messages_through_MsgPack_and_JSON_and_retrieve_equal_messages_through_raw_JSON_GET() throws {
+    func test__113__Connection__with_fixture_messages__should_send_messages_through_MsgPack_and_JSON_and_retrieve_equal_messages_through_raw_JSON_GET() throws {
         let test = Test()
         try setupDependencies(for: test)
         let restPublishClientMsgPack = ARTRest(options: msgpackOptions)

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -122,7 +122,7 @@ private func expectDataToMatch(_ message: ARTMessage, _ fixtureMessage: Any) {
             fail("expected NSArray")
         }
     case "binary":
-        XCTAssertEqual(message.data as? NSData, (dictionaryValue["dictionaryValue"] as! String).dataFromHexadecimalString()! as NSData?)
+        XCTAssertEqual(message.data as? NSData, (dictionaryValue["expectedHexValue"] as! String).dataFromHexadecimalString()! as NSData?)
     default:
         fail("unhandled: \(dictionaryValue["expectedType"] as! String)")
     }
@@ -5187,7 +5187,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     }
 
     // https://github.com/ably/wiki/issues/22
-    func skipped__test__111__Connection__with_fixture_messages__should_encode_and_decode_fixture_messages_as_expected() throws {
+    func test__111__Connection__with_fixture_messages__should_encode_and_decode_fixture_messages_as_expected() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         options.useBinaryProtocol = false
@@ -5261,7 +5261,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
     }
 
-    func skipped__test__112__Connection__with_fixture_messages__should_send_messages_through_raw_JSON_POST_and_retrieve_equal_messages_through_MsgPack_and_JSON() throws {
+    func test__112__Connection__with_fixture_messages__should_send_messages_through_raw_JSON_POST_and_retrieve_equal_messages_through_MsgPack_and_JSON() throws {
         let test = Test()
         try setupDependencies(for: test)
         let restPublishClient = ARTRest(options: jsonOptions)

--- a/Test/Tests/RealtimeClientTests.swift
+++ b/Test/Tests/RealtimeClientTests.swift
@@ -320,7 +320,7 @@ class RealtimeClientTests: XCTestCase {
     }
 
     // RTC5b
-    func test__FLAKY__023__RealtimeClient__stats__should_accept_all_the_same_params_as_RestClient() throws {
+    func test__023__RealtimeClient__stats__should_accept_all_the_same_params_as_RestClient() throws {
         let test = Test()
         let client = ARTRealtime(options: try AblyTests.commonAppSetup(for: test))
         defer { client.close() }
@@ -1014,7 +1014,7 @@ class RealtimeClientTests: XCTestCase {
     }
 
     // RTC8b1 - part 4
-    func test__FLAKY__036__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_an_error_if_the_connection_moves_to_the_CLOSED_state() throws {
+    func test__036__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_an_error_if_the_connection_moves_to_the_CLOSED_state() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         options.autoConnect = false
@@ -1282,7 +1282,7 @@ class RealtimeClientTests: XCTestCase {
     }
     
     // https://github.com/ably/ably-cocoa/issues/577
-    func test__FLAKY__005__RealtimeClient__background_behaviour() {
+    func test__005__RealtimeClient__background_behaviour() {
         let test = Test()
         waitUntil(timeout: testTimeout) { done in
             URLSession.shared.dataTask(with: URL(string: "https://ably.com")!) { _, _, _ in
@@ -1514,7 +1514,7 @@ class RealtimeClientTests: XCTestCase {
         }
     }
 
-    func test__FLAKY__012__RealtimeClient__moves_to_DISCONNECTED_on_an_unexpected_normal_WebSocket_close() throws {
+    func test__012__RealtimeClient__moves_to_DISCONNECTED_on_an_unexpected_normal_WebSocket_close() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRealtime(options: options)

--- a/Test/Tests/RealtimeClientTests.swift
+++ b/Test/Tests/RealtimeClientTests.swift
@@ -320,7 +320,7 @@ class RealtimeClientTests: XCTestCase {
     }
 
     // RTC5b
-    func skipped__test__023__RealtimeClient__stats__should_accept_all_the_same_params_as_RestClient() throws {
+    func test__FLAKY__023__RealtimeClient__stats__should_accept_all_the_same_params_as_RestClient() throws {
         let test = Test()
         let client = ARTRealtime(options: try AblyTests.commonAppSetup(for: test))
         defer { client.close() }
@@ -1014,7 +1014,7 @@ class RealtimeClientTests: XCTestCase {
     }
 
     // RTC8b1 - part 4
-    func skipped__test__036__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_an_error_if_the_connection_moves_to_the_CLOSED_state() throws {
+    func test__FLAKY__036__RealtimeClient__Auth_authorize_should_upgrade_the_connection_with_current_token__authorize_call_should_complete_with_an_error_if_the_connection_moves_to_the_CLOSED_state() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         options.autoConnect = false
@@ -1280,13 +1280,12 @@ class RealtimeClientTests: XCTestCase {
             }
         }
     }
-
-    // FIXME: Fix flaky presence tests and re-enable. See https://ably-real-time.slack.com/archives/C030C5YLY/p1623172436085700
+    
     // https://github.com/ably/ably-cocoa/issues/577
-    func skipped__test__005__RealtimeClient__background_behaviour() {
+    func test__FLAKY__005__RealtimeClient__background_behaviour() {
         let test = Test()
         waitUntil(timeout: testTimeout) { done in
-            URLSession.shared.dataTask(with: URL(string: "https://ably.io")!) { _, _, _ in
+            URLSession.shared.dataTask(with: URL(string: "https://ably.com")!) { _, _, _ in
                 let realtime: ARTRealtime
 
                 do {
@@ -1515,7 +1514,7 @@ class RealtimeClientTests: XCTestCase {
         }
     }
 
-    func skipped__test__012__RealtimeClient__moves_to_DISCONNECTED_on_an_unexpected_normal_WebSocket_close() throws {
+    func test__FLAKY__012__RealtimeClient__moves_to_DISCONNECTED_on_an_unexpected_normal_WebSocket_close() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRealtime(options: options)

--- a/Test/Tests/RestClientChannelTests.swift
+++ b/Test/Tests/RestClientChannelTests.swift
@@ -1211,7 +1211,7 @@ class RestClientChannelTests: XCTestCase {
 
     // RSP3
 
-    func skipped__test__035__presence__get__should_return_presence_fixture_data() throws {
+    func test__035__presence__get__should_return_presence_fixture_data() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         options.testOptions.channelNamePrefix = nil

--- a/Test/Tests/RestClientPresenceTests.swift
+++ b/Test/Tests/RestClientPresenceTests.swift
@@ -6,7 +6,7 @@ class RestClientPresenceTests: XCTestCase {
     // RSP3
 
     // RSP3a
-    func skipped__test__002__Presence__get__should_return_a_PaginatedResult_page_containing_the_first_page_of_members() throws {
+    func test__FLAKY__002__Presence__get__should_return_a_PaginatedResult_page_containing_the_first_page_of_members() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRest(options: options)
@@ -222,9 +222,7 @@ class RestClientPresenceTests: XCTestCase {
     // RSP4b
 
     // RSP4b2
-    // Disabled because there's something wrong in the Sandbox.
-    // More info at https://ably-real-time.slack.com/archives/C030C5YLY/p1614269570000400
-    func skipped__test__007__Presence__history__query_argument__direction_should_change_the_order_of_the_members() throws {
+    func test__FLAKY__007__Presence__history__query_argument__direction_should_change_the_order_of_the_members() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRest(options: options)

--- a/Test/Tests/RestClientPresenceTests.swift
+++ b/Test/Tests/RestClientPresenceTests.swift
@@ -6,7 +6,7 @@ class RestClientPresenceTests: XCTestCase {
     // RSP3
 
     // RSP3a
-    func test__FLAKY__002__Presence__get__should_return_a_PaginatedResult_page_containing_the_first_page_of_members() throws {
+    func test__002__Presence__get__should_return_a_PaginatedResult_page_containing_the_first_page_of_members() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRest(options: options)
@@ -222,7 +222,7 @@ class RestClientPresenceTests: XCTestCase {
     // RSP4b
 
     // RSP4b2
-    func test__FLAKY__007__Presence__history__query_argument__direction_should_change_the_order_of_the_members() throws {
+    func test__007__Presence__history__query_argument__direction_should_change_the_order_of_the_members() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRest(options: options)

--- a/Test/Tests/RestClientStatsTests.swift
+++ b/Test/Tests/RestClientStatsTests.swift
@@ -99,7 +99,7 @@ class RestClientStatsTests: XCTestCase {
         statsOptions = try postTestStats(statsFixtures, for: test)
     }
 
-    func skipped__test__001__RestClient__stats__result__should_match_minute_level_inbound_and_outbound_fixture_data__forwards_() throws {
+    func test__FLAKY__001__RestClient__stats__result__should_match_minute_level_inbound_and_outbound_fixture_data__forwards_() throws {
         let test = Test()
         try beforeEach__RestClient__stats__result(for: test)
 
@@ -164,7 +164,7 @@ class RestClientStatsTests: XCTestCase {
         XCTAssertEqual(totalOutbound, 20 + 10 + 40)
     }
 
-    func skipped__test__004__RestClient__stats__result__should_match_month_level_inbound_and_outbound_fixture_data__forwards_() throws {
+    func test__FLAKY__004__RestClient__stats__result__should_match_month_level_inbound_and_outbound_fixture_data__forwards_() throws {
         let test = Test()
         try beforeEach__RestClient__stats__result(for: test)
 
@@ -183,7 +183,7 @@ class RestClientStatsTests: XCTestCase {
         XCTAssertEqual(totalOutbound, 20 + 10 + 40)
     }
 
-    func skipped__test__005__RestClient__stats__result__should_contain_only_one_item_when_limit_is_1__backwards() throws {
+    func test__FLAKY__005__RestClient__stats__result__should_contain_only_one_item_when_limit_is_1__backwards() throws {
         let test = Test()
         try beforeEach__RestClient__stats__result(for: test)
 
@@ -269,7 +269,7 @@ class RestClientStatsTests: XCTestCase {
         XCTAssertEqual((firstPageAgain.items)[0].inbound.all.messages.data, 7000)
     }
 
-    func skipped__test__008__RestClient__stats__result__should_be_paginated_according_to_the_limit__fowards_() throws {
+    func test__FLAKY__008__RestClient__stats__result__should_be_paginated_according_to_the_limit__fowards_() throws {
         let test = Test()
         try beforeEach__RestClient__stats__result(for: test)
 

--- a/Test/Tests/RestClientStatsTests.swift
+++ b/Test/Tests/RestClientStatsTests.swift
@@ -99,7 +99,7 @@ class RestClientStatsTests: XCTestCase {
         statsOptions = try postTestStats(statsFixtures, for: test)
     }
 
-    func test__FLAKY__001__RestClient__stats__result__should_match_minute_level_inbound_and_outbound_fixture_data__forwards_() throws {
+    func test__001__RestClient__stats__result__should_match_minute_level_inbound_and_outbound_fixture_data__forwards_() throws {
         let test = Test()
         try beforeEach__RestClient__stats__result(for: test)
 
@@ -164,7 +164,7 @@ class RestClientStatsTests: XCTestCase {
         XCTAssertEqual(totalOutbound, 20 + 10 + 40)
     }
 
-    func test__FLAKY__004__RestClient__stats__result__should_match_month_level_inbound_and_outbound_fixture_data__forwards_() throws {
+    func test__004__RestClient__stats__result__should_match_month_level_inbound_and_outbound_fixture_data__forwards_() throws {
         let test = Test()
         try beforeEach__RestClient__stats__result(for: test)
 
@@ -183,7 +183,7 @@ class RestClientStatsTests: XCTestCase {
         XCTAssertEqual(totalOutbound, 20 + 10 + 40)
     }
 
-    func test__FLAKY__005__RestClient__stats__result__should_contain_only_one_item_when_limit_is_1__backwards() throws {
+    func test__005__RestClient__stats__result__should_contain_only_one_item_when_limit_is_1__backwards() throws {
         let test = Test()
         try beforeEach__RestClient__stats__result(for: test)
 
@@ -269,7 +269,7 @@ class RestClientStatsTests: XCTestCase {
         XCTAssertEqual((firstPageAgain.items)[0].inbound.all.messages.data, 7000)
     }
 
-    func test__FLAKY__008__RestClient__stats__result__should_be_paginated_according_to_the_limit__fowards_() throws {
+    func test__008__RestClient__stats__result__should_be_paginated_according_to_the_limit__fowards_() throws {
         let test = Test()
         try beforeEach__RestClient__stats__result(for: test)
 


### PR DESCRIPTION
Closes #1406

All tests were successfully unskipped except "test__105__Connection__Transport_disconnected_side_effects__should_resent_the_DETACH_message_if_there_are_any_pending_channels" that has the same issue as the one described [here](https://github.com/ably/ably-cocoa/issues/1932).

[Results](https://test-observability.herokuapp.com/repos/ably/ably-cocoa/uploads?branches%5B%5D=fix%2F1406-unskip-tests-in-loop) in a loop.