### PR TITLE
[ECO-4886] respect RSH3a3a

### DIFF
--- a/Source/ARTPushActivationState.m
+++ b/Source/ARTPushActivationState.m
@@ -135,6 +135,9 @@ ARTPushActivationState *validateAndSync(ARTPushActivationStateMachine *machine, 
     else if ([event isKindOfClass:[ARTPushActivationEventCalledActivate class]]) {
         return validateAndSync(self.machine, event, self.logger);
     }
+    else if ([event isKindOfClass:[ARTPushActivationEventGotPushDeviceDetails class]]) {
+        return self; // Consuming event (RSH3a3a)
+    }
     return nil;
 }
 

--- a/Source/PrivateHeaders/Ably/ARTPushActivationStateMachine.h
+++ b/Source/PrivateHeaders/Ably/ARTPushActivationStateMachine.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly, nonatomic) ARTPushActivationEvent *lastEvent;
 @property (readonly, nonatomic) ARTPushActivationState *current;
-@property (readonly, nonatomic) NSMutableArray<ARTPushActivationEvent *> *pendingEvents;
+@property (readonly, nonatomic) NSArray<ARTPushActivationEvent *> *pendingEvents;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/Test/Tests/PushActivationStateMachineTests.swift
+++ b/Test/Tests/PushActivationStateMachineTests.swift
@@ -203,7 +203,9 @@ class PushActivationStateMachineTests: XCTestCase {
         beforeEach__Activation_state_machine__State_NotActivated()
 
         stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
+        
         expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateNotActivated.self))
+        XCTAssertEqual(stateMachine.pendingEvents.count, 0)
     }
 
     // RSH3b
@@ -982,7 +984,7 @@ class PushActivationStateMachineTests: XCTestCase {
         expect(stateMachine.pendingEvents).toEventually(haveCount(1), timeout: testTimeout)
         stateMachine.transitions = nil
 
-        let pendingEvent = try XCTUnwrap(stateMachine.pendingEvents.firstObject, "Pending event is missing")
+        let pendingEvent = try XCTUnwrap(stateMachine.pendingEvents.first, "Pending event is missing")
         expect(pendingEvent).to(beAKindOf(ARTPushActivationEventCalledActivate.self))
 
         waitUntil(timeout: testTimeout) { done in


### PR DESCRIPTION
Closes #1951 

Made `ARTPushActivationStateNotActivated` to consume `GotPushDeviceDetails` event. Also replaced state machine's `pendingEvents` public property to immutable array. Updatetd RSH3a3 test to check RSH3a3a point.