### PR TITLE
[ECO-4874] Replaced all occurences of checking error message

### DIFF
--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -464,9 +464,7 @@ class AuthTests: XCTestCase {
                 guard let error = error else {
                     fail("Error is nil"); done(); return
                 }
-                XCTAssertEqual(error.code, Int(ARTState.requestTokenFailed.rawValue))
-                expect(error.message).to(contain("no means to renew the token is provided"))
-
+                XCTAssertEqual(error.code, Int(ARTState.requestTokenFailed.rawValue)) // no means to renew the token is provided
                 XCTAssertEqual(proxyHTTPExecutor.requests.count, 0)
                 done()
             }
@@ -505,8 +503,7 @@ class AuthTests: XCTestCase {
                 guard let error = error else {
                     fail("Error is nil"); done(); return
                 }
-                XCTAssertEqual(error.code, Int(ARTState.requestTokenFailed.rawValue))
-                expect(error.message).to(contain("no means to renew the token is provided"))
+                XCTAssertEqual(error.code, Int(ARTState.requestTokenFailed.rawValue)) // no means to renew the token is provided
                 XCTAssertEqual(proxyHTTPExecutor.requests.count, 1)
                 XCTAssertEqual(proxyHTTPExecutor.responses.count, 1)
                 guard let response = proxyHTTPExecutor.responses.first else {
@@ -1914,7 +1911,7 @@ class AuthTests: XCTestCase {
                 guard let error = error else {
                     fail("Error is nil"); done(); return
                 }
-                expect(error.message).to(contain("invalid clientId"))
+                XCTAssertTrue(error.code == ARTErrorCode.invalidClientId.rawValue)
                 done()
             }
         }
@@ -2423,10 +2420,10 @@ class AuthTests: XCTestCase {
         waitUntil(timeout: testTimeout) { done in
             rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
                 defer { done() }
-                guard let error = error else {
+                guard let error = error as? NSError else {
                     XCTFail("Error is nil"); return
                 }
-                expect(error.localizedDescription).to(contain("Capability"))
+                XCTAssertTrue(error.code == 3840) // Capability: The data couldn’t be read because it isn’t in the correct format.
                 XCTAssertNil(tokenRequest?.capability)
             })
         }
@@ -4086,8 +4083,7 @@ class AuthTests: XCTestCase {
                 guard let reason = stateChange.reason else {
                     fail("Reason error is nil"); done(); return
                 }
-                XCTAssertEqual(reason.code, ARTErrorCode.invalidJwtFormat.intValue)
-                expect(reason.description).to(satisfyAnyOf(contain("invalid signature"), contain("signature verification failed")))
+                XCTAssertEqual(reason.code, ARTErrorCode.invalidJwtFormat.intValue) // Error verifying JWT; err = Unexpected exception decoding token; err = signature verification failed. (See https://help.ably.io/error/40144 for help.)
                 done()
             }
             client.connect()
@@ -4137,8 +4133,7 @@ class AuthTests: XCTestCase {
                 guard let reason = stateChange.reason else {
                     fail("Reason error is nil"); done(); return
                 }
-                XCTAssertEqual(reason.code, ARTErrorCode.invalidJwtFormat.intValue)
-                expect(reason.description).to(satisfyAnyOf(contain("invalid signature"), contain("signature verification failed")))
+                XCTAssertEqual(reason.code, ARTErrorCode.invalidJwtFormat.intValue) // Error verifying JWT; err = Unexpected exception decoding token; err = signature verification failed. (See https://help.ably.io/error/40144 for help.)
                 done()
             }
             client.connect()
@@ -4257,8 +4252,7 @@ class AuthTests: XCTestCase {
                 guard let reason = stateChange.reason else {
                     fail("Reason error is nil"); done(); return
                 }
-                XCTAssertEqual(reason.code, ARTErrorCode.invalidJwtFormat.intValue)
-                expect(reason.description).to(satisfyAnyOf(contain("invalid signature"), contain("signature verification failed")))
+                XCTAssertEqual(reason.code, ARTErrorCode.invalidJwtFormat.intValue) // Error verifying JWT; err = Unexpected exception decoding token; err = signature verification failed. (See https://help.ably.io/error/40144 for help.)
                 done()
             }
             client.connect()
@@ -4334,8 +4328,7 @@ class AuthTests: XCTestCase {
 
         waitUntil(timeout: testTimeout) { done in
             client.channels.get(channelName).publish(messageName, data: nil, callback: { error in
-                XCTAssertEqual(error?.code, ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue)
-                expect(error?.message).to(contain("permission denied"))
+                XCTAssertEqual(error?.code, ARTErrorCode.operationNotPermittedWithProvidedCapability.intValue) // Unable to perform publish (permission denied)
                 done()
             })
         }

--- a/Test/Tests/PushAdminTests.swift
+++ b/Test/Tests/PushAdminTests.swift
@@ -279,7 +279,7 @@ class PushAdminTests: XCTestCase {
                     fail("Error is missing"); done(); return
                 }
                 XCTAssertEqual(error.statusCode, 400)
-                expect(error.message).to(contain("recipient must contain"))
+                XCTAssertTrue(error.code == ARTErrorCode.badRequest.rawValue) // recipient must contain a 'deviceId', 'clientId', or 'transportType'
                 done()
             }
         }
@@ -368,7 +368,7 @@ class PushAdminTests: XCTestCase {
                     fail("Error should not be empty"); done(); return
                 }
                 XCTAssertEqual(error.statusCode, 404)
-                expect(error.message).to(contain("not found"))
+                XCTAssertTrue(error.code == ARTErrorCode.notFound.rawValue)
                 done()
             }
         }
@@ -715,7 +715,7 @@ class PushAdminTests: XCTestCase {
                     fail("Error is nil"); done(); return
                 }
                 XCTAssertEqual(error.statusCode, 400)
-                expect(error.message).to(contain("device madeup doesn't exist"))
+                XCTAssertTrue(error.code == ARTErrorCode.badRequest.rawValue) // registration for device madeup doesn't exist
                 done()
             }
         }

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -1558,7 +1558,7 @@ class RealtimeClientChannelTests: XCTestCase {
                 guard let error = error else {
                     fail("Reason error is nil"); return
                 }
-                expect(error.message).to(contain("timed out"))
+                XCTAssertTrue(error.code == ARTState.detachTimedOut.rawValue)
                 XCTAssertEqual(channel.state, ARTRealtimeChannelState.attached)
                 done()
             }
@@ -1948,7 +1948,7 @@ class RealtimeClientChannelTests: XCTestCase {
             guard let error = error else {
                 fail("Error is nil"); return
             }
-            expect(error.message).to(contain("timed out"))
+            XCTAssertTrue(error.code == ARTState.detachTimedOut.rawValue)
             XCTAssertEqual(error, channel.errorReason)
             callbackCalled = true
         }
@@ -3959,7 +3959,7 @@ class RealtimeClientChannelTests: XCTestCase {
                 guard let error = stateChange.reason else {
                     fail("Reason error is nil"); done(); return
                 }
-                expect(error.message).to(contain("timed out"))
+                XCTAssertTrue(error.code == ARTState.attachTimedOut.rawValue)
                 XCTAssertTrue(channel.errorReason === error)
                 done()
             }
@@ -4186,7 +4186,7 @@ class RealtimeClientChannelTests: XCTestCase {
                 guard let error = stateChange.reason else {
                     fail("Reason error is nil"); done(); return
                 }
-                expect(error.message).to(contain("timed out"))
+                XCTAssertTrue(error.code == ARTState.attachTimedOut.rawValue)
                 XCTAssertTrue(channel.errorReason === error)
                 done()
             }

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -1936,7 +1936,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                     fail("expected error"); done(); return
                 }
                 let end = NSDate()
-                expect(error.message).to(contain("timed out"))
+                XCTAssertTrue(error.code == ARTErrorCode.connectionTimedOut.rawValue)
                 expect(end.timeIntervalSince(start as Date)).to(beCloseTo(realtimeRequestTimeout, within: 1.5))
                 done()
             }
@@ -2094,9 +2094,8 @@ class RealtimeClientConnectionTests: XCTestCase {
                 guard let reason = stateChange.reason else {
                     fail("Reason is nil"); done(); return
                 }
-                XCTAssertEqual(reason.code, ARTErrorCode.tokenExpired.intValue)
+                XCTAssertEqual(reason.code, ARTErrorCode.tokenExpired.intValue) // Key/token status changed (expire)
                 XCTAssertEqual(reason.statusCode, 401)
-                expect(reason.message).to(contain("Key/token status changed (expire)"))
                 partialDone()
             }
             client.connect()
@@ -2312,9 +2311,8 @@ class RealtimeClientConnectionTests: XCTestCase {
             options.authCallback = { _, _ in
                 // Ignore `completion` closure to force a time out
             }
-        },
-                              checkError: { error in
-            XCTAssertTrue(error.message.contains("timed out"))
+        }, checkError: { error in
+            XCTAssertTrue(error.code == ARTErrorCode.authConfiguredProviderFailure.rawValue) // timed out
         })
     }
 
@@ -4104,7 +4102,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                 guard let error = stateChange.reason else {
                     fail("Error is nil"); done(); return
                 }
-                expect(error.message).to(contain("Invalid key"))
+                XCTAssertTrue(error.code == ARTErrorCode.invalidCredential.rawValue)
                 done()
             }
         }

--- a/Test/Tests/RealtimeClientPresenceTests.swift
+++ b/Test/Tests/RealtimeClientPresenceTests.swift
@@ -1922,7 +1922,7 @@ class RealtimeClientPresenceTests: XCTestCase {
                 guard let error = error else {
                     fail("error expected"); done(); return
                 }
-                expect(error.message).to(contain("Channel denied access based on given capability"))
+                XCTAssertTrue(error.code == ARTErrorCode.operationNotPermittedWithProvidedCapability.rawValue)
                 done()
             }
         }
@@ -2002,7 +2002,7 @@ class RealtimeClientPresenceTests: XCTestCase {
                 guard let error = error else {
                     fail("Error is nil"); done(); return
                 }
-                expect(error.message).to(contain("Channel denied access based on given capability"))
+                XCTAssertTrue(error.code == ARTErrorCode.operationNotPermittedWithProvidedCapability.rawValue)
                 done()
             }
         }

--- a/Test/Tests/RealtimeClientTests.swift
+++ b/Test/Tests/RealtimeClientTests.swift
@@ -573,7 +573,7 @@ class RealtimeClientTests: XCTestCase {
                 guard let error = stateChange.reason else {
                     fail("Error is nil"); done(); return
                 }
-                expect(error.message).to(contain("Channel denied access based on given capability"))
+                XCTAssertTrue(error.code == ARTErrorCode.operationNotPermittedWithProvidedCapability.rawValue)
                 done()
             }
             channel.attach()
@@ -741,10 +741,10 @@ class RealtimeClientTests: XCTestCase {
             }
 
             client.auth.authorize(nil, options: authOptions) { tokenDetails, error in
-                guard let error = error else {
+                guard let error = error as? NSError else {
                     fail("ErrorInfo is nil"); partialDone(); return
                 }
-                expect(error.localizedDescription).to(contain("Invalid accessToken"))
+                XCTAssertTrue(error.code == ARTErrorCode.invalidCredential.rawValue) // Invalid accessToken in request: xxxxxxxxxxxx
                 XCTAssertEqual(tokenDetails?.token, invalidToken)
                 authError = error as NSError?
                 partialDone()

--- a/Test/Tests/RestClientTests.swift
+++ b/Test/Tests/RestClientTests.swift
@@ -1757,7 +1757,6 @@ class RestClientTests: XCTestCase {
                         return
                     }
                     XCTAssertEqual(error.code, Int(ARTState.requestTokenFailed.rawValue))
-                    expect(error.message).to(contain("no means to renew the token is provided"))
                     done()
                 }
             }
@@ -2053,7 +2052,6 @@ class RestClientTests: XCTestCase {
                 }
                 XCTAssertEqual(error.statusCode, 401)
                 XCTAssertEqual(error.code, ARTErrorCode.errorFromClientTokenCallback.intValue)
-                expect(error.message).to(contain("Error in requesting auth token"))
                 done()
             }
         }


### PR DESCRIPTION
Replaced all occurences of checking error message instead of error code (or removed where the error code check was already presented) except places where error is locally generated (since it doesn't contain proper error code - 0 usually).

Closes #1946 