### PR TITLE
[ECO-4933] Added readonly `ARTChannelProperties` object to the public interface

### DIFF
--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -69,6 +69,10 @@
     return _internal.state;
 }
 
+- (ARTChannelProperties *)properties {
+    return _internal.properties;
+}
+
 - (ARTErrorInfo *)errorReason {
     return _internal.errorReason;
 }
@@ -1078,6 +1082,18 @@ dispatch_sync(_queue, ^{
     return (ARTRealtimeChannelOptions *)[self options_nosync];
 }
 
+- (ARTChannelProperties *)properties {
+    __block ARTChannelProperties *ret;
+    dispatch_sync(_queue, ^{
+        ret = [self properties_nosync];
+    });
+    return ret;
+}
+
+- (ARTChannelProperties *)properties_nosync {
+    return [[ARTChannelProperties alloc] initWithAttachSerial:_attachSerial channelSerial:_channelSerial];
+}
+
 - (void)setOptions:(ARTRealtimeChannelOptions *_Nullable)options callback:(nullable ARTCallback)callback {
     if (callback) {
         ARTCallback userCallback = callback;
@@ -1115,6 +1131,21 @@ dispatch_sync(_queue, ^{
                 callback(nil);
             break;
     }
+}
+
+@end
+
+#pragma mark - Channel Properties (RTL15)
+
+@implementation ARTChannelProperties
+
+- (instancetype)initWithAttachSerial:(NSString *)attachSerial channelSerial:(NSString *)channelSerial {
+    self = [super init];
+    if (self) {
+        _attachSerial = attachSerial;
+        _channelSerial = channelSerial;
+    }
+    return self;
 }
 
 @end

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -640,7 +640,7 @@ dispatch_sync(_queue, ^{
     if (message.resumed) {
         ARTLogDebug(self.logger, @"R:%p C:%p (%@) channel has resumed", _realtime, self, self.name);
     }
-
+    // RTL15a
     self.attachSerial = message.channelSerial;
     // RTL15b
     if (message.channelSerial) {

--- a/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
@@ -34,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString * _Nullable)clientId_nosync;
 - (BOOL)canBeReattached;
 - (BOOL)shouldAttach;
+- (ARTChannelProperties *)properties_nosync;
 
 @property (readonly, weak, nonatomic) ARTRealtimeInternal *realtime; // weak because realtime owns self
 @property (readonly, nonatomic) ARTRestChannelInternal *restChannel;
@@ -92,6 +93,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)internalSync:(void (^)(ARTRealtimeChannelInternal *))use;
 
 - (instancetype)initWithInternal:(ARTRealtimeChannelInternal *)internal queuedDealloc:(ARTQueuedDealloc *)dealloc;
+
+@end
+
+@interface ARTChannelProperties ()
+
+- (instancetype)initWithAttachSerial:(nullable NSString *)attachSerial channelSerial:(nullable NSString *)channelSerial;
 
 @end
 

--- a/Source/include/Ably/ARTRealtimeChannel.h
+++ b/Source/include/Ably/ARTRealtimeChannel.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class ARTRealtimePresence;
 @class ARTRealtimeChannelOptions;
+@class ARTChannelProperties;
 #if TARGET_OS_IPHONE
 @class ARTPushChannel;
 #endif
@@ -24,6 +25,11 @@ NS_ASSUME_NONNULL_BEGIN
  * The current `ARTRealtimeChannelState` of the channel.
  */
 @property (readonly) ARTRealtimeChannelState state;
+
+/**
+ * An `ARTChannelProperties` object.
+ */
+@property (readonly) ARTChannelProperties *properties;
 
 /**
  * An `ARTErrorInfo` object describing the last error which occurred on the channel, if any.
@@ -142,6 +148,18 @@ NS_ASSUME_NONNULL_BEGIN
  * `ARTRealtimeChannel` implements `ARTEventEmitter` and emits `ARTChannelEvent` events, where a `ARTChannelEvent` is either a `ARTRealtimeChannelState` or an `ARTChannelEventUpdate`.
  */
 ART_EMBED_INTERFACE_EVENT_EMITTER(ARTChannelEvent, ARTChannelStateChange *)
+
+@end
+
+/**
+ * Describes the properties of the channel state.
+ */
+@interface ARTChannelProperties : NSObject
+/**
+ * Starts unset when a channel is instantiated, then updated with the `channelSerial` from each `ARTChannelEventAttached` event that matches the channel. Used as the value for `ARTRealtimeHistoryQuery.untilAttach`.
+ */
+@property (nonatomic, readonly, nullable) NSString *attachSerial; // CP2a
+@property (nonatomic, readonly, nullable) NSString *channelSerial; // CP2b
 
 @end
 

--- a/Source/include/Ably/ARTRealtimeChannel.h
+++ b/Source/include/Ably/ARTRealtimeChannel.h
@@ -159,6 +159,9 @@ ART_EMBED_INTERFACE_EVENT_EMITTER(ARTChannelEvent, ARTChannelStateChange *)
  * Starts unset when a channel is instantiated, then updated with the `channelSerial` from each `ARTChannelEventAttached` event that matches the channel. Used as the value for `ARTRealtimeHistoryQuery.untilAttach`.
  */
 @property (nonatomic, readonly, nullable) NSString *attachSerial; // CP2a
+/**
+ * Updated by the framework whenever there is some activity on the channel (user message received, presence updated or a channel attached).
+ */
 @property (nonatomic, readonly, nullable) NSString *channelSerial; // CP2b
 
 @end

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -134,7 +134,7 @@ private func testWithUntilAttach(_ untilAttach: Bool, for test: Test, channelNam
     let queryString = testHTTPExecutor.requests.last!.url!.query
 
     if query.untilAttach {
-        expect(queryString).to(contain("fromSerial=\(channel.internal.attachSerial!)"))
+        expect(queryString).to(contain("fromSerial=\(channel.properties.attachSerial!)"))
     } else {
         expect(queryString).toNot(contain("fromSerial"))
     }
@@ -4256,14 +4256,14 @@ class RealtimeClientChannelTests: XCTestCase {
                 expect(error).to(beNil())
                 let attachMessage = transport.protocolMessagesReceived.filter { $0.action == .attached }[0]
                 if attachMessage.channelSerial != nil {
-                    expect(attachMessage.channelSerial).to(equal(channel.internal.channelSerial))
+                    expect(attachMessage.channelSerial).to(equal(channel.properties.channelSerial))
                 }
                 partialDone()
                 
                 channel.subscribe { message in
                     let messageMessage = transport.protocolMessagesReceived.filter { $0.action == .message }[0]
                     if messageMessage.channelSerial != nil {
-                        expect(messageMessage.channelSerial).to(equal(channel.internal.channelSerial))
+                        expect(messageMessage.channelSerial).to(equal(channel.properties.channelSerial))
                     }
                     channel.presence.enterClient("client1", data: "Hey")
                     partialDone()
@@ -4271,7 +4271,7 @@ class RealtimeClientChannelTests: XCTestCase {
                 channel.presence.subscribe { presenceMessage in
                     let presenceMessage = transport.protocolMessagesReceived.filter { $0.action == .presence }[0]
                     if presenceMessage.channelSerial != nil {
-                        expect(presenceMessage.channelSerial).to(equal(channel.internal.channelSerial))
+                        expect(presenceMessage.channelSerial).to(equal(channel.properties.channelSerial))
                     }
                     partialDone()
                 }

--- a/Test/Tests/RealtimeClientChannelTests.swift
+++ b/Test/Tests/RealtimeClientChannelTests.swift
@@ -4238,7 +4238,7 @@ class RealtimeClientChannelTests: XCTestCase {
     
     // RTL15
     
-    // RTL15b
+    // RTL15a/RTL15b
     func test__200__channel_serial_is_updated_whenever_a_protocol_message_with_either_message_presence_or_attached_actions_is_received_in_a_channel() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
@@ -4256,14 +4256,15 @@ class RealtimeClientChannelTests: XCTestCase {
                 expect(error).to(beNil())
                 let attachMessage = transport.protocolMessagesReceived.filter { $0.action == .attached }[0]
                 if attachMessage.channelSerial != nil {
-                    expect(attachMessage.channelSerial).to(equal(channel.properties.channelSerial))
+                    expect(attachMessage.channelSerial).to(equal(channel.properties.attachSerial)) // RTL15a
+                    expect(attachMessage.channelSerial).to(equal(channel.properties.channelSerial)) // RTL15b
                 }
                 partialDone()
                 
                 channel.subscribe { message in
                     let messageMessage = transport.protocolMessagesReceived.filter { $0.action == .message }[0]
                     if messageMessage.channelSerial != nil {
-                        expect(messageMessage.channelSerial).to(equal(channel.properties.channelSerial))
+                        expect(messageMessage.channelSerial).to(equal(channel.properties.channelSerial)) // RTL15b
                     }
                     channel.presence.enterClient("client1", data: "Hey")
                     partialDone()
@@ -4271,7 +4272,7 @@ class RealtimeClientChannelTests: XCTestCase {
                 channel.presence.subscribe { presenceMessage in
                     let presenceMessage = transport.protocolMessagesReceived.filter { $0.action == .presence }[0]
                     if presenceMessage.channelSerial != nil {
-                        expect(presenceMessage.channelSerial).to(equal(channel.properties.channelSerial))
+                        expect(presenceMessage.channelSerial).to(equal(channel.properties.channelSerial)) // RTL15b
                     }
                     partialDone()
                 }


### PR DESCRIPTION
Added readonly ARTChannelProperties object to the public interface not touching existing internal properties `attachSerial` and `channelSerial` (from which it's being constructed with a private constructor for each call).

Closes #1960 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced new methods for accessing channel properties, including a synchronized method for thread-safe access.
	- Enhanced the `ARTChannelProperties` class with a dedicated initializer for improved encapsulation of channel properties.
	- Added a new `properties` property to `ARTRealtimeChannel` for better access to channel state.

- **Bug Fixes**
	- Updated test cases to reflect changes in channel serial number references, ensuring assertions target the correct properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->