### PR TITLE
fix test__144__JWT_and_realtime__when_using_authUrl__when_token_expires against frontdoor

### DIFF
--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -4159,7 +4159,8 @@ class AuthTests: XCTestCase {
             client.connection.once(.connected) { stateChange in
                 client.connection.once(.disconnected) { stateChange in
                     XCTAssertEqual(stateChange.reason?.code, ARTErrorCode.tokenExpired.intValue)
-                    expect(stateChange.reason?.description).to(contain("Key/token status changed (expire)"))
+                    expect(stateChange.reason?.description).to(contain("token"))
+                    expect(stateChange.reason?.description).to(contain("expire"))
                     done()
                 }
             }


### PR DESCRIPTION
The current test is over-specified - searching for exact error text. Updated so test asserts that error text contains the words token and expire

Fixes
https://ably.atlassian.net/jira/software/projects/RAR/boards/159?selectedIssue=RAR-692
```::error file=/Users/runner/work/ably-cocoa/ably-cocoa/Test/Tests/AuthTests.swift,line=4162:: test__144__JWT_and_realtime__when_using_authUrl__when_token_expires__receives_a_40142_error_from_the_server, expected to contain <Key/token status changed (expire)>, got <Error 40142 - Key/token status changed (token expired).```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved the specificity of authentication tests by changing assertions to check for individual keywords in error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->