### PR TITLE
Added `attachOnSubscribe` to `ARTRealtimeChannelOptions`.

### DIFF
--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -435,12 +435,16 @@ dispatch_sync(_queue, ^{
 
     __block ARTEventListener *listener = nil;
 dispatch_sync(_queue, ^{
+    ARTRealtimeChannelOptions *options = self.getOptions_nosync;
+    BOOL attachOnSubscribe = options != nil ? options.attachOnSubscribe : true;
     if (self.state_nosync == ARTRealtimeChannelFailed) {
-        if (onAttach) onAttach([ARTErrorInfo createWithCode:ARTErrorChannelOperationFailedInvalidState message:@"attempted to subscribe while channel is in FAILED state."]);
+        if (onAttach && attachOnSubscribe) { // RTL7h
+            onAttach([ARTErrorInfo createWithCode:ARTErrorChannelOperationFailedInvalidState message:@"attempted to subscribe while channel is in FAILED state."]);
+        }
         ARTLogWarn(self.logger, @"R:%p C:%p (%@) subscribe of '%@' has been ignored (attempted to subscribe while channel is in FAILED state)", self->_realtime, self, self.name, name == nil ? @"all" : name);
         return;
     }
-    if (self.shouldAttach) { // RTL7c
+    if (self.shouldAttach && attachOnSubscribe) { // RTL7g
         [self _attach:onAttach];
     }
     listener = name == nil ? [self.messagesEventEmitter on:cb] : [self.messagesEventEmitter on:name callback:cb];

--- a/Source/ARTRealtimeChannelOptions.m
+++ b/Source/ARTRealtimeChannelOptions.m
@@ -4,6 +4,21 @@
 @implementation ARTRealtimeChannelOptions {
     NSStringDictionary *_params;
     ARTChannelMode _modes;
+    BOOL _attachOnSubscribe;
+}
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _attachOnSubscribe = true;
+    }
+    return self;
+}
+
+- (instancetype)initWithCipher:(id<ARTCipherParamsCompatible>)cipherParams {
+    if (self = [super initWithCipher:cipherParams]) {
+        _attachOnSubscribe = true;
+    }
+    return self;
 }
 
 - (NSStringDictionary *)params {
@@ -30,6 +45,19 @@
                                      userInfo:nil];
     }
     _modes = modes;
+}
+
+- (BOOL)attachOnSubscribe {
+    return _attachOnSubscribe;
+}
+
+- (void)setAttachOnSubscribe:(BOOL)value {
+    if (self.isFrozen) {
+        @throw [NSException exceptionWithName:NSObjectInaccessibleException
+                                       reason:[NSString stringWithFormat:@"%@: You can't change options after you've passed it to receiver.", self.class]
+                                     userInfo:nil];
+    }
+    _attachOnSubscribe = value;
 }
 
 @end

--- a/Source/include/Ably/ARTRealtimeChannel.h
+++ b/Source/include/Ably/ARTRealtimeChannel.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)attach;
 
 /**
- * Attach to this channel ensuring the channel is created in the Ably system and all messages published on the channel are received by any channel listeners registered using `-[ARTRealtimeChannelProtocol subscribe:]`. Any resulting channel state change will be emitted to any listeners registered using the `-[ARTEventEmitter on:]` or `-[ARTEventEmitter once:]` methods. A callback may optionally be passed in to this call to be notified of success or failure of the operation. As a convenience, `attach:` is called implicitly if `-[ARTRealtimeChannelProtocol subscribe:]` for the channel is called, or `-[ARTRealtimePresenceProtocol enter:]` or `-[ARTRealtimePresenceProtocol subscribe:]` are called on the `ARTRealtimePresence` object for this channel.
+ * Attach to this channel ensuring the channel is created in the Ably system and all messages published on the channel are received by any channel listeners registered using `-[ARTRealtimeChannelProtocol subscribe:]`. Any resulting channel state change will be emitted to any listeners registered using the `-[ARTEventEmitter on:]` or `-[ARTEventEmitter once:]` methods. A callback may optionally be passed in to this call to be notified of success or failure of the operation. As a convenience, `attach:` is called implicitly if `-[ARTRealtimeChannelProtocol subscribe:]` is called on the channel or `-[ARTRealtimePresenceProtocol subscribe:]` is called on the `ARTRealtimePresence` object for this channel, unless you’ve set the `ARTRealtimeChannelOptions.attachOnSubscribe` channel option to `false`. It is also called implicitly if `-[ARTRealtimePresenceProtocol enter:]` is called on the `ARTRealtimePresence` object for this channel.
  *
  * @param callback A success or failure callback function.
  */
@@ -69,12 +69,14 @@ NS_ASSUME_NONNULL_BEGIN
  * @param callback An event listener function.
  *
  * @return An `ARTEventListener` object.
+ *
+ * @see See `subscribeWithAttachCallback:` for more details.
  */
 - (ARTEventListener *_Nullable)subscribe:(ARTMessageCallback)callback;
 
 /**
  * Registers a listener for messages on this channel. The caller supplies a listener function, which is called each time one or more messages arrives on the channel.
- * An attach callback may optionally be passed in to this call to be notified of success or failure of the channel `-[ARTRealtimeChannelProtocol attach]` operation.
+ * An attach callback may optionally be passed in to this call to be notified of success or failure of the channel `-[ARTRealtimeChannelProtocol attach]` operation. It will not be called if the `ARTRealtimeChannelOptions.attachOnSubscribe` channel option is set to `false`.
  *
  * @param onAttach An attach callback function.
  * @param callback An event listener function.
@@ -90,11 +92,13 @@ NS_ASSUME_NONNULL_BEGIN
  * @param callback An event listener function.
  *
  * @return An `ARTEventListener` object.
- */
+ *
+ * @see See `subscribeWithAttachCallback:` for more details.
+*/
 - (ARTEventListener *_Nullable)subscribe:(NSString *)name callback:(ARTMessageCallback)callback;
 
 /**
- * Registers a listener for messages with a given event `name` on this channel. The caller supplies a listener function, which is called each time one or more matching messages arrives on the channel. A callback may optionally be passed in to this call to be notified of success or failure of the channel `-[ARTRealtimeChannelProtocol attach]` operation.
+ * Registers a listener for messages with a given event `name` on this channel. The caller supplies a listener function, which is called each time one or more matching messages arrives on the channel. A callback may optionally be passed in to this call to be notified of success or failure of the channel `-[ARTRealtimeChannelProtocol attach]` operation. It will not be called if the `ARTRealtimeChannelOptions.attachOnSubscribe` channel option is set to `false`.
  *
  * @param name The event name.
  * @param callback An event listener function.

--- a/Source/include/Ably/ARTRealtimeChannelOptions.h
+++ b/Source/include/Ably/ARTRealtimeChannelOptions.h
@@ -42,6 +42,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) ARTChannelMode modes;
 
+/**
+ * A boolean which determines whether calling `subscribe` on a `ARTRealtimeChannel` or `ARTRealtimePresense` object should trigger an implicit attach (for realtime client libraries only). Defaults to true.
+ */
+@property (nonatomic) BOOL attachOnSubscribe;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/include/Ably/ARTRealtimePresence.h
+++ b/Source/include/Ably/ARTRealtimePresence.h
@@ -146,7 +146,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (ARTEventListener *_Nullable)subscribe:(ARTPresenceMessageCallback)callback;
 
 /**
- * Registers a listener that is called each time a `ARTPresenceMessage` is received on the channel, such as a new member entering the presence set. A callback may optionally be passed in to this call to be notified of success or failure of the channel `-[ARTRealtimeChannelProtocol attach]` operation.
+ * Registers a listener that is called each time a `ARTPresenceMessage` is received on the channel, such as a new member entering the presence set. A callback may optionally be passed in to this call to be notified of success or failure of the channel `-[ARTRealtimeChannelProtocol attach]` operation. It will not be called if the `ARTRealtimeChannelOptions.attachOnSubscribe` channel option is set to `false`.
  *
  * @param onAttach An attach callback function.
  * @param callback An event listener function.
@@ -166,7 +166,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (ARTEventListener *_Nullable)subscribe:(ARTPresenceAction)action callback:(ARTPresenceMessageCallback)callback;
 
 /**
- * Registers a listener that is called each time a `ARTPresenceMessage` matching a given `ARTPresenceAction` is received on the channel, such as a new member entering the presence set. A callback may optionally be passed in to this call to be notified of success or failure of the channel `-[ARTRealtimeChannelProtocol attach]` operation.
+ * Registers a listener that is called each time a `ARTPresenceMessage` matching a given `ARTPresenceAction` is received on the channel, such as a new member entering the presence set. A callback may optionally be passed in to this call to be notified of success or failure of the channel `-[ARTRealtimeChannelProtocol attach]` operation. It will not be called if the `ARTRealtimeChannelOptions.attachOnSubscribe` channel option is set to `false`.
  *
  * @param action A `ARTPresenceAction` to register the listener for.
  * @param onAttach An attach callback function.


### PR DESCRIPTION
Closes #1972 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new option `attachOnSubscribe` in channel options to control implicit attachment behavior during subscription.

- **Bug Fixes**
	- Improved error handling for channel subscriptions in a `Failed` state based on the `attachOnSubscribe` setting.

- **Documentation**
	- Updated documentation to clarify the conditions under which the `attach` method is implicitly invoked and the behavior of the `attachOnSubscribe` option.

- **Tests**
	- Enhanced test coverage for subscription behavior related to the `attachOnSubscribe` option, including new tests for both attachment and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->