### PR TITLE
[ECO-5022] Fixed `isSynthesized` to not parse message's `id`

### DIFF
--- a/Source/ARTPresenceMessage.m
+++ b/Source/ARTPresenceMessage.m
@@ -56,8 +56,7 @@ NSString *const ARTAblyMessageInvalidPresenceId = @"Received presence message id
 }
 
 - (BOOL)isSynthesized {
-    NSString *connectionId = [[self parseId] objectAtIndex:0];
-    return ![connectionId isEqualToString:self.connectionId];
+    return ![self.id hasPrefix:self.connectionId];
 }
 
 - (NSInteger)msgSerialFromId {


### PR DESCRIPTION
Closes #1981

Similar [check](https://github.com/ably/ably-go/blob/a81632dfeb26bd545232674622463e5709d42e03/ably/proto_presence_message.go#L65) in ably-go library.

Results in a loop - https://github.com/ably/ably-cocoa/pull/1983

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new initializers for creating `ARTEvent` objects with specific presence actions.
- **Improvements**
	- Simplified the logic for determining if a message is synthesized, enhancing performance and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->