### PR TITLE
Make initialiser for ARTPaginatedResult available

### DIFF
--- a/Source/ARTPaginatedResult.m
+++ b/Source/ARTPaginatedResult.m
@@ -137,4 +137,9 @@
     }];
 }
 
+- (nonnull instancetype)init {
+    [NSException raise:NSInternalInconsistencyException format:@"ARTPaginatedResult can't be initialized with init."];
+    __builtin_unreachable();
+}
+
 @end

--- a/Source/include/Ably/ARTPaginatedResult.h
+++ b/Source/include/Ably/ARTPaginatedResult.h
@@ -27,7 +27,7 @@ NS_SWIFT_SENDABLE
 @property (nonatomic, readonly) BOOL isLast;
 
 /// :nodoc:
-- (instancetype)init UNAVAILABLE_ATTRIBUTE;
+- (instancetype)init;
 
 /**
  * Returns a new `ARTPaginatedResult` for the first page of results.


### PR DESCRIPTION
Make initialiser for ARTPaginatedResult available - allows mocking and subclassing in other SDKs e.g. Chat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a public initializer for the `ARTPaginatedResult` class, allowing users to create instances directly with the required parameters.
- **Bug Fixes**
	- Prevented misuse of the `ARTPaginatedResult` class by enforcing a specific initialization pattern, ensuring proper instance creation.
- **Style**
	- Minor formatting adjustments for improved code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->