### PR TITLE
Allow mocking of ARTPaginatedResult 

### DIFF
--- a/Source/ARTPaginatedResult.m
+++ b/Source/ARTPaginatedResult.m
@@ -9,14 +9,17 @@
 #import "ARTInternalLog.h"
 
 @implementation ARTPaginatedResult {
-    ARTRestInternal *_rest;
-    dispatch_queue_t _userQueue;
-    dispatch_queue_t _queue;
-    NSMutableURLRequest *_relFirst;
-    NSMutableURLRequest *_relCurrent;
-    NSMutableURLRequest *_relNext;
-    ARTPaginatedResultResponseProcessor _responseProcessor;
-    ARTQueuedDealloc *_dealloc;
+    BOOL _initializedViaInit;
+
+    // All of the below instance variables are non-nil if and only if _initializedViaInit is NO
+    ARTRestInternal *_Nullable _rest;
+    dispatch_queue_t _Nullable _userQueue;
+    dispatch_queue_t _Nullable _queue;
+    NSMutableURLRequest *_Nullable _relFirst;
+    NSMutableURLRequest *_Nullable _relCurrent;
+    NSMutableURLRequest *_Nullable _relNext;
+    ARTPaginatedResultResponseProcessor _Nullable _responseProcessor;
+    ARTQueuedDealloc *_Nullable _dealloc;
 }
 
 @synthesize rest = _rest;
@@ -25,6 +28,17 @@
 @synthesize relFirst = _relFirst;
 @synthesize relCurrent = _relCurrent;
 @synthesize relNext = _relNext;
+@synthesize hasNext = _hasNext;
+@synthesize isLast = _isLast;
+@synthesize items = _items;
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _initializedViaInit = YES;
+    }
+
+    return self;
+}
 
 - (instancetype)initWithItems:(NSArray *)items
                      rest:(ARTRestInternal *)rest
@@ -34,6 +48,8 @@
             responseProcessor:(ARTPaginatedResultResponseProcessor)responseProcessor
                        logger:(ARTInternalLog *)logger {
     if (self = [super init]) {
+        _initializedViaInit = NO;
+
         _items = items;
         
         _relFirst = relFirst;
@@ -67,7 +83,30 @@
     return self;
 }
 
+- (void)initializedViaInitCheck {
+    if (_initializedViaInit) {
+        [NSException raise:NSInternalInconsistencyException format:@"When initializing this class using -init, you need to override this method in a subclass"];
+    }
+}
+
+- (BOOL)hasNext {
+    [self initializedViaInitCheck];
+    return _hasNext;
+}
+
+- (BOOL)isLast {
+    [self initializedViaInitCheck];
+    return _isLast;
+}
+
+- (NSArray<id> *)items {
+    [self initializedViaInitCheck];
+    return _items;
+}
+
 - (void)first:(void (^)(ARTPaginatedResult<id> *_Nullable result, ARTErrorInfo *_Nullable error))callback {
+    [self initializedViaInitCheck];
+    
     if (callback) {
         void (^userCallback)(ARTPaginatedResult<id> *_Nullable result, ARTErrorInfo *_Nullable error) = callback;
         callback = ^(ARTPaginatedResult<id> *_Nullable result, ARTErrorInfo *_Nullable error) {
@@ -81,6 +120,8 @@
 }
 
 - (void)next:(void (^)(ARTPaginatedResult<id> *_Nullable result, ARTErrorInfo *_Nullable error))callback {
+    [self initializedViaInitCheck];
+    
     if (callback) {
         void (^userCallback)(ARTPaginatedResult<id> *_Nullable result, ARTErrorInfo *_Nullable error) = callback;
         callback = ^(ARTPaginatedResult<id> *_Nullable result, ARTErrorInfo *_Nullable error) {

--- a/Source/PrivateHeaders/Ably/ARTPaginatedResult+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPaginatedResult+Private.h
@@ -24,7 +24,7 @@ typedef NSArray<ItemType> *_Nullable(^ARTPaginatedResultResponseProcessor)(NSHTT
                    relCurrent:(NSMutableURLRequest *)relCurrent
                       relNext:(NSMutableURLRequest *)relNext
             responseProcessor:(ARTPaginatedResultResponseProcessor)responseProcessor
-                       logger:(ARTInternalLog *)logger;
+                       logger:(ARTInternalLog *)logger NS_DESIGNATED_INITIALIZER;
 
 + (void)executePaginated:(ARTRestInternal *)rest
              withRequest:(NSMutableURLRequest *)request

--- a/Source/include/Ably/ARTPaginatedResult.h
+++ b/Source/include/Ably/ARTPaginatedResult.h
@@ -26,8 +26,8 @@ NS_SWIFT_SENDABLE
  */
 @property (nonatomic, readonly) BOOL isLast;
 
-/// :nodoc:
-- (instancetype)init UNAVAILABLE_ATTRIBUTE;
+/// If you use this initializer, trying to call any of the methods or properties in `ARTPaginatedResult` will throw an exception; you must provide your own implementation in a subclass. This initializer exists purely to allow you to provide a mock implementation of this class in your tests.
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
 
 /**
  * Returns a new `ARTPaginatedResult` for the first page of results.


### PR DESCRIPTION
Allow mocking of ARTPaginatedResult by passing responsibility of property initialisation to any subclassing parties 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new initialization mechanism for the `ARTPaginatedResult` class, allowing for better control over object instantiation.
	- Added methods to check pagination status (`hasNext`, `isLast`, and `items`).

- **Bug Fixes**
	- Improved error handling by enforcing proper initialization before calling certain methods, preventing misuse of the default initializer.

- **Documentation**
	- Expanded comments for the `init` method to clarify its intended use and restrictions for subclasses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->