### PR TITLE
[ECO-5116] Added new fields to the `ARTMessage`.

### DIFF
--- a/Source/ARTBaseMessage.m
+++ b/Source/ARTBaseMessage.m
@@ -21,6 +21,7 @@
     message->_data = [self.data copy];
     message->_connectionId = self.connectionId;
     message->_encoding = self.encoding;
+    message->_extras = self.extras;
     return message;
 }
 

--- a/Source/ARTMessage.m
+++ b/Source/ARTMessage.m
@@ -40,7 +40,10 @@
 - (id)copyWithZone:(NSZone *)zone {
     ARTMessage *message = [super copyWithZone:zone];
     message.name = self.name;
-    message.extras = self.extras;
+    message.action = self.action;
+    message.serial = self.serial;
+    message.version = self.version;
+    message.createdAt = self.createdAt;
     return message;
 }
 
@@ -67,7 +70,7 @@
         return nil;
     }
     
-    ARTMessage *message = [jsonEncoder messageFromDictionary:jsonObject];
+    ARTMessage *message = [jsonEncoder messageFromDictionary:jsonObject protocolMessage:nil];
     
     NSError *decodeError = nil;
     message = [message decodeWithEncoder:decoder error:&decodeError];
@@ -97,7 +100,7 @@
         return nil;
     }
     
-    NSArray<ARTMessage *> *messages = [jsonEncoder messagesFromArray:jsonArray];
+    NSArray<ARTMessage *> *messages = [jsonEncoder messagesFromArray:jsonArray protocolMessage:nil];
     
     NSMutableArray<ARTMessage *> *decodedMessages = [NSMutableArray array];
     for (ARTMessage *message in messages) {

--- a/Source/PrivateHeaders/Ably/ARTJsonLikeEncoder.h
+++ b/Source/PrivateHeaders/Ably/ARTJsonLikeEncoder.h
@@ -30,8 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ARTJsonLikeEncoder ()
 
-- (nullable ARTMessage *)messageFromDictionary:(NSDictionary *)input;
-- (nullable NSArray *)messagesFromArray:(NSArray *)input;
+- (nullable ARTMessage *)messageFromDictionary:(NSDictionary *)input protocolMessage:(nullable ARTProtocolMessage *)protocolMessage;
+- (nullable NSArray *)messagesFromArray:(NSArray *)input protocolMessage:(nullable ARTProtocolMessage *)protocolMessage;
 
 - (nullable ARTPresenceMessage *)presenceMessageFromDictionary:(NSDictionary *)input;
 - (nullable NSArray *)presenceMessagesFromArray:(NSArray *)input;

--- a/Source/include/Ably/ARTMessage.h
+++ b/Source/include/Ably/ARTMessage.h
@@ -4,6 +4,41 @@
 #import <Ably/ARTTypes.h>
 #import <Ably/ARTChannelOptions.h>
 
+/**
+ * The namespace containing the different types of message actions.
+ */
+NS_SWIFT_SENDABLE
+typedef NS_ENUM(NSUInteger, ARTMessageAction) {
+    /**
+     * Message action has not been set.
+     */
+    ARTMessageActionUnset,
+    /**
+     * Message action for a newly created message.
+     */
+    ARTMessageActionCreate,
+    /**
+     * Message action for an updated message.
+     */
+    ARTMessageActionUpdate,
+    /**
+     * Message action for a deleted message.
+     */
+    ARTMessageActionDelete,
+    /**
+     * Message action for a newly created annotation.
+     */
+    ARTMessageActionAnnotationCreate,
+    /**
+     * Message action for a deleted annotation.
+     */
+    ARTMessageActionAnnotationDelete,
+    /**
+     * Message action for a meta-message that contains channel occupancy information.
+     */
+    ARTMessageActionMetaOccupancy,
+};
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -13,6 +48,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// The event name, if available
 @property (nullable, readwrite, nonatomic) NSString *name;
+
+/// The action type of the message, one of the `ARTMessageAction` enum values.
+@property (readwrite, nonatomic) ARTMessageAction action;
+
+/// The version of the message, lexicographically-comparable with other versions (that share the same serial).
+/// Will differ from the serial only if the message has been updated or deleted.
+@property (nullable, readwrite, nonatomic) NSString *version;
+
+/// This message's unique serial (an identifier that will be the same in all future updates of this message).
+@property (nullable, readwrite, nonatomic) NSString *serial;
+
+/// The timestamp of the very first version of a given message.
+@property (nonatomic, nullable) NSDate *createdAt;
 
 /**
  * Construct an `ARTMessage` object with an event name and payload.

--- a/Test/Tests/RestClientChannelTests.swift
+++ b/Test/Tests/RestClientChannelTests.swift
@@ -568,7 +568,7 @@ class RestClientChannelTests: XCTestCase {
         XCTAssertTrue((client.internal.encoders["application/json"] as! ARTJsonLikeEncoder).message(from: [
             "data": "foo",
             "extras": ["push": ["notification": ["title": "Hello from Ably!"]]],
-        ])?.extras == extras)
+        ], protocolMessage: nil)?.extras == extras)
 
         waitUntil(timeout: testTimeout) { done in
             channel.publish("name", data: "some data", extras: extras) { error in


### PR DESCRIPTION
Added new fields to the `ARTMessage` to fit into new v2 chat protocol.

Docstrings [PR](https://github.com/ably/sdk-api-reference/pull/43)

A par of a bigger task - https://github.com/ably/ably-cocoa/issues/2000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced new properties `action`, `serial`, `version`, and `createdAt` in the `ARTMessage` class for enhanced message identification and versioning.
	- Added an enumeration `ARTMessageAction` to define various message action types.
	- Enhanced message creation methods to utilize `protocolMessage`, improving message processing.
	- Improved cloning functionality by preserving the `_extras` property during message duplication.
	- Added new test cases to validate message publishing, encoding, and error handling.
	- Enhanced tests for the `ARTJsonLikeEncoder` to ensure proper decoding of protocol messages based on action types.

- **Bug Fixes**
	- Improved error handling in methods to prevent crashes from unexpected input types and provide clearer error reporting.
	- Enhanced error reporting during message decoding to include additional context about failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->