### PR TITLE
Fix some test failures that result from Realtime error changes

### DIFF
--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -412,7 +412,7 @@ class AuthTests: XCTestCase {
                 guard let errorInfo = stateChange.reason else {
                     fail("ErrorInfo is nil"); done(); return
                 }
-                expect(errorInfo.message).to(contain("No application found with id"))
+                expect(errorInfo.code).to(equal(ARTErrorCode.invalidCredentials.intValue))
                 done()
             }
             realtime.connection.once(.disconnected) { _ in

--- a/Test/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/Tests/RealtimeClientConnectionTests.swift
@@ -4132,7 +4132,8 @@ class RealtimeClientConnectionTests: XCTestCase {
                 guard let error = stateChange.reason else {
                     fail("Error is nil"); done(); return
                 }
-                XCTAssertTrue(error.code == ARTErrorCode.invalidCredential.rawValue)
+                // This is because, at time of writing, the production environment is handling connections using both frontend (which returns invalidCredential) and frontdoor (which returns invalidCredentials). So we need to handle both cases at least for now (unlike other tests, which use sandbox which is 100% using frontdoor).
+                XCTAssertTrue(error.code == ARTErrorCode.invalidCredential.rawValue || error.code == ARTErrorCode.invalidCredentials.rawValue)
                 done()
             }
         }

--- a/Test/Tests/RestClientTests.swift
+++ b/Test/Tests/RestClientTests.swift
@@ -193,7 +193,7 @@ class RestClientTests: XCTestCase {
 
         let publishTask = publishTestMessage(client, channelName: test.uniqueChannelName(), failOnError: false)
 
-        expect(publishTask.error?.code).toEventually(equal(ARTErrorCode.invalidCredential.intValue), timeout: testTimeout)
+        expect(publishTask.error?.code).toEventually(equal(ARTErrorCode.invalidCredentials.intValue), timeout: testTimeout)
     }
 
     func test__018__RestClient__initializer__should_accept_a_token() throws {
@@ -234,7 +234,7 @@ class RestClientTests: XCTestCase {
 
         let publishTask = publishTestMessage(client, channelName: test.uniqueChannelName(), failOnError: false)
 
-        expect(publishTask.error?.code).toEventually(equal(ARTErrorCode.invalidCredential.intValue), timeout: testTimeout)
+        expect(publishTask.error?.code).toEventually(equal(ARTErrorCode.invalidCredentials.intValue), timeout: testTimeout)
     }
 
     // RSC2


### PR DESCRIPTION
See commit messages for more details. Resolves #2008.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test cases in multiple test files to use `ARTErrorCode.invalidCredentials` instead of `ARTErrorCode.invalidCredential`
	- Refined error code validation for connection and authentication scenarios
	- Improved consistency in error handling tests across different client components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->