### PR TITLE
[ECO-5187] Update message actions in line with updated TM5 spec point

### DIFF
--- a/Source/include/Ably/ARTMessage.h
+++ b/Source/include/Ably/ARTMessage.h
@@ -10,10 +10,6 @@
 NS_SWIFT_SENDABLE
 typedef NS_ENUM(NSUInteger, ARTMessageAction) {
     /**
-     * Message action has not been set.
-     */
-    ARTMessageActionUnset,
-    /**
      * Message action for a newly created message.
      */
     ARTMessageActionCreate,
@@ -26,17 +22,14 @@ typedef NS_ENUM(NSUInteger, ARTMessageAction) {
      */
     ARTMessageActionDelete,
     /**
-     * Message action for a newly created annotation.
-     */
-    ARTMessageActionAnnotationCreate,
-    /**
-     * Message action for a deleted annotation.
-     */
-    ARTMessageActionAnnotationDelete,
-    /**
      * Message action for a meta-message that contains channel occupancy information.
      */
     ARTMessageActionMetaOccupancy,
+    /**
+     * Message action for a message containing the latest rolled-up summary of annotations
+     * that have been made to this message.
+     */
+    ARTMessageActionSummary,
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Test/Tests/UtilitiesTests.swift
+++ b/Test/Tests/UtilitiesTests.swift
@@ -492,7 +492,7 @@ class UtilitiesTests: XCTestCase {
         {
             "messages": [
                 {
-                    "action": 1,
+                    "action": 0,
                     "version": "123"
                 }
             ]
@@ -510,7 +510,7 @@ class UtilitiesTests: XCTestCase {
         {
             "messages": [
                 {
-                    "action": 0,
+                    "action": 1,
                     "version": "123"
                 }
             ]
@@ -519,7 +519,7 @@ class UtilitiesTests: XCTestCase {
         data = json.data(using: .utf8)!
         pm = try jsonEncoder.decodeProtocolMessage(data)
         messages = try XCTUnwrap(pm.messages)
-        XCTAssert(messages[0].action == .unset)
+        XCTAssert(messages[0].action == .update)
         XCTAssert(messages[0].version == "123")
         XCTAssertNil(messages[0].serial)
     }
@@ -558,7 +558,7 @@ class UtilitiesTests: XCTestCase {
         {
             "messages": [
                 {
-                    "action": 1,
+                    "action": 0,
                     "timestamp": "1234512345",
                 }
             ]
@@ -576,7 +576,7 @@ class UtilitiesTests: XCTestCase {
         {
             "messages": [
                 {
-                    "action": 0,
+                    "action": 1,
                     "timestamp": "1234512345",
                 }
             ]
@@ -585,7 +585,7 @@ class UtilitiesTests: XCTestCase {
         data = json.data(using: .utf8)!
         pm = try jsonEncoder.decodeProtocolMessage(data)
         messages = try XCTUnwrap(pm.messages)
-        XCTAssert(messages[0].action == .unset)
+        XCTAssert(messages[0].action == .update)
         XCTAssertNil(messages[0].createdAt)
     }
 }


### PR DESCRIPTION
Updates message actions based on changes to spec @ https://github.com/ably/specification/pull/263


JS equivalent: https://github.com/ably/ably-js/pull/1941/commits/52d143a0a7598298673e63f46e0b661504764e10 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new message action `ARTMessageActionSummary` for rolled-up annotation summaries.

- **Refactor**
	- Removed deprecated message action enum values related to annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->