### PR TITLE
Bump `upload-artifact` version

### DIFF
--- a/.github/workflows/check-pod.yaml
+++ b/.github/workflows/check-pod.yaml
@@ -52,7 +52,7 @@ jobs:
           mkdir -p carthage-built-framework-artifact-contents/carthage-built-framework
           mv Ably.framework.zip carthage-built-framework-artifact-contents/carthage-built-framework
       - name: Archive built framework
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: carthage-built-framework
           path: carthage-built-framework-artifact-contents


### PR DESCRIPTION
Jobs seem to be randomly failing now that it’s deprecated; e.g. [this job](https://github.com/ably/ably-cocoa/actions/runs/12694870211/job/35385596818?pr=2010) gave

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration to use the latest version of the upload artifact action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->