### PR TITLE
Implement TM2p change (no message version populating from channelmessage)

### DIFF
--- a/Test/Tests/UtilitiesTests.swift
+++ b/Test/Tests/UtilitiesTests.swift
@@ -524,33 +524,6 @@ class UtilitiesTests: XCTestCase {
         XCTAssertNil(messages[0].serial)
     }
     
-    // TM2p
-    func test__026_Utilities__message_received_over_a_realtime_transport_does_not_contain_a_version() throws {
-        beforeEach__Utilities__JSON_Encoder()
-        let json = """
-        {
-            "channelSerial": "foo",
-            "messages": [
-                {
-                    "serial": "12345"
-                },
-                {
-                    "serial": "123456"
-                }
-            ]
-        }
-        """
-        let data = json.data(using: .utf8)!
-        let pm = try jsonEncoder.decodeProtocolMessage(data)
-        let messages = try XCTUnwrap(pm.messages)
-        XCTAssert(messages[0].action == .create)
-        XCTAssert(messages[0].version == "foo:000")
-        XCTAssert(messages[0].serial == "12345")
-        XCTAssert(messages[1].action == .create)
-        XCTAssert(messages[1].version == "foo:001")
-        XCTAssert(messages[1].serial == "123456")
-    }
-    
     // TM2o
     func test__027_Utilities__message_received_with_action_create_does_not_contain_createdAt() throws {
         beforeEach__Utilities__JSON_Encoder()


### PR DESCRIPTION
Implements https://github.com/ably/specification/pull/275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved messaging workflow to streamline how version and identifier information are handled, enhancing consistency in message processing.
- **Tests**
  - Removed an outdated test case related to message version verification to align with the updated processing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->