### PR TITLE
[ECO-5216] Attribute most REST requests to wrapper SDK

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -208,6 +208,15 @@
 		2147F03529E5872C0071CB94 /* MockInternalLogCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2147F03429E5872C0071CB94 /* MockInternalLogCore.swift */; };
 		2147F03629E5872C0071CB94 /* MockInternalLogCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2147F03429E5872C0071CB94 /* MockInternalLogCore.swift */; };
 		2147F03729E5872C0071CB94 /* MockInternalLogCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2147F03429E5872C0071CB94 /* MockInternalLogCore.swift */; };
+		2159248B2D636826004A235C /* ARTWrapperSDKProxyPush.h in Headers */ = {isa = PBXBuildFile; fileRef = 2159248A2D636826004A235C /* ARTWrapperSDKProxyPush.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2159248C2D636826004A235C /* ARTWrapperSDKProxyPush.h in Headers */ = {isa = PBXBuildFile; fileRef = 2159248A2D636826004A235C /* ARTWrapperSDKProxyPush.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2159248D2D636826004A235C /* ARTWrapperSDKProxyPush.h in Headers */ = {isa = PBXBuildFile; fileRef = 2159248A2D636826004A235C /* ARTWrapperSDKProxyPush.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2159248F2D636839004A235C /* ARTWrapperSDKProxyPush+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2159248E2D636839004A235C /* ARTWrapperSDKProxyPush+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		215924902D636839004A235C /* ARTWrapperSDKProxyPush+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2159248E2D636839004A235C /* ARTWrapperSDKProxyPush+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		215924912D636839004A235C /* ARTWrapperSDKProxyPush+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2159248E2D636839004A235C /* ARTWrapperSDKProxyPush+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		215924932D636A6E004A235C /* ARTWrapperSDKProxyPush.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924922D636A6E004A235C /* ARTWrapperSDKProxyPush.m */; };
+		215924942D636A6E004A235C /* ARTWrapperSDKProxyPush.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924922D636A6E004A235C /* ARTWrapperSDKProxyPush.m */; };
+		215924952D636A6E004A235C /* ARTWrapperSDKProxyPush.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924922D636A6E004A235C /* ARTWrapperSDKProxyPush.m */; };
 		215F75F82922B1DB009E0E76 /* ARTClientInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 215F75F62922B1DB009E0E76 /* ARTClientInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		215F75F92922B1DB009E0E76 /* ARTClientInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 215F75F62922B1DB009E0E76 /* ARTClientInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		215F75FA2922B1DB009E0E76 /* ARTClientInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 215F75F62922B1DB009E0E76 /* ARTClientInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1241,6 +1250,9 @@
 		2147F02C29E583AD0071CB94 /* ARTInternalLogCore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTInternalLogCore.h; path = PrivateHeaders/Ably/ARTInternalLogCore.h; sourceTree = "<group>"; };
 		2147F03029E583CE0071CB94 /* ARTInternalLogCore.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTInternalLogCore.m; sourceTree = "<group>"; };
 		2147F03429E5872C0071CB94 /* MockInternalLogCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInternalLogCore.swift; sourceTree = "<group>"; };
+		2159248A2D636826004A235C /* ARTWrapperSDKProxyPush.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTWrapperSDKProxyPush.h; path = include/Ably/ARTWrapperSDKProxyPush.h; sourceTree = "<group>"; };
+		2159248E2D636839004A235C /* ARTWrapperSDKProxyPush+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTWrapperSDKProxyPush+Private.h"; path = "PrivateHeaders/Ably/ARTWrapperSDKProxyPush+Private.h"; sourceTree = "<group>"; };
+		215924922D636A6E004A235C /* ARTWrapperSDKProxyPush.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWrapperSDKProxyPush.m; sourceTree = "<group>"; };
 		215F75F62922B1DB009E0E76 /* ARTClientInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTClientInformation.h; path = include/Ably/ARTClientInformation.h; sourceTree = "<group>"; };
 		215F75F72922B1DB009E0E76 /* ARTClientInformation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTClientInformation.m; sourceTree = "<group>"; };
 		215F75FE2922B30F009E0E76 /* ClientInformationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientInformationTests.swift; sourceTree = "<group>"; };
@@ -1667,6 +1679,9 @@
 				21AC0CC02D4AA0630030BD23 /* ARTWrapperSDKProxyRealtimeChannel.h */,
 				21AC0CC82D4AA0F50030BD23 /* ARTWrapperSDKProxyRealtimeChannel+Private.h */,
 				21AC0CD02D4AA3200030BD23 /* ARTWrapperSDKProxyRealtimeChannel.m */,
+				2159248A2D636826004A235C /* ARTWrapperSDKProxyPush.h */,
+				2159248E2D636839004A235C /* ARTWrapperSDKProxyPush+Private.h */,
+				215924922D636A6E004A235C /* ARTWrapperSDKProxyPush.m */,
 			);
 			name = "Wrapper SDK Proxy";
 			sourceTree = "<group>";
@@ -2416,6 +2431,7 @@
 				D7D06F0826330E2800DEBDAD /* ARTHttp+Private.h in Headers */,
 				EB1B541922FB1D7F006A59AC /* ARTPushChannelSubscriptions+Private.h in Headers */,
 				2105ED1E29E7242400DE6D67 /* ARTLogAdapter+Testing.h in Headers */,
+				2159248D2D636826004A235C /* ARTWrapperSDKProxyPush.h in Headers */,
 				21E5D8812D5E3EC300526C4C /* ARTChannelProtocol.h in Headers */,
 				EBF2285B1F4D9AD6009091DD /* ARTWebSocketTransport+Private.h in Headers */,
 				EBFFAC191E97919C003E7326 /* ARTLocalDevice+Private.h in Headers */,
@@ -2482,6 +2498,7 @@
 				EB1B541522FB1CE1006A59AC /* ARTPushDeviceRegistrations+Private.h in Headers */,
 				D7D8F82B1BC2C706009718F2 /* ARTTokenRequest.h in Headers */,
 				2147F02D29E583AD0071CB94 /* ARTInternalLogCore.h in Headers */,
+				2159248F2D636839004A235C /* ARTWrapperSDKProxyPush+Private.h in Headers */,
 				D5BB211126AA993E00AA5F3E /* ARTNSURL+ARTUtils.h in Headers */,
 				84039A4C2C811F49001C053E /* ARTChannelOptions+Private.h in Headers */,
 				EB1AE0CC1C5C1EB200D62250 /* ARTEventEmitter+Private.h in Headers */,
@@ -2537,6 +2554,7 @@
 				D710D64521949E61008F54AD /* ARTEventEmitter+Private.h in Headers */,
 				2105ED2329E7429E00DE6D67 /* ARTPaginatedResult+Subclass.h in Headers */,
 				D710D4D121949BC0008F54AD /* ARTPresence+Private.h in Headers */,
+				2159248C2D636826004A235C /* ARTWrapperSDKProxyPush.h in Headers */,
 				21088DC42A5354F10033C722 /* ARTConnectRetryState.h in Headers */,
 				2105ED2729E830D600DE6D67 /* ARTInternalLog+Testing.h in Headers */,
 				D710D69021949EFF008F54AD /* ARTCrypto.h in Headers */,
@@ -2627,6 +2645,7 @@
 				D710D56A21949CB9008F54AD /* ARTPushAdmin.h in Headers */,
 				D710D48321949A4E008F54AD /* ARTDefault+Private.h in Headers */,
 				D70C36C4233E6831002FD6E3 /* ARTFormEncode.h in Headers */,
+				215924902D636839004A235C /* ARTWrapperSDKProxyPush+Private.h in Headers */,
 				D710D59021949D29008F54AD /* ARTStatus.h in Headers */,
 				D5BB213A26AAA60500AA5F3E /* ARTNSError+ARTUtils.h in Headers */,
 				D710D61D21949DEC008F54AD /* ARTHTTPPaginatedResponse+Private.h in Headers */,
@@ -2718,6 +2737,7 @@
 				D710D5AD21949D2A008F54AD /* ARTChannelOptions.h in Headers */,
 				2105ED2429E7429E00DE6D67 /* ARTPaginatedResult+Subclass.h in Headers */,
 				D710D64B21949E62008F54AD /* ARTEventEmitter+Private.h in Headers */,
+				2159248B2D636826004A235C /* ARTWrapperSDKProxyPush.h in Headers */,
 				21088DC52A5354F10033C722 /* ARTConnectRetryState.h in Headers */,
 				2105ED2829E830D600DE6D67 /* ARTInternalLog+Testing.h in Headers */,
 				D710D4D321949BC1008F54AD /* ARTPresence+Private.h in Headers */,
@@ -2808,6 +2828,7 @@
 				EB1B53FF22F8D91C006A59AC /* ARTQueuedDealloc.h in Headers */,
 				D710D57021949CBA008F54AD /* ARTPushAdmin.h in Headers */,
 				D710D48521949A4F008F54AD /* ARTDefault+Private.h in Headers */,
+				215924912D636839004A235C /* ARTWrapperSDKProxyPush+Private.h in Headers */,
 				D70C36C5233E6831002FD6E3 /* ARTFormEncode.h in Headers */,
 				D710D5B621949D2A008F54AD /* ARTStatus.h in Headers */,
 				D710D62921949DED008F54AD /* ARTHTTPPaginatedResponse+Private.h in Headers */,
@@ -3237,6 +3258,7 @@
 				EB89D40B1C61C6EA007FA5B7 /* ARTRealtimeChannels.m in Sources */,
 				217D183B254222F600DFF07E /* ARTSRDelegateController.m in Sources */,
 				D746AE231BBB60EE003ECEF8 /* ARTChannel.m in Sources */,
+				215924932D636A6E004A235C /* ARTWrapperSDKProxyPush.m in Sources */,
 				D76F153C23DB010C00B5133C /* ARTRealtimeChannelOptions.m in Sources */,
 				D769E15421270F3400DC5CD1 /* ARTHTTPPaginatedResponse.m in Sources */,
 				D7DEAFD21E65926D00D23F24 /* ARTLocalDevice.m in Sources */,
@@ -3485,6 +3507,7 @@
 				D710D53121949C54008F54AD /* ARTPush.m in Sources */,
 				217D1852254222F700DFF07E /* ARTSRDelegateController.m in Sources */,
 				D710D5E021949D78008F54AD /* ARTStats.m in Sources */,
+				215924942D636A6E004A235C /* ARTWrapperSDKProxyPush.m in Sources */,
 				D76F153F23DB013000B5133C /* ARTRealtimeChannelOptions.m in Sources */,
 				D710D4F121949C0D008F54AD /* ARTQueuedMessage.m in Sources */,
 				D710D49521949AC2008F54AD /* ARTRest.m in Sources */,
@@ -3613,6 +3636,7 @@
 				217D1869254222FA00DFF07E /* ARTSRDelegateController.m in Sources */,
 				D710D60621949D79008F54AD /* ARTStats.m in Sources */,
 				D76F154023DB013000B5133C /* ARTRealtimeChannelOptions.m in Sources */,
+				215924952D636A6E004A235C /* ARTWrapperSDKProxyPush.m in Sources */,
 				D710D50121949C0E008F54AD /* ARTQueuedMessage.m in Sources */,
 				D710D49721949AC3008F54AD /* ARTRest.m in Sources */,
 				D710D54B21949C55008F54AD /* ARTNSMutableRequest+ARTPush.m in Sources */,

--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -226,6 +226,24 @@
 		2159249F2D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m in Sources */ = {isa = PBXBuildFile; fileRef = 2159249E2D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m */; };
 		215924A02D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m in Sources */ = {isa = PBXBuildFile; fileRef = 2159249E2D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m */; };
 		215924A12D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m in Sources */ = {isa = PBXBuildFile; fileRef = 2159249E2D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m */; };
+		215924A42D636B5C004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924A32D636B5C004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		215924A52D636B5C004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924A22D636B5C004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		215924A62D636B5C004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924A32D636B5C004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		215924A72D636B5C004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924A22D636B5C004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		215924A82D636B5C004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924A32D636B5C004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		215924A92D636B5C004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924A22D636B5C004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		215924AC2D636B6B004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924AB2D636B6B004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		215924AD2D636B6B004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924AA2D636B6B004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		215924AE2D636B6B004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924AB2D636B6B004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		215924AF2D636B6B004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924AA2D636B6B004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		215924B02D636B6B004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924AB2D636B6B004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		215924B12D636B6B004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924AA2D636B6B004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		215924B42D636B89004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924B22D636B89004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.m */; };
+		215924B52D636B89004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924B32D636B89004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.m */; };
+		215924B62D636B89004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924B22D636B89004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.m */; };
+		215924B72D636B89004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924B32D636B89004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.m */; };
+		215924B82D636B89004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924B22D636B89004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.m */; };
+		215924B92D636B89004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924B32D636B89004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.m */; };
 		215F75F82922B1DB009E0E76 /* ARTClientInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 215F75F62922B1DB009E0E76 /* ARTClientInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		215F75F92922B1DB009E0E76 /* ARTClientInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 215F75F62922B1DB009E0E76 /* ARTClientInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		215F75FA2922B1DB009E0E76 /* ARTClientInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 215F75F62922B1DB009E0E76 /* ARTClientInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1265,6 +1283,12 @@
 		215924962D636AC5004A235C /* ARTWrapperSDKProxyPushAdmin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTWrapperSDKProxyPushAdmin.h; path = include/Ably/ARTWrapperSDKProxyPushAdmin.h; sourceTree = "<group>"; };
 		2159249A2D636AD5004A235C /* ARTWrapperSDKProxyPushAdmin+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTWrapperSDKProxyPushAdmin+Private.h"; path = "PrivateHeaders/Ably/ARTWrapperSDKProxyPushAdmin+Private.h"; sourceTree = "<group>"; };
 		2159249E2D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWrapperSDKProxyPushAdmin.m; sourceTree = "<group>"; };
+		215924A22D636B5C004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTWrapperSDKProxyPushChannelSubscriptions.h; path = include/Ably/ARTWrapperSDKProxyPushChannelSubscriptions.h; sourceTree = "<group>"; };
+		215924A32D636B5C004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTWrapperSDKProxyPushDeviceRegistrations.h; path = include/Ably/ARTWrapperSDKProxyPushDeviceRegistrations.h; sourceTree = "<group>"; };
+		215924AA2D636B6B004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTWrapperSDKProxyPushChannelSubscriptions+Private.h"; path = "PrivateHeaders/Ably/ARTWrapperSDKProxyPushChannelSubscriptions+Private.h"; sourceTree = "<group>"; };
+		215924AB2D636B6B004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTWrapperSDKProxyPushDeviceRegistrations+Private.h"; path = "PrivateHeaders/Ably/ARTWrapperSDKProxyPushDeviceRegistrations+Private.h"; sourceTree = "<group>"; };
+		215924B22D636B89004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWrapperSDKProxyPushChannelSubscriptions.m; sourceTree = "<group>"; };
+		215924B32D636B89004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWrapperSDKProxyPushDeviceRegistrations.m; sourceTree = "<group>"; };
 		215F75F62922B1DB009E0E76 /* ARTClientInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTClientInformation.h; path = include/Ably/ARTClientInformation.h; sourceTree = "<group>"; };
 		215F75F72922B1DB009E0E76 /* ARTClientInformation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTClientInformation.m; sourceTree = "<group>"; };
 		215F75FE2922B30F009E0E76 /* ClientInformationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientInformationTests.swift; sourceTree = "<group>"; };
@@ -1697,6 +1721,12 @@
 				215924962D636AC5004A235C /* ARTWrapperSDKProxyPushAdmin.h */,
 				2159249A2D636AD5004A235C /* ARTWrapperSDKProxyPushAdmin+Private.h */,
 				2159249E2D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m */,
+				215924A32D636B5C004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.h */,
+				215924AB2D636B6B004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations+Private.h */,
+				215924B32D636B89004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.m */,
+				215924A22D636B5C004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.h */,
+				215924AA2D636B6B004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions+Private.h */,
+				215924B22D636B89004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.m */,
 			);
 			name = "Wrapper SDK Proxy";
 			sourceTree = "<group>";
@@ -2410,6 +2440,8 @@
 				EB9C530B1CD7BEB100.8.557 /* ARTJsonLikeEncoder.h in Headers */,
 				D74CBC0E212F076000D090E4 /* ARTConstants.h in Headers */,
 				D7CEF12D1C8D821D004FB242 /* ARTRealtimeChannels+Private.h in Headers */,
+				215924A42D636B5C004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.h in Headers */,
+				215924A52D636B5C004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.h in Headers */,
 				EB89D4011C61C10E007FA5B7 /* ARTChannels+Private.h in Headers */,
 				D74CBC03212EB58700D090E4 /* ARTNSHTTPURLResponse+ARTPaginated.h in Headers */,
 				1CD8DC9F1B1C7315007EAF36 /* ARTDefault.h in Headers */,
@@ -2510,6 +2542,8 @@
 				96A507A51A377DE90077CDF8 /* ARTNSDictionary+ARTDictionaryUtil.h in Headers */,
 				D75A3F1B1DDE5B62002A4AAD /* ARTGCD.h in Headers */,
 				D3AD0EBD215E2FB000312105 /* ARTNSString+ARTUtil.h in Headers */,
+				215924B02D636B6B004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations+Private.h in Headers */,
+				215924B12D636B6B004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions+Private.h in Headers */,
 				EB2D85011CD769C800F23CDA /* ARTOSReachability.h in Headers */,
 				21E1C0E52A0DC47400A5DB65 /* ARTWebSocketFactory.h in Headers */,
 				EB1B541522FB1CE1006A59AC /* ARTPushDeviceRegistrations+Private.h in Headers */,
@@ -2670,6 +2704,8 @@
 				D710D58321949D28008F54AD /* ARTTokenDetails.h in Headers */,
 				D710D54C21949C66008F54AD /* ARTPush+Private.h in Headers */,
 				D710D68A21949EDA008F54AD /* ARTNSDate+ARTUtil.h in Headers */,
+				215924A62D636B5C004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.h in Headers */,
+				215924A72D636B5C004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.h in Headers */,
 				D710D4D721949BF9008F54AD /* ARTConnectionDetails.h in Headers */,
 				D710D4DB21949BF9008F54AD /* ARTRealtimeChannels.h in Headers */,
 				D710D61021949DDB008F54AD /* ARTFallback.h in Headers */,
@@ -2701,6 +2737,8 @@
 				D5BB211026AA993C00AA5F3E /* ARTNSURL+ARTUtils.h in Headers */,
 				D710D60E21949DDB008F54AD /* ARTPaginatedResult.h in Headers */,
 				215924972D636AC5004A235C /* ARTWrapperSDKProxyPushAdmin.h in Headers */,
+				215924AE2D636B6B004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations+Private.h in Headers */,
+				215924AF2D636B6B004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions+Private.h in Headers */,
 				2114D4302D4BCAE20032839A /* ARTRealtime+WrapperSDKProxy.h in Headers */,
 				D710D4BF21949B6C008F54AD /* ARTNSMutableRequest+ARTRest.h in Headers */,
 				2147F02E29E583AD0071CB94 /* ARTInternalLogCore.h in Headers */,
@@ -2855,6 +2893,8 @@
 				D710D5A921949D2A008F54AD /* ARTTokenDetails.h in Headers */,
 				D710D55221949C67008F54AD /* ARTPush+Private.h in Headers */,
 				D710D68C21949EDB008F54AD /* ARTNSDate+ARTUtil.h in Headers */,
+				215924A82D636B5C004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.h in Headers */,
+				215924A92D636B5C004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.h in Headers */,
 				D710D4E721949BFB008F54AD /* ARTConnectionDetails.h in Headers */,
 				D710D4EB21949BFB008F54AD /* ARTRealtimeChannels.h in Headers */,
 				D710D61A21949DDC008F54AD /* ARTFallback.h in Headers */,
@@ -2886,6 +2926,8 @@
 				D710D61821949DDC008F54AD /* ARTPaginatedResult.h in Headers */,
 				D5BB213B26AAA60500AA5F3E /* ARTNSError+ARTUtils.h in Headers */,
 				215924982D636AC5004A235C /* ARTWrapperSDKProxyPushAdmin.h in Headers */,
+				215924AC2D636B6B004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations+Private.h in Headers */,
+				215924AD2D636B6B004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions+Private.h in Headers */,
 				2114D42F2D4BCAE20032839A /* ARTRealtime+WrapperSDKProxy.h in Headers */,
 				D710D4C121949B6D008F54AD /* ARTNSMutableRequest+ARTRest.h in Headers */,
 				2147F02F29E583AD0071CB94 /* ARTInternalLogCore.h in Headers */,
@@ -3334,6 +3376,8 @@
 				961343D91A42E0B7006DC822 /* ARTClientOptions.m in Sources */,
 				96BF615F1A35C1C8004CF2B3 /* ARTTypes.m in Sources */,
 				217D1838254222F600DFF07E /* NSRunLoop+ARTSRWebSocket.m in Sources */,
+				215924B82D636B89004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.m in Sources */,
+				215924B92D636B89004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.m in Sources */,
 				D7D8F82E1BC2C706009718F2 /* ARTTokenParams.m in Sources */,
 				D746AE411BBC5B14003ECEF8 /* ARTEventEmitter.m in Sources */,
 				2104EFA82A4CC30C00CC1184 /* ARTAttachRetryState.m in Sources */,
@@ -3584,6 +3628,8 @@
 				D710D55E21949C97008F54AD /* ARTPushActivationStateMachine.m in Sources */,
 				D710D49C21949ACA008F54AD /* ARTNSMutableRequest+ARTRest.m in Sources */,
 				217D184F254222F700DFF07E /* NSRunLoop+ARTSRWebSocket.m in Sources */,
+				215924B42D636B89004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.m in Sources */,
+				215924B52D636B89004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.m in Sources */,
 				D710D66C21949E78008F54AD /* ARTMsgPackEncoder.m in Sources */,
 				D710D48621949A5B008F54AD /* ARTDefault.m in Sources */,
 				2104EFA92A4CC30C00CC1184 /* ARTAttachRetryState.m in Sources */,
@@ -3714,6 +3760,8 @@
 				D710D56421949C98008F54AD /* ARTPushActivationStateMachine.m in Sources */,
 				D710D4A621949ACB008F54AD /* ARTNSMutableRequest+ARTRest.m in Sources */,
 				217D1866254222FA00DFF07E /* NSRunLoop+ARTSRWebSocket.m in Sources */,
+				215924B62D636B89004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.m in Sources */,
+				215924B72D636B89004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.m in Sources */,
 				D710D65221949E77008F54AD /* ARTMsgPackEncoder.m in Sources */,
 				D710D48821949A5C008F54AD /* ARTDefault.m in Sources */,
 				2104EFAA2A4CC30C00CC1184 /* ARTAttachRetryState.m in Sources */,

--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -244,6 +244,15 @@
 		215924B72D636B89004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924B32D636B89004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.m */; };
 		215924B82D636B89004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924B22D636B89004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.m */; };
 		215924B92D636B89004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924B32D636B89004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.m */; };
+		215924C32D636D2F004A235C /* ARTWrapperSDKProxyPushChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924C22D636D2F004A235C /* ARTWrapperSDKProxyPushChannel.m */; };
+		215924C42D636D2F004A235C /* ARTWrapperSDKProxyPushChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924C22D636D2F004A235C /* ARTWrapperSDKProxyPushChannel.m */; };
+		215924C52D636D2F004A235C /* ARTWrapperSDKProxyPushChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924C22D636D2F004A235C /* ARTWrapperSDKProxyPushChannel.m */; };
+		215924C72D636D43004A235C /* ARTWrapperSDKProxyPushChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924C62D636D43004A235C /* ARTWrapperSDKProxyPushChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		215924C82D636D43004A235C /* ARTWrapperSDKProxyPushChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924C62D636D43004A235C /* ARTWrapperSDKProxyPushChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		215924C92D636D43004A235C /* ARTWrapperSDKProxyPushChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924C62D636D43004A235C /* ARTWrapperSDKProxyPushChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		215924CB2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924CA2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		215924CC2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924CA2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		215924CD2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924CA2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		215F75F82922B1DB009E0E76 /* ARTClientInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 215F75F62922B1DB009E0E76 /* ARTClientInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		215F75F92922B1DB009E0E76 /* ARTClientInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 215F75F62922B1DB009E0E76 /* ARTClientInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		215F75FA2922B1DB009E0E76 /* ARTClientInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 215F75F62922B1DB009E0E76 /* ARTClientInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1289,6 +1298,9 @@
 		215924AB2D636B6B004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTWrapperSDKProxyPushDeviceRegistrations+Private.h"; path = "PrivateHeaders/Ably/ARTWrapperSDKProxyPushDeviceRegistrations+Private.h"; sourceTree = "<group>"; };
 		215924B22D636B89004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWrapperSDKProxyPushChannelSubscriptions.m; sourceTree = "<group>"; };
 		215924B32D636B89004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWrapperSDKProxyPushDeviceRegistrations.m; sourceTree = "<group>"; };
+		215924C22D636D2F004A235C /* ARTWrapperSDKProxyPushChannel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWrapperSDKProxyPushChannel.m; sourceTree = "<group>"; };
+		215924C62D636D43004A235C /* ARTWrapperSDKProxyPushChannel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTWrapperSDKProxyPushChannel.h; path = include/Ably/ARTWrapperSDKProxyPushChannel.h; sourceTree = "<group>"; };
+		215924CA2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTWrapperSDKProxyPushChannel+Private.h"; path = "PrivateHeaders/Ably/ARTWrapperSDKProxyPushChannel+Private.h"; sourceTree = "<group>"; };
 		215F75F62922B1DB009E0E76 /* ARTClientInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTClientInformation.h; path = include/Ably/ARTClientInformation.h; sourceTree = "<group>"; };
 		215F75F72922B1DB009E0E76 /* ARTClientInformation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTClientInformation.m; sourceTree = "<group>"; };
 		215F75FE2922B30F009E0E76 /* ClientInformationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientInformationTests.swift; sourceTree = "<group>"; };
@@ -1727,6 +1739,9 @@
 				215924A22D636B5C004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.h */,
 				215924AA2D636B6B004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions+Private.h */,
 				215924B22D636B89004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.m */,
+				215924C62D636D43004A235C /* ARTWrapperSDKProxyPushChannel.h */,
+				215924CA2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h */,
+				215924C22D636D2F004A235C /* ARTWrapperSDKProxyPushChannel.m */,
 			);
 			name = "Wrapper SDK Proxy";
 			sourceTree = "<group>";
@@ -2392,6 +2407,7 @@
 				961343D81A42E0B7006DC822 /* ARTClientOptions.h in Headers */,
 				2105ED1A29E722DD00DE6D67 /* ARTInternalLogCore+Testing.h in Headers */,
 				D7534C321D79E5C20054C182 /* Ably.h in Headers */,
+				215924C92D636D43004A235C /* ARTWrapperSDKProxyPushChannel.h in Headers */,
 				D777EEE0206285CF002EBA03 /* ARTDeviceIdentityTokenDetails.h in Headers */,
 				2124B79F29DB14D000AD8361 /* ARTLogAdapter.h in Headers */,
 				215F76032922C76C009E0E76 /* ARTClientInformation+Private.h in Headers */,
@@ -2544,6 +2560,7 @@
 				D3AD0EBD215E2FB000312105 /* ARTNSString+ARTUtil.h in Headers */,
 				215924B02D636B6B004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations+Private.h in Headers */,
 				215924B12D636B6B004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions+Private.h in Headers */,
+				215924CB2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h in Headers */,
 				EB2D85011CD769C800F23CDA /* ARTOSReachability.h in Headers */,
 				21E1C0E52A0DC47400A5DB65 /* ARTWebSocketFactory.h in Headers */,
 				EB1B541522FB1CE1006A59AC /* ARTPushDeviceRegistrations+Private.h in Headers */,
@@ -2680,6 +2697,7 @@
 				2132C21B29D230CF000C4355 /* ARTErrorChecker.h in Headers */,
 				D710D51B21949C42008F54AD /* ARTDeviceIdentityTokenDetails.h in Headers */,
 				D76F153D23DB012100B5133C /* ARTRealtimeChannelOptions.h in Headers */,
+				215924CD2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h in Headers */,
 				D5D83C0826AAED1A00AADC8E /* ARTStringifiable+Private.h in Headers */,
 				D710D48021949A42008F54AD /* ARTDefault.h in Headers */,
 				2124B7A429DB153500AD8361 /* ARTDeviceIdentityTokenDetails+Private.h in Headers */,
@@ -2741,6 +2759,7 @@
 				215924AF2D636B6B004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions+Private.h in Headers */,
 				2114D4302D4BCAE20032839A /* ARTRealtime+WrapperSDKProxy.h in Headers */,
 				D710D4BF21949B6C008F54AD /* ARTNSMutableRequest+ARTRest.h in Headers */,
+				215924C82D636D43004A235C /* ARTWrapperSDKProxyPushChannel.h in Headers */,
 				2147F02E29E583AD0071CB94 /* ARTInternalLogCore.h in Headers */,
 				D710D5BE21949D4F008F54AD /* ARTBaseMessage+Private.h in Headers */,
 				D5BB20FE26A7F50000AA5F3E /* ARTSRPinningSecurityPolicy.h in Headers */,
@@ -2869,6 +2888,7 @@
 				2132C21C29D230D0000C4355 /* ARTErrorChecker.h in Headers */,
 				D5BB210F26AA98A900AA5F3E /* ARTStringifiable.h in Headers */,
 				D5C0CB3F268317B500C06521 /* NSURLQueryItem+Stringifiable.h in Headers */,
+				215924CC2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h in Headers */,
 				D710D52D21949C44008F54AD /* ARTDeviceIdentityTokenDetails.h in Headers */,
 				D76F153E23DB012100B5133C /* ARTRealtimeChannelOptions.h in Headers */,
 				D710D48221949A43008F54AD /* ARTDefault.h in Headers */,
@@ -2930,6 +2950,7 @@
 				215924AD2D636B6B004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions+Private.h in Headers */,
 				2114D42F2D4BCAE20032839A /* ARTRealtime+WrapperSDKProxy.h in Headers */,
 				D710D4C121949B6D008F54AD /* ARTNSMutableRequest+ARTRest.h in Headers */,
+				215924C72D636D43004A235C /* ARTWrapperSDKProxyPushChannel.h in Headers */,
 				2147F02F29E583AD0071CB94 /* ARTInternalLogCore.h in Headers */,
 				D710D5CE21949D50008F54AD /* ARTBaseMessage+Private.h in Headers */,
 				D5BB20FF26A7F50800AA5F3E /* ARTSRPinningSecurityPolicy.h in Headers */,
@@ -3433,6 +3454,7 @@
 				96A507A61A377DE90077CDF8 /* ARTNSDictionary+ARTDictionaryUtil.m in Sources */,
 				217D182D254222F500DFF07E /* ARTSRSIMDHelpers.m in Sources */,
 				D5BB210D26AA98A500AA5F3E /* ARTStringifiable.m in Sources */,
+				215924C52D636D2F004A235C /* ARTWrapperSDKProxyPushChannel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3685,6 +3707,7 @@
 				D710D53821949C54008F54AD /* ARTLocalDeviceStorage.m in Sources */,
 				D5BB210C26AA98A500AA5F3E /* ARTStringifiable.m in Sources */,
 				217D1844254222F700DFF07E /* ARTSRSIMDHelpers.m in Sources */,
+				215924C32D636D2F004A235C /* ARTWrapperSDKProxyPushChannel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3817,6 +3840,7 @@
 				D710D60221949D79008F54AD /* ARTPresence.m in Sources */,
 				D710D54A21949C55008F54AD /* ARTLocalDeviceStorage.m in Sources */,
 				217D185B254222F900DFF07E /* ARTSRSIMDHelpers.m in Sources */,
+				215924C42D636D2F004A235C /* ARTWrapperSDKProxyPushChannel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -253,6 +253,15 @@
 		215924CB2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924CA2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		215924CC2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924CA2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		215924CD2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924CA2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		215924CF2D636DED004A235C /* ARTWrapperSDKProxyRealtimePresence.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924CE2D636DED004A235C /* ARTWrapperSDKProxyRealtimePresence.m */; };
+		215924D02D636DED004A235C /* ARTWrapperSDKProxyRealtimePresence.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924CE2D636DED004A235C /* ARTWrapperSDKProxyRealtimePresence.m */; };
+		215924D12D636DED004A235C /* ARTWrapperSDKProxyRealtimePresence.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924CE2D636DED004A235C /* ARTWrapperSDKProxyRealtimePresence.m */; };
+		215924D32D636DF8004A235C /* ARTWrapperSDKProxyRealtimePresence.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924D22D636DF8004A235C /* ARTWrapperSDKProxyRealtimePresence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		215924D42D636DF8004A235C /* ARTWrapperSDKProxyRealtimePresence.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924D22D636DF8004A235C /* ARTWrapperSDKProxyRealtimePresence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		215924D52D636DF8004A235C /* ARTWrapperSDKProxyRealtimePresence.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924D22D636DF8004A235C /* ARTWrapperSDKProxyRealtimePresence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		215924D72D636E04004A235C /* ARTWrapperSDKProxyRealtimePresence+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924D62D636E04004A235C /* ARTWrapperSDKProxyRealtimePresence+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		215924D82D636E04004A235C /* ARTWrapperSDKProxyRealtimePresence+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924D62D636E04004A235C /* ARTWrapperSDKProxyRealtimePresence+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		215924D92D636E04004A235C /* ARTWrapperSDKProxyRealtimePresence+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924D62D636E04004A235C /* ARTWrapperSDKProxyRealtimePresence+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		215F75F82922B1DB009E0E76 /* ARTClientInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 215F75F62922B1DB009E0E76 /* ARTClientInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		215F75F92922B1DB009E0E76 /* ARTClientInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 215F75F62922B1DB009E0E76 /* ARTClientInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		215F75FA2922B1DB009E0E76 /* ARTClientInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 215F75F62922B1DB009E0E76 /* ARTClientInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1301,6 +1310,9 @@
 		215924C22D636D2F004A235C /* ARTWrapperSDKProxyPushChannel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWrapperSDKProxyPushChannel.m; sourceTree = "<group>"; };
 		215924C62D636D43004A235C /* ARTWrapperSDKProxyPushChannel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTWrapperSDKProxyPushChannel.h; path = include/Ably/ARTWrapperSDKProxyPushChannel.h; sourceTree = "<group>"; };
 		215924CA2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTWrapperSDKProxyPushChannel+Private.h"; path = "PrivateHeaders/Ably/ARTWrapperSDKProxyPushChannel+Private.h"; sourceTree = "<group>"; };
+		215924CE2D636DED004A235C /* ARTWrapperSDKProxyRealtimePresence.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWrapperSDKProxyRealtimePresence.m; sourceTree = "<group>"; };
+		215924D22D636DF8004A235C /* ARTWrapperSDKProxyRealtimePresence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTWrapperSDKProxyRealtimePresence.h; path = include/Ably/ARTWrapperSDKProxyRealtimePresence.h; sourceTree = "<group>"; };
+		215924D62D636E04004A235C /* ARTWrapperSDKProxyRealtimePresence+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTWrapperSDKProxyRealtimePresence+Private.h"; path = "PrivateHeaders/Ably/ARTWrapperSDKProxyRealtimePresence+Private.h"; sourceTree = "<group>"; };
 		215F75F62922B1DB009E0E76 /* ARTClientInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTClientInformation.h; path = include/Ably/ARTClientInformation.h; sourceTree = "<group>"; };
 		215F75F72922B1DB009E0E76 /* ARTClientInformation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTClientInformation.m; sourceTree = "<group>"; };
 		215F75FE2922B30F009E0E76 /* ClientInformationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientInformationTests.swift; sourceTree = "<group>"; };
@@ -1742,6 +1754,9 @@
 				215924C62D636D43004A235C /* ARTWrapperSDKProxyPushChannel.h */,
 				215924CA2D636D50004A235C /* ARTWrapperSDKProxyPushChannel+Private.h */,
 				215924C22D636D2F004A235C /* ARTWrapperSDKProxyPushChannel.m */,
+				215924D22D636DF8004A235C /* ARTWrapperSDKProxyRealtimePresence.h */,
+				215924D62D636E04004A235C /* ARTWrapperSDKProxyRealtimePresence+Private.h */,
+				215924CE2D636DED004A235C /* ARTWrapperSDKProxyRealtimePresence.m */,
 			);
 			name = "Wrapper SDK Proxy";
 			sourceTree = "<group>";
@@ -2417,6 +2432,7 @@
 				EB2D84F71CD75CCE00F23CDA /* ARTReachability.h in Headers */,
 				D73B655523EF2B2900D459A6 /* ARTDeltaCodec.h in Headers */,
 				213AEA1C2D35A6120067FD5F /* ARTWrapperSDKProxyOptions.h in Headers */,
+				215924D52D636DF8004A235C /* ARTWrapperSDKProxyRealtimePresence.h in Headers */,
 				1C1EC3FA1AE26A8B00AAADD7 /* ARTStatus.h in Headers */,
 				840FCE532C875B8A001163E1 /* ARTDevicePushDetails+Private.h in Headers */,
 				D70EAAED1BC3376200CD8B9E /* ARTRestChannel.h in Headers */,
@@ -2428,6 +2444,7 @@
 				2114D4312D4BCAE20032839A /* ARTRealtime+WrapperSDKProxy.h in Headers */,
 				96A507B51A37881C0077CDF8 /* ARTNSDate+ARTUtil.h in Headers */,
 				D5BB211926AA9A9F00AA5F3E /* ARTNSMutableDictionary+ARTDictionaryUtil.h in Headers */,
+				215924D92D636E04004A235C /* ARTWrapperSDKProxyRealtimePresence+Private.h in Headers */,
 				967A43211A39AEAF00E4CE23 /* ARTNSArray+ARTFunctional.h in Headers */,
 				21113B4529DB484200652C86 /* ARTChannel+Subclass.h in Headers */,
 				D7C1B8791BBF5F810087B55F /* ARTAuth+Private.h in Headers */,
@@ -2671,6 +2688,7 @@
 				21AC0CCC2D4AA0F50030BD23 /* ARTWrapperSDKProxyRealtimeChannel+Private.h in Headers */,
 				21AC0CCD2D4AA0F50030BD23 /* ARTWrapperSDKProxyRealtimeChannels+Private.h in Headers */,
 				D710D51D21949C42008F54AD /* ARTDeviceStorage.h in Headers */,
+				215924D42D636DF8004A235C /* ARTWrapperSDKProxyRealtimePresence.h in Headers */,
 				D710D60D21949DDB008F54AD /* ARTDataQuery.h in Headers */,
 				D710D58221949D28008F54AD /* ARTTokenParams.h in Headers */,
 				D710D51921949C42008F54AD /* ARTDeviceDetails.h in Headers */,
@@ -2724,6 +2742,7 @@
 				D710D68A21949EDA008F54AD /* ARTNSDate+ARTUtil.h in Headers */,
 				215924A62D636B5C004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.h in Headers */,
 				215924A72D636B5C004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.h in Headers */,
+				215924D72D636E04004A235C /* ARTWrapperSDKProxyRealtimePresence+Private.h in Headers */,
 				D710D4D721949BF9008F54AD /* ARTConnectionDetails.h in Headers */,
 				D710D4DB21949BF9008F54AD /* ARTRealtimeChannels.h in Headers */,
 				D710D61021949DDB008F54AD /* ARTFallback.h in Headers */,
@@ -2862,6 +2881,7 @@
 				21AC0CCA2D4AA0F50030BD23 /* ARTWrapperSDKProxyRealtimeChannel+Private.h in Headers */,
 				21AC0CCB2D4AA0F50030BD23 /* ARTWrapperSDKProxyRealtimeChannels+Private.h in Headers */,
 				D710D52F21949C44008F54AD /* ARTDeviceStorage.h in Headers */,
+				215924D32D636DF8004A235C /* ARTWrapperSDKProxyRealtimePresence.h in Headers */,
 				D710D61721949DDC008F54AD /* ARTDataQuery.h in Headers */,
 				D710D5A821949D2A008F54AD /* ARTTokenParams.h in Headers */,
 				D710D52B21949C44008F54AD /* ARTDeviceDetails.h in Headers */,
@@ -2915,6 +2935,7 @@
 				D710D68C21949EDB008F54AD /* ARTNSDate+ARTUtil.h in Headers */,
 				215924A82D636B5C004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations.h in Headers */,
 				215924A92D636B5C004A235C /* ARTWrapperSDKProxyPushChannelSubscriptions.h in Headers */,
+				215924D82D636E04004A235C /* ARTWrapperSDKProxyRealtimePresence+Private.h in Headers */,
 				D710D4E721949BFB008F54AD /* ARTConnectionDetails.h in Headers */,
 				D710D4EB21949BFB008F54AD /* ARTRealtimeChannels.h in Headers */,
 				D710D61A21949DDC008F54AD /* ARTFallback.h in Headers */,
@@ -3412,6 +3433,7 @@
 				96BF61711A35FB7C004CF2B3 /* ARTAuth.m in Sources */,
 				96E408441A38939E00087F77 /* ARTProtocolMessage.m in Sources */,
 				D71966E51E5DF360000974DD /* ARTPushActivationStateMachine.m in Sources */,
+				215924D12D636DED004A235C /* ARTWrapperSDKProxyRealtimePresence.m in Sources */,
 				EB9121401CA0AD8200BA0A40 /* ARTMsgPackEncoder.m in Sources */,
 				96BF61651A35CDE1004CF2B3 /* ARTBaseMessage.m in Sources */,
 				D7F1D3781BF4DE72001A4B5E /* ARTRealtimePresence.m in Sources */,
@@ -3665,6 +3687,7 @@
 				D710D53221949C54008F54AD /* ARTPushChannel.m in Sources */,
 				D710D5D421949D78008F54AD /* ARTTokenDetails.m in Sources */,
 				D710D49B21949ACA008F54AD /* ARTRestChannels.m in Sources */,
+				215924CF2D636DED004A235C /* ARTWrapperSDKProxyRealtimePresence.m in Sources */,
 				D710D62E21949E03008F54AD /* ARTURLSessionServerTrust.m in Sources */,
 				D710D66B21949E78008F54AD /* ARTJsonEncoder.m in Sources */,
 				D710D5D521949D78008F54AD /* ARTClientOptions.m in Sources */,
@@ -3798,6 +3821,7 @@
 				D710D5FA21949D79008F54AD /* ARTTokenDetails.m in Sources */,
 				D710D4A521949ACB008F54AD /* ARTRestChannels.m in Sources */,
 				D710D63E21949E04008F54AD /* ARTURLSessionServerTrust.m in Sources */,
+				215924D02D636DED004A235C /* ARTWrapperSDKProxyRealtimePresence.m in Sources */,
 				D710D65121949E77008F54AD /* ARTJsonEncoder.m in Sources */,
 				D710D5FB21949D79008F54AD /* ARTClientOptions.m in Sources */,
 				D710D5FC21949D79008F54AD /* ARTChannel.m in Sources */,

--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -320,6 +320,9 @@
 		21E1C0E92A0DC5E600A5DB65 /* ARTWebSocketFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 21E1C0E82A0DC5E600A5DB65 /* ARTWebSocketFactory.m */; };
 		21E1C0EA2A0DC5E600A5DB65 /* ARTWebSocketFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 21E1C0E82A0DC5E600A5DB65 /* ARTWebSocketFactory.m */; };
 		21E1C0EB2A0DC5E600A5DB65 /* ARTWebSocketFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 21E1C0E82A0DC5E600A5DB65 /* ARTWebSocketFactory.m */; };
+		21E5D87F2D5E3EC300526C4C /* ARTChannelProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 21E5D87E2D5E3EC300526C4C /* ARTChannelProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21E5D8802D5E3EC300526C4C /* ARTChannelProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 21E5D87E2D5E3EC300526C4C /* ARTChannelProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21E5D8812D5E3EC300526C4C /* ARTChannelProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 21E5D87E2D5E3EC300526C4C /* ARTChannelProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		21FD9F272A015BE400216482 /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FD9F262A015BE400216482 /* Test.swift */; };
 		21FD9F282A015BE400216482 /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FD9F262A015BE400216482 /* Test.swift */; };
 		21FD9F292A015BE400216482 /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FD9F262A015BE400216482 /* Test.swift */; };
@@ -694,7 +697,7 @@
 		D710D58221949D28008F54AD /* ARTTokenParams.h in Headers */ = {isa = PBXBuildFile; fileRef = D7D8F8291BC2C706009718F2 /* ARTTokenParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D710D58321949D28008F54AD /* ARTTokenDetails.h in Headers */ = {isa = PBXBuildFile; fileRef = D7D8F8231BC2C691009718F2 /* ARTTokenDetails.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D710D58421949D28008F54AD /* ARTClientOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 961343D61A42E0B7006DC822 /* ARTClientOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D710D58521949D28008F54AD /* ARTChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = D746AE201BBB60EE003ECEF8 /* ARTChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D710D58521949D28008F54AD /* ARTChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = D746AE201BBB60EE003ECEF8 /* ARTChannel.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D710D58621949D29008F54AD /* ARTChannels.h in Headers */ = {isa = PBXBuildFile; fileRef = D746AE511BBD85C5003ECEF8 /* ARTChannels.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D710D58721949D29008F54AD /* ARTChannelOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = D746AE4D1BBD84E7003ECEF8 /* ARTChannelOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D710D58821949D29008F54AD /* ARTProtocolMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 96E408411A38939E00087F77 /* ARTProtocolMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -712,7 +715,7 @@
 		D710D5A821949D2A008F54AD /* ARTTokenParams.h in Headers */ = {isa = PBXBuildFile; fileRef = D7D8F8291BC2C706009718F2 /* ARTTokenParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D710D5A921949D2A008F54AD /* ARTTokenDetails.h in Headers */ = {isa = PBXBuildFile; fileRef = D7D8F8231BC2C691009718F2 /* ARTTokenDetails.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D710D5AA21949D2A008F54AD /* ARTClientOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 961343D61A42E0B7006DC822 /* ARTClientOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D710D5AB21949D2A008F54AD /* ARTChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = D746AE201BBB60EE003ECEF8 /* ARTChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D710D5AB21949D2A008F54AD /* ARTChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = D746AE201BBB60EE003ECEF8 /* ARTChannel.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D710D5AC21949D2A008F54AD /* ARTChannels.h in Headers */ = {isa = PBXBuildFile; fileRef = D746AE511BBD85C5003ECEF8 /* ARTChannels.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D710D5AD21949D2A008F54AD /* ARTChannelOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = D746AE4D1BBD84E7003ECEF8 /* ARTChannelOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D710D5AE21949D2A008F54AD /* ARTProtocolMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 96E408411A38939E00087F77 /* ARTProtocolMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -902,7 +905,7 @@
 		D746AE1D1BBB5207003ECEF8 /* ARTDataQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = D746AE1A1BBB5207003ECEF8 /* ARTDataQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D746AE1E1BBB5207003ECEF8 /* ARTDataQuery+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = D746AE1B1BBB5207003ECEF8 /* ARTDataQuery+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D746AE1F1BBB5207003ECEF8 /* ARTDataQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = D746AE1C1BBB5207003ECEF8 /* ARTDataQuery.m */; };
-		D746AE221BBB60EE003ECEF8 /* ARTChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = D746AE201BBB60EE003ECEF8 /* ARTChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D746AE221BBB60EE003ECEF8 /* ARTChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = D746AE201BBB60EE003ECEF8 /* ARTChannel.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D746AE231BBB60EE003ECEF8 /* ARTChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = D746AE211BBB60EE003ECEF8 /* ARTChannel.m */; };
 		D746AE251BBB611C003ECEF8 /* ARTChannel+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = D746AE241BBB611C003ECEF8 /* ARTChannel+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D746AE281BBB61C9003ECEF8 /* ARTPresence.h in Headers */ = {isa = PBXBuildFile; fileRef = D746AE261BBB61C9003ECEF8 /* ARTPresence.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1298,6 +1301,7 @@
 		21DCDA8429F81B550073A211 /* Ably-tvOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Ably-tvOS.xctestplan"; sourceTree = "<group>"; };
 		21E1C0E42A0DC47400A5DB65 /* ARTWebSocketFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTWebSocketFactory.h; path = PrivateHeaders/ARTWebSocketFactory.h; sourceTree = "<group>"; };
 		21E1C0E82A0DC5E600A5DB65 /* ARTWebSocketFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWebSocketFactory.m; sourceTree = "<group>"; };
+		21E5D87E2D5E3EC300526C4C /* ARTChannelProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTChannelProtocol.h; path = include/Ably/ARTChannelProtocol.h; sourceTree = "<group>"; };
 		21FD9F262A015BE400216482 /* Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test.swift; sourceTree = "<group>"; };
 		560579D824AF1BA900A4D03D /* ARTDefaultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARTDefaultTests.swift; sourceTree = "<group>"; };
 		56190953238C3D3200A862A6 /* CryptoTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CryptoTest.m; sourceTree = "<group>"; };
@@ -1417,7 +1421,7 @@
 		D746AE1A1BBB5207003ECEF8 /* ARTDataQuery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARTDataQuery.h; path = include/Ably/ARTDataQuery.h; sourceTree = "<group>"; };
 		D746AE1B1BBB5207003ECEF8 /* ARTDataQuery+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "ARTDataQuery+Private.h"; path = "PrivateHeaders/Ably/ARTDataQuery+Private.h"; sourceTree = "<group>"; };
 		D746AE1C1BBB5207003ECEF8 /* ARTDataQuery.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTDataQuery.m; sourceTree = "<group>"; };
-		D746AE201BBB60EE003ECEF8 /* ARTChannel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARTChannel.h; path = include/Ably/ARTChannel.h; sourceTree = "<group>"; };
+		D746AE201BBB60EE003ECEF8 /* ARTChannel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARTChannel.h; path = PrivateHeaders/Ably/ARTChannel.h; sourceTree = "<group>"; };
 		D746AE211BBB60EE003ECEF8 /* ARTChannel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTChannel.m; sourceTree = "<group>"; };
 		D746AE241BBB611C003ECEF8 /* ARTChannel+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "ARTChannel+Private.h"; path = "PrivateHeaders/Ably/ARTChannel+Private.h"; sourceTree = "<group>"; };
 		D746AE261BBB61C9003ECEF8 /* ARTPresence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARTPresence.h; path = include/Ably/ARTPresence.h; sourceTree = "<group>"; };
@@ -2089,6 +2093,7 @@
 				21113B5029DC6AAF00652C86 /* ARTTestClientOptions.h */,
 				21113B5429DC6ACD00652C86 /* ARTTestClientOptions.m */,
 				961343D71A42E0B7006DC822 /* ARTClientOptions.m */,
+				21E5D87E2D5E3EC300526C4C /* ARTChannelProtocol.h */,
 				D746AE201BBB60EE003ECEF8 /* ARTChannel.h */,
 				D746AE241BBB611C003ECEF8 /* ARTChannel+Private.h */,
 				21113B4429DB484200652C86 /* ARTChannel+Subclass.h */,
@@ -2411,6 +2416,7 @@
 				D7D06F0826330E2800DEBDAD /* ARTHttp+Private.h in Headers */,
 				EB1B541922FB1D7F006A59AC /* ARTPushChannelSubscriptions+Private.h in Headers */,
 				2105ED1E29E7242400DE6D67 /* ARTLogAdapter+Testing.h in Headers */,
+				21E5D8812D5E3EC300526C4C /* ARTChannelProtocol.h in Headers */,
 				EBF2285B1F4D9AD6009091DD /* ARTWebSocketTransport+Private.h in Headers */,
 				EBFFAC191E97919C003E7326 /* ARTLocalDevice+Private.h in Headers */,
 				211A60DB29D726F800D169C5 /* ARTConnectionStateChangeParams.h in Headers */,
@@ -2616,6 +2622,7 @@
 				2124B78C29DB12A900AD8361 /* ARTVersion2Log.h in Headers */,
 				EB1B53FE22F8D91C006A59AC /* ARTQueuedDealloc.h in Headers */,
 				2114D4282D4BC5470032839A /* AblyInternal.h in Headers */,
+				21E5D87F2D5E3EC300526C4C /* ARTChannelProtocol.h in Headers */,
 				2114D4292D4BC5470032839A /* AblyPublic.h in Headers */,
 				D710D56A21949CB9008F54AD /* ARTPushAdmin.h in Headers */,
 				D710D48321949A4E008F54AD /* ARTDefault+Private.h in Headers */,
@@ -2796,6 +2803,7 @@
 				2124B78D29DB12A900AD8361 /* ARTVersion2Log.h in Headers */,
 				D710D47F21949A28008F54AD /* Ably.h in Headers */,
 				2114D42C2D4BC5470032839A /* AblyInternal.h in Headers */,
+				21E5D8802D5E3EC300526C4C /* ARTChannelProtocol.h in Headers */,
 				2114D42D2D4BC5470032839A /* AblyPublic.h in Headers */,
 				EB1B53FF22F8D91C006A59AC /* ARTQueuedDealloc.h in Headers */,
 				D710D57021949CBA008F54AD /* ARTPushAdmin.h in Headers */,

--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -217,6 +217,15 @@
 		215924932D636A6E004A235C /* ARTWrapperSDKProxyPush.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924922D636A6E004A235C /* ARTWrapperSDKProxyPush.m */; };
 		215924942D636A6E004A235C /* ARTWrapperSDKProxyPush.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924922D636A6E004A235C /* ARTWrapperSDKProxyPush.m */; };
 		215924952D636A6E004A235C /* ARTWrapperSDKProxyPush.m in Sources */ = {isa = PBXBuildFile; fileRef = 215924922D636A6E004A235C /* ARTWrapperSDKProxyPush.m */; };
+		215924972D636AC5004A235C /* ARTWrapperSDKProxyPushAdmin.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924962D636AC5004A235C /* ARTWrapperSDKProxyPushAdmin.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		215924982D636AC5004A235C /* ARTWrapperSDKProxyPushAdmin.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924962D636AC5004A235C /* ARTWrapperSDKProxyPushAdmin.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		215924992D636AC5004A235C /* ARTWrapperSDKProxyPushAdmin.h in Headers */ = {isa = PBXBuildFile; fileRef = 215924962D636AC5004A235C /* ARTWrapperSDKProxyPushAdmin.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2159249B2D636AD5004A235C /* ARTWrapperSDKProxyPushAdmin+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2159249A2D636AD5004A235C /* ARTWrapperSDKProxyPushAdmin+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2159249C2D636AD5004A235C /* ARTWrapperSDKProxyPushAdmin+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2159249A2D636AD5004A235C /* ARTWrapperSDKProxyPushAdmin+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2159249D2D636AD5004A235C /* ARTWrapperSDKProxyPushAdmin+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2159249A2D636AD5004A235C /* ARTWrapperSDKProxyPushAdmin+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2159249F2D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m in Sources */ = {isa = PBXBuildFile; fileRef = 2159249E2D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m */; };
+		215924A02D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m in Sources */ = {isa = PBXBuildFile; fileRef = 2159249E2D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m */; };
+		215924A12D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m in Sources */ = {isa = PBXBuildFile; fileRef = 2159249E2D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m */; };
 		215F75F82922B1DB009E0E76 /* ARTClientInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 215F75F62922B1DB009E0E76 /* ARTClientInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		215F75F92922B1DB009E0E76 /* ARTClientInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 215F75F62922B1DB009E0E76 /* ARTClientInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		215F75FA2922B1DB009E0E76 /* ARTClientInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 215F75F62922B1DB009E0E76 /* ARTClientInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1253,6 +1262,9 @@
 		2159248A2D636826004A235C /* ARTWrapperSDKProxyPush.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTWrapperSDKProxyPush.h; path = include/Ably/ARTWrapperSDKProxyPush.h; sourceTree = "<group>"; };
 		2159248E2D636839004A235C /* ARTWrapperSDKProxyPush+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTWrapperSDKProxyPush+Private.h"; path = "PrivateHeaders/Ably/ARTWrapperSDKProxyPush+Private.h"; sourceTree = "<group>"; };
 		215924922D636A6E004A235C /* ARTWrapperSDKProxyPush.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWrapperSDKProxyPush.m; sourceTree = "<group>"; };
+		215924962D636AC5004A235C /* ARTWrapperSDKProxyPushAdmin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTWrapperSDKProxyPushAdmin.h; path = include/Ably/ARTWrapperSDKProxyPushAdmin.h; sourceTree = "<group>"; };
+		2159249A2D636AD5004A235C /* ARTWrapperSDKProxyPushAdmin+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTWrapperSDKProxyPushAdmin+Private.h"; path = "PrivateHeaders/Ably/ARTWrapperSDKProxyPushAdmin+Private.h"; sourceTree = "<group>"; };
+		2159249E2D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWrapperSDKProxyPushAdmin.m; sourceTree = "<group>"; };
 		215F75F62922B1DB009E0E76 /* ARTClientInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTClientInformation.h; path = include/Ably/ARTClientInformation.h; sourceTree = "<group>"; };
 		215F75F72922B1DB009E0E76 /* ARTClientInformation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTClientInformation.m; sourceTree = "<group>"; };
 		215F75FE2922B30F009E0E76 /* ClientInformationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientInformationTests.swift; sourceTree = "<group>"; };
@@ -1682,6 +1694,9 @@
 				2159248A2D636826004A235C /* ARTWrapperSDKProxyPush.h */,
 				2159248E2D636839004A235C /* ARTWrapperSDKProxyPush+Private.h */,
 				215924922D636A6E004A235C /* ARTWrapperSDKProxyPush.m */,
+				215924962D636AC5004A235C /* ARTWrapperSDKProxyPushAdmin.h */,
+				2159249A2D636AD5004A235C /* ARTWrapperSDKProxyPushAdmin+Private.h */,
+				2159249E2D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m */,
 			);
 			name = "Wrapper SDK Proxy";
 			sourceTree = "<group>";
@@ -2465,12 +2480,14 @@
 				2132C31129D5E4C6000C4355 /* ARTBackoffRetryDelayCalculator.h in Headers */,
 				2114D42A2D4BC5470032839A /* AblyInternal.h in Headers */,
 				2114D42B2D4BC5470032839A /* AblyPublic.h in Headers */,
+				2159249B2D636AD5004A235C /* ARTWrapperSDKProxyPushAdmin+Private.h in Headers */,
 				D5BB213926AAA60500AA5F3E /* ARTNSError+ARTUtils.h in Headers */,
 				D746AE431BBC5CD0003ECEF8 /* ARTRealtimeChannel+Private.h in Headers */,
 				D746AE251BBB611C003ECEF8 /* ARTChannel+Private.h in Headers */,
 				D5BB210B26AA98A200AA5F3E /* ARTStringifiable+Private.h in Headers */,
 				EB4B1A0C1F2190BB00467F07 /* ARTRestChannels+Private.h in Headers */,
 				D785C4291E549E33008FEC05 /* ARTPushChannelSubscription.h in Headers */,
+				215924992D636AC5004A235C /* ARTWrapperSDKProxyPushAdmin.h in Headers */,
 				D7F1D3731BF4DE07001A4B5E /* ARTRestPresence.h in Headers */,
 				D7B17EE31C07208B00A6958E /* ARTConnectionDetails.h in Headers */,
 				D7F2B8B21E42410D00B65151 /* ARTPresenceMessage+Private.h in Headers */,
@@ -2569,6 +2586,7 @@
 				21AC0CC42D4AA0630030BD23 /* ARTWrapperSDKProxyRealtimeChannel.h in Headers */,
 				21AC0CC52D4AA0630030BD23 /* ARTWrapperSDKProxyRealtimeChannels.h in Headers */,
 				213AEA1B2D35A6120067FD5F /* ARTWrapperSDKProxyOptions.h in Headers */,
+				2159249D2D636AD5004A235C /* ARTWrapperSDKProxyPushAdmin+Private.h in Headers */,
 				D798556123ECCDAF00946BE2 /* ARTVCDiffDecoder.h in Headers */,
 				21E1C0E62A0DC47400A5DB65 /* ARTWebSocketFactory.h in Headers */,
 				2132C32129D5FE74000C4355 /* ARTTypes+Private.h in Headers */,
@@ -2682,6 +2700,7 @@
 				D710D61E21949DEC008F54AD /* ARTFallback+Private.h in Headers */,
 				D5BB211026AA993C00AA5F3E /* ARTNSURL+ARTUtils.h in Headers */,
 				D710D60E21949DDB008F54AD /* ARTPaginatedResult.h in Headers */,
+				215924972D636AC5004A235C /* ARTWrapperSDKProxyPushAdmin.h in Headers */,
 				2114D4302D4BCAE20032839A /* ARTRealtime+WrapperSDKProxy.h in Headers */,
 				D710D4BF21949B6C008F54AD /* ARTNSMutableRequest+ARTRest.h in Headers */,
 				2147F02E29E583AD0071CB94 /* ARTInternalLogCore.h in Headers */,
@@ -2752,6 +2771,7 @@
 				21AC0CC22D4AA0630030BD23 /* ARTWrapperSDKProxyRealtimeChannel.h in Headers */,
 				21AC0CC32D4AA0630030BD23 /* ARTWrapperSDKProxyRealtimeChannels.h in Headers */,
 				213AEA1A2D35A6120067FD5F /* ARTWrapperSDKProxyOptions.h in Headers */,
+				2159249C2D636AD5004A235C /* ARTWrapperSDKProxyPushAdmin+Private.h in Headers */,
 				D710D57221949CBA008F54AD /* ARTPushChannelSubscriptions.h in Headers */,
 				21E1C0E72A0DC47400A5DB65 /* ARTWebSocketFactory.h in Headers */,
 				2132C32229D5FE74000C4355 /* ARTTypes+Private.h in Headers */,
@@ -2865,6 +2885,7 @@
 				D710D62A21949DED008F54AD /* ARTFallback+Private.h in Headers */,
 				D710D61821949DDC008F54AD /* ARTPaginatedResult.h in Headers */,
 				D5BB213B26AAA60500AA5F3E /* ARTNSError+ARTUtils.h in Headers */,
+				215924982D636AC5004A235C /* ARTWrapperSDKProxyPushAdmin.h in Headers */,
 				2114D42F2D4BCAE20032839A /* ARTRealtime+WrapperSDKProxy.h in Headers */,
 				D710D4C121949B6D008F54AD /* ARTNSMutableRequest+ARTRest.h in Headers */,
 				2147F02F29E583AD0071CB94 /* ARTInternalLogCore.h in Headers */,
@@ -3257,6 +3278,7 @@
 				D7B621991E4A762A00684474 /* ARTPushChannel.m in Sources */,
 				EB89D40B1C61C6EA007FA5B7 /* ARTRealtimeChannels.m in Sources */,
 				217D183B254222F600DFF07E /* ARTSRDelegateController.m in Sources */,
+				2159249F2D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m in Sources */,
 				D746AE231BBB60EE003ECEF8 /* ARTChannel.m in Sources */,
 				215924932D636A6E004A235C /* ARTWrapperSDKProxyPush.m in Sources */,
 				D76F153C23DB010C00B5133C /* ARTRealtimeChannelOptions.m in Sources */,
@@ -3506,6 +3528,7 @@
 				D710D62F21949E03008F54AD /* ARTDataQuery.m in Sources */,
 				D710D53121949C54008F54AD /* ARTPush.m in Sources */,
 				217D1852254222F700DFF07E /* ARTSRDelegateController.m in Sources */,
+				215924A02D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m in Sources */,
 				D710D5E021949D78008F54AD /* ARTStats.m in Sources */,
 				215924942D636A6E004A235C /* ARTWrapperSDKProxyPush.m in Sources */,
 				D76F153F23DB013000B5133C /* ARTRealtimeChannelOptions.m in Sources */,
@@ -3635,6 +3658,7 @@
 				D710D54321949C55008F54AD /* ARTPush.m in Sources */,
 				217D1869254222FA00DFF07E /* ARTSRDelegateController.m in Sources */,
 				D710D60621949D79008F54AD /* ARTStats.m in Sources */,
+				215924A12D636ADF004A235C /* ARTWrapperSDKProxyPushAdmin.m in Sources */,
 				D76F154023DB013000B5133C /* ARTRealtimeChannelOptions.m in Sources */,
 				215924952D636A6E004A235C /* ARTWrapperSDKProxyPush.m in Sources */,
 				D710D50121949C0E008F54AD /* ARTQueuedMessage.m in Sources */,

--- a/Source/ARTAuth.m
+++ b/Source/ARTAuth.m
@@ -708,7 +708,8 @@ dispatch_async(_queue, ^{
     }
     else {
         if (replacedOptions.queryTime) {
-            return [_rest _time:^(NSDate *time, NSError *error) {
+            return [_rest _timeWithWrapperSDKAgents:nil
+                                         completion:^(NSDate *time, NSError *error) {
                 if (error) {
                     callback(nil, error);
                 } else {

--- a/Source/ARTChannel.m
+++ b/Source/ARTChannel.m
@@ -176,7 +176,7 @@
     return message;
 }
 
-- (void)history:(ARTPaginatedMessagesCallback)callback {
+- (void)historyWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents completion:(ARTPaginatedMessagesCallback)callback {
     NSAssert(false, @"-[%@ %@] should always be overriden.", self.class, NSStringFromSelector(_cmd));
 }
 

--- a/Source/ARTChannel.m
+++ b/Source/ARTChannel.m
@@ -17,8 +17,6 @@
     ARTChannelOptions *_options;
 }
 
-@synthesize name = _name;
-
 - (instancetype)initWithName:(NSString *)name andOptions:(ARTChannelOptions *)options rest:(ARTRestInternal *)rest logger:(ARTInternalLog *)logger {
     if (self = [super init]) {
         _name = name;

--- a/Source/ARTHTTPPaginatedResponse.m
+++ b/Source/ARTHTTPPaginatedResponse.m
@@ -22,10 +22,9 @@
                responseProcessor:(ARTPaginatedResultResponseProcessor)responseProcessor
                 wrapperSDKAgents:(nullable NSDictionary<NSString *,NSString *> *)wrapperSDKAgents
                           logger:(ARTInternalLog *)logger {
-    self = [super initWithItems:items rest:rest relFirst:relFirst relCurrent:relCurrent relNext:relNext responseProcessor:responseProcessor logger:logger];
+    self = [super initWithItems:items rest:rest relFirst:relFirst relCurrent:relCurrent relNext:relNext responseProcessor:responseProcessor wrapperSDKAgents:wrapperSDKAgents logger:logger];
     if (self) {
         _response = response;
-        _wrapperSDKAgents = [wrapperSDKAgents copy];
     }
     return self;
 }

--- a/Source/ARTPaginatedResult.m
+++ b/Source/ARTPaginatedResult.m
@@ -46,6 +46,7 @@
                    relCurrent:(NSMutableURLRequest *)relCurrent
                       relNext:(NSMutableURLRequest *)relNext
             responseProcessor:(ARTPaginatedResultResponseProcessor)responseProcessor
+             wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
                        logger:(ARTInternalLog *)logger {
     if (self = [super init]) {
         _initializedViaInit = NO;
@@ -64,6 +65,7 @@
         _userQueue = rest.userQueue;
         _queue = rest.queue;
         _responseProcessor = responseProcessor;
+        _wrapperSDKAgents = wrapperSDKAgents;
         _logger = logger;
 
         // ARTPaginatedResult doesn't need a internal counterpart, as other
@@ -116,7 +118,7 @@
         };
     }
 
-    [self.class executePaginated:_rest withRequest:_relFirst andResponseProcessor:_responseProcessor logger:_logger callback:callback];
+    [self.class executePaginated:_rest withRequest:_relFirst andResponseProcessor:_responseProcessor wrapperSDKAgents:_wrapperSDKAgents logger:_logger callback:callback];
 }
 
 - (void)next:(void (^)(ARTPaginatedResult<id> *_Nullable result, ARTErrorInfo *_Nullable error))callback {
@@ -138,13 +140,13 @@
         callback(nil, nil);
         return;
     }
-    [self.class executePaginated:_rest withRequest:_relNext andResponseProcessor:_responseProcessor logger:_logger callback:callback];
+    [self.class executePaginated:_rest withRequest:_relNext andResponseProcessor:_responseProcessor wrapperSDKAgents:_wrapperSDKAgents logger:_logger callback:callback];
 }
 
-+ (void)executePaginated:(ARTRestInternal *)rest withRequest:(NSMutableURLRequest *)request andResponseProcessor:(ARTPaginatedResultResponseProcessor)responseProcessor logger:(ARTInternalLog *)logger callback:(void (^)(ARTPaginatedResult<id> *_Nullable result, ARTErrorInfo *_Nullable error))callback {
++ (void)executePaginated:(ARTRestInternal *)rest withRequest:(NSMutableURLRequest *)request andResponseProcessor:(ARTPaginatedResultResponseProcessor)responseProcessor wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents logger:(ARTInternalLog *)logger callback:(void (^)(ARTPaginatedResult<id> *_Nullable result, ARTErrorInfo *_Nullable error))callback {
     ARTLogDebug(logger, @"Paginated request: %@", request);
 
-    [rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             callback(nil, [ARTErrorInfo createFromNSError:error]);
         } else {
@@ -171,6 +173,7 @@
                                                                         relCurrent:currentRel
                                                                            relNext:nextRel
                                                                  responseProcessor:responseProcessor
+                                                                  wrapperSDKAgents:wrapperSDKAgents
                                                                             logger:logger];
 
             callback(result, nil);

--- a/Source/ARTPushAdmin.m
+++ b/Source/ARTPushAdmin.m
@@ -21,7 +21,7 @@
 }
 
 - (void)publish:(ARTPushRecipient *)recipient data:(ARTJsonObject *)data callback:(nullable ARTCallback)callback {
-    [_internal publish:recipient data:data callback:callback];
+    [_internal publish:recipient data:data wrapperSDKAgents:nil callback:callback];
 }
 
 - (ARTPushDeviceRegistrations *)deviceRegistrations {
@@ -53,7 +53,7 @@
     return self;
 }
 
-- (void)publish:(ARTPushRecipient *)recipient data:(ARTJsonObject *)data callback:(nullable ARTCallback)callback {
+- (void)publish:(ARTPushRecipient *)recipient data:(ARTJsonObject *)data wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(nullable ARTCallback)callback {
     if (callback) {
         ARTCallback userCallback = callback;
         callback = ^(ARTErrorInfo *error) {
@@ -83,7 +83,7 @@
             [request setValue:[[self->_rest defaultEncoder] mimeType] forHTTPHeaderField:@"Content-Type"];
 
             ARTLogDebug(self->_logger, @"push notification to a single device %@", request);
-        [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+        [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
                 if (error) {
                     ARTLogError(self->_logger, @"%@: push notification to a single device failed (%@)", NSStringFromClass(self.class), error.localizedDescription);
                     if (callback) callback([ARTErrorInfo createFromNSError:error]);

--- a/Source/ARTPushChannel.m
+++ b/Source/ARTPushChannel.m
@@ -290,7 +290,7 @@ dispatch_sync(_queue, ^{
         return [self->_rest.encoders[response.MIMEType] decodePushChannelSubscriptions:data error:error];
     };
 
-    [ARTPaginatedResult executePaginated:self->_rest withRequest:request andResponseProcessor:responseProcessor logger:self->_logger callback:callback];
+    [ARTPaginatedResult executePaginated:self->_rest withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:nil logger:self->_logger callback:callback];
     ret = YES;
 });
     return ret;

--- a/Source/ARTPushChannel.m
+++ b/Source/ARTPushChannel.m
@@ -24,41 +24,41 @@
 }
 
 - (void)subscribeDevice {
-    [_internal subscribeDevice];
+    [_internal subscribeDeviceWithWrapperSDKAgents:nil];
 }
 
 - (void)subscribeDevice:(ARTCallback)callback {
-    [_internal subscribeDevice:callback];
+    [_internal subscribeDeviceWithWrapperSDKAgents:nil completion:callback];
 }
 
 - (void)subscribeClient {
-    [_internal subscribeClient];
+    [_internal subscribeClientWithWrapperSDKAgents:nil];
 }
 
 - (void)subscribeClient:(ARTCallback)callback {
-    [_internal subscribeClient:callback];
+    [_internal subscribeClientWithWrapperSDKAgents:nil completion:callback];
 }
 
 - (void)unsubscribeDevice {
-    [_internal unsubscribeDevice];
+    [_internal unsubscribeDeviceWithWrapperSDKAgents:nil];
 }
 
 - (void)unsubscribeDevice:(ARTCallback)callback {
-    [_internal unsubscribeDevice:callback];
+    [_internal unsubscribeDeviceWithWrapperSDKAgents:nil completion:callback];
 }
 
 - (void)unsubscribeClient {
-    [_internal unsubscribeClient];
+    [_internal unsubscribeClientWithWrapperSDKAgents:nil];
 }
 
 - (void)unsubscribeClient:(ARTCallback)callback {
-    [_internal unsubscribeClient:callback];
+    [_internal unsubscribeClientWithWrapperSDKAgents:nil completion:callback];
 }
 
 - (BOOL)listSubscriptions:(NSStringDictionary *)params
                  callback:(ARTPaginatedPushChannelCallback)callback
                     error:(NSError *_Nullable *_Nullable)errorPtr {
-    return [_internal listSubscriptions:params callback:callback error:errorPtr];
+    return [_internal listSubscriptions:params wrapperSDKAgents:nil callback:callback error:errorPtr];
 }
 
 @end
@@ -86,23 +86,23 @@ const NSUInteger ARTDefaultLimit = 100;
     return self;
 }
 
-- (void)subscribeDevice {
-    [self subscribeDevice:nil];
+- (void)subscribeDeviceWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents {
+    [self subscribeDeviceWithWrapperSDKAgents:wrapperSDKAgents completion:nil];
 }
 
-- (void)unsubscribeDevice {
-    [self unsubscribeDevice:nil];
+- (void)unsubscribeDeviceWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents {
+    [self unsubscribeDeviceWithWrapperSDKAgents:wrapperSDKAgents completion:nil];
 }
 
-- (void)subscribeClient {
-    [self subscribeClient:nil];
+- (void)subscribeClientWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents {
+    [self subscribeClientWithWrapperSDKAgents:wrapperSDKAgents completion:nil];
 }
 
-- (void)unsubscribeClient {
-    [self unsubscribeClient:nil];
+- (void)unsubscribeClientWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents {
+    [self unsubscribeClientWithWrapperSDKAgents:wrapperSDKAgents completion:nil];
 }
 
-- (void)subscribeDevice:(ARTCallback)callback {
+- (void)subscribeDeviceWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents completion:(ARTCallback)callback {
     if (callback) {
         ARTCallback userCallback = callback;
         callback = ^(ARTErrorInfo *_Nullable error) {
@@ -129,7 +129,7 @@ dispatch_async(_queue, ^{
     [request setDeviceAuthentication:deviceId localDevice:device];
 
     ARTLogDebug(self->_logger, @"subscribe notifications for device %@ in channel %@", deviceId, self->_channel.name);
-    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             ARTLogError(self->_logger, @"%@: subscribe notifications for device %@ in channel %@ failed (%@)", NSStringFromClass(self.class), deviceId, self->_channel.name, error.localizedDescription);
         }
@@ -138,7 +138,7 @@ dispatch_async(_queue, ^{
 });
 }
 
-- (void)subscribeClient:(ARTCallback)callback {
+- (void)subscribeClientWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents completion:(ARTCallback)callback {
     if (callback) {
         ARTCallback userCallback = callback;
         callback = ^(ARTErrorInfo *_Nullable error) {
@@ -163,7 +163,7 @@ dispatch_async(_queue, ^{
     [request setValue:[[self->_rest defaultEncoder] mimeType] forHTTPHeaderField:@"Content-Type"];
 
     ARTLogDebug(self->_logger, @"subscribe notifications for clientId %@ in channel %@", clientId, self->_channel.name);
-    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             ARTLogError(self->_logger, @"%@: subscribe notifications for clientId %@ in channel %@ failed (%@)", NSStringFromClass(self.class), clientId, self->_channel.name, error.localizedDescription);
         }
@@ -172,7 +172,7 @@ dispatch_async(_queue, ^{
 });
 }
 
-- (void)unsubscribeDevice:(ARTCallback)callback {
+- (void)unsubscribeDeviceWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents completion:(ARTCallback)callback {
     if (callback) {
         ARTCallback userCallback = callback;
         callback = ^(ARTErrorInfo *_Nullable error) {
@@ -200,7 +200,7 @@ dispatch_async(_queue, ^{
     [request setDeviceAuthentication:deviceId localDevice:device];
 
     ARTLogDebug(self->_logger, @"unsubscribe notifications for device %@ in channel %@", deviceId, self->_channel.name);
-    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             ARTLogError(self->_logger, @"%@: unsubscribe notifications for device %@ in channel %@ failed (%@)", NSStringFromClass(self.class), deviceId, self->_channel.name, error.localizedDescription);
         }
@@ -209,7 +209,7 @@ dispatch_async(_queue, ^{
 });
 }
 
-- (void)unsubscribeClient:(ARTCallback)callback {
+- (void)unsubscribeClientWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents completion:(ARTCallback)callback {
     if (callback) {
         ARTCallback userCallback = callback;
         callback = ^(ARTErrorInfo *_Nullable error) {
@@ -235,7 +235,7 @@ dispatch_async(_queue, ^{
     request.HTTPMethod = @"DELETE";
 
     ARTLogDebug(self->_logger, @"unsubscribe notifications for clientId %@ in channel %@", clientId, self->_channel.name);
-    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             ARTLogError(self->_logger, @"%@: unsubscribe notifications for clientId %@ in channel %@ failed (%@)", NSStringFromClass(self.class), clientId, self->_channel.name, error.localizedDescription);
         }
@@ -245,6 +245,7 @@ dispatch_async(_queue, ^{
 }
 
 - (BOOL)listSubscriptions:(NSStringDictionary *)params
+         wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
                  callback:(ARTPaginatedPushChannelCallback)callback
                     error:(NSError * __autoreleasing *)errorPtr {
     if (callback) {
@@ -290,7 +291,7 @@ dispatch_sync(_queue, ^{
         return [self->_rest.encoders[response.MIMEType] decodePushChannelSubscriptions:data error:error];
     };
 
-    [ARTPaginatedResult executePaginated:self->_rest withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:nil logger:self->_logger callback:callback];
+    [ARTPaginatedResult executePaginated:self->_rest withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:wrapperSDKAgents logger:self->_logger callback:callback];
     ret = YES;
 });
     return ret;

--- a/Source/ARTPushChannelSubscriptions.m
+++ b/Source/ARTPushChannelSubscriptions.m
@@ -126,7 +126,7 @@
         ARTPaginatedResultResponseProcessor responseProcessor = ^(NSHTTPURLResponse *response, NSData *data, NSError **error) {
             return [self->_rest.encoders[response.MIMEType] decode:data error:error];
         };
-        [ARTPaginatedResult executePaginated:self->_rest withRequest:request andResponseProcessor:responseProcessor logger:self->_logger callback:callback];
+        [ARTPaginatedResult executePaginated:self->_rest withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:nil logger:self->_logger callback:callback];
     });
 }
 
@@ -149,7 +149,7 @@
         ARTPaginatedResultResponseProcessor responseProcessor = ^(NSHTTPURLResponse *response, NSData *data, NSError **error) {
             return [self->_rest.encoders[response.MIMEType] decodePushChannelSubscriptions:data error:error];
         };
-        [ARTPaginatedResult executePaginated:self->_rest withRequest:request andResponseProcessor:responseProcessor logger:self->_logger callback:callback];
+        [ARTPaginatedResult executePaginated:self->_rest withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:nil logger:self->_logger callback:callback];
     });
 }
 

--- a/Source/ARTPushDeviceRegistrations.m
+++ b/Source/ARTPushDeviceRegistrations.m
@@ -188,7 +188,7 @@ dispatch_async(_queue, ^{
     ARTPaginatedResultResponseProcessor responseProcessor = ^(NSHTTPURLResponse *response, NSData *data, NSError **error) {
         return [self->_rest.encoders[response.MIMEType] decodeDevicesDetails:data error:error];
     };
-    [ARTPaginatedResult executePaginated:self->_rest withRequest:request andResponseProcessor:responseProcessor logger:self->_logger callback:callback];
+    [ARTPaginatedResult executePaginated:self->_rest withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:nil logger:self->_logger callback:callback];
 });
 }
 

--- a/Source/ARTPushDeviceRegistrations.m
+++ b/Source/ARTPushDeviceRegistrations.m
@@ -25,23 +25,23 @@
 }
 
 - (void)save:(ARTDeviceDetails *)deviceDetails callback:(ARTCallback)callback {
-    [_internal save:deviceDetails callback:callback];
+    [_internal save:deviceDetails wrapperSDKAgents:nil callback:callback];
 }
 
 - (void)get:(ARTDeviceId *)deviceId callback:(void (^)(ARTDeviceDetails *_Nullable,  ARTErrorInfo *_Nullable))callback {
-    [_internal get:deviceId callback:callback];
+    [_internal get:deviceId wrapperSDKAgents:nil callback:callback];
 }
 
 - (void)list:(NSStringDictionary *)params callback:(ARTPaginatedDeviceDetailsCallback)callback {
-    [_internal list:params callback:callback];
+    [_internal list:params wrapperSDKAgents:nil callback:callback];
 }
 
 - (void)remove:(NSString *)deviceId callback:(ARTCallback)callback {
-    [_internal remove:deviceId callback:callback];
+    [_internal remove:deviceId wrapperSDKAgents:nil callback:callback];
 }
 
 - (void)removeWhere:(NSStringDictionary *)params callback:(ARTCallback)callback {
-    [_internal removeWhere:params callback:callback];
+    [_internal removeWhere:params wrapperSDKAgents:nil callback:callback];
 }
 
 @end
@@ -63,7 +63,7 @@
     return self;
 }
 
-- (void)save:(ARTDeviceDetails *)deviceDetails callback:(ARTCallback)callback {
+- (void)save:(ARTDeviceDetails *)deviceDetails wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTCallback)callback {
     if (callback) {
         ARTCallback userCallback = callback;
         callback = ^(ARTErrorInfo *error) {
@@ -91,7 +91,7 @@ dispatch_async(_queue, ^{
     [request setDeviceAuthentication:deviceDetails.id localDevice:local logger:self->_logger];
 
     ARTLogDebug(self->_logger, @"save device with request %@", request);
-    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (response.statusCode == 200 /*OK*/) {
             NSError *decodeError = nil;
             ARTDeviceDetails *deviceDetails = [[self->_rest defaultEncoder] decodeDeviceDetails:data error:&decodeError];
@@ -117,7 +117,7 @@ dispatch_async(_queue, ^{
 });
 }
 
-- (void)get:(ARTDeviceId *)deviceId callback:(void (^)(ARTDeviceDetails *, ARTErrorInfo *))callback {
+- (void)get:(ARTDeviceId *)deviceId wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(void (^)(ARTDeviceDetails *, ARTErrorInfo *))callback {
     if (callback) {
         void (^userCallback)(ARTDeviceDetails *, ARTErrorInfo *error) = callback;
         callback = ^(ARTDeviceDetails *device, ARTErrorInfo *error) {
@@ -139,7 +139,7 @@ dispatch_async(_queue, ^{
     [request setDeviceAuthentication:deviceId localDevice:local logger:self->_logger];
 
     ARTLogDebug(self->_logger, @"get device with request %@", request);
-    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (response.statusCode == 200 /*OK*/) {
             NSError *decodeError = nil;
             ARTDeviceDetails *device = [self->_rest.encoders[response.MIMEType] decodeDeviceDetails:data error:&decodeError];
@@ -169,7 +169,7 @@ dispatch_async(_queue, ^{
 });
 }
 
-- (void)list:(NSStringDictionary *)params callback:(ARTPaginatedDeviceDetailsCallback)callback {
+- (void)list:(NSStringDictionary *)params wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTPaginatedDeviceDetailsCallback)callback {
     if (callback) {
         void (^userCallback)(ARTPaginatedResult *, ARTErrorInfo *error) = callback;
         callback = ^(ARTPaginatedResult *result, ARTErrorInfo *error) {
@@ -188,11 +188,11 @@ dispatch_async(_queue, ^{
     ARTPaginatedResultResponseProcessor responseProcessor = ^(NSHTTPURLResponse *response, NSData *data, NSError **error) {
         return [self->_rest.encoders[response.MIMEType] decodeDevicesDetails:data error:error];
     };
-    [ARTPaginatedResult executePaginated:self->_rest withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:nil logger:self->_logger callback:callback];
+    [ARTPaginatedResult executePaginated:self->_rest withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:wrapperSDKAgents logger:self->_logger callback:callback];
 });
 }
 
-- (void)remove:(NSString *)deviceId callback:(ARTCallback)callback {
+- (void)remove:(NSString *)deviceId wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTCallback)callback {
     if (callback) {
         ARTCallback userCallback = callback;
         callback = ^(ARTErrorInfo *error) {
@@ -212,7 +212,7 @@ dispatch_async(_queue, ^{
     [request setValue:[[self->_rest defaultEncoder] mimeType] forHTTPHeaderField:@"Content-Type"];
 
     ARTLogDebug(self->_logger, @"remove device with request %@", request);
-    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (response.statusCode == 200 /*Ok*/ || response.statusCode == 204 /*not returning any content*/) {
             ARTLogDebug(self->_logger, @"%@: save device successfully", NSStringFromClass(self.class));
             callback(nil);
@@ -230,7 +230,7 @@ dispatch_async(_queue, ^{
 });
 }
 
-- (void)removeWhere:(NSStringDictionary *)params callback:(ARTCallback)callback {
+- (void)removeWhere:(NSStringDictionary *)params wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTCallback)callback {
     if (callback) {
         ARTCallback userCallback = callback;
         callback = ^(ARTErrorInfo *error) {
@@ -257,7 +257,7 @@ dispatch_async(_queue, ^{
     [request setDeviceAuthentication:[params objectForKey:@"deviceId"] localDevice:local];
 
     ARTLogDebug(self->_logger, @"remove devices with request %@", request);
-    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (response.statusCode == 200 /*Ok*/ || response.statusCode == 204 /*not returning any content*/) {
             ARTLogDebug(self->_logger, @"%@: remove devices successfully", NSStringFromClass(self.class));
             callback(nil);

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -169,11 +169,12 @@
 }
 
 - (BOOL)stats:(ARTPaginatedStatsCallback)callback {
-    return [_internal stats:callback];
+    return [_internal statsWithWrapperSDKAgents:nil
+                                       callback:callback];
 }
 
 - (BOOL)stats:(nullable ARTStatsQuery *)query callback:(ARTPaginatedStatsCallback)callback error:(NSError **)errorPtr {
-    return [_internal stats:query callback:callback error:errorPtr];
+    return [_internal stats:query wrapperSDKAgents:nil callback:callback error:errorPtr];
 }
 
 - (void)connect {
@@ -556,12 +557,13 @@ wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
     });
 }
 
-- (BOOL)stats:(ARTPaginatedStatsCallback)callback {
-    return [self stats:[[ARTStatsQuery alloc] init] callback:callback error:nil];
+- (BOOL)statsWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                         callback:(ARTPaginatedStatsCallback)callback {
+               return [self stats:[[ARTStatsQuery alloc] init] wrapperSDKAgents:wrapperSDKAgents callback:callback error:nil];
 }
 
-- (BOOL)stats:(ARTStatsQuery *)query callback:(ARTPaginatedStatsCallback)callback error:(NSError **)errorPtr {
-    return [self.rest stats:query callback:callback error:errorPtr];
+- (BOOL)stats:(ARTStatsQuery *)query wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTPaginatedStatsCallback)callback error:(NSError **)errorPtr {
+    return [self.rest stats:query wrapperSDKAgents:wrapperSDKAgents callback:callback error:errorPtr];
 }
 
 - (void)performTransitionToDisconnectedOrSuspendedWithParams:(ARTConnectionStateChangeParams *)params {

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -150,7 +150,8 @@
 }
 
 - (void)time:(ARTDateTimeCallback)cb {
-    [_internal time:cb];
+    [_internal timeWithWrapperSDKAgents:nil
+                             completion:cb];
 }
 
 - (BOOL)request:(NSString *)method
@@ -501,8 +502,10 @@ const NSTimeInterval _immediateReconnectionDelay = 0.1;
     }
 }
 
-- (void)time:(ARTDateTimeCallback)cb {
-    [self.rest time:cb];
+- (void)timeWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                      completion:(ARTDateTimeCallback)cb {
+    [self.rest timeWithWrapperSDKAgents:wrapperSDKAgents
+                             completion:cb];
 }
 
 - (BOOL)request:(NSString *)method

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -130,7 +130,7 @@
 }
 
 - (void)history:(ARTPaginatedMessagesCallback)callback {
-    [_internal history:callback];
+    [_internal historyWithWrapperSDKAgents:nil completion:callback];
 }
 
 - (BOOL)exceedMaxSize:(NSArray<ARTBaseMessage *> *)messages {
@@ -182,7 +182,7 @@
 }
 
 - (BOOL)history:(ARTRealtimeHistoryQuery *_Nullable)query callback:(ARTPaginatedMessagesCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr {
-    return [_internal history:query callback:callback error:errorPtr];
+    return [_internal history:query wrapperSDKAgents:nil callback:callback error:errorPtr];
 }
 
 - (ARTEventListener *)on:(ARTChannelStateCallback)cb {
@@ -1043,13 +1043,14 @@ dispatch_sync(_queue, ^{
     return self.realtime.auth.clientId_nosync;
 }
 
-- (void)history:(ARTPaginatedMessagesCallback)callback {
-    [self history:[[ARTRealtimeHistoryQuery alloc] init] callback:callback error:nil];
+- (void)historyWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                         completion:(ARTPaginatedMessagesCallback)callback {
+    [self history:[[ARTRealtimeHistoryQuery alloc] init] wrapperSDKAgents:wrapperSDKAgents callback:callback error:nil];
 }
 
-- (BOOL)history:(ARTRealtimeHistoryQuery *)query callback:(ARTPaginatedMessagesCallback)callback error:(NSError **)errorPtr {
+- (BOOL)history:(ARTRealtimeHistoryQuery *)query wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTPaginatedMessagesCallback)callback error:(NSError **)errorPtr {
     query.realtimeChannel = self;
-    return [_restChannel history:query callback:callback error:errorPtr];
+    return [_restChannel history:query wrapperSDKAgents:wrapperSDKAgents callback:callback error:errorPtr];
 }
 
 - (void)startDecodeFailureRecoveryWithErrorInfo:(ARTErrorInfo *)error {

--- a/Source/ARTRealtimePresence.m
+++ b/Source/ARTRealtimePresence.m
@@ -134,11 +134,11 @@
 }
 
 - (void)history:(ARTPaginatedPresenceCallback)callback {
-    [_internal history:callback];
+    [_internal historyWithWrapperSDKAgents:nil completion:callback];
 }
 
 - (BOOL)history:(ARTRealtimeHistoryQuery *_Nullable)query callback:(ARTPaginatedPresenceCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr {
-    return [_internal history:query callback:callback error:errorPtr];
+    return [_internal history:query wrapperSDKAgents:nil callback:callback error:errorPtr];
 }
 
 @end
@@ -272,13 +272,14 @@ dispatch_async(_queue, ^{
 
 // RTP12
 
-- (void)history:(ARTPaginatedPresenceCallback)callback {
-    [self history:[[ARTRealtimeHistoryQuery alloc] init] callback:callback error:nil];
+- (void)historyWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                         completion:(ARTPaginatedPresenceCallback)callback {
+    [self history:[[ARTRealtimeHistoryQuery alloc] init] wrapperSDKAgents:wrapperSDKAgents callback:callback error:nil];
 }
 
-- (BOOL)history:(ARTRealtimeHistoryQuery *)query callback:(ARTPaginatedPresenceCallback)callback error:(NSError **)errorPtr {
+- (BOOL)history:(ARTRealtimeHistoryQuery *)query wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTPaginatedPresenceCallback)callback error:(NSError **)errorPtr {
     query.realtimeChannel = _channel;
-    return [_channel.restChannel.presence history:query callback:callback error:errorPtr];
+    return [_channel.restChannel.presence history:query wrapperSDKAgents:wrapperSDKAgents callback:callback error:errorPtr];
 }
 
 // RTP8

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -102,7 +102,8 @@
 }
 
 - (void)time:(ARTDateTimeCallback)callback {
-    [_internal time:callback];
+    [_internal timeWithWrapperSDKAgents:nil
+                             completion:callback];
 }
 
 - (BOOL)request:(NSString *)method
@@ -525,7 +526,8 @@ NS_ASSUME_NONNULL_END
     return [NSString stringWithFormat:@"Bearer %@", token];
 }
 
-- (void)time:(ARTDateTimeCallback)callback {
+- (void)timeWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                      completion:(ARTDateTimeCallback)callback {
     if (callback) {
         ARTDateTimeCallback userCallback = callback;
         callback = ^(NSDate *time, NSError *error) {
@@ -535,18 +537,20 @@ NS_ASSUME_NONNULL_END
         };
     }
     dispatch_async(_queue, ^{
-        [self _time:callback];
+        [self _timeWithWrapperSDKAgents:wrapperSDKAgents
+                             completion:callback];
     });
 }
 
-- (NSObject<ARTCancellable> *)_time:(ARTDateTimeCallback)callback {
+- (NSObject<ARTCancellable> *)_timeWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                                             completion:(ARTDateTimeCallback)callback {
     NSURL *requestUrl = [NSURL URLWithString:@"/time" relativeToURL:self.baseUrl];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestUrl];
     request.HTTPMethod = @"GET";
     NSString *accept = [[_encoders.allValues valueForKeyPath:@"mimeType"] componentsJoinedByString:@","];
     [request setValue:accept forHTTPHeaderField:@"Accept"];
     
-    return [self executeRequest:request withAuthOption:ARTAuthenticationOff wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    return [self executeRequest:request withAuthOption:ARTAuthenticationOff wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             callback(nil, error);
             return;

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -727,7 +727,7 @@ wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
     };
     
 dispatch_async(_queue, ^{
-    [ARTPaginatedResult executePaginated:self withRequest:request andResponseProcessor:responseProcessor logger:self.logger callback:callback];
+    [ARTPaginatedResult executePaginated:self withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:nil logger:self.logger callback:callback];
 });
     return YES;
 }

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -117,11 +117,12 @@
 }
 
 - (BOOL)stats:(ARTPaginatedStatsCallback)callback {
-    return [_internal stats:callback];
+    return [_internal statsWithWrapperSDKAgents:nil
+                                     completion:callback];
 }
 
 - (BOOL)stats:(nullable ARTStatsQuery *)query callback:(ARTPaginatedStatsCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr {
-    return [_internal stats:query callback:callback error:errorPtr];
+    return [_internal stats:query wrapperSDKAgents:nil callback:callback error:errorPtr];
 }
 
 - (ARTRestChannels *)channels {
@@ -680,11 +681,12 @@ wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
     }];
 }
 
-- (BOOL)stats:(ARTPaginatedStatsCallback)callback {
-    return [self stats:[[ARTStatsQuery alloc] init] callback:callback error:nil];
+- (BOOL)statsWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                       completion:(ARTPaginatedStatsCallback)callback {
+    return [self stats:[[ARTStatsQuery alloc] init] wrapperSDKAgents:wrapperSDKAgents callback:callback error:nil];
 }
 
-- (BOOL)stats:(ARTStatsQuery *)query callback:(ARTPaginatedStatsCallback)callback error:(NSError **)errorPtr {
+- (BOOL)stats:(ARTStatsQuery *)query wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTPaginatedStatsCallback)callback error:(NSError **)errorPtr {
     if (callback) {
         ARTPaginatedStatsCallback userCallback = callback;
         callback = ^(ARTPaginatedResult<ARTStats *> *r, ARTErrorInfo *e) {
@@ -727,7 +729,7 @@ wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
     };
     
 dispatch_async(_queue, ^{
-    [ARTPaginatedResult executePaginated:self withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:nil logger:self.logger callback:callback];
+    [ARTPaginatedResult executePaginated:self withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:wrapperSDKAgents logger:self.logger callback:callback];
 });
     return YES;
 }

--- a/Source/ARTRestChannel.m
+++ b/Source/ARTRestChannel.m
@@ -210,7 +210,7 @@ dispatch_sync(_queue, ^{
     };
 
     ARTLogDebug(self.logger, @"RS:%p C:%p (%@) stats request %@", self->_rest, self, self.name, request);
-    [ARTPaginatedResult executePaginated:self->_rest withRequest:request andResponseProcessor:responseProcessor logger:self.logger callback:callback];
+    [ARTPaginatedResult executePaginated:self->_rest withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:nil logger:self.logger callback:callback];
     ret = YES;
 });
     return ret;

--- a/Source/ARTRestChannel.m
+++ b/Source/ARTRestChannel.m
@@ -45,7 +45,7 @@
 }
 
 - (BOOL)history:(nullable ARTDataQuery *)query callback:(ARTPaginatedMessagesCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr {
-    return [_internal history:query callback:callback error:errorPtr];
+    return [_internal history:query wrapperSDKAgents:nil callback:callback error:errorPtr];
 }
 
 - (void)status:(ARTChannelDetailsCallback)callback {
@@ -93,7 +93,7 @@
 }
 
 - (void)history:(ARTPaginatedMessagesCallback)callback {
-    [_internal history:callback];
+    [_internal historyWithWrapperSDKAgents:nil completion:callback];
 }
 
 - (ARTChannelOptions *)options {
@@ -148,11 +148,11 @@ static const NSUInteger kIdempotentLibraryGeneratedIdLength = 9; //bytes
     return _pushChannel;
 }
 
-- (void)history:(ARTPaginatedMessagesCallback)callback {
-    [self history:[[ARTDataQuery alloc] init] callback:callback error:nil];
+- (void)historyWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents completion:(ARTPaginatedMessagesCallback)callback {
+    [self history:[[ARTDataQuery alloc] init] wrapperSDKAgents:wrapperSDKAgents callback:callback error:nil];
 }
 
-- (BOOL)history:(ARTDataQuery *)query callback:(ARTPaginatedMessagesCallback)callback error:(NSError * __autoreleasing *)errorPtr {
+- (BOOL)history:(ARTDataQuery *)query wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTPaginatedMessagesCallback)callback error:(NSError * __autoreleasing *)errorPtr {
     if (callback) {
         void (^userCallback)(ARTPaginatedResult<ARTMessage *> *result, ARTErrorInfo *error) = callback;
         callback = ^(ARTPaginatedResult<ARTMessage *> *result, ARTErrorInfo *error) {
@@ -210,7 +210,7 @@ dispatch_sync(_queue, ^{
     };
 
     ARTLogDebug(self.logger, @"RS:%p C:%p (%@) stats request %@", self->_rest, self, self.name, request);
-    [ARTPaginatedResult executePaginated:self->_rest withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:nil logger:self.logger callback:callback];
+    [ARTPaginatedResult executePaginated:self->_rest withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:wrapperSDKAgents logger:self.logger callback:callback];
     ret = YES;
 });
     return ret;

--- a/Source/ARTRestPresence.m
+++ b/Source/ARTRestPresence.m
@@ -77,11 +77,11 @@
 }
 
 - (BOOL)history:(nullable ARTDataQuery *)query callback:(ARTPaginatedPresenceCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr {
-    return [_internal history:query callback:callback error:errorPtr];
+    return [_internal history:query wrapperSDKAgents:nil callback:callback error:errorPtr];
 }
 
 - (void)history:(ARTPaginatedPresenceCallback)callback {
-    [_internal history:callback];
+    [_internal historyWithWrapperSDKAgents:nil completion:callback];
 }
 
 @end
@@ -161,11 +161,12 @@ dispatch_async(_queue, ^{
     return YES;
 }
 
-- (void)history:(ARTPaginatedPresenceCallback)callback {
-    [self history:[[ARTDataQuery alloc] init] callback:callback error:nil];
+- (void)historyWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                         completion:(ARTPaginatedPresenceCallback)callback {
+    [self history:[[ARTDataQuery alloc] init] wrapperSDKAgents:wrapperSDKAgents callback:callback error:nil];
 }
 
-- (BOOL)history:(ARTDataQuery *)query callback:(ARTPaginatedPresenceCallback)callback error:(NSError **)errorPtr {
+- (BOOL)history:(ARTDataQuery *)query wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTPaginatedPresenceCallback)callback error:(NSError **)errorPtr {
     if (callback) {
         void (^userCallback)(ARTPaginatedResult<ARTPresenceMessage *> *result, ARTErrorInfo *error) = callback;
         callback = ^(ARTPaginatedResult<ARTPresenceMessage *> *result, ARTErrorInfo *error) {
@@ -217,7 +218,7 @@ dispatch_async(_queue, ^{
     };
 
 dispatch_async(_queue, ^{
-    [ARTPaginatedResult executePaginated:self->_channel.rest withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:nil logger:self->_logger callback:callback];
+    [ARTPaginatedResult executePaginated:self->_channel.rest withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:wrapperSDKAgents logger:self->_logger callback:callback];
 });
     return YES;
 }

--- a/Source/ARTRestPresence.m
+++ b/Source/ARTRestPresence.m
@@ -156,7 +156,7 @@ NS_ASSUME_NONNULL_END
     };
 
 dispatch_async(_queue, ^{
-    [ARTPaginatedResult executePaginated:self->_channel.rest withRequest:request andResponseProcessor:responseProcessor logger:self->_logger callback:callback];
+    [ARTPaginatedResult executePaginated:self->_channel.rest withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:nil logger:self->_logger callback:callback];
 });
     return YES;
 }
@@ -217,7 +217,7 @@ dispatch_async(_queue, ^{
     };
 
 dispatch_async(_queue, ^{
-    [ARTPaginatedResult executePaginated:self->_channel.rest withRequest:request andResponseProcessor:responseProcessor logger:self->_logger callback:callback];
+    [ARTPaginatedResult executePaginated:self->_channel.rest withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:nil logger:self->_logger callback:callback];
 });
     return YES;
 }

--- a/Source/ARTWrapperSDKProxyPush.m
+++ b/Source/ARTWrapperSDKProxyPush.m
@@ -1,4 +1,5 @@
 #import "ARTWrapperSDKProxyPush+Private.h"
+#import "ARTWrapperSDKProxyPushAdmin+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,13 +18,11 @@ NS_ASSUME_NONNULL_END
     if (self = [super init]) {
         _underlyingPush = push;
         _proxyOptions = proxyOptions;
+        _admin = [[ARTWrapperSDKProxyPushAdmin alloc] initWithPushAdmin:push.admin
+                                                           proxyOptions:proxyOptions];
     }
 
     return self;
-}
-
-- (ARTPushAdmin *)admin {
-    return self.underlyingPush.admin;
 }
 
 #if TARGET_OS_IOS

--- a/Source/ARTWrapperSDKProxyPush.m
+++ b/Source/ARTWrapperSDKProxyPush.m
@@ -1,0 +1,73 @@
+#import "ARTWrapperSDKProxyPush+Private.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARTWrapperSDKProxyPush ()
+
+@property (nonatomic, readonly) ARTPush *underlyingPush;
+@property (nonatomic, readonly) ARTWrapperSDKProxyOptions *proxyOptions;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+@implementation ARTWrapperSDKProxyPush
+
+- (instancetype)initWithPush:(ARTPush *)push proxyOptions:(ARTWrapperSDKProxyOptions *)proxyOptions {
+    if (self = [super init]) {
+        _underlyingPush = push;
+        _proxyOptions = proxyOptions;
+    }
+
+    return self;
+}
+
+- (ARTPushAdmin *)admin {
+    return self.underlyingPush.admin;
+}
+
+#if TARGET_OS_IOS
+
+- (void)activate {
+    [self.underlyingPush activate];
+}
+
+- (void)deactivate {
+    [self.underlyingPush deactivate];
+}
+
++ (void)didFailToRegisterForLocationNotificationsWithError:(nonnull NSError *)error realtime:(nonnull ARTRealtime *)realtime {
+    [ARTPush didFailToRegisterForLocationNotificationsWithError:error realtime:realtime];
+}
+
++ (void)didFailToRegisterForLocationNotificationsWithError:(nonnull NSError *)error rest:(nonnull ARTRest *)rest {
+    [ARTPush didFailToRegisterForLocationNotificationsWithError:error rest:rest];
+}
+
++ (void)didFailToRegisterForRemoteNotificationsWithError:(nonnull NSError *)error realtime:(nonnull ARTRealtime *)realtime {
+    [ARTPush didFailToRegisterForRemoteNotificationsWithError:error realtime:realtime];
+}
+
++ (void)didFailToRegisterForRemoteNotificationsWithError:(nonnull NSError *)error rest:(nonnull ARTRest *)rest {
+    [ARTPush didFailToRegisterForRemoteNotificationsWithError:error rest:rest];
+}
+
++ (void)didRegisterForLocationNotificationsWithDeviceToken:(nonnull NSData *)deviceToken realtime:(nonnull ARTRealtime *)realtime {
+    [ARTPush didRegisterForLocationNotificationsWithDeviceToken:deviceToken realtime:realtime];
+}
+
++ (void)didRegisterForLocationNotificationsWithDeviceToken:(nonnull NSData *)deviceToken rest:(nonnull ARTRest *)rest {
+    [ARTPush didRegisterForLocationNotificationsWithDeviceToken:deviceToken rest:rest];
+}
+
++ (void)didRegisterForRemoteNotificationsWithDeviceToken:(nonnull NSData *)deviceToken realtime:(nonnull ARTRealtime *)realtime {
+    [ARTPush didRegisterForRemoteNotificationsWithDeviceToken:deviceToken realtime:realtime];
+}
+
++ (void)didRegisterForRemoteNotificationsWithDeviceToken:(nonnull NSData *)deviceToken rest:(nonnull ARTRest *)rest {
+    [ARTPush didRegisterForRemoteNotificationsWithDeviceToken:deviceToken rest:rest];
+}
+
+#endif
+
+@end

--- a/Source/ARTWrapperSDKProxyPushAdmin.m
+++ b/Source/ARTWrapperSDKProxyPushAdmin.m
@@ -1,6 +1,8 @@
 #import "ARTWrapperSDKProxyPushAdmin+Private.h"
 #import "ARTPushAdmin+Private.h"
 #import "ARTWrapperSDKProxyOptions.h"
+#import "ARTWrapperSDKProxyPushDeviceRegistrations+Private.h"
+#import "ARTWrapperSDKProxyPushChannelSubscriptions+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,17 +21,13 @@ NS_ASSUME_NONNULL_END
     if (self = [super init]) {
         _underlyingPushAdmin = pushAdmin;
         _proxyOptions = proxyOptions;
+        _deviceRegistrations = [[ARTWrapperSDKProxyPushDeviceRegistrations alloc] initWithPushDeviceRegistrations:pushAdmin.deviceRegistrations
+                                                                                                     proxyOptions:proxyOptions];
+        _channelSubscriptions = [[ARTWrapperSDKProxyPushChannelSubscriptions alloc] initWithPushChannelSubscriptions:pushAdmin.channelSubscriptions
+                                                                                                        proxyOptions:proxyOptions];
     }
 
     return self;
-}
-
-- (ARTPushDeviceRegistrations *)deviceRegistrations {
-    return self.underlyingPushAdmin.deviceRegistrations;
-}
-
-- (ARTPushChannelSubscriptions *)channelSubscriptions {
-    return self.underlyingPushAdmin.channelSubscriptions;
 }
 
 - (void)publish:(nonnull ARTPushRecipient *)recipient data:(nonnull ARTJsonObject *)data callback:(nullable ARTCallback)callback {

--- a/Source/ARTWrapperSDKProxyPushAdmin.m
+++ b/Source/ARTWrapperSDKProxyPushAdmin.m
@@ -1,0 +1,39 @@
+#import "ARTWrapperSDKProxyPushAdmin+Private.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARTWrapperSDKProxyPushAdmin ()
+
+@property (nonatomic, readonly) ARTPushAdmin *underlyingPushAdmin;
+@property (nonatomic, readonly) ARTWrapperSDKProxyOptions *proxyOptions;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+@implementation ARTWrapperSDKProxyPushAdmin
+
+- (instancetype)initWithPushAdmin:(ARTPushAdmin *)pushAdmin proxyOptions:(ARTWrapperSDKProxyOptions *)proxyOptions {
+    if (self = [super init]) {
+        _underlyingPushAdmin = pushAdmin;
+        _proxyOptions = proxyOptions;
+    }
+
+    return self;
+}
+
+- (ARTPushDeviceRegistrations *)deviceRegistrations {
+    return self.underlyingPushAdmin.deviceRegistrations;
+}
+
+- (ARTPushChannelSubscriptions *)channelSubscriptions {
+    return self.underlyingPushAdmin.channelSubscriptions;
+}
+
+- (void)publish:(nonnull ARTPushRecipient *)recipient data:(nonnull ARTJsonObject *)data callback:(nullable ARTCallback)callback {
+    [self.underlyingPushAdmin publish:recipient
+                                 data:data
+                             callback:callback];
+}
+
+@end

--- a/Source/ARTWrapperSDKProxyPushAdmin.m
+++ b/Source/ARTWrapperSDKProxyPushAdmin.m
@@ -1,4 +1,6 @@
 #import "ARTWrapperSDKProxyPushAdmin+Private.h"
+#import "ARTPushAdmin+Private.h"
+#import "ARTWrapperSDKProxyOptions.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -31,9 +33,10 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)publish:(nonnull ARTPushRecipient *)recipient data:(nonnull ARTJsonObject *)data callback:(nullable ARTCallback)callback {
-    [self.underlyingPushAdmin publish:recipient
-                                 data:data
-                             callback:callback];
+    [self.underlyingPushAdmin.internal publish:recipient
+                                          data:data
+                              wrapperSDKAgents:self.proxyOptions.agents
+                                      callback:callback];
 }
 
 @end

--- a/Source/ARTWrapperSDKProxyPushChannel.m
+++ b/Source/ARTWrapperSDKProxyPushChannel.m
@@ -1,0 +1,61 @@
+#import "ARTWrapperSDKProxyPushChannel+Private.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARTWrapperSDKProxyPushChannel ()
+
+@property (nonatomic, readonly) ARTPushChannel *underlyingPushChannel;
+@property (nonatomic, readonly) ARTWrapperSDKProxyOptions *proxyOptions;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+@implementation ARTWrapperSDKProxyPushChannel
+
+- (instancetype)initWithPushChannel:(ARTPushChannel *)pushChannel proxyOptions:(ARTWrapperSDKProxyOptions *)proxyOptions {
+    if (self = [super init]) {
+        _underlyingPushChannel = pushChannel;
+        _proxyOptions = proxyOptions;
+    }
+
+    return self;
+}
+
+- (BOOL)listSubscriptions:(nonnull NSStringDictionary *)params callback:(nonnull ARTPaginatedPushChannelCallback)callback error:(NSError * _Nullable __autoreleasing * _Nullable)errorPtr {
+    return [self.underlyingPushChannel listSubscriptions:params callback:callback error:errorPtr];
+}
+
+- (void)subscribeClient {
+    [self.underlyingPushChannel subscribeClient];
+}
+
+- (void)subscribeClient:(nullable ARTCallback)callback {
+    [self.underlyingPushChannel subscribeClient:callback];
+}
+
+- (void)subscribeDevice {
+    [self.underlyingPushChannel subscribeDevice];
+}
+
+- (void)subscribeDevice:(nullable ARTCallback)callback {
+    [self.underlyingPushChannel subscribeDevice:callback];
+}
+
+- (void)unsubscribeClient {
+    [self.underlyingPushChannel unsubscribeClient];
+}
+
+- (void)unsubscribeClient:(nullable ARTCallback)callback {
+    [self.underlyingPushChannel unsubscribeClient:callback];
+}
+
+- (void)unsubscribeDevice {
+    [self.underlyingPushChannel unsubscribeDevice];
+}
+
+- (void)unsubscribeDevice:(nullable ARTCallback)callback {
+    [self.underlyingPushChannel unsubscribeDevice:callback];
+}
+
+@end

--- a/Source/ARTWrapperSDKProxyPushChannel.m
+++ b/Source/ARTWrapperSDKProxyPushChannel.m
@@ -1,4 +1,6 @@
 #import "ARTWrapperSDKProxyPushChannel+Private.h"
+#import "ARTPushChannel+Private.h"
+#import "ARTWrapperSDKProxyOptions.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -27,35 +29,39 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)subscribeClient {
-    [self.underlyingPushChannel subscribeClient];
+    [self.underlyingPushChannel.internal subscribeClientWithWrapperSDKAgents:self.proxyOptions.agents];
 }
 
 - (void)subscribeClient:(nullable ARTCallback)callback {
-    [self.underlyingPushChannel subscribeClient:callback];
+    [self.underlyingPushChannel.internal subscribeClientWithWrapperSDKAgents:self.proxyOptions.agents
+                                                                  completion:callback];
 }
 
 - (void)subscribeDevice {
-    [self.underlyingPushChannel subscribeDevice];
+    [self.underlyingPushChannel.internal subscribeDeviceWithWrapperSDKAgents:self.proxyOptions.agents];
 }
 
 - (void)subscribeDevice:(nullable ARTCallback)callback {
-    [self.underlyingPushChannel subscribeDevice:callback];
+    [self.underlyingPushChannel.internal subscribeDeviceWithWrapperSDKAgents:self.proxyOptions.agents
+                                                                  completion:callback];
 }
 
 - (void)unsubscribeClient {
-    [self.underlyingPushChannel unsubscribeClient];
+    [self.underlyingPushChannel.internal unsubscribeClientWithWrapperSDKAgents:self.proxyOptions.agents];
 }
 
 - (void)unsubscribeClient:(nullable ARTCallback)callback {
-    [self.underlyingPushChannel unsubscribeClient:callback];
+    [self.underlyingPushChannel.internal unsubscribeClientWithWrapperSDKAgents:self.proxyOptions.agents
+                                                                    completion:callback];
 }
 
 - (void)unsubscribeDevice {
-    [self.underlyingPushChannel unsubscribeDevice];
+    [self.underlyingPushChannel.internal unsubscribeDeviceWithWrapperSDKAgents:self.proxyOptions.agents];
 }
 
 - (void)unsubscribeDevice:(nullable ARTCallback)callback {
-    [self.underlyingPushChannel unsubscribeDevice:callback];
+    [self.underlyingPushChannel.internal unsubscribeDeviceWithWrapperSDKAgents:self.proxyOptions.agents
+                                                                    completion:callback];
 }
 
 @end

--- a/Source/ARTWrapperSDKProxyPushChannelSubscriptions.m
+++ b/Source/ARTWrapperSDKProxyPushChannelSubscriptions.m
@@ -1,4 +1,6 @@
 #import "ARTWrapperSDKProxyPushChannelSubscriptions+Private.h"
+#import "ARTWrapperSDKProxyOptions.h"
+#import "ARTPushChannelSubscriptions+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -23,27 +25,32 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)list:(nonnull NSStringDictionary *)params callback:(nonnull ARTPaginatedPushChannelCallback)callback {
-    [self.underlyingPushChannelSubscriptions list:params
-                                         callback:callback];
+    [self.underlyingPushChannelSubscriptions.internal list:params
+                                          wrapperSDKAgents:self.proxyOptions.agents
+                                                  callback:callback];
 }
 
 - (void)listChannels:(nonnull ARTPaginatedTextCallback)callback {
-    [self.underlyingPushChannelSubscriptions listChannels:callback];
+    [self.underlyingPushChannelSubscriptions.internal listChannelsWithWrapperSDKAgents:self.proxyOptions.agents
+                                                                            completion:callback];
 }
 
 - (void)remove:(nonnull ARTPushChannelSubscription *)subscription callback:(nonnull ARTCallback)callback {
-    [self.underlyingPushChannelSubscriptions remove:subscription
-                                           callback:callback];
+    [self.underlyingPushChannelSubscriptions.internal remove:subscription
+                                            wrapperSDKAgents:self.proxyOptions.agents
+                                                    callback:callback];
 }
 
 - (void)removeWhere:(nonnull NSStringDictionary *)params callback:(nonnull ARTCallback)callback {
-    [self.underlyingPushChannelSubscriptions removeWhere:params
-                                                callback:callback];
+    [self.underlyingPushChannelSubscriptions.internal removeWhere:params
+                                                 wrapperSDKAgents:self.proxyOptions.agents
+                                                         callback:callback];
 }
 
 - (void)save:(nonnull ARTPushChannelSubscription *)channelSubscription callback:(nonnull ARTCallback)callback {
-    [self.underlyingPushChannelSubscriptions save:channelSubscription
-                                         callback:callback];
+    [self.underlyingPushChannelSubscriptions.internal save:channelSubscription
+                                          wrapperSDKAgents:self.proxyOptions.agents
+                                                  callback:callback];
 }
 
 @end

--- a/Source/ARTWrapperSDKProxyPushChannelSubscriptions.m
+++ b/Source/ARTWrapperSDKProxyPushChannelSubscriptions.m
@@ -1,0 +1,49 @@
+#import "ARTWrapperSDKProxyPushChannelSubscriptions+Private.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARTWrapperSDKProxyPushChannelSubscriptions ()
+
+@property (nonatomic, readonly) ARTPushChannelSubscriptions *underlyingPushChannelSubscriptions;
+@property (nonatomic, readonly) ARTWrapperSDKProxyOptions *proxyOptions;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+@implementation ARTWrapperSDKProxyPushChannelSubscriptions
+
+- (instancetype)initWithPushChannelSubscriptions:(ARTPushChannelSubscriptions *)pushChannelSubscriptions proxyOptions:(ARTWrapperSDKProxyOptions *)proxyOptions {
+    if (self = [super init]) {
+        _underlyingPushChannelSubscriptions = pushChannelSubscriptions;
+        _proxyOptions = proxyOptions;
+    }
+
+    return self;
+}
+
+- (void)list:(nonnull NSStringDictionary *)params callback:(nonnull ARTPaginatedPushChannelCallback)callback {
+    [self.underlyingPushChannelSubscriptions list:params
+                                         callback:callback];
+}
+
+- (void)listChannels:(nonnull ARTPaginatedTextCallback)callback {
+    [self.underlyingPushChannelSubscriptions listChannels:callback];
+}
+
+- (void)remove:(nonnull ARTPushChannelSubscription *)subscription callback:(nonnull ARTCallback)callback {
+    [self.underlyingPushChannelSubscriptions remove:subscription
+                                           callback:callback];
+}
+
+- (void)removeWhere:(nonnull NSStringDictionary *)params callback:(nonnull ARTCallback)callback {
+    [self.underlyingPushChannelSubscriptions removeWhere:params
+                                                callback:callback];
+}
+
+- (void)save:(nonnull ARTPushChannelSubscription *)channelSubscription callback:(nonnull ARTCallback)callback {
+    [self.underlyingPushChannelSubscriptions save:channelSubscription
+                                         callback:callback];
+}
+
+@end

--- a/Source/ARTWrapperSDKProxyPushDeviceRegistrations.m
+++ b/Source/ARTWrapperSDKProxyPushDeviceRegistrations.m
@@ -1,4 +1,6 @@
 #import "ARTWrapperSDKProxyPushDeviceRegistrations+Private.h"
+#import "ARTWrapperSDKProxyOptions.h"
+#import "ARTPushDeviceRegistrations+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -23,28 +25,33 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)get:(nonnull ARTDeviceId *)deviceId callback:(nonnull void (^)(ARTDeviceDetails * _Nullable, ARTErrorInfo * _Nullable))callback {
-    [self.underlyingPushDeviceRegistrations get:deviceId
-                                       callback:callback];
+    [self.underlyingPushDeviceRegistrations.internal get:deviceId
+                                        wrapperSDKAgents:self.proxyOptions.agents
+                                                callback:callback];
 }
 
 - (void)list:(nonnull NSStringDictionary *)params callback:(nonnull ARTPaginatedDeviceDetailsCallback)callback {
-    [self.underlyingPushDeviceRegistrations list:params
-                                        callback:callback];
+    [self.underlyingPushDeviceRegistrations.internal list:params
+                                         wrapperSDKAgents:self.proxyOptions.agents
+                                                 callback:callback];
 }
 
 - (void)remove:(nonnull NSString *)deviceId callback:(nonnull ARTCallback)callback {
-    [self.underlyingPushDeviceRegistrations remove:deviceId
-                                          callback:callback];
+    [self.underlyingPushDeviceRegistrations.internal remove:deviceId
+                                           wrapperSDKAgents:self.proxyOptions.agents
+                                                   callback:callback];
 }
 
 - (void)removeWhere:(nonnull NSStringDictionary *)params callback:(nonnull ARTCallback)callback {
-    [self.underlyingPushDeviceRegistrations removeWhere:params
-                                               callback:callback];
+    [self.underlyingPushDeviceRegistrations.internal removeWhere:params
+                                                wrapperSDKAgents:self.proxyOptions.agents
+                                                        callback:callback];
 }
 
 - (void)save:(nonnull ARTDeviceDetails *)deviceDetails callback:(nonnull ARTCallback)callback {
-    [self.underlyingPushDeviceRegistrations save:deviceDetails
-                                        callback:callback];
+    [self.underlyingPushDeviceRegistrations.internal save:deviceDetails
+                                         wrapperSDKAgents:self.proxyOptions.agents
+                                                 callback:callback];
 }
 
 @end

--- a/Source/ARTWrapperSDKProxyPushDeviceRegistrations.m
+++ b/Source/ARTWrapperSDKProxyPushDeviceRegistrations.m
@@ -1,0 +1,50 @@
+#import "ARTWrapperSDKProxyPushDeviceRegistrations+Private.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARTWrapperSDKProxyPushDeviceRegistrations ()
+
+@property (nonatomic, readonly) ARTPushDeviceRegistrations *underlyingPushDeviceRegistrations;
+@property (nonatomic, readonly) ARTWrapperSDKProxyOptions *proxyOptions;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+@implementation ARTWrapperSDKProxyPushDeviceRegistrations
+
+- (instancetype)initWithPushDeviceRegistrations:(ARTPushDeviceRegistrations *)pushDeviceRegistrations proxyOptions:(ARTWrapperSDKProxyOptions *)proxyOptions {
+    if (self = [super init]) {
+        _underlyingPushDeviceRegistrations = pushDeviceRegistrations;
+        _proxyOptions = proxyOptions;
+    }
+
+    return self;
+}
+
+- (void)get:(nonnull ARTDeviceId *)deviceId callback:(nonnull void (^)(ARTDeviceDetails * _Nullable, ARTErrorInfo * _Nullable))callback {
+    [self.underlyingPushDeviceRegistrations get:deviceId
+                                       callback:callback];
+}
+
+- (void)list:(nonnull NSStringDictionary *)params callback:(nonnull ARTPaginatedDeviceDetailsCallback)callback {
+    [self.underlyingPushDeviceRegistrations list:params
+                                        callback:callback];
+}
+
+- (void)remove:(nonnull NSString *)deviceId callback:(nonnull ARTCallback)callback {
+    [self.underlyingPushDeviceRegistrations remove:deviceId
+                                          callback:callback];
+}
+
+- (void)removeWhere:(nonnull NSStringDictionary *)params callback:(nonnull ARTCallback)callback {
+    [self.underlyingPushDeviceRegistrations removeWhere:params
+                                               callback:callback];
+}
+
+- (void)save:(nonnull ARTDeviceDetails *)deviceDetails callback:(nonnull ARTCallback)callback {
+    [self.underlyingPushDeviceRegistrations save:deviceDetails
+                                        callback:callback];
+}
+
+@end

--- a/Source/ARTWrapperSDKProxyRealtime.m
+++ b/Source/ARTWrapperSDKProxyRealtime.m
@@ -90,7 +90,8 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)time:(nonnull ARTDateTimeCallback)callback {
-    [self.underlyingRealtime time:callback];
+    [self.underlyingRealtime.internal timeWithWrapperSDKAgents:self.proxyOptions.agents
+                                                    completion:callback];
 }
 
 @end

--- a/Source/ARTWrapperSDKProxyRealtime.m
+++ b/Source/ARTWrapperSDKProxyRealtime.m
@@ -80,13 +80,15 @@ NS_ASSUME_NONNULL_END
 }
 
 - (BOOL)stats:(nonnull ARTPaginatedStatsCallback)callback {
-    return [self.underlyingRealtime stats:callback];
+    return [self.underlyingRealtime.internal statsWithWrapperSDKAgents:self.proxyOptions.agents
+                                                              callback:callback];
 }
 
 - (BOOL)stats:(nullable ARTStatsQuery *)query callback:(nonnull ARTPaginatedStatsCallback)callback error:(NSError * _Nullable __autoreleasing * _Nullable)errorPtr {
-    return [self.underlyingRealtime stats:query
-                                 callback:callback
-                                    error:errorPtr];
+    return [self.underlyingRealtime.internal stats:query
+                                  wrapperSDKAgents:self.proxyOptions.agents
+                                          callback:callback
+                                             error:errorPtr];
 }
 
 - (void)time:(nonnull ARTDateTimeCallback)callback {

--- a/Source/ARTWrapperSDKProxyRealtime.m
+++ b/Source/ARTWrapperSDKProxyRealtime.m
@@ -1,5 +1,6 @@
 #import "ARTWrapperSDKProxyRealtime+Private.h"
 #import "ARTWrapperSDKProxyRealtimeChannels+Private.h"
+#import "ARTWrapperSDKProxyPush+Private.h"
 #import "ARTWrapperSDKProxyOptions.h"
 #import "ARTRealtime+Private.h"
 
@@ -23,6 +24,8 @@ NS_ASSUME_NONNULL_END
         _proxyOptions = proxyOptions;
         _channels = [[ARTWrapperSDKProxyRealtimeChannels alloc] initWithChannels:realtime.channels
                                                                     proxyOptions:proxyOptions];
+        _push = [[ARTWrapperSDKProxyPush alloc] initWithPush:realtime.push
+                                                proxyOptions:proxyOptions];
     }
 
     return self;
@@ -30,10 +33,6 @@ NS_ASSUME_NONNULL_END
 
 - (ARTConnection *)connection {
     return self.underlyingRealtime.connection;
-}
-
-- (ARTPush *)push {
-    return self.underlyingRealtime.push;
 }
 
 - (ARTAuth *)auth {

--- a/Source/ARTWrapperSDKProxyRealtimeChannel.m
+++ b/Source/ARTWrapperSDKProxyRealtimeChannel.m
@@ -1,4 +1,6 @@
 #import "ARTWrapperSDKProxyRealtimeChannel+Private.h"
+#import "ARTRealtimeChannel+Private.h"
+#import "ARTWrapperSDKProxyOptions.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -54,7 +56,8 @@ NS_ASSUME_NONNULL_END
 #endif
 
 - (void)history:(nonnull ARTPaginatedMessagesCallback)callback {
-    [self.underlyingChannel history:callback];
+    [self.underlyingChannel.internal historyWithWrapperSDKAgents:self.proxyOptions.agents
+                                                      completion:callback];
 }
 
 - (void)publish:(nonnull NSArray<ARTMessage *> *)messages {
@@ -114,7 +117,7 @@ NS_ASSUME_NONNULL_END
 }
 
 - (BOOL)history:(ARTRealtimeHistoryQuery * _Nullable)query callback:(nonnull ARTPaginatedMessagesCallback)callback error:(NSError * _Nullable __autoreleasing * _Nullable)errorPtr {
-    return [self.underlyingChannel history:query callback:callback error:errorPtr];
+    return [self.underlyingChannel.internal history:query wrapperSDKAgents:self.proxyOptions.agents callback:callback error:errorPtr];
 }
 
 - (void)off {

--- a/Source/ARTWrapperSDKProxyRealtimeChannel.m
+++ b/Source/ARTWrapperSDKProxyRealtimeChannel.m
@@ -1,6 +1,7 @@
 #import "ARTWrapperSDKProxyRealtimeChannel+Private.h"
 #import "ARTRealtimeChannel+Private.h"
 #import "ARTWrapperSDKProxyOptions.h"
+#import "ARTWrapperSDKProxyPushChannel+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,6 +20,10 @@ NS_ASSUME_NONNULL_END
     if (self = [super init]) {
         _underlyingChannel = channel;
         _proxyOptions = proxyOptions;
+#if TARGET_OS_IOS
+        _push = [[ARTWrapperSDKProxyPushChannel alloc] initWithPushChannel:channel.push
+                                                              proxyOptions:proxyOptions];
+#endif
     }
 
     return self;
@@ -48,12 +53,6 @@ NS_ASSUME_NONNULL_END
     return self.underlyingChannel.state;
 
 }
-
-#if TARGET_OS_IOS
-- (ARTPushChannel *)push {
-    return self.underlyingChannel.push;
-}
-#endif
 
 - (void)history:(nonnull ARTPaginatedMessagesCallback)callback {
     [self.underlyingChannel.internal historyWithWrapperSDKAgents:self.proxyOptions.agents

--- a/Source/ARTWrapperSDKProxyRealtimeChannel.m
+++ b/Source/ARTWrapperSDKProxyRealtimeChannel.m
@@ -2,6 +2,7 @@
 #import "ARTRealtimeChannel+Private.h"
 #import "ARTWrapperSDKProxyOptions.h"
 #import "ARTWrapperSDKProxyPushChannel+Private.h"
+#import "ARTWrapperSDKProxyRealtimePresence+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -24,6 +25,8 @@ NS_ASSUME_NONNULL_END
         _push = [[ARTWrapperSDKProxyPushChannel alloc] initWithPushChannel:channel.push
                                                               proxyOptions:proxyOptions];
 #endif
+        _presence = [[ARTWrapperSDKProxyRealtimePresence alloc] initWithRealtimePresence:channel.presence
+                                                                            proxyOptions:proxyOptions];
     }
 
     return self;
@@ -39,10 +42,6 @@ NS_ASSUME_NONNULL_END
 
 - (ARTRealtimeChannelOptions *)getOptions {
     return self.underlyingChannel.options;
-}
-
-- (id<ARTRealtimePresenceProtocol>)presence {
-    return self.underlyingChannel.presence;
 }
 
 - (ARTChannelProperties *)properties {

--- a/Source/ARTWrapperSDKProxyRealtimePresence.m
+++ b/Source/ARTWrapperSDKProxyRealtimePresence.m
@@ -1,0 +1,121 @@
+#import "ARTWrapperSDKProxyRealtimePresence+Private.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARTWrapperSDKProxyRealtimePresence ()
+
+@property (nonatomic, readonly) ARTRealtimePresence *underlyingRealtimePresence;
+@property (nonatomic, readonly) ARTWrapperSDKProxyOptions *proxyOptions;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+@implementation ARTWrapperSDKProxyRealtimePresence
+
+- (instancetype)initWithRealtimePresence:(ARTRealtimePresence *)push proxyOptions:(ARTWrapperSDKProxyOptions *)proxyOptions {
+    if (self = [super init]) {
+        _underlyingRealtimePresence = push;
+        _proxyOptions = proxyOptions;
+    }
+
+    return self;
+}
+
+- (BOOL)syncComplete {
+    return self.underlyingRealtimePresence.syncComplete;
+}
+
+- (void)enter:(id _Nullable)data {
+    [self.underlyingRealtimePresence enter:data];
+}
+
+- (void)enter:(id _Nullable)data callback:(nullable ARTCallback)callback {
+    [self.underlyingRealtimePresence enter:data callback:callback];
+}
+
+- (void)enterClient:(nonnull NSString *)clientId data:(id _Nullable)data {
+    [self.underlyingRealtimePresence enterClient:clientId data:data];
+}
+
+- (void)enterClient:(nonnull NSString *)clientId data:(id _Nullable)data callback:(nullable ARTCallback)callback {
+    [self.underlyingRealtimePresence enterClient:clientId data:data callback:callback];
+}
+
+- (void)get:(nonnull ARTPresenceMessagesCallback)callback {
+    [self.underlyingRealtimePresence get:callback];
+}
+
+- (void)get:(nonnull ARTRealtimePresenceQuery *)query callback:(nonnull ARTPresenceMessagesCallback)callback {
+    [self.underlyingRealtimePresence get:query callback:callback];
+}
+
+- (void)history:(nonnull ARTPaginatedPresenceCallback)callback {
+    [self.underlyingRealtimePresence history:callback];
+}
+
+- (BOOL)history:(ARTRealtimeHistoryQuery * _Nullable)query callback:(nonnull ARTPaginatedPresenceCallback)callback error:(NSError * _Nullable __autoreleasing * _Nullable)errorPtr {
+    return [self.underlyingRealtimePresence history:query callback:callback error:errorPtr];
+}
+
+- (void)leave:(id _Nullable)data {
+    [self.underlyingRealtimePresence leave:data];
+}
+
+- (void)leave:(id _Nullable)data callback:(nullable ARTCallback)callback {
+    [self.underlyingRealtimePresence leave:data callback:callback];
+}
+
+- (void)leaveClient:(nonnull NSString *)clientId data:(id _Nullable)data {
+    [self.underlyingRealtimePresence leaveClient:clientId data:data];
+}
+
+- (void)leaveClient:(nonnull NSString *)clientId data:(id _Nullable)data callback:(nullable ARTCallback)callback {
+    [self.underlyingRealtimePresence leaveClient:clientId data:data callback:callback];
+}
+
+- (ARTEventListener * _Nullable)subscribe:(nonnull ARTPresenceMessageCallback)callback {
+    return [self.underlyingRealtimePresence subscribe:callback];
+}
+
+- (ARTEventListener * _Nullable)subscribe:(ARTPresenceAction)action callback:(nonnull ARTPresenceMessageCallback)callback {
+    return [self.underlyingRealtimePresence subscribe:action callback:callback];
+}
+
+- (ARTEventListener * _Nullable)subscribe:(ARTPresenceAction)action onAttach:(nullable ARTCallback)onAttach callback:(nonnull ARTPresenceMessageCallback)callback {
+    return [self.underlyingRealtimePresence subscribe:action onAttach:onAttach callback:callback];
+}
+
+- (ARTEventListener * _Nullable)subscribeWithAttachCallback:(nullable ARTCallback)onAttach callback:(nonnull ARTPresenceMessageCallback)callback {
+    return [self.underlyingRealtimePresence subscribeWithAttachCallback:onAttach callback:callback];
+}
+
+- (void)unsubscribe {
+    [self.underlyingRealtimePresence unsubscribe];
+}
+
+- (void)unsubscribe:(nonnull ARTEventListener *)listener {
+    [self.underlyingRealtimePresence unsubscribe:listener];
+}
+
+- (void)unsubscribe:(ARTPresenceAction)action listener:(nonnull ARTEventListener *)listener {
+    [self.underlyingRealtimePresence unsubscribe:action listener:listener];
+}
+
+- (void)update:(id _Nullable)data {
+    [self.underlyingRealtimePresence update:data];
+}
+
+- (void)update:(id _Nullable)data callback:(nullable ARTCallback)callback {
+    [self.underlyingRealtimePresence update:data callback:callback];
+}
+
+- (void)updateClient:(nonnull NSString *)clientId data:(id _Nullable)data {
+    [self.underlyingRealtimePresence updateClient:clientId data:data];
+}
+
+- (void)updateClient:(nonnull NSString *)clientId data:(id _Nullable)data callback:(nullable ARTCallback)callback {
+    [self.underlyingRealtimePresence updateClient:clientId data:data callback:callback];
+}
+
+@end

--- a/Source/ARTWrapperSDKProxyRealtimePresence.m
+++ b/Source/ARTWrapperSDKProxyRealtimePresence.m
@@ -1,4 +1,6 @@
 #import "ARTWrapperSDKProxyRealtimePresence+Private.h"
+#import "ARTRealtimePresence+Private.h"
+#import "ARTWrapperSDKProxyOptions.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -51,11 +53,15 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)history:(nonnull ARTPaginatedPresenceCallback)callback {
-    [self.underlyingRealtimePresence history:callback];
+    [self.underlyingRealtimePresence.internal historyWithWrapperSDKAgents:self.proxyOptions.agents
+                                                               completion:callback];
 }
 
 - (BOOL)history:(ARTRealtimeHistoryQuery * _Nullable)query callback:(nonnull ARTPaginatedPresenceCallback)callback error:(NSError * _Nullable __autoreleasing * _Nullable)errorPtr {
-    return [self.underlyingRealtimePresence history:query callback:callback error:errorPtr];
+    return [self.underlyingRealtimePresence.internal history:query
+                                            wrapperSDKAgents:self.proxyOptions.agents
+                                                    callback:callback
+                                                       error:errorPtr];
 }
 
 - (void)leave:(id _Nullable)data {

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -118,5 +118,7 @@ framework module Ably {
         header "ARTChannel.h"
         header "ARTWrapperSDKProxyPush+Private.h"
         header "ARTWrapperSDKProxyPushAdmin+Private.h"
+        header "ARTWrapperSDKProxyPushDeviceRegistrations+Private.h"
+        header "ARTWrapperSDKProxyPushChannelSubscriptions+Private.h"
     }
 }

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -116,5 +116,6 @@ framework module Ably {
         header "ARTWrapperSDKProxyRealtimeChannels+Private.h"
         header "ARTWrapperSDKProxyRealtimeChannel+Private.h"
         header "ARTChannel.h"
+        header "ARTWrapperSDKProxyPush+Private.h"
     }
 }

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -115,5 +115,6 @@ framework module Ably {
         header "ARTWrapperSDKProxyRealtime+Private.h"
         header "ARTWrapperSDKProxyRealtimeChannels+Private.h"
         header "ARTWrapperSDKProxyRealtimeChannel+Private.h"
+        header "ARTChannel.h"
     }
 }

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -120,5 +120,6 @@ framework module Ably {
         header "ARTWrapperSDKProxyPushAdmin+Private.h"
         header "ARTWrapperSDKProxyPushDeviceRegistrations+Private.h"
         header "ARTWrapperSDKProxyPushChannelSubscriptions+Private.h"
+        header "ARTWrapperSDKProxyPushChannel+Private.h"
     }
 }

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -117,5 +117,6 @@ framework module Ably {
         header "ARTWrapperSDKProxyRealtimeChannel+Private.h"
         header "ARTChannel.h"
         header "ARTWrapperSDKProxyPush+Private.h"
+        header "ARTWrapperSDKProxyPushAdmin+Private.h"
     }
 }

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -121,5 +121,6 @@ framework module Ably {
         header "ARTWrapperSDKProxyPushDeviceRegistrations+Private.h"
         header "ARTWrapperSDKProxyPushChannelSubscriptions+Private.h"
         header "ARTWrapperSDKProxyPushChannel+Private.h"
+        header "ARTWrapperSDKProxyRealtimePresence+Private.h"
     }
 }

--- a/Source/PrivateHeaders/Ably/ARTChannel.h
+++ b/Source/PrivateHeaders/Ably/ARTChannel.h
@@ -20,7 +20,32 @@ NS_ASSUME_NONNULL_BEGIN
  * @see See `ARTChannelProtocol` for details.
  */
 NS_SWIFT_SENDABLE
-@interface ARTChannel : NSObject<ARTChannelProtocol>
+@interface ARTChannel : NSObject
+
+@property (readonly) NSString *name;
+
+- (void)publish:(nullable NSString *)name data:(nullable id)data;
+
+- (void)publish:(nullable NSString *)name data:(nullable id)data callback:(nullable ARTCallback)callback;
+
+- (void)publish:(nullable NSString *)name data:(nullable id)data clientId:(NSString *)clientId;
+
+- (void)publish:(nullable NSString *)name data:(nullable id)data clientId:(NSString *)clientId callback:(nullable ARTCallback)callback;
+
+- (void)publish:(nullable NSString *)name data:(nullable id)data extras:(nullable id<ARTJsonCompatible>)extras;
+
+- (void)publish:(nullable NSString *)name data:(nullable id)data extras:(nullable id<ARTJsonCompatible>)extras callback:(nullable ARTCallback)callback;
+
+- (void)publish:(nullable NSString *)name data:(nullable id)data clientId:(NSString *)clientId extras:(nullable id<ARTJsonCompatible>)extras;
+
+- (void)publish:(nullable NSString *)name data:(nullable id)data clientId:(NSString *)clientId extras:(nullable id<ARTJsonCompatible>)extras callback:(nullable ARTCallback)callback;
+
+- (void)publish:(NSArray<ARTMessage *> *)messages;
+
+- (void)publish:(NSArray<ARTMessage *> *)messages callback:(nullable ARTCallback)callback;
+
+- (void)history:(ARTPaginatedMessagesCallback)callback;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTChannel.h
+++ b/Source/PrivateHeaders/Ably/ARTChannel.h
@@ -1,0 +1,26 @@
+#import <Foundation/Foundation.h>
+
+#import <Ably/ARTTypes.h>
+#import <Ably/ARTChannelProtocol.h>
+
+@class ARTRest;
+@class ARTChannelOptions;
+@class ARTMessage;
+@class ARTBaseMessage;
+@class ARTPaginatedResult<ItemType>;
+@class ARTDataQuery;
+@class ARTLocalDevice;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * The base class for `ARTRestChannel` and `ARTRealtimeChannel`.
+ * Ably platform service organizes the message traffic within applications into named channels. Channels are the medium through which messages are distributed; clients attach to channels to subscribe to messages, and every message published to a unique channel is broadcast by Ably to all subscribers.
+ *
+ * @see See `ARTChannelProtocol` for details.
+ */
+NS_SWIFT_SENDABLE
+@interface ARTChannel : NSObject<ARTChannelProtocol>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTChannel.h
+++ b/Source/PrivateHeaders/Ably/ARTChannel.h
@@ -44,7 +44,8 @@ NS_SWIFT_SENDABLE
 
 - (void)publish:(NSArray<ARTMessage *> *)messages callback:(nullable ARTCallback)callback;
 
-- (void)history:(ARTPaginatedMessagesCallback)callback;
+- (void)historyWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                         completion:(ARTPaginatedMessagesCallback)callback;
 
 @end
 

--- a/Source/PrivateHeaders/Ably/ARTHTTPPaginatedResponse+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTHTTPPaginatedResponse+Private.h
@@ -9,7 +9,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ARTHTTPPaginatedResponse ()
 
 @property (nonatomic) NSHTTPURLResponse *response;
-@property (nullable, nonatomic, readonly) NSDictionary<NSString *, NSString *> *wrapperSDKAgents;
 
 - (instancetype)initWithResponse:(NSHTTPURLResponse *)response
                            items:(NSArray *)items

--- a/Source/PrivateHeaders/Ably/ARTPaginatedResult+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPaginatedResult+Private.h
@@ -22,11 +22,13 @@ typedef NSArray<ItemType> *_Nullable(^ARTPaginatedResultResponseProcessor)(NSHTT
                    relCurrent:(NSMutableURLRequest *)relCurrent
                       relNext:(NSMutableURLRequest *)relNext
             responseProcessor:(ARTPaginatedResultResponseProcessor)responseProcessor
+             wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
                        logger:(ARTInternalLog *)logger NS_DESIGNATED_INITIALIZER;
 
 + (void)executePaginated:(ARTRestInternal *)rest
              withRequest:(NSMutableURLRequest *)request
     andResponseProcessor:(ARTPaginatedResultResponseProcessor)responseProcessor
+        wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
                   logger:(ARTInternalLog *)logger
                 callback:(void (^)(ARTPaginatedResult<ItemType> *_Nullable result, ARTErrorInfo *_Nullable error))callback;
 

--- a/Source/PrivateHeaders/Ably/ARTPaginatedResult+Subclass.h
+++ b/Source/PrivateHeaders/Ably/ARTPaginatedResult+Subclass.h
@@ -5,6 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ARTPaginatedResult ()
 
+@property (nullable, nonatomic, readonly) NSStringDictionary *wrapperSDKAgents;
 @property (nonatomic, readonly) ARTInternalLog *logger;
 
 @end

--- a/Source/PrivateHeaders/Ably/ARTPushAdmin+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPushAdmin+Private.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithRest:(ARTRestInternal *)rest logger:(ARTInternalLog *)logger;
 
-- (void)publish:(ARTPushRecipient *)recipient data:(ARTJsonObject *)data callback:(nullable ARTCallback)callback;
+- (void)publish:(ARTPushRecipient *)recipient data:(ARTJsonObject *)data wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(nullable ARTCallback)callback;
 
 @end
 

--- a/Source/PrivateHeaders/Ably/ARTPushChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPushChannel+Private.h
@@ -11,23 +11,28 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init:(ARTRestInternal *)rest withChannel:(ARTChannel *)channel logger:(ARTInternalLog *)logger;
 
-- (void)subscribeDevice;
+- (void)subscribeDeviceWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents;
 
-- (void)subscribeDevice:(nullable ARTCallback)callback;
+- (void)subscribeDeviceWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                                 completion:(nullable ARTCallback)callback;
 
-- (void)subscribeClient;
+- (void)subscribeClientWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents;
 
-- (void)subscribeClient:(nullable ARTCallback)callback;
+- (void)subscribeClientWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                                 completion:(nullable ARTCallback)callback;
 
-- (void)unsubscribeDevice;
+- (void)unsubscribeDeviceWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents;
 
-- (void)unsubscribeDevice:(nullable ARTCallback)callback;
+- (void)unsubscribeDeviceWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                                   completion:(nullable ARTCallback)callback;
 
-- (void)unsubscribeClient;
+- (void)unsubscribeClientWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents;
 
-- (void)unsubscribeClient:(nullable ARTCallback)callback;
+- (void)unsubscribeClientWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                                   completion:(nullable ARTCallback)callback;
 
 - (BOOL)listSubscriptions:(NSStringDictionary *)params
+         wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
                  callback:(ARTPaginatedPushChannelCallback)callback
                     error:(NSError *_Nullable *_Nullable)errorPtr;
 

--- a/Source/PrivateHeaders/Ably/ARTPushChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPushChannel+Private.h
@@ -1,6 +1,7 @@
 #import <Ably/ARTPushChannel.h>
 #import <Ably/ARTQueuedDealloc.h>
 
+@class ARTChannel;
 @class ARTRestInternal;
 @class ARTInternalLog;
 

--- a/Source/PrivateHeaders/Ably/ARTPushChannelSubscriptions+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPushChannelSubscriptions+Private.h
@@ -10,15 +10,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithRest:(ARTRestInternal *)rest logger:(ARTInternalLog *)logger;
 
-- (void)save:(ARTPushChannelSubscription *)channelSubscription callback:(ARTCallback)callback;
+- (void)save:(ARTPushChannelSubscription *)channelSubscription wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTCallback)callback;
 
-- (void)listChannels:(ARTPaginatedTextCallback)callback;
+- (void)listChannelsWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents completion:(ARTPaginatedTextCallback)callback;
 
-- (void)list:(NSStringDictionary *)params callback:(ARTPaginatedPushChannelCallback)callback;
+- (void)list:(NSStringDictionary *)params wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTPaginatedPushChannelCallback)callback;
 
-- (void)remove:(ARTPushChannelSubscription *)subscription callback:(ARTCallback)callback;
+- (void)remove:(ARTPushChannelSubscription *)subscription wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTCallback)callback;
 
-- (void)removeWhere:(NSStringDictionary *)params callback:(ARTCallback)callback;
+- (void)removeWhere:(NSStringDictionary *)params wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTCallback)callback;
 
 @end
 

--- a/Source/PrivateHeaders/Ably/ARTPushDeviceRegistrations+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPushDeviceRegistrations+Private.h
@@ -10,15 +10,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithRest:(ARTRestInternal *)rest logger:(ARTInternalLog *)logger;
 
-- (void)save:(ARTDeviceDetails *)deviceDetails callback:(ARTCallback)callback;
+- (void)save:(ARTDeviceDetails *)deviceDetails wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTCallback)callback;
 
-- (void)get:(ARTDeviceId *)deviceId callback:(void (^)(ARTDeviceDetails *_Nullable,  ARTErrorInfo *_Nullable))callback;
+- (void)get:(ARTDeviceId *)deviceId wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(void (^)(ARTDeviceDetails *_Nullable,  ARTErrorInfo *_Nullable))callback;
 
-- (void)list:(NSStringDictionary *)params callback:(ARTPaginatedDeviceDetailsCallback)callback;
+- (void)list:(NSStringDictionary *)params wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTPaginatedDeviceDetailsCallback)callback;
 
-- (void)remove:(NSString *)deviceId callback:(ARTCallback)callback;
+- (void)remove:(NSString *)deviceId wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTCallback)callback;
 
-- (void)removeWhere:(NSStringDictionary *)params callback:(ARTCallback)callback;
+- (void)removeWhere:(NSStringDictionary *)params wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTCallback)callback;
 
 @end
 

--- a/Source/PrivateHeaders/Ably/ARTRealtime+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtime+Private.h
@@ -59,9 +59,10 @@ wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
 
 - (void)ping:(ARTCallback)cb;
 
-- (BOOL)stats:(ARTPaginatedStatsCallback)callback;
+- (BOOL)statsWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                         callback:(ARTPaginatedStatsCallback)callback;
 
-- (BOOL)stats:(nullable ARTStatsQuery *)query callback:(ARTPaginatedStatsCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr;
+- (BOOL)stats:(nullable ARTStatsQuery *)query wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTPaginatedStatsCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr;
 
 - (void)connect;
 

--- a/Source/PrivateHeaders/Ably/ARTRealtime+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtime+Private.h
@@ -45,7 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly, nonatomic) dispatch_queue_t queue;
 
-- (void)time:(ARTDateTimeCallback)callback;
+- (void)timeWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                      completion:(ARTDateTimeCallback)callback;
 
 - (BOOL)request:(NSString *)method
            path:(NSString *)path

--- a/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
@@ -86,7 +86,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)unsubscribe:(NSString *)name listener:(ARTEventListener *_Nullable)listener;
 
-- (BOOL)history:(ARTRealtimeHistoryQuery *_Nullable)query callback:(ARTPaginatedMessagesCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr;
+- (void)historyWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                         completion:(ARTPaginatedMessagesCallback)callback;
+- (BOOL)history:(ARTRealtimeHistoryQuery *_Nullable)query wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTPaginatedMessagesCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr;
 
 - (void)setOptions:(ARTRealtimeChannelOptions *_Nullable)options callback:(nullable ARTCallback)callback;
 

--- a/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
@@ -3,6 +3,7 @@
 //
 //
 
+#import <Ably/ARTChannel.h>
 #import <Ably/ARTRestChannel+Private.h>
 #import <Ably/ARTRealtimeChannel.h>
 #import <Ably/ARTEventEmitter.h>

--- a/Source/PrivateHeaders/Ably/ARTRealtimePresence+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimePresence+Private.h
@@ -67,9 +67,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)unsubscribe:(ARTPresenceAction)action listener:(ARTEventListener *)listener;
 
-- (void)history:(ARTPaginatedPresenceCallback)callback;
+- (void)historyWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                         completion:(ARTPaginatedPresenceCallback)callback;
 
-- (BOOL)history:(ARTRealtimeHistoryQuery *_Nullable)query callback:(ARTPaginatedPresenceCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr;
+- (BOOL)history:(ARTRealtimeHistoryQuery *_Nullable)query wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTPaginatedPresenceCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr;
 
 @end
 

--- a/Source/PrivateHeaders/Ably/ARTRest+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRest+Private.h
@@ -106,9 +106,11 @@ wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
        callback:(ARTHTTPPaginatedCallback)callback
           error:(NSError *_Nullable *_Nullable)errorPtr;
 
-- (BOOL)stats:(ARTPaginatedStatsCallback)callback;
+- (BOOL)statsWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                       completion:(ARTPaginatedStatsCallback)callback;
 
 - (BOOL)stats:(nullable ARTStatsQuery *)query
+wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
      callback:(ARTPaginatedStatsCallback)callback
         error:(NSError *_Nullable *_Nullable)errorPtr;
 

--- a/Source/PrivateHeaders/Ably/ARTRest+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRest+Private.h
@@ -66,7 +66,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithOptions:(ARTClientOptions *)options realtime:(ARTRealtimeInternal *_Nullable)realtime logger:(ARTInternalLog *)logger;
 
-- (nullable NSObject<ARTCancellable> *)_time:(ARTDateTimeCallback)callback;
+- (nullable NSObject<ARTCancellable> *)_timeWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                                                      completion:(ARTDateTimeCallback)callback;
 
 // MARK: ARTHTTPExecutor
 
@@ -93,7 +94,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setAndPersistAPNSDeviceTokenData:(NSData *)deviceTokenData tokenType:(NSString *)tokenType;
 #endif
 
-- (void)time:(ARTDateTimeCallback)callback;
+- (void)timeWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                      completion:(ARTDateTimeCallback)callback;
 
 - (BOOL)request:(NSString *)method
            path:(NSString *)path

--- a/Source/PrivateHeaders/Ably/ARTRestChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRestChannel+Private.h
@@ -3,6 +3,7 @@
 //
 //
 
+#import <Ably/ARTChannel.h>
 #import <Ably/ARTRestChannel.h>
 #import <Ably/ARTRestPresence+Private.h>
 #import <Ably/ARTPushChannel+Private.h>

--- a/Source/PrivateHeaders/Ably/ARTRestChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRestChannel+Private.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly, nullable) ARTChannelOptions *options;
 
-- (BOOL)history:(nullable ARTDataQuery *)query callback:(ARTPaginatedMessagesCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr;
+- (BOOL)history:(nullable ARTDataQuery *)query wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTPaginatedMessagesCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr;
 
 - (void)status:(ARTChannelDetailsCallback)callback;
 

--- a/Source/PrivateHeaders/Ably/ARTRestPresence+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRestPresence+Private.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class ARTRestChannelInternal;
 @class ARTInternalLog;
 
-@interface ARTRestPresenceInternal : ARTPresence
+@interface ARTRestPresenceInternal : NSObject
 
 - (instancetype)initWithChannel:(ARTRestChannelInternal *)channel logger:(ARTInternalLog *)logger;
 
@@ -17,6 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)get:(ARTPresenceQuery *)query callback:(ARTPaginatedPresenceCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr;
 
 - (BOOL)history:(nullable ARTDataQuery *)query callback:(ARTPaginatedPresenceCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr;
+
+- (void)history:(ARTPaginatedPresenceCallback)callback;
 
 @end
 

--- a/Source/PrivateHeaders/Ably/ARTRestPresence+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRestPresence+Private.h
@@ -16,9 +16,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)get:(ARTPresenceQuery *)query callback:(ARTPaginatedPresenceCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr;
 
-- (BOOL)history:(nullable ARTDataQuery *)query callback:(ARTPaginatedPresenceCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr;
+- (BOOL)history:(nullable ARTDataQuery *)query wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTPaginatedPresenceCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr;
 
-- (void)history:(ARTPaginatedPresenceCallback)callback;
+- (void)historyWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                         completion:(ARTPaginatedPresenceCallback)callback;
 
 @end
 

--- a/Source/PrivateHeaders/Ably/ARTWrapperSDKProxyPush+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTWrapperSDKProxyPush+Private.h
@@ -1,0 +1,14 @@
+#import <Ably/ARTWrapperSDKProxyPush.h>
+
+@class ARTWrapperSDKProxyOptions;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARTWrapperSDKProxyPush ()
+
+- (instancetype)initWithPush:(ARTPush *)push
+                proxyOptions:(ARTWrapperSDKProxyOptions *)proxyOptions NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTWrapperSDKProxyPushAdmin+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTWrapperSDKProxyPushAdmin+Private.h
@@ -1,0 +1,14 @@
+#import <Ably/ARTWrapperSDKProxyPushAdmin.h>
+
+@class ARTWrapperSDKProxyOptions;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARTWrapperSDKProxyPushAdmin ()
+
+- (instancetype)initWithPushAdmin:(ARTPushAdmin *)pushAdmin
+                     proxyOptions:(ARTWrapperSDKProxyOptions *)proxyOptions NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTWrapperSDKProxyPushChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTWrapperSDKProxyPushChannel+Private.h
@@ -1,0 +1,14 @@
+#import <Ably/ARTWrapperSDKProxyPushChannel.h>
+
+@class ARTWrapperSDKProxyOptions;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARTWrapperSDKProxyPushChannel ()
+
+- (instancetype)initWithPushChannel:(ARTPushChannel *)pushChannel
+                       proxyOptions:(ARTWrapperSDKProxyOptions *)proxyOptions NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTWrapperSDKProxyPushChannelSubscriptions+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTWrapperSDKProxyPushChannelSubscriptions+Private.h
@@ -1,0 +1,14 @@
+#import <Ably/ARTWrapperSDKProxyPushChannelSubscriptions.h>
+
+@class ARTWrapperSDKProxyOptions;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARTWrapperSDKProxyPushChannelSubscriptions ()
+
+- (instancetype)initWithPushChannelSubscriptions:(ARTPushChannelSubscriptions *)pushChannelSubscriptions
+                                    proxyOptions:(ARTWrapperSDKProxyOptions *)proxyOptions NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTWrapperSDKProxyPushDeviceRegistrations+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTWrapperSDKProxyPushDeviceRegistrations+Private.h
@@ -1,0 +1,14 @@
+#import <Ably/ARTWrapperSDKProxyPushDeviceRegistrations.h>
+
+@class ARTWrapperSDKProxyOptions;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARTWrapperSDKProxyPushDeviceRegistrations ()
+
+- (instancetype)initWithPushDeviceRegistrations:(ARTPushDeviceRegistrations *)pushDeviceRegistrations
+                                   proxyOptions:(ARTWrapperSDKProxyOptions *)proxyOptions NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTWrapperSDKProxyRealtimePresence+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTWrapperSDKProxyRealtimePresence+Private.h
@@ -1,0 +1,14 @@
+#import <Ably/ARTWrapperSDKProxyRealtimePresence.h>
+
+@class ARTWrapperSDKProxyOptions;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARTWrapperSDKProxyRealtimePresence ()
+
+- (instancetype)initWithRealtimePresence:(ARTRealtimePresence *)realtimePresence
+                            proxyOptions:(ARTWrapperSDKProxyOptions *)proxyOptions NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/include/Ably.modulemap
+++ b/Source/include/Ably.modulemap
@@ -116,5 +116,7 @@ framework module Ably {
         header "Ably/ARTChannel.h"
         header "Ably/ARTWrapperSDKProxyPush+Private.h"
         header "Ably/ARTWrapperSDKProxyPushAdmin+Private.h"
+        header "Ably/ARTWrapperSDKProxyPushDeviceRegistrations+Private.h"
+        header "Ably/ARTWrapperSDKProxyPushChannelSubscriptions+Private.h"
     }
 }

--- a/Source/include/Ably.modulemap
+++ b/Source/include/Ably.modulemap
@@ -118,5 +118,6 @@ framework module Ably {
         header "Ably/ARTWrapperSDKProxyPushAdmin+Private.h"
         header "Ably/ARTWrapperSDKProxyPushDeviceRegistrations+Private.h"
         header "Ably/ARTWrapperSDKProxyPushChannelSubscriptions+Private.h"
+        header "Ably/ARTWrapperSDKProxyPushChannel+Private.h"
     }
 }

--- a/Source/include/Ably.modulemap
+++ b/Source/include/Ably.modulemap
@@ -115,5 +115,6 @@ framework module Ably {
         header "Ably/ARTWrapperSDKProxyRealtimeChannel+Private.h"
         header "Ably/ARTChannel.h"
         header "Ably/ARTWrapperSDKProxyPush+Private.h"
+        header "Ably/ARTWrapperSDKProxyPushAdmin+Private.h"
     }
 }

--- a/Source/include/Ably.modulemap
+++ b/Source/include/Ably.modulemap
@@ -114,5 +114,6 @@ framework module Ably {
         header "Ably/ARTWrapperSDKProxyRealtimeChannels+Private.h"
         header "Ably/ARTWrapperSDKProxyRealtimeChannel+Private.h"
         header "Ably/ARTChannel.h"
+        header "Ably/ARTWrapperSDKProxyPush+Private.h"
     }
 }

--- a/Source/include/Ably.modulemap
+++ b/Source/include/Ably.modulemap
@@ -113,5 +113,6 @@ framework module Ably {
         header "Ably/ARTWrapperSDKProxyRealtime+Private.h"
         header "Ably/ARTWrapperSDKProxyRealtimeChannels+Private.h"
         header "Ably/ARTWrapperSDKProxyRealtimeChannel+Private.h"
+        header "Ably/ARTChannel.h"
     }
 }

--- a/Source/include/Ably.modulemap
+++ b/Source/include/Ably.modulemap
@@ -119,5 +119,6 @@ framework module Ably {
         header "Ably/ARTWrapperSDKProxyPushDeviceRegistrations+Private.h"
         header "Ably/ARTWrapperSDKProxyPushChannelSubscriptions+Private.h"
         header "Ably/ARTWrapperSDKProxyPushChannel+Private.h"
+        header "Ably/ARTWrapperSDKProxyRealtimePresence+Private.h"
     }
 }

--- a/Source/include/Ably/ARTChannelProtocol.h
+++ b/Source/include/Ably/ARTChannelProtocol.h
@@ -13,7 +13,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- The protocol upon which the `ARTChannel` is implemented.
+ The protocol upon which `ARTRestChannelProtocol` and `ARTRealtimeChannelProtocol` are based.
  */
 @protocol ARTChannelProtocol
 
@@ -71,16 +71,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// :nodoc: TODO: docstring
 - (void)history:(ARTPaginatedMessagesCallback)callback;
 
-@end
-
-/**
- * The base class for `ARTRestChannel` and `ARTRealtimeChannel`.
- * Ably platform service organizes the message traffic within applications into named channels. Channels are the medium through which messages are distributed; clients attach to channels to subscribe to messages, and every message published to a unique channel is broadcast by Ably to all subscribers.
- *
- * @see See `ARTChannelProtocol` for details.
- */
-NS_SWIFT_SENDABLE
-@interface ARTChannel : NSObject<ARTChannelProtocol>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/include/Ably/ARTPushChannel.h
+++ b/Source/include/Ably/ARTPushChannel.h
@@ -1,6 +1,5 @@
 #import <Foundation/Foundation.h>
 #import <Ably/ARTPush.h>
-#import <Ably/ARTChannel.h>
 
 @class ARTPushChannelSubscription;
 @class ARTPaginatedResult;

--- a/Source/include/Ably/ARTRestChannel.h
+++ b/Source/include/Ably/ARTRestChannel.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-#import <Ably/ARTChannel.h>
+#import <Ably/ARTChannelProtocol.h>
 
 @class ARTRest;
 @class ARTRestPresence;

--- a/Source/include/Ably/ARTWrapperSDKProxyPush.h
+++ b/Source/include/Ably/ARTWrapperSDKProxyPush.h
@@ -1,0 +1,22 @@
+#import <Foundation/Foundation.h>
+#import <Ably/ARTPush.h>
+
+@class ARTPushAdmin;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * An object which wraps an instance of `ARTPush` and provides a similar API. It allows Ably-authored wrapper SDKs to send analytics information so that Ably can track the usage of the wrapper SDK.
+ *
+ * - Important: This class should only be used by Ably-authored SDKs.
+ */
+NS_SWIFT_SENDABLE
+@interface ARTWrapperSDKProxyPush : NSObject <ARTPushProtocol>
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@property (readonly) ARTPushAdmin *admin;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/include/Ably/ARTWrapperSDKProxyPush.h
+++ b/Source/include/Ably/ARTWrapperSDKProxyPush.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 #import <Ably/ARTPush.h>
 
-@class ARTPushAdmin;
+@class ARTWrapperSDKProxyPushAdmin;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -15,7 +15,7 @@ NS_SWIFT_SENDABLE
 
 - (instancetype)init NS_UNAVAILABLE;
 
-@property (readonly) ARTPushAdmin *admin;
+@property (readonly) ARTWrapperSDKProxyPushAdmin *admin;
 
 @end
 

--- a/Source/include/Ably/ARTWrapperSDKProxyPushAdmin.h
+++ b/Source/include/Ably/ARTWrapperSDKProxyPushAdmin.h
@@ -1,8 +1,8 @@
 #import <Foundation/Foundation.h>
 #import <Ably/ARTPushAdmin.h>
 
-@class ARTPushDeviceRegistrations;
-@class ARTPushChannelSubscriptions;
+@class ARTWrapperSDKProxyPushDeviceRegistrations;
+@class ARTWrapperSDKProxyPushChannelSubscriptions;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -16,8 +16,8 @@ NS_SWIFT_SENDABLE
 
 - (instancetype)init NS_UNAVAILABLE;
 
-@property (nonatomic, readonly) ARTPushDeviceRegistrations *deviceRegistrations;
-@property (nonatomic, readonly) ARTPushChannelSubscriptions *channelSubscriptions;
+@property (nonatomic, readonly) ARTWrapperSDKProxyPushDeviceRegistrations *deviceRegistrations;
+@property (nonatomic, readonly) ARTWrapperSDKProxyPushChannelSubscriptions *channelSubscriptions;
 
 @end
 

--- a/Source/include/Ably/ARTWrapperSDKProxyPushAdmin.h
+++ b/Source/include/Ably/ARTWrapperSDKProxyPushAdmin.h
@@ -1,0 +1,24 @@
+#import <Foundation/Foundation.h>
+#import <Ably/ARTPushAdmin.h>
+
+@class ARTPushDeviceRegistrations;
+@class ARTPushChannelSubscriptions;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * An object which wraps an instance of `ARTPushAdmin` and provides a similar API. It allows Ably-authored wrapper SDKs to send analytics information so that Ably can track the usage of the wrapper SDK.
+ *
+ * - Important: This class should only be used by Ably-authored SDKs.
+ */
+NS_SWIFT_SENDABLE
+@interface ARTWrapperSDKProxyPushAdmin : NSObject <ARTPushAdminProtocol>
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@property (nonatomic, readonly) ARTPushDeviceRegistrations *deviceRegistrations;
+@property (nonatomic, readonly) ARTPushChannelSubscriptions *channelSubscriptions;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/include/Ably/ARTWrapperSDKProxyPushChannel.h
+++ b/Source/include/Ably/ARTWrapperSDKProxyPushChannel.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+#import <Ably/ARTPushChannel.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * An object which wraps an instance of `ARTPushChannel` and provides a similar API. It allows Ably-authored wrapper SDKs to send analytics information so that Ably can track the usage of the wrapper SDK.
+ *
+ * - Important: This class should only be used by Ably-authored SDKs.
+ */
+NS_SWIFT_SENDABLE
+@interface ARTWrapperSDKProxyPushChannel : NSObject <ARTPushChannelProtocol>
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/include/Ably/ARTWrapperSDKProxyPushChannelSubscriptions.h
+++ b/Source/include/Ably/ARTWrapperSDKProxyPushChannelSubscriptions.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+#import <Ably/ARTPushChannelSubscriptions.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * An object which wraps an instance of `ARTPushChannelSubscriptions` and provides a similar API. It allows Ably-authored wrapper SDKs to send analytics information so that Ably can track the usage of the wrapper SDK.
+ *
+ * - Important: This class should only be used by Ably-authored SDKs.
+ */
+NS_SWIFT_SENDABLE
+@interface ARTWrapperSDKProxyPushChannelSubscriptions : NSObject <ARTPushChannelSubscriptionsProtocol>
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/include/Ably/ARTWrapperSDKProxyPushDeviceRegistrations.h
+++ b/Source/include/Ably/ARTWrapperSDKProxyPushDeviceRegistrations.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+#import <Ably/ARTPushDeviceRegistrations.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * An object which wraps an instance of `ARTPushDeviceRegistrations` and provides a similar API. It allows Ably-authored wrapper SDKs to send analytics information so that Ably can track the usage of the wrapper SDK.
+ *
+ * - Important: This class should only be used by Ably-authored SDKs.
+ */
+NS_SWIFT_SENDABLE
+@interface ARTWrapperSDKProxyPushDeviceRegistrations : NSObject <ARTPushDeviceRegistrationsProtocol>
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/include/Ably/ARTWrapperSDKProxyRealtime.h
+++ b/Source/include/Ably/ARTWrapperSDKProxyRealtime.h
@@ -3,7 +3,7 @@
 
 @class ARTConnection;
 @class ARTWrapperSDKProxyRealtimeChannels;
-@class ARTPush;
+@class ARTWrapperSDKProxyPush;
 @class ARTAuth;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -20,7 +20,7 @@ NS_SWIFT_SENDABLE
 
 @property (readonly) ARTConnection *connection;
 @property (readonly) ARTWrapperSDKProxyRealtimeChannels *channels;
-@property (readonly) ARTPush *push;
+@property (readonly) ARTWrapperSDKProxyPush *push;
 @property (readonly) ARTAuth *auth;
 
 @end

--- a/Source/include/Ably/ARTWrapperSDKProxyRealtimeChannel.h
+++ b/Source/include/Ably/ARTWrapperSDKProxyRealtimeChannel.h
@@ -3,6 +3,7 @@
 
 @class ARTWrapperSDKProxyRealtimeChannel;
 @class ARTWrapperSDKProxyPushChannel;
+@class ARTWrapperSDKProxyRealtimePresence;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -16,7 +17,7 @@ NS_SWIFT_SENDABLE
 
 - (instancetype)init NS_UNAVAILABLE;
 
-@property (readonly) ARTRealtimePresence *presence;
+@property (readonly) ARTWrapperSDKProxyRealtimePresence *presence;
 
 #if TARGET_OS_IPHONE
 @property (readonly) ARTWrapperSDKProxyPushChannel *push;

--- a/Source/include/Ably/ARTWrapperSDKProxyRealtimeChannel.h
+++ b/Source/include/Ably/ARTWrapperSDKProxyRealtimeChannel.h
@@ -2,6 +2,7 @@
 #import <Ably/ARTRealtimeChannel.h>
 
 @class ARTWrapperSDKProxyRealtimeChannel;
+@class ARTWrapperSDKProxyPushChannel;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -18,7 +19,7 @@ NS_SWIFT_SENDABLE
 @property (readonly) ARTRealtimePresence *presence;
 
 #if TARGET_OS_IPHONE
-@property (readonly) ARTPushChannel *push;
+@property (readonly) ARTWrapperSDKProxyPushChannel *push;
 #endif
 
 @end

--- a/Source/include/Ably/ARTWrapperSDKProxyRealtimePresence.h
+++ b/Source/include/Ably/ARTWrapperSDKProxyRealtimePresence.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+#import <Ably/ARTRealtimePresence.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * An object which wraps an instance of `ARTRealtimePresence` and provides a similar API. It allows Ably-authored wrapper SDKs to send analytics information so that Ably can track the usage of the wrapper SDK.
+ *
+ * - Important: This class should only be used by Ably-authored SDKs.
+ */
+NS_SWIFT_SENDABLE
+@interface ARTWrapperSDKProxyRealtimePresence : NSObject <ARTRealtimePresenceProtocol>
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/include/Ably/AblyInternal.h
+++ b/Source/include/Ably/AblyInternal.h
@@ -6,3 +6,4 @@
 #import <Ably/ARTWrapperSDKProxyRealtimeChannels.h>
 #import <Ably/ARTWrapperSDKProxyRealtimeChannel.h>
 #import <Ably/ARTWrapperSDKProxyPush.h>
+#import <Ably/ARTWrapperSDKProxyPushAdmin.h>

--- a/Source/include/Ably/AblyInternal.h
+++ b/Source/include/Ably/AblyInternal.h
@@ -7,3 +7,5 @@
 #import <Ably/ARTWrapperSDKProxyRealtimeChannel.h>
 #import <Ably/ARTWrapperSDKProxyPush.h>
 #import <Ably/ARTWrapperSDKProxyPushAdmin.h>
+#import <Ably/ARTWrapperSDKProxyPushDeviceRegistrations.h>
+#import <Ably/ARTWrapperSDKProxyPushChannelSubscriptions.h>

--- a/Source/include/Ably/AblyInternal.h
+++ b/Source/include/Ably/AblyInternal.h
@@ -10,3 +10,4 @@
 #import <Ably/ARTWrapperSDKProxyPushDeviceRegistrations.h>
 #import <Ably/ARTWrapperSDKProxyPushChannelSubscriptions.h>
 #import <Ably/ARTWrapperSDKProxyPushChannel.h>
+#import <Ably/ARTWrapperSDKProxyRealtimePresence.h>

--- a/Source/include/Ably/AblyInternal.h
+++ b/Source/include/Ably/AblyInternal.h
@@ -9,3 +9,4 @@
 #import <Ably/ARTWrapperSDKProxyPushAdmin.h>
 #import <Ably/ARTWrapperSDKProxyPushDeviceRegistrations.h>
 #import <Ably/ARTWrapperSDKProxyPushChannelSubscriptions.h>
+#import <Ably/ARTWrapperSDKProxyPushChannel.h>

--- a/Source/include/Ably/AblyInternal.h
+++ b/Source/include/Ably/AblyInternal.h
@@ -5,3 +5,4 @@
 #import <Ably/ARTWrapperSDKProxyRealtime.h>
 #import <Ably/ARTWrapperSDKProxyRealtimeChannels.h>
 #import <Ably/ARTWrapperSDKProxyRealtimeChannel.h>
+#import <Ably/ARTWrapperSDKProxyPush.h>

--- a/Source/include/Ably/AblyPublic.h
+++ b/Source/include/Ably/AblyPublic.h
@@ -47,3 +47,4 @@
 #import <Ably/ARTPendingMessage.h>
 #import <Ably/ARTStringifiable.h>
 #import <Ably/ARTClientInformation.h>
+#import <Ably/ARTChannelProtocol.h>

--- a/Test/Tests/AuthTests.swift
+++ b/Test/Tests/AuthTests.swift
@@ -2027,7 +2027,7 @@ class AuthTests: XCTestCase {
         rest.auth.internal.testSuite_returnValue(for: NSSelectorFromString("handleServerTime:"), with: mockServerDate)
 
         var serverTimeRequestCount = 0
-        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
+        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(withWrapperSDKAgents:completion:))) {
             serverTimeRequestCount += 1
         }
         defer { hook.remove() }
@@ -2171,7 +2171,7 @@ class AuthTests: XCTestCase {
         authOptions.key = options.key
 
         var serverTimeRequestCount = 0
-        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
+        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(withWrapperSDKAgents:completion:))) {
             serverTimeRequestCount += 1
         }
         defer { hook.remove() }
@@ -2306,7 +2306,7 @@ class AuthTests: XCTestCase {
 
         let hook = ARTRestInternal.aspect_hook(rest.internal)
         // Adds a block of code after `time` is triggered
-        _ = try hook(#selector(ARTRestInternal._time(_:)), .positionBefore, unsafeBitCast(block, to: ARTRestInternal.self))
+        _ = try hook(#selector(ARTRestInternal._time(withWrapperSDKAgents:completion:)), .positionBefore, unsafeBitCast(block, to: ARTRestInternal.self))
 
         let authOptions = ARTAuthOptions()
         authOptions.queryTime = true
@@ -2776,7 +2776,7 @@ class AuthTests: XCTestCase {
         authOptions.queryTime = true
 
         var serverTimeRequestWasMade = false
-        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
+        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(withWrapperSDKAgents:completion:))) {
             serverTimeRequestWasMade = true
         }
         defer { hook.remove() }
@@ -3334,7 +3334,7 @@ class AuthTests: XCTestCase {
         authOptions.queryTime = true
 
         var serverTimeRequestCount = 0
-        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
+        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(withWrapperSDKAgents:completion:))) {
             serverTimeRequestCount += 1
         }
         defer { hook.remove() }
@@ -3437,7 +3437,7 @@ class AuthTests: XCTestCase {
         let currentDate = Date()
 
         var serverTimeRequestCount = 0
-        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
+        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(withWrapperSDKAgents:completion:))) {
             serverTimeRequestCount += 1
         }
         defer { hook.remove() }
@@ -3493,7 +3493,7 @@ class AuthTests: XCTestCase {
         rest.auth.internal.testSuite_returnValue(for: NSSelectorFromString("handleServerTime:"), with: mockServerDate)
 
         var serverTimeRequestCount = 0
-        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
+        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(withWrapperSDKAgents:completion:))) {
             serverTimeRequestCount += 1
         }
         defer { hook.remove() }
@@ -3527,7 +3527,7 @@ class AuthTests: XCTestCase {
         let rest = ARTRest(options: options)
 
         var serverTimeRequestCount = 0
-        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(_:))) {
+        let hook = rest.internal.testSuite_injectIntoMethod(after: #selector(rest.internal._time(withWrapperSDKAgents:completion:))) {
             serverTimeRequestCount += 1
         }
         defer { hook.remove() }

--- a/Test/Tests/RealtimeClientPresenceTests.swift
+++ b/Test/Tests/RealtimeClientPresenceTests.swift
@@ -3569,12 +3569,12 @@ class RealtimeClientPresenceTests: XCTestCase {
 
         var restPresenceHistoryMethodWasCalled = false
 
-        let hookRest = channelRest.presence.internal.testSuite_injectIntoMethod(after: #selector(ARTRestPresenceInternal.history(_:callback:))) {
+        let hookRest = channelRest.presence.internal.testSuite_injectIntoMethod(after: #selector(ARTRestPresenceInternal.history(_:wrapperSDKAgents:callback:))) {
             restPresenceHistoryMethodWasCalled = true
         }
         defer { hookRest.remove() }
 
-        let hookRealtime = channelRealtime.presence.internal.testSuite_injectIntoMethod(after: #selector(ARTRestPresenceInternal.history(_:callback:))) {
+        let hookRealtime = channelRealtime.presence.internal.testSuite_injectIntoMethod(after: #selector(ARTRestPresenceInternal.history(_:wrapperSDKAgents:callback:))) {
             restPresenceHistoryMethodWasCalled = true
         }
         defer { hookRealtime.remove() }

--- a/Test/Tests/RealtimeClientTests.swift
+++ b/Test/Tests/RealtimeClientTests.swift
@@ -348,7 +348,7 @@ class RealtimeClientTests: XCTestCase {
         // Rest
         waitUntil(timeout: testTimeout) { done in
             expect {
-                try client.internal.rest.stats(query, callback: { paginated, error in
+                try client.internal.rest.stats(query, wrapperSDKAgents:nil, callback: { paginated, error in
                     defer { done() }
                     if let e = error {
                         XCTFail(e.localizedDescription)

--- a/Test/Tests/WrapperSDKProxyTests.swift
+++ b/Test/Tests/WrapperSDKProxyTests.swift
@@ -430,6 +430,19 @@ class WrapperSDKProxyTests: XCTestCase {
         }
     }
 
+    func test_pushAdmin_addsWrapperSDKAgentToRequests() throws {
+        let test = Test()
+
+        try parameterizedTest_addsWrapperSDKAgentToRequests(test: test) { proxyClient in
+            waitUntil(timeout: testTimeout) { done in
+                proxyClient.push.admin.publish(["clientId" : "foo"], data: ["notification" : ["title" : "Welcome"]]) { error in
+                    XCTAssertNil(error)
+                    done()
+                }
+            }
+        }
+    }
+
     // MARK: - `agent` channel param
 
     private func parameterizedTest_checkAttachProtocolMessage(

--- a/Test/Tests/WrapperSDKProxyTests.swift
+++ b/Test/Tests/WrapperSDKProxyTests.swift
@@ -502,6 +502,21 @@ class WrapperSDKProxyTests: XCTestCase {
     }
 #endif
 
+    func test_presenceHistory_addsWrapperSDKAgentToRequest() throws {
+        let test = Test()
+
+        try parameterizedTest_addsWrapperSDKAgentToRequests(test: test) { proxyClient in
+            let channel = proxyClient.channels.get(test.uniqueChannelName())
+
+            waitUntil(timeout: testTimeout) { done in
+                channel.presence.history() { _, error in
+                    XCTAssertNil(error)
+                    done()
+                }
+            }
+        }
+    }
+
     // MARK: - `agent` channel param
 
     private func parameterizedTest_checkAttachProtocolMessage(

--- a/Test/Tests/WrapperSDKProxyTests.swift
+++ b/Test/Tests/WrapperSDKProxyTests.swift
@@ -417,6 +417,19 @@ class WrapperSDKProxyTests: XCTestCase {
         }
     }
 
+    func test_stats_addsWrapperSDKAgentToRequest() throws {
+        let test = Test()
+
+        try parameterizedTest_addsWrapperSDKAgentToRequests(test: test) { proxyClient in
+            waitUntil(timeout: testTimeout) { done in
+                proxyClient.stats() { _, error in
+                    XCTAssertNil(error)
+                    done()
+                }
+            }
+        }
+    }
+
     // MARK: - `agent` channel param
 
     private func parameterizedTest_checkAttachProtocolMessage(

--- a/Test/Tests/WrapperSDKProxyTests.swift
+++ b/Test/Tests/WrapperSDKProxyTests.swift
@@ -443,6 +443,36 @@ class WrapperSDKProxyTests: XCTestCase {
         }
     }
 
+    func test_pushAdmin_channelSubscriptions_addsWrapperSDKAgentToRequests() throws {
+        let test = Test()
+
+        // We just do a smoke test of one of the methods offered by this class
+
+        try parameterizedTest_addsWrapperSDKAgentToRequests(test: test) { proxyClient in
+            waitUntil(timeout: testTimeout) { done in
+                proxyClient.push.admin.channelSubscriptions.listChannels { _, error in
+                    XCTAssertNil(error)
+                    done()
+                }
+            }
+        }
+    }
+
+    func test_pushAdmin_deviceRegistrations_addsWrapperSDKAgentToRequests() throws {
+        let test = Test()
+
+        // We just do a smoke test of one of the methods offered by this class
+
+        try parameterizedTest_addsWrapperSDKAgentToRequests(test: test) { proxyClient in
+            waitUntil(timeout: testTimeout) { done in
+                proxyClient.push.admin.deviceRegistrations.list([:]) { _, error in
+                    XCTAssertNil(error)
+                    done()
+                }
+            }
+        }
+    }
+
     // MARK: - `agent` channel param
 
     private func parameterizedTest_checkAttachProtocolMessage(


### PR DESCRIPTION
Continuation of #2020. Adds wrapper SDK agent to all HTTP requests initiated by a wrapper SDK proxy client, except for:

- token requests
- fetching server time as part of a token request
- internet-up check
- push activation

I'm going to update https://github.com/ably/specification/pull/273 to describe the behaviour implemented here.

Resolves #2029.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new, flexible client instantiation methods for real‑time connections.
  - Enhanced retrieval of message history, statistics, and presence data with improved contextual support for more robust communication.
  - Upgraded push notification management to provide more reliable and configurable alert delivery.

These improvements help ensure a smoother, more adaptable experience in managing real‑time messaging and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->