### PR TITLE
[WIP, ECO-5224] Add an example of a plugins mechanism

### DIFF
--- a/Ably.podspec
+++ b/Ably.podspec
@@ -20,6 +20,12 @@ Pod::Spec.new do |s|
   s.resource_bundles        = {'Ably' => ['Source/PrivacyInfo.xcprivacy']}
   s.private_header_files    = 'Source/PrivateHeaders/**/*.h', 'Source/SocketRocket/**/*.h'
   s.module_map              = 'Source/Ably.modulemap'
+  # This is for the import of `APLivePlugin.h` to resolve. Copied from:
+  # - https://stackoverflow.com/questions/28425765/add-a-user-header-search-path-to-a-podspec
+  # - https://stackoverflow.com/questions/58690010/including-a-directory-as-a-search-path-during-compilation-with-cocoapods
+  s.pod_target_xcconfig     = {
+    'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}/AblyPlugin/include"'
+  }
   s.dependency 'msgpack', '0.4.0'
   s.dependency 'AblyDeltaCodec', '1.3.3'
 end

--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -368,6 +368,9 @@
 		21AC0CD52D4AA3200030BD23 /* ARTWrapperSDKProxyRealtimeChannels.m in Sources */ = {isa = PBXBuildFile; fileRef = 21AC0CD12D4AA3200030BD23 /* ARTWrapperSDKProxyRealtimeChannels.m */; };
 		21AC0CD62D4AA3200030BD23 /* ARTWrapperSDKProxyRealtimeChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = 21AC0CD02D4AA3200030BD23 /* ARTWrapperSDKProxyRealtimeChannel.m */; };
 		21AC0CD72D4AA3200030BD23 /* ARTWrapperSDKProxyRealtimeChannels.m in Sources */ = {isa = PBXBuildFile; fileRef = 21AC0CD12D4AA3200030BD23 /* ARTWrapperSDKProxyRealtimeChannels.m */; };
+		21BFC2D62D67C58800C05E8B /* ARTRealtimeChannel+Plugins.h in Headers */ = {isa = PBXBuildFile; fileRef = 21BFC2D52D67C58800C05E8B /* ARTRealtimeChannel+Plugins.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		21BFC2D72D67C58800C05E8B /* ARTRealtimeChannel+Plugins.h in Headers */ = {isa = PBXBuildFile; fileRef = 21BFC2D52D67C58800C05E8B /* ARTRealtimeChannel+Plugins.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		21BFC2D82D67C58800C05E8B /* ARTRealtimeChannel+Plugins.h in Headers */ = {isa = PBXBuildFile; fileRef = 21BFC2D52D67C58800C05E8B /* ARTRealtimeChannel+Plugins.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21E1C0E52A0DC47400A5DB65 /* ARTWebSocketFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 21E1C0E42A0DC47400A5DB65 /* ARTWebSocketFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21E1C0E62A0DC47400A5DB65 /* ARTWebSocketFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 21E1C0E42A0DC47400A5DB65 /* ARTWebSocketFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21E1C0E72A0DC47400A5DB65 /* ARTWebSocketFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 21E1C0E42A0DC47400A5DB65 /* ARTWebSocketFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1377,6 +1380,7 @@
 		21AC0CC92D4AA0F50030BD23 /* ARTWrapperSDKProxyRealtimeChannels+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTWrapperSDKProxyRealtimeChannels+Private.h"; path = "PrivateHeaders/Ably/ARTWrapperSDKProxyRealtimeChannels+Private.h"; sourceTree = "<group>"; };
 		21AC0CD02D4AA3200030BD23 /* ARTWrapperSDKProxyRealtimeChannel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWrapperSDKProxyRealtimeChannel.m; sourceTree = "<group>"; };
 		21AC0CD12D4AA3200030BD23 /* ARTWrapperSDKProxyRealtimeChannels.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWrapperSDKProxyRealtimeChannels.m; sourceTree = "<group>"; };
+		21BFC2D52D67C58800C05E8B /* ARTRealtimeChannel+Plugins.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTRealtimeChannel+Plugins.h"; path = "PrivateHeaders/Ably/ARTRealtimeChannel+Plugins.h"; sourceTree = "<group>"; };
 		21DCDA8229F818630073A211 /* Ably-iOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = "Ably-iOS.xctestplan"; path = "Test/Ably-iOS.xctestplan"; sourceTree = SOURCE_ROOT; };
 		21DCDA8329F81B350073A211 /* Ably-macOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Ably-macOS.xctestplan"; sourceTree = "<group>"; };
 		21DCDA8429F81B550073A211 /* Ably-tvOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Ably-tvOS.xctestplan"; sourceTree = "<group>"; };
@@ -2124,6 +2128,7 @@
 				211A60DE29D7272000D169C5 /* ARTConnectionStateChangeParams.m */,
 				D746AE3A1BBC5AE1003ECEF8 /* ARTRealtimeChannel.h */,
 				D746AE421BBC5CD0003ECEF8 /* ARTRealtimeChannel+Private.h */,
+				21BFC2D52D67C58800C05E8B /* ARTRealtimeChannel+Plugins.h */,
 				D746AE3B1BBC5AE1003ECEF8 /* ARTRealtimeChannel.m */,
 				211A60FA29D8ABCF00D169C5 /* ARTChannelStateChangeParams.h */,
 				211A60FE29D8ABF100D169C5 /* ARTChannelStateChangeParams.m */,
@@ -2547,6 +2552,7 @@
 				D746AE1E1BBB5207003ECEF8 /* ARTDataQuery+Private.h in Headers */,
 				2132C2BD29D482E8000C4355 /* ARTClientOptions+TestConfiguration.h in Headers */,
 				D7AE18C91E5B40C900478D82 /* ARTPushAdmin.h in Headers */,
+				21BFC2D72D67C58800C05E8B /* ARTRealtimeChannel+Plugins.h in Headers */,
 				EB1B53FD22F8D91C006A59AC /* ARTQueuedDealloc.h in Headers */,
 				D77394031C6F6FFE00F5478F /* ARTProtocolMessage+Private.h in Headers */,
 				D746AE2F1BBBE7D7003ECEF8 /* ARTPaginatedResult+Private.h in Headers */,
@@ -2682,6 +2688,7 @@
 				D710D69221949EFF008F54AD /* ARTJsonEncoder.h in Headers */,
 				21113B4629DB484200652C86 /* ARTChannel+Subclass.h in Headers */,
 				D710D5B921949D4F008F54AD /* ARTTokenParams+Private.h in Headers */,
+				21BFC2D82D67C58800C05E8B /* ARTRealtimeChannel+Plugins.h in Headers */,
 				D710D51821949C42008F54AD /* ARTPushChannelSubscription.h in Headers */,
 				D710D4B421949B47008F54AD /* ARTAuth+Private.h in Headers */,
 				D710D4C221949B9C008F54AD /* ARTRealtimeTransport.h in Headers */,
@@ -2877,6 +2884,7 @@
 				D710D61621949DDC008F54AD /* ARTHttp.h in Headers */,
 				21113B4729DB484200652C86 /* ARTChannel+Subclass.h in Headers */,
 				D710D69D21949F00008F54AD /* ARTMsgPackEncoder.h in Headers */,
+				21BFC2D62D67C58800C05E8B /* ARTRealtimeChannel+Plugins.h in Headers */,
 				D710D69C21949F00008F54AD /* ARTJsonEncoder.h in Headers */,
 				D710D5C921949D50008F54AD /* ARTTokenParams+Private.h in Headers */,
 				D710D52A21949C44008F54AD /* ARTPushChannelSubscription.h in Headers */,
@@ -4152,7 +4160,10 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Source/Private";
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Source/Private",
+					"$(PROJECT_DIR)/AblyPlugin/include",
+				);
 				INFOPLIST_FILE = "Source/Info-iOS.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4179,7 +4190,10 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Source/Private";
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Source/Private",
+					"$(PROJECT_DIR)/AblyPlugin/include",
+				);
 				INFOPLIST_FILE = "Source/Info-iOS.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4352,7 +4366,10 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/include";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/include",
+					"$(PROJECT_DIR)/AblyPlugin/include",
+				);
 				INFOPLIST_FILE = "Source/Info-macOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4392,7 +4409,10 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/include";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/include",
+					"$(PROJECT_DIR)/AblyPlugin/include",
+				);
 				INFOPLIST_FILE = "Source/Info-macOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4427,7 +4447,10 @@
 				DEFINES_MODULE = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/include";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/include",
+					"$(PROJECT_DIR)/AblyPlugin/include",
+				);
 				INFOPLIST_FILE = "Source/Info-tvOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4466,7 +4489,10 @@
 				DEFINES_MODULE = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/include";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/include",
+					"$(PROJECT_DIR)/AblyPlugin/include",
+				);
 				INFOPLIST_FILE = "Source/Info-tvOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/AblyPlugin/APPluginAPI.m
+++ b/AblyPlugin/APPluginAPI.m
@@ -1,0 +1,28 @@
+#import "APPluginAPI.h"
+#import "ARTRealtimeChannel+Plugins.h"
+#import "ARTRealtimeChannel+Private.h"
+
+@implementation APPluginAPI
+
++ (void)setPluginDataValue:(nonnull id)value
+                    forKey:(nonnull NSString *)key
+                   channel:(nonnull ARTRealtimeChannel *)channel {
+    [channel setPluginDataValue:value forKey:key];
+}
+
++ (nullable id)pluginDataValueForKey:(nonnull NSString *)key
+                             channel:(nonnull ARTRealtimeChannel *)channel {
+    return [channel pluginDataValueForKey:key];
+}
+
++ (void)addPluginProtocolMessageListener:(APProtocolMessageListener)listener
+                                 channel:(nonnull ARTRealtimeChannel *)channel {
+    [channel addPluginProtocolMessageListener:listener];
+}
+
++ (void)sendProtocolMessage:(ARTProtocolMessage *)protocolMessage
+                    channel:(ARTRealtimeChannel *)channel {
+    [channel.internal sendProtocolMessage:protocolMessage];
+}
+
+@end

--- a/AblyPlugin/include/APLiveObjectsPlugin.h
+++ b/AblyPlugin/include/APLiveObjectsPlugin.h
@@ -1,0 +1,24 @@
+#import <Foundation/Foundation.h>
+
+@class ARTRealtimeChannel;
+@protocol APLiveObjectsPluginProtocol;
+
+NS_ASSUME_NONNULL_BEGIN
+
+// The `AblyLiveObjects.Plugin` class will _informally_ conform to this (informally so that we don't have to expose this protocol publicly); we keep this protocol simple because there will be no compiler checking
+NS_SWIFT_NAME(LiveObjectsPluginFactoryProtocol)
+@protocol APLiveObjectsPluginFactoryProtocol <NSObject>
+
++ (id<APLiveObjectsPluginProtocol>)createPlugin;
+
+@end
+
+// An internal class of `AblyLiveObjects` will conform to this; this protocol can be complex because compiler will check conformance
+NS_SWIFT_NAME(LiveObjectsPluginProtocol)
+@protocol APLiveObjectsPluginProtocol <NSObject>
+
+- (void)prepareChannel:(ARTRealtimeChannel *)channel;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AblyPlugin/include/APPluginAPI.h
+++ b/AblyPlugin/include/APPluginAPI.h
@@ -1,0 +1,32 @@
+@import Foundation;
+
+@class ARTRealtimeChannel;
+@class ARTProtocolMessage;
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(ProtocolMessageListener)
+typedef void (^APProtocolMessageListener)(ARTProtocolMessage *);
+
+NS_SWIFT_NAME(PluginAPI)
+
+/// This class provides a stable API for Ably-authored plugins to access certain private functionality of ably-cocoa.
+@interface APPluginAPI: NSObject
+
++ (void)setPluginDataValue:(id)value
+                    forKey:(NSString *)key
+                   channel:(ARTRealtimeChannel *)channel;
+
++ (nullable id)pluginDataValueForKey:(NSString *)key
+                             channel:(ARTRealtimeChannel *)channel;
+
+// Listener will be called each time a protocol message is received
++ (void)addPluginProtocolMessageListener:(APProtocolMessageListener)listener
+                                 channel:(ARTRealtimeChannel *)channel;
+
++ (void)sendProtocolMessage:(ARTProtocolMessage *)protocolMessage
+                    channel:(ARTRealtimeChannel *)channel;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AblyPlugin/include/ARTProtocolMessage.h
+++ b/AblyPlugin/include/ARTProtocolMessage.h
@@ -1,0 +1,1 @@
+../../Source/PrivateHeaders/Ably/ARTProtocolMessage.h

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,11 @@ let package = Package(
             name: "Ably",
             targets: ["Ably"]
         ),
+        // This library should only be used by Ably-authored plugins.
+        .library(
+            name: "AblyPlugin",
+            targets: ["AblyPlugin"]
+        ),
     ],
     dependencies: [
         .package(name: "msgpack", url: "https://github.com/rvi/msgpack-objective-C", from: "0.4.0"),
@@ -46,6 +51,18 @@ let package = Package(
                 .headerSearchPath("SocketRocket/Internal/RunLoop"),
                 .headerSearchPath("SocketRocket/Internal/Delegate"),
                 .headerSearchPath("SocketRocket/Internal/IOConsumer"),
+                .headerSearchPath("../AblyPlugin/include"),
+            ]
+        ),
+        .target(
+            name: "AblyPlugin",
+            dependencies: [
+                .byName(name: "Ably")
+            ],
+            path: "AblyPlugin",
+            cSettings: [
+                .headerSearchPath("../Source/PrivateHeaders"),
+                .headerSearchPath("../Source/PrivateHeaders/Ably")
             ]
         )
     ]

--- a/Source/ARTClientOptions.m
+++ b/Source/ARTClientOptions.m
@@ -10,6 +10,8 @@
 #import "ARTNSString+ARTUtil.h"
 #import "ARTTestClientOptions.h"
 
+const ARTPluginName ARTPluginNameLiveObjects = @"LiveObjects";
+
 NSString *ARTDefaultEnvironment = nil;
 
 @interface ARTClientOptions ()
@@ -140,6 +142,7 @@ NSString *ARTDefaultEnvironment = nil;
     options.transportParams = self.transportParams;
     options.agents = self.agents;
     options.testOptions = self.testOptions;
+    options.plugins = self.plugins;
 
     return options;
 }

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -130,5 +130,6 @@ framework module Ably {
         header "ARTPendingMessage.h"
         header "ARTEncoder.h"
         header "ARTDeviceStorage.h"
+        header "ARTRealtimeChannel+Plugins.h"
     }
 }

--- a/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Plugins.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Plugins.h
@@ -1,0 +1,16 @@
+#import <Ably/ARTRealtimeChannel.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^ARTProtocolMessageListener)(ARTProtocolMessage *);
+
+@interface ARTRealtimeChannel ()
+
+- (void)setPluginDataValue:(id)value forKey:(NSString *)key;
+- (nullable id)pluginDataValueForKey:(NSString *)key;
+
+- (void)addPluginProtocolMessageListener:(ARTProtocolMessageListener)listener;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
@@ -10,6 +10,7 @@
 #import <Ably/ARTRealtime+Private.h>
 #import <Ably/ARTQueuedDealloc.h>
 #import <Ably/ARTPushChannel+Private.h>
+#import <Ably/ARTRealtimeChannel+Plugins.h>
 
 @class ARTProtocolMessage;
 @class ARTRealtimePresenceInternal;
@@ -91,6 +92,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)history:(ARTRealtimeHistoryQuery *_Nullable)query wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTPaginatedMessagesCallback)callback error:(NSError *_Nullable *_Nullable)errorPtr;
 
 - (void)setOptions:(ARTRealtimeChannelOptions *_Nullable)options callback:(nullable ARTCallback)callback;
+
+- (void)addPluginProtocolMessageListener:(ARTProtocolMessageListener)listener;
+
+- (void)sendProtocolMessage:(ARTProtocolMessage *)protocolMessage;
 
 #pragma mark ARTEventEmitter
 

--- a/Source/include/Ably/ARTClientOptions.h
+++ b/Source/include/Ably/ARTClientOptions.h
@@ -9,6 +9,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NSString *ARTPluginName NS_TYPED_EXTENSIBLE_ENUM;
+extern const ARTPluginName ARTPluginNameLiveObjects;
+
 /**
  * Passes additional client-specific properties to the REST `-[ARTRestProtocol initWithOptions:]` or the Realtime `-[ARTRealtimeProtocol initWithOptions:]`.
  */
@@ -196,6 +199,13 @@ NS_ASSUME_NONNULL_BEGIN
  * A set of additional entries for the Ably agent header. Each entry can be a key string or set of key-value pairs. This should only be used by Ably-authored SDKs. If an agent does not have a version, represent this by using the `ARTClientInformationAgentNotVersioned` pointer as the version.
  */
 @property (nonatomic, copy, nullable) NSDictionary<NSString *, NSString *> *agents;
+
+/// A set of plugins that provide additional functionality to the client.
+///
+/// Currently supported keys:
+///
+/// - `ARTPluginNameLiveObjects`: Import the `AblyLiveObjects` module from the ably/ably-cocoa-liveobjects-plugin repository and set the value to `AblyLiveObjects.Plugin.self`.
+@property (nonatomic, copy, nullable) NSDictionary<ARTPluginName, id> *plugins;
 
 @end
 

--- a/liveobjects-dr.md
+++ b/liveobjects-dr.md
@@ -1,0 +1,119 @@
+# DR-xxx: Plugins for ably-cocoa SDK
+
+## Background
+
+We are going to introduce LiveObjects functionality into the ably-cocoa SDK in a way that meets the requirements outlined in https://ably.atlassian.net/wiki/spaces/SDK/pages/3814752393/LiveObject+Feature+-+Requirements+Design+Considerations.
+
+I think that, from those requirements, the ones which are most interesting to explore for ably-cocoa are how we can build something which:
+
+- is optional so as not to increase ably-cocoa size
+- can be implemented in Swift, using latest Swift language features
+- is unshackled from ably-cocoa's ancient OS requirements
+- can offer an API that uses Swift language features
+- can consume plugin-only API from ably-cocoa
+
+The rest of this DR is written with reference to the specific example of LiveObjects functionality, but the intention is to provide an outline for how we would also implement further plugins in the future.
+
+## Proposal
+
+### Distribution and OS requirements
+
+- We will only offer the LiveObjects SDK as a Swift Package Manager (SPM) package. The other package managers that we currently support in ably-cocoa, namely Carthage and CocoaPods, are rarely used for new projects and are not very maintained (CocoaPods is basically [being shut down by the end of 2026](https://blog.cocoapods.org/CocoaPods-Specs-Repo/)), and we already intend to remove support for them in the next major version of ably-cocoa.
+- We will distribute the LiveObjects SDK as a separate Swift package (thus necessitating us also distributing it in a separate Git repository) to ably-cocoa. This is because OS version requirements are package-wide, and we do not wish LiveObjects to be bound by ably-cocoa's OS requirements. LiveObjects will follow the same OS requirements as used in our Swift Chat SDK (the decisions that led to the Chat OS requirements can be found in [this commit message](https://github.com/ably/ably-chat-swift/commit/646c220cb68b4b184ed48412077ee96d13e64798)), unless we discover a compelling reason to only support even newer OS versions.
+
+### Example implementation
+
+An working example of the implementation which I describe below can be found in:
+
+- https://github.com/ably/ably-cocoa/pull/2039 - draft PR that adds a plugins mechanism to ably-cocoa, including the ability to pass a LiveObjects plugin
+- https://github.com/lawrence-forooghian/ably-cocoa-liveobjects-plugin - the LiveObjects plugin Swift package
+- https://github.com/lawrence-forooghian/ably-cocoa-liveobjects-example - a command-line app that uses the LiveObjects plugin
+
+### Structure
+
+#### Initial setup
+
+This sequence diagram shows the initial setup of the LiveObjects plugin:
+
+```mermaid
+sequenceDiagram
+  user app->>ably-cocoa: import
+  user app->>LiveObjects plugin: import
+  user app->>ably-cocoa: create client, passing plugin
+```
+
+The participants are the following:
+
+- user app: an application written by a user who wishes to use LiveObjects functionality
+- ably-cocoa: The core SDK
+- LiveObjects plugin: a class exported by the LiveObjects plugin Swift package
+
+ably-cocoa's `ClientOptions` will now implement the `plugins` option described in [TO3o](https://sdk.ably.com/builds/ably/specification/main/features/#TO3o).
+
+When the user app imports the LiveObjects plugin package, the ably-cocoa `ARTRealtimeChannel` type will be extended to provide a public `liveObjects` property. The return property of this type is a Swift type that exposes an API that can use Swift language features. Below I describe how this property will be implemented.
+
+#### Hooking into channel
+
+This sequence diagram shows how the LiveObjects plugin hooks in to the channel, allowing it to provide the `channel.liveObjects` property and (as an example of finding out non-public core SDK information) registering to receive information about incoming `ProtocolMessage`s:
+
+```mermaid
+sequenceDiagram
+  participant user app
+  participant ably-cocoa
+  participant AblyPlugin
+  user app->>ably-cocoa: fetch channel
+  ably-cocoa->>LiveObjects plugin: -prepareChannel:
+  LiveObjects plugin->>AblyPlugin: +setPluginDataValue:forKey:channel:
+  AblyPlugin->>ably-cocoa: private API
+  LiveObjects plugin->>AblyPlugin: +addPluginProtocolMessageListener:channel:
+  AblyPlugin->>ably-cocoa: private API
+```
+
+The additional participant here is the `AblyPlugin` library. This is a new library, which:
+
+- is exported by the ably-cocoa SPM package
+- is only intended for use by Ably-authored plugins
+- offers access to private API of the core SDK
+   - the intention is that this provide a _stable_ API that plugins can depend on, allowing the internals of the SDK to continue to evolve
+   - as currently written, it does also directly expose the `ARTProtocolMessage` type; we can consider whether we wish to do this, or wrap it in a guaranteed-to-be-stable type for plugin consumption (I didn't explore this here because I think that this is a pretty stable type)
+   - implementation note: `AblyPlugin` is able to access the internals of ably-cocoa because it lives in the same repository and thus can be configured to have access to ably-cocoa's private headers. This is easy because all of ably-cocoa is currently written in Objective-C. We would have to revisit this approach if we were to rewrite some of ably-cocoa in Swift, but since we don't yet know what such an ably-cocoa would look like it's hard to speculate about what approach we'd use instead. Given that such a rewrite would very likely coincide with a new major release of ably-cocoa, we'd be able to completely revisit the plugin approach at that moment.
+- in our example, the current APIs that it offers are:
+   - `+setPluginDataValue:forKey:channel:`, which allows a plugin to store arbitrary key-value data on a channel instance; this is used to provide the backing storage for the `channel.liveObjects` property
+   - `+addPluginProtocolMessageListener:channel:`, which allows a plugin to register a listener that receives all `ProtocolMessage`s received on a channel
+   - `+sendProtocolMessage:channel:`, which requests that ably-cocoa send a `ProtocolMessage` on a channel
+- is imported by the LiveObjects plugin using the recent Swift language feature `internal import` (see [SE-0409: Access-level modifiers on import declarations](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md)), which means that none of `AblyPlugin`'s API gets exposed to users of the LiveObjects plugin
+
+#### Receiving `ProtocolMessage`s
+
+This sequence diagram shows how the LiveObjects plugin receives incoming `ProtocolMessage`s via the previously-registered listener:
+
+```mermaid
+sequenceDiagram
+  participant ably-cocoa
+  participant LiveObjects plugin
+  Realtime service->>ably-cocoa: ProtocolMessage
+  ably-cocoa->>LiveObjects plugin: call protocol message listener
+``` 
+
+(In the case of LiveObjects, the LiveObjects plugin would then use this `ProtocolMessage` to update some internal state and notify the user about the new state of some live object.)
+
+#### Sending `ProtocolMessage`s
+
+The example implementation also demonstrates how the LiveObjects plugin might request that ably-cocoa send a `ProtocolMessage` on a channel, in response to a user calling the example method `channel.liveObjects.doALiveObjectsThing()`. If what's been proposed until now makes sense, then what's shown below probably isn't very surprising, but here it is for the sake of completeness.
+
+```mermaid
+sequenceDiagram
+  participant user app
+  participant ably-cocoa
+  participant AblyPlugin
+  participant LiveObjects plugin
+  participant Realtime service
+  user app->>LiveObjects plugin: channel.liveObjects.doALiveObjectsThing()
+  LiveObjects plugin->>AblyPlugin: +sendProtocolMessage:channel:
+  AblyPlugin->>ably-cocoa: private API
+  ably-cocoa->>Realtime service: ProtocolMessage
+```
+
+## Alternatives considered
+
+- Using a module map to expose a plugin API via a Clang submodule (i.e. `import Ably.PluginAPI`). This is similar to the mechanism that we currently use to expose ably-cocoa internals to its tests. The problem with this approach is that, when I tried it out, it appeared that there was no way to hide the plugin-only API from consumers of the LiveObjects plugin; the use of `internal import`, which is meant to hide these transitive dependencies, was (for some reason unknown to me) ineffective.


### PR DESCRIPTION
Part of #2035, investigating how we might implement the upcoming LiveObjects SDK as a plugin to the core SDK.

The code here is consumed by the following proof of concepts:

- LiveObjects plugin (https://github.com/lawrence-forooghian/ably-cocoa-liveobjects-plugin) - demonstrates how to consume the APIs that this commit exposes
- LiveObjects example (https://github.com/lawrence-forooghian/ably-cocoa-liveobjects-example) - demonstrates how a user would use the LiveObjects plugin

This demonstrates [ADR-128: Plugins for ably-cocoa SDK](https://ably.atlassian.net/wiki/spaces/ENG/pages/3838574593/ADR-128+Plugins+for+ably-cocoa+SDK).