### PR TITLE
Rename MetaOccupancy action Meta

### DIFF
--- a/Source/include/Ably/ARTMessage.h
+++ b/Source/include/Ably/ARTMessage.h
@@ -22,9 +22,12 @@ typedef NS_ENUM(NSUInteger, ARTMessageAction) {
      */
     ARTMessageActionDelete,
     /**
-     * Message action for a meta-message that contains channel occupancy information.
+     * A meta-message (a message originating from ably rather than being
+     * explicitly published on a channel), containing information such as
+     * inband channel occupancy events that has been requested by channel
+     * param.
      */
-    ARTMessageActionMetaOccupancy,
+    ARTMessageActionMeta,
     /**
      * Message action for a message containing the latest rolled-up summary of
      * annotations that have been made to this message.


### PR DESCRIPTION
https://github.com/ably/specification/pull/292/commits/35bbeb7f8ed9f384fb7105eac8adab7430254f45

Technically a breaking change. We're not considering it such because `Message.action` was only introduced recently as part of the annotations/materialization work, which isn't yet part of a publicly released feature yet, and isn't added to our [main documentation](https://ably.com/docs/api/realtime-sdk/types#message). So it's just very unlikely that anyone is relying on the action yet. Our inband occupancy events docs still all say to use the message name, which is not changing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed an enum value for improved clarity in message actions.
  - Updated comments to better explain the meaning and origin of meta-messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->