### PR TITLE
[ECO-5328] Add example of the methods needed for LiveObjects

### DIFF
--- a/AblyPlugin/APPluginAPI.m
+++ b/AblyPlugin/APPluginAPI.m
@@ -30,4 +30,18 @@
     return channel.internal.logger;
 }
 
+- (BOOL)throwIfUnpublishableStateForChannel:(ARTRealtimeChannel *)channel error:(ARTErrorInfo * _Nullable __autoreleasing *)error {
+    [NSException raise:NSInternalInconsistencyException format:@"Not yet implemented"];
+}
+
+- (void)sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages channel:(ARTRealtimeChannel *)channel completion:(void (^)(ARTErrorInfo * _Nonnull))completion {
+    [NSException raise:NSInternalInconsistencyException format:@"Not yet implemented"];
+}
+
+- (void)fetchTimestampWithQueryTime:(BOOL)queryTime
+                           realtime:(ARTRealtime *)realtime
+                         completion:(void (^ _Nullable)(ARTErrorInfo *_Nullable error, NSDate *_Nullable timestamp))completion {
+    [NSException raise:NSInternalInconsistencyException format:@"Not yet implemented"];
+}
+
 @end

--- a/AblyPlugin/include/APLiveObjectsPlugin.h
+++ b/AblyPlugin/include/APLiveObjectsPlugin.h
@@ -2,6 +2,7 @@
 
 @class ARTRealtimeChannel;
 @protocol APLiveObjectsInternalPluginProtocol;
+@protocol APObjectMessageProtocol;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -29,6 +30,53 @@ NS_SWIFT_SENDABLE
 /// The plugin can use this as an opportunity to perform any initial setup of LiveObjects functionality for this channel.
 - (void)prepareChannel:(ARTRealtimeChannel *)channel;
 
+/// Decodes an `ObjectMessage` received over the wire. Copied from ably-js; the exact meaning of this method and what it should return still to be decided. There will almost certainly be further parameters to add relating to format etc.
+- (id<APObjectMessageProtocol>)decodeObjectMessage:(NSDictionary *)serialized;
+
+/// Encodes an `ObjectMessage` to be sent over the wire. Copied from ably-js; the exact meaning of this method and what it should return still to be decided
+- (NSDictionary *)encodeObjectMessage:(id<APObjectMessageProtocol>)objectMessage;
+
+/// Called when a channel received an `ATTACHED` `ProtocolMessage`. (This is copied from ably-js, will document this method properly once exact meaning decided.)
+///
+/// TODO: what thread is this called on, and does it matter? Decide in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/3
+///
+/// Parameters:
+/// - channel: The channel that received the `ProtocolMessage`.
+/// - hasObjects: Whether the `ProtocolMessage` has the `HAS_OBJECTS` flag set.
+- (void)onChannelAttached:(ARTRealtimeChannel *)channel
+               hasObjects:(BOOL)hasObjects;
+
+/// Processes a received `OBJECT` `ProtocolMessage`.
+///
+/// TODO: what thread is this called on, and does it matter? Decide in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/3
+///
+/// Parameters:
+/// - objectMessages: The contents of the `ProtocolMessage`'s `state` property.
+/// - channel: The channel on which the `ProtocolMessage` was received.
+- (void)handleObjectProtocolMessageWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
+                                              channel:(ARTRealtimeChannel *)channel;
+
+/// Processes a received `OBJECT_SYNC` `ProtocolMessage`.
+///
+/// TODO: what thread is this called on, and does it matter? Decide in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/3
+///
+/// Parameters:
+/// - objectMessages: The contents of the `ProtocolMessage`'s `state` property.
+/// - channel: The channel on which the `ProtocolMessage` was received.
+- (void)handleObjectSyncProtocolMessageWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
+                             protocolMessageChannelSerial:(NSString *)protocolMessageChannelSerial
+                                                  channel:(ARTRealtimeChannel *)channel;
+
+@end
+
+/// An `ObjectMessage`, as found in the `state` property of an `OBJECT` or `OBJECT_SYNC` `ProtocolMessage`.
+///
+/// This protocol is empty because ably-cocoa does not need to interact with the contents of an `ObjectMessage`.
+///
+/// An instance of `APLiveObjectsInternalPluginProtocol` is expected to be able to handle any `APObjectMessageProtocol` instance that it creates.
+NS_SWIFT_NAME(ObjectMessageProtocol)
+NS_SWIFT_SENDABLE
+@protocol APObjectMessageProtocol
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AblyPlugin/include/APPluginAPI.h
+++ b/AblyPlugin/include/APPluginAPI.h
@@ -4,6 +4,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol APLogger;
+@protocol APObjectMessageProtocol;
 
 /// `APPluginAPIProtocol` provides a stable API (that is, one which will not introduce backwards-incompatible changes within a given major version of ably-cocoa) for Ably-authored plugins to access certain private functionality of ably-cocoa.
 ///
@@ -27,6 +28,20 @@ NS_SWIFT_SENDABLE
 ///
 /// - Parameter channel: The channel whose logger the returned logger should wrap.
 - (id<APLogger>)loggerForChannel:(ARTRealtimeChannel *)channel;
+
+/// Throws an error if the channel is in a state in which a message should not be published. Copied from ably-js, not yet implemented. Will document this method properly once exact meaning decided, or may replace it with something that makes more sense for ably-cocoa.
+- (BOOL)throwIfUnpublishableStateForChannel:(ARTRealtimeChannel *)channel
+                                      error:(ARTErrorInfo *_Nullable *_Nullable)error;
+
+/// Sends an `OBJECT` `ProtocolMessage` on a channel and indicates the result of waiting for an `ACK`. Copied from ably-js, not yet implemented. Will document this method properly once exact meaning decided, or may replace it with something that makes more sense for ably-cocoa.
+- (void)sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
+                             channel:(ARTRealtimeChannel *)channel
+                          completion:(void (^ _Nullable)(ARTErrorInfo *_Nullable error))completion;
+
+/// Returns the server time, as calculated from the `ARTRealtimeInstance`'s stored offset between the local clock and the server time. Copied from ably-js, not yet implemented. Will document this method once exact meaning decided, or may replace it with something that makes more sense for ably-cocoa.
+- (void)fetchTimestampWithQueryTime:(BOOL)queryTime
+                           realtime:(ARTRealtime *)realtime
+                         completion:(void (^ _Nullable)(ARTErrorInfo *_Nullable error, NSDate *_Nullable timestamp))completion;
 
 @end
 


### PR DESCRIPTION
An initial example of the plugin-to-core and core-to-plugin APIs, based on looking at ably-js at `caa8ba1`. Nothing implemented yet, will do so (and refine the meaning of the methods) later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for encoding, decoding, and handling object messages within channels.
  - Introduced plugin capabilities to validate channel state, send object messages, and fetch server timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->