### PR TITLE
Fix crash when receiving `ProtocolMessage` with unknown action

### DIFF
--- a/Source/ARTProtocolMessage.m
+++ b/Source/ARTProtocolMessage.m
@@ -216,4 +216,9 @@ NSString* ARTProtocolMessageActionToStr(ARTProtocolMessageAction action) {
         case ARTProtocolMessageAuth:
             return @"Auth"; //17
     }
+
+    // Because we blindly assign the action field of a ProtocolMessage received over the wire to a variable of type ARTProtocolMessageAction, we can't rely on the compiler's exhaustive checking of switch statements for ARTProtocolMessageAction.
+    //
+    // TODO: we have https://github.com/ably/specification/issues/304 for making sure we properly implement the RSF1 robustness principle for enums.
+    return @"Unknown";
 }


### PR DESCRIPTION
Noticed this when adding new actions for LiveObjects.

Because we blindly assign the `action` field of a `ProtocolMessage` received over the wire to a variable of type `ARTProtocolMessageAction`, we can't rely on the compiler's exhaustive checking of `switch` statements for `ARTProtocolMessageAction`.

I'm not making any broader fixes, since we have already have https://github.com/ably/specification/issues/304 for making sure we properly implement the RSF1 robustness principle for enums.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of unrecognized action values by displaying "Unknown" instead of returning no value. This ensures clearer feedback for unexpected cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->