### PR TITLE
[ECO-5239] Implement protocol-level changes needed for LiveObjects

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -347,6 +347,12 @@
 		21881E7A283BD08300CFD9E2 /* GCDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A22171266F526600C87C42 /* GCDTests.swift */; };
 		21881E7B283BD0DF00CFD9E2 /* StringifiableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D520C4DD2680A1E3000012B2 /* StringifiableTests.swift */; };
 		21881E7C283BD0E100CFD9E2 /* StringifiableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D520C4DD2680A1E3000012B2 /* StringifiableTests.swift */; };
+		2188F74B2DF773D3009C8A23 /* ARTPluginDecodingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 2188F74A2DF773D3009C8A23 /* ARTPluginDecodingContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2188F74C2DF773D3009C8A23 /* ARTPluginDecodingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 2188F74A2DF773D3009C8A23 /* ARTPluginDecodingContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2188F74D2DF773D3009C8A23 /* ARTPluginDecodingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 2188F74A2DF773D3009C8A23 /* ARTPluginDecodingContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2188F74F2DF773ED009C8A23 /* ARTPluginDecodingContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 2188F74E2DF773ED009C8A23 /* ARTPluginDecodingContext.m */; };
+		2188F7502DF773ED009C8A23 /* ARTPluginDecodingContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 2188F74E2DF773ED009C8A23 /* ARTPluginDecodingContext.m */; };
+		2188F7512DF773ED009C8A23 /* ARTPluginDecodingContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 2188F74E2DF773ED009C8A23 /* ARTPluginDecodingContext.m */; };
 		21AC0CC22D4AA0630030BD23 /* ARTWrapperSDKProxyRealtimeChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 21AC0CC02D4AA0630030BD23 /* ARTWrapperSDKProxyRealtimeChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		21AC0CC32D4AA0630030BD23 /* ARTWrapperSDKProxyRealtimeChannels.h in Headers */ = {isa = PBXBuildFile; fileRef = 21AC0CC12D4AA0630030BD23 /* ARTWrapperSDKProxyRealtimeChannels.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		21AC0CC42D4AA0630030BD23 /* ARTWrapperSDKProxyRealtimeChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 21AC0CC02D4AA0630030BD23 /* ARTWrapperSDKProxyRealtimeChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1367,6 +1373,8 @@
 		217FCF3D29D626E4006E5F2D /* StaticJitterCoefficients.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StaticJitterCoefficients.swift; sourceTree = "<group>"; };
 		217FCF3E29D626E4006E5F2D /* MockJitterCoefficientGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockJitterCoefficientGenerator.swift; sourceTree = "<group>"; };
 		217FCF4529D626F6006E5F2D /* DefaultJitterCoefficientGeneratorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultJitterCoefficientGeneratorTests.swift; sourceTree = "<group>"; };
+		2188F74A2DF773D3009C8A23 /* ARTPluginDecodingContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTPluginDecodingContext.h; path = PrivateHeaders/Ably/ARTPluginDecodingContext.h; sourceTree = "<group>"; };
+		2188F74E2DF773ED009C8A23 /* ARTPluginDecodingContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTPluginDecodingContext.m; sourceTree = "<group>"; };
 		21AC0CC02D4AA0630030BD23 /* ARTWrapperSDKProxyRealtimeChannel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTWrapperSDKProxyRealtimeChannel.h; path = include/Ably/ARTWrapperSDKProxyRealtimeChannel.h; sourceTree = "<group>"; };
 		21AC0CC12D4AA0630030BD23 /* ARTWrapperSDKProxyRealtimeChannels.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTWrapperSDKProxyRealtimeChannels.h; path = include/Ably/ARTWrapperSDKProxyRealtimeChannels.h; sourceTree = "<group>"; };
 		21AC0CC82D4AA0F50030BD23 /* ARTWrapperSDKProxyRealtimeChannel+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTWrapperSDKProxyRealtimeChannel+Private.h"; path = "PrivateHeaders/Ably/ARTWrapperSDKProxyRealtimeChannel+Private.h"; sourceTree = "<group>"; };
@@ -2306,6 +2314,8 @@
 				2124B79A29DB14C000AD8361 /* ARTLogAdapter.m */,
 				21276CB929EF323100107B5F /* ARTContinuousClock.h */,
 				21276CBD29EF34AE00107B5F /* ARTContinuousClock.m */,
+				2188F74A2DF773D3009C8A23 /* ARTPluginDecodingContext.h */,
+				2188F74E2DF773ED009C8A23 /* ARTPluginDecodingContext.m */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -2463,6 +2473,7 @@
 				21113B5129DC6AAF00652C86 /* ARTTestClientOptions.h in Headers */,
 				EB8AC6431C6515ED002ABA92 /* ARTTokenParams+Private.h in Headers */,
 				2105ED2629E830D600DE6D67 /* ARTInternalLog+Testing.h in Headers */,
+				2188F74D2DF773D3009C8A23 /* ARTPluginDecodingContext.h in Headers */,
 				D746AE1D1BBB5207003ECEF8 /* ARTDataQuery.h in Headers */,
 				D71966E41E5DF360000974DD /* ARTPushActivationStateMachine.h in Headers */,
 				D71966EA1E5E006E000974DD /* ARTPushActivationState.h in Headers */,
@@ -2745,6 +2756,7 @@
 				D710D56A21949CB9008F54AD /* ARTPushAdmin.h in Headers */,
 				D710D48321949A4E008F54AD /* ARTDefault+Private.h in Headers */,
 				D70C36C4233E6831002FD6E3 /* ARTFormEncode.h in Headers */,
+				2188F74C2DF773D3009C8A23 /* ARTPluginDecodingContext.h in Headers */,
 				215924902D636839004A235C /* ARTWrapperSDKProxyPush+Private.h in Headers */,
 				D710D59021949D29008F54AD /* ARTStatus.h in Headers */,
 				D5BB213A26AAA60500AA5F3E /* ARTNSError+ARTUtils.h in Headers */,
@@ -2939,6 +2951,7 @@
 				EB1B53FF22F8D91C006A59AC /* ARTQueuedDealloc.h in Headers */,
 				D710D57021949CBA008F54AD /* ARTPushAdmin.h in Headers */,
 				D710D48521949A4F008F54AD /* ARTDefault+Private.h in Headers */,
+				2188F74B2DF773D3009C8A23 /* ARTPluginDecodingContext.h in Headers */,
 				215924912D636839004A235C /* ARTWrapperSDKProxyPush+Private.h in Headers */,
 				D70C36C5233E6831002FD6E3 /* ARTFormEncode.h in Headers */,
 				D710D5B621949D2A008F54AD /* ARTStatus.h in Headers */,
@@ -3382,6 +3395,7 @@
 				D769E15421270F3400DC5CD1 /* ARTHTTPPaginatedResponse.m in Sources */,
 				D7DEAFD21E65926D00D23F24 /* ARTLocalDevice.m in Sources */,
 				EB2D84FD1CD769B800F23CDA /* ARTOSReachability.m in Sources */,
+				2188F7512DF773ED009C8A23 /* ARTPluginDecodingContext.m in Sources */,
 				217D1829254222F500DFF07E /* ARTSRHash.m in Sources */,
 				D5D83C0A26AAEFEB00AADC8E /* NSURLQueryItem+Stringifiable.m in Sources */,
 				D746AE481BBD6FE9003ECEF8 /* ARTQueuedMessage.m in Sources */,
@@ -3637,6 +3651,7 @@
 				D710D4F121949C0D008F54AD /* ARTQueuedMessage.m in Sources */,
 				D710D49521949AC2008F54AD /* ARTRest.m in Sources */,
 				D710D53921949C54008F54AD /* ARTNSMutableRequest+ARTPush.m in Sources */,
+				2188F7502DF773ED009C8A23 /* ARTPluginDecodingContext.m in Sources */,
 				217D1840254222F700DFF07E /* ARTSRHash.m in Sources */,
 				D5D83C0926AAEFEA00AADC8E /* NSURLQueryItem+Stringifiable.m in Sources */,
 				D710D66D21949E78008F54AD /* ARTLog.m in Sources */,
@@ -3772,6 +3787,7 @@
 				D710D49721949AC3008F54AD /* ARTRest.m in Sources */,
 				D710D54B21949C55008F54AD /* ARTNSMutableRequest+ARTPush.m in Sources */,
 				D5BB213326AAA55C00AA5F3E /* ARTNSMutableURLRequest+ARTUtils.m in Sources */,
+				2188F74F2DF773ED009C8A23 /* ARTPluginDecodingContext.m in Sources */,
 				217D1857254222F900DFF07E /* ARTSRHash.m in Sources */,
 				D710D65321949E77008F54AD /* ARTLog.m in Sources */,
 				217D185E254222F900DFF07E /* ARTSRMutex.m in Sources */,

--- a/AblyPlugin/APPluginAPI.m
+++ b/AblyPlugin/APPluginAPI.m
@@ -35,7 +35,8 @@
 }
 
 - (void)sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages channel:(ARTRealtimeChannel *)channel completion:(void (^)(ARTErrorInfo * _Nonnull))completion {
-    [NSException raise:NSInternalInconsistencyException format:@"Not yet implemented"];
+    [channel.internal sendStateWithObjectMessages:objectMessages
+                                       completion:completion];
 }
 
 - (void)fetchTimestampWithQueryTime:(BOOL)queryTime

--- a/AblyPlugin/include/APDecodingContext.h
+++ b/AblyPlugin/include/APDecodingContext.h
@@ -1,0 +1,24 @@
+@import Foundation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(DecodingContextProtocol)
+NS_SWIFT_SENDABLE
+/// Contains contextual information that may be needed when decoding an object contained within a `ProtocolMessage`.
+@protocol APDecodingContextProtocol
+
+/// The `id` of the `ProtocolMessage` that contains the object that is being decoded.
+@property (nonatomic, readonly, nullable) NSString *parentID;
+
+/// The `connectionId` of the `ProtocolMessage` that contains the object that is being decoded.
+@property (nonatomic, readonly, nullable) NSString *parentConnectionID;
+
+/// The `timestamp` of the `ProtocolMessage` that contains the object that is being decoded.
+@property (nonatomic, readonly, nullable) NSDate *parentTimestamp;
+
+/// The index, inside the array in the `ProtocolMessage` that contains the object that is being decoded, of the object that is being decoded.
+@property (nonatomic, readonly) NSInteger indexInParent;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AblyPlugin/include/APLiveObjectsPlugin.h
+++ b/AblyPlugin/include/APLiveObjectsPlugin.h
@@ -1,8 +1,10 @@
 #import <Foundation/Foundation.h>
 
 @class ARTRealtimeChannel;
+@class ARTErrorInfo;
 @protocol APLiveObjectsInternalPluginProtocol;
 @protocol APObjectMessageProtocol;
+@protocol APDecodingContextProtocol;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -30,11 +32,24 @@ NS_SWIFT_SENDABLE
 /// The plugin can use this as an opportunity to perform any initial setup of LiveObjects functionality for this channel.
 - (void)prepareChannel:(ARTRealtimeChannel *)channel;
 
-/// Decodes an `ObjectMessage` received over the wire. Copied from ably-js; the exact meaning of this method and what it should return still to be decided. There will almost certainly be further parameters to add relating to format etc.
-- (id<APObjectMessageProtocol>)decodeObjectMessage:(NSDictionary *)serialized;
+/// Decodes an `ObjectMessage` received over the wire.
+///
+/// Parameters:
+/// - serialized: A dictionary that contains the representation of the `ObjectMessage` received over the wire. You should expect to find the same types of values here as you would in the output of Foundation's `JSONSerialization`.
+/// - context: Contains information that may be needed in the decoding, such as information about the containing `ProtocolMessage`.
+///
+/// Returns: A `ObjectMessageProtocol` object that ably-cocoa can later pass to this plugin's `-handleObjectProtocolMessageWithObjectMessages:channel:` method, or `nil` if decoding fails (in which case `error` must be populated).
+- (nullable id<APObjectMessageProtocol>)decodeObjectMessage:(NSDictionary<NSString *, id> *)serialized
+                                                    context:(id<APDecodingContextProtocol>)context
+                                                      error:(ARTErrorInfo *_Nullable *_Nullable)error;
 
-/// Encodes an `ObjectMessage` to be sent over the wire. Copied from ably-js; the exact meaning of this method and what it should return still to be decided
-- (NSDictionary *)encodeObjectMessage:(id<APObjectMessageProtocol>)objectMessage;
+/// Encodes an `ObjectMessage` to be sent over the wire.
+///
+/// Parameters:
+/// - objectMessage: An `ObjectMessage` that this plugin earlier passed to `APPluginAPI`'s `-sendStateWithObjectMessages:channel:completion:`.
+///
+/// Returns: An object that ably-cocoa can pass to Foundation's `JSONSerialization`.
+- (NSDictionary<NSString *, id> *)encodeObjectMessage:(id<APObjectMessageProtocol>)objectMessage;
 
 /// Called when a channel received an `ATTACHED` `ProtocolMessage`. (This is copied from ably-js, will document this method properly once exact meaning decided.)
 ///

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ These are the header files that form the internal interface of the SDK.
 
 1. Put `.h` file in directory `Source/PrivateHeaders/Ably`.
 1. Add `header` declaration to the `Private` module in module map files `Source/Ably.modulemap` and `Source/include/module.modulemap`.
+   - Note that if a header file imports a header file from `ARTPlugin` (for example `ARTPluginDecodingContext.h`'s import of `APDecodingContext.h`), then it must not go in this header map, else you get an error "Include of non-modular header inside framework module 'Ably.Private'".
 1. Add to the Xcode project `Ably.xcodeproj` — you need to add it as a Private header to all three SDK targets (Ably-iOS, Ably-macOS, Ably-tvOS).
 
 ### Implementation (`.m`) files

--- a/Docs/plugins.md
+++ b/Docs/plugins.md
@@ -12,7 +12,7 @@ Currently, our only plugin is for adding LiveObjects functionality. This plugin 
 
 - Written in Objective-C (so that it can access ably-cocoa's private headers).
 - There is a two-way dependency between ably-cocoa and `AblyPlugin`:
-    - ably-cocoa imports `AblyPlugin`'s plugin headers (e.g. `APLiveObjectsPlugin.h`) so that it can access the methods exposed by plugins.
+    - ably-cocoa imports `AblyPlugin`'s plugin headers (e.g. `APLiveObjectsPlugin.h`) so that it can access the methods exposed by plugins. However, ably-cocoa does not _link_ to `AblyPlugin`, and so it cannot depend on any classes defined in `AblyPlugin`.
     - `AblyPlugin` imports ably-cocoa's private headers so that it can expose ably-cocoa's internals to plugins via `PluginAPI`.
 - Currently, the plan is to test all the LiveObjects functionality within the LiveObjects plugin repository, so ably-cocoa does not contain any tests for the plugins mechanism.
 

--- a/Source/ARTJsonLikeEncoder.m
+++ b/Source/ARTJsonLikeEncoder.m
@@ -789,7 +789,9 @@
                                               subscribers:[input artInteger:@"subscribers"]
                                       presenceConnections:[input artInteger:@"presenceConnections"]
                                           presenceMembers:[input artInteger:@"presenceMembers"]
-                                      presenceSubscribers:[input artInteger:@"presenceSubscribers"]];;
+                                      presenceSubscribers:[input artInteger:@"presenceSubscribers"]
+                                         objectPublishers:[input artInteger:@"objectPublishers"]
+                                        objectSubscribers:[input artInteger:@"objectSubscribers"]];
 }
 
 - (ARTChannelOccupancy *)channelOccupancyFromDictionary:(NSDictionary *)input {

--- a/Source/ARTJsonLikeEncoder.m
+++ b/Source/ARTJsonLikeEncoder.m
@@ -26,6 +26,9 @@
 #import "ARTJsonEncoder.h"
 #import "ARTPushChannelSubscription.h"
 #import "ARTMessageOperation+Private.h"
+#import "ARTClientOptions+Private.h"
+#import "APLiveObjectsPlugin.h"
+#import "ARTPluginDecodingContext.h"
 
 @implementation ARTJsonLikeEncoder {
     __weak ARTRestInternal *_rest; // weak because rest owns self
@@ -522,6 +525,10 @@
         output[@"params"] = message.params;
     }
 
+    if (message.state) {
+        output[@"state"] = [self objectMessagesToArray:message.state];
+    }
+
     ARTLogVerbose(_logger, @"RS:%p ARTJsonLikeEncoder<%@>: protocolMessageToDictionary %@", _rest, [_delegate formatAsString], output);
     return output;
 }
@@ -765,6 +772,7 @@
     NSMutableArray *messages = [[input objectForKey:@"messages"] mutableCopy];
     message.messages = [self messagesFromArray:messages protocolMessage:message];
     message.presence = [self presenceMessagesFromArray:[input objectForKey:@"presence"]];
+    message.state = [self objectMessagesFromArray:[input objectForKey:@"state"] protocolMessage:message];
 
     return message;
 }
@@ -1041,6 +1049,79 @@
     }
     ARTLogDebug(_logger, @"RS:%p ARTJsonLikeEncoder<%@> encoding '%@'; got: %@", _rest, [_delegate formatAsString], obj, encoded);
     return encoded;
+}
+
+/// Uses the LiveObjects plugin to decode an array of `ObjectMessage`s.
+///
+/// Returns `nil` if the LiveObjects plugin has not been supplied, or if we fail to decode any of the `ObjectMessage`s.
+- (nullable NSArray<id<APObjectMessageProtocol>> *)objectMessagesFromArray:(nullable id)input
+                                                           protocolMessage:(ARTProtocolMessage *)protocolMessage {
+    if (![input isKindOfClass:[NSArray class]]) {
+        return nil;
+    }
+
+    NSArray *inputArray = input;
+
+    id<APLiveObjectsInternalPluginProtocol> liveObjectsPlugin = _rest.options.liveObjectsPlugin;
+
+    if (!liveObjectsPlugin) {
+        return nil;
+    }
+
+    NSMutableArray<id<APObjectMessageProtocol>> *output = [NSMutableArray array];
+
+    for (NSInteger i = 0; i < inputArray.count; i++) {
+        id item = inputArray[i];
+
+        if (![item isKindOfClass:[NSDictionary class]]) {
+            return nil;
+        }
+
+        ARTPluginDecodingContext *decodingContext = [[ARTPluginDecodingContext alloc] initWithParentID:protocolMessage.id
+                                                                                    parentConnectionID:protocolMessage.connectionId
+                                                                                       parentTimestamp:protocolMessage.timestamp
+                                                                                         indexInParent:i];
+
+        ARTErrorInfo *error;
+
+        id<APObjectMessageProtocol> objectMessage = [liveObjectsPlugin decodeObjectMessage:item
+                                                                                   context:decodingContext
+                                                                                     error:&error];
+
+        if (!objectMessage) {
+            ARTLogWarn(_logger, @"RS:%p ARTJsonLikeEncoder<%@>: LiveObjects plugin failed to decode ObjectMessage %@, error %@", _rest, [_delegate formatAsString], item, error);
+            return nil;
+        }
+
+        [output addObject:objectMessage];
+    }
+
+    return output;
+}
+
+/// Uses the LiveObjects plugin to encode an array of `ObjectMessage`s.
+///
+/// Returns `nil` if the input is `nil`.
+- (NSArray<NSDictionary *> *)objectMessagesToArray:(nullable NSArray<id<APObjectMessageProtocol>> *)objectMessages {
+    if (!objectMessages) {
+        return nil;
+    }
+
+    id<APLiveObjectsInternalPluginProtocol> liveObjectsPlugin = _rest.options.liveObjectsPlugin;
+
+    if (!liveObjectsPlugin) {
+        // The only thing that sends ObjectMessage is the LiveObjects plugin, so if we have some to encode then the plugin must be present
+        [NSException raise:NSInternalInconsistencyException format:@"Attempted to encode ObjectMessages without a LiveObjects plugin; this should not be possible."];
+        return nil;
+    }
+
+    NSMutableArray<NSDictionary *> *result = [NSMutableArray array];
+
+    for (id objectMessage in objectMessages) {
+        [result addObject:[liveObjectsPlugin encodeObjectMessage:objectMessage]];
+    }
+
+    return result;
 }
 
 @end

--- a/Source/ARTPluginDecodingContext.m
+++ b/Source/ARTPluginDecodingContext.m
@@ -1,0 +1,24 @@
+#import "ARTPluginDecodingContext.h"
+
+@implementation ARTPluginDecodingContext
+
+@synthesize parentID = _parentID;
+@synthesize parentConnectionID = _parentConnectionID;
+@synthesize parentTimestamp = _parentTimestamp;
+@synthesize indexInParent = _indexInParent;
+
+- (instancetype)initWithParentID:(NSString *)parentID
+              parentConnectionID:(NSString *)parentConnectionID
+                 parentTimestamp:(NSDate *)parentTimestamp
+                   indexInParent:(NSInteger)indexInParent {
+    self = [super init];
+    if (self) {
+        _parentID = [parentID copy];
+        _parentConnectionID = [parentConnectionID copy];
+        _parentTimestamp = [parentTimestamp copy];
+        _indexInParent = indexInParent;
+    }
+    return self;
+}
+
+@end

--- a/Source/ARTProtocolMessage.m
+++ b/Source/ARTProtocolMessage.m
@@ -48,6 +48,7 @@
     [description appendFormat:@" timestamp: %@,\n", self.timestamp];
     [description appendFormat:@" flags: %lld,\n", self.flags];
     [description appendFormat:@" flags.hasPresence: %@,\n", NSStringFromBOOL(self.hasPresence)];
+    [description appendFormat:@" flags.hasObjects: %@,\n", NSStringFromBOOL(self.hasObjects)];
     [description appendFormat:@" flags.hasBacklog: %@,\n", NSStringFromBOOL(self.hasBacklog)];
     [description appendFormat:@" flags.resumed: %@,\n", NSStringFromBOOL(self.resumed)];
     [description appendFormat:@" messages: %@\n", self.messages];
@@ -161,6 +162,10 @@
 
 - (BOOL)hasPresence {
     return self.flags & ARTProtocolMessageFlagHasPresence;
+}
+
+- (BOOL)hasObjects {
+    return self.flags & ARTProtocolMessageFlagHasObjects;
 }
 
 - (BOOL)hasBacklog {

--- a/Source/ARTProtocolMessage.m
+++ b/Source/ARTProtocolMessage.m
@@ -157,7 +157,10 @@
 }
 
 - (BOOL)ackRequired {
-    return self.action == ARTProtocolMessageMessage || self.action == ARTProtocolMessagePresence;
+    // RTN7a
+    return self.action == ARTProtocolMessageMessage
+    || self.action == ARTProtocolMessagePresence
+    || self.action == ARTProtocolMessageObject;
 }
 
 - (BOOL)hasPresence {

--- a/Source/ARTProtocolMessage.m
+++ b/Source/ARTProtocolMessage.m
@@ -220,6 +220,10 @@ NSString* ARTProtocolMessageActionToStr(ARTProtocolMessageAction action) {
             return @"Sync"; //16
         case ARTProtocolMessageAuth:
             return @"Auth"; //17
+        case ARTProtocolMessageObject:
+            return @"Object"; //19
+        case ARTProtocolMessageObjectSync:
+            return @"ObjectSync"; //20
     }
 
     // Because we blindly assign the action field of a ProtocolMessage received over the wire to a variable of type ARTProtocolMessageAction, we can't rely on the compiler's exhaustive checking of switch statements for ARTProtocolMessageAction.

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -660,6 +660,9 @@ dispatch_sync(_queue, ^{
         self.channelSerial = message.channelSerial;
     }
 
+    [self.realtime.options.liveObjectsPlugin onChannelAttached:self.channel
+                                                    hasObjects:message.hasObjects];
+
     if (state == ARTRealtimeChannelAttached) {
         if (!message.resumed) { // RTL12
             if (message.error != nil) {

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -56,6 +56,7 @@
 - (instancetype)initWithInternal:(ARTRealtimeChannelInternal *)internal queuedDealloc:(ARTQueuedDealloc *)dealloc {
     self = [super init];
     if (self) {
+        internal.channel_onlyForPassingToPlugins = self;
         _internal = internal;
         _dealloc = dealloc;
 
@@ -398,6 +399,20 @@ dispatch_sync(_queue, ^{
 });
 }
 
+- (void)sendStateWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
+                         completion:(ARTCallback)completion {
+    ARTProtocolMessage *pm = [[ARTProtocolMessage alloc] init];
+    pm.action = ARTProtocolMessageObject;
+    pm.channel = self.name;
+    pm.state = objectMessages;
+
+    [self publishProtocolMessage:pm callback:^(ARTStatus *status) {
+        if (completion) {
+            completion(status.errorInfo);
+        }
+    }];
+ }
+
 - (void)publishProtocolMessage:(ARTProtocolMessage *)pm callback:(ARTStatusCallback)cb {
     switch (self.state_nosync) {
         case ARTRealtimeChannelSuspended:
@@ -634,10 +649,10 @@ dispatch_sync(_queue, ^{
             [self onSync:message];
             break;
         case ARTProtocolMessageObject:
-            // TODO: Add code for this to get handled by the LiveObjects plugin
+            [self onObject:message];
             break;
         case ARTProtocolMessageObjectSync:
-            // TODO: Add code for this to get handled by the LiveObjects plugin
+            [self onObjectSync:message];
             break;
         default:
             ARTLogWarn(self.logger, @"R:%p C:%p (%@) unknown ARTProtocolMessage action: %tu", _realtime, self, self.name, message.action);
@@ -666,7 +681,7 @@ dispatch_sync(_queue, ^{
         self.channelSerial = message.channelSerial;
     }
 
-    [self.realtime.options.liveObjectsPlugin onChannelAttached:self.channel
+    [self.realtime.options.liveObjectsPlugin onChannelAttached:self.channel_onlyForPassingToPlugins
                                                     hasObjects:message.hasObjects];
 
     if (state == ARTRealtimeChannelAttached) {
@@ -834,6 +849,32 @@ dispatch_sync(_queue, ^{
                                                                                                errorInfo:msg.error];
     [self performTransitionToState:ARTRealtimeChannelFailed withParams:params];
     [self failPendingPresenceWithState:ARTStateError info:msg.error];
+}
+
+- (void)onObject:(ARTProtocolMessage *)pm {
+    // RTL15b
+    if (pm.channelSerial) {
+        self.channelSerial = pm.channelSerial;
+    }
+
+    if (!pm.state) {
+        // Because the plugin isn't set up or because decoding failed
+        return;
+    }
+
+    [self.realtime.options.liveObjectsPlugin handleObjectProtocolMessageWithObjectMessages:pm.state
+                                                                                   channel:self.channel_onlyForPassingToPlugins];
+}
+
+- (void)onObjectSync:(ARTProtocolMessage *)pm {
+    if (!pm.state) {
+        // Because the plugin isn't set up or because decoding failed
+        return;
+    }
+
+    [self.realtime.options.liveObjectsPlugin handleObjectSyncProtocolMessageWithObjectMessages:pm.state
+                                                                  protocolMessageChannelSerial:pm.channelSerial
+                                                                                       channel:self.channel_onlyForPassingToPlugins];
 }
 
 - (void)attach {

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -633,6 +633,12 @@ dispatch_sync(_queue, ^{
         case ARTProtocolMessageSync:
             [self onSync:message];
             break;
+        case ARTProtocolMessageObject:
+            // TODO: Add code for this to get handled by the LiveObjects plugin
+            break;
+        case ARTProtocolMessageObjectSync:
+            // TODO: Add code for this to get handled by the LiveObjects plugin
+            break;
         default:
             ARTLogWarn(self.logger, @"R:%p C:%p (%@) unknown ARTProtocolMessage action: %tu", _realtime, self, self.name, message.action);
             break;

--- a/Source/ARTTypes.m
+++ b/Source/ARTTypes.m
@@ -155,7 +155,9 @@ NSString *ARTRealtimeConnectionEventToStr(ARTRealtimeConnectionEvent event) {
                         subscribers:(NSInteger)subscribers
                 presenceConnections:(NSInteger)presenceConnections
                     presenceMembers:(NSInteger)presenceMembers
-                presenceSubscribers:(NSInteger)presenceSubscribers {
+                presenceSubscribers:(NSInteger)presenceSubscribers
+                   objectPublishers:(NSInteger)objectPublishers
+                  objectSubscribers:(NSInteger)objectSubscribers {
     
     if (self = [super init]) {
         _connections = connections;
@@ -164,6 +166,8 @@ NSString *ARTRealtimeConnectionEventToStr(ARTRealtimeConnectionEvent event) {
         _presenceConnections = presenceConnections;
         _presenceMembers = presenceMembers;
         _presenceSubscribers = presenceSubscribers;
+        _objectPublishers = objectPublishers;
+        _objectSubscribers = objectSubscribers;
     }
     return self;
 }

--- a/Source/PrivateHeaders/Ably/ARTDataEncoder.h
+++ b/Source/PrivateHeaders/Ably/ARTDataEncoder.h
@@ -20,7 +20,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-/// :nodoc:
+/**
+ * `ARTDataEncoder` is used to:
+ *
+ * - convert the `data` property of an `ARTMessage` into a format that's suitable to be sent over the wire; that is, to ensure that this `ARTMessage` can be placed inside an `ARTProtocolMessage`
+ * - convert the `data` property of an `ARTMessage` contained inside an `ARTProtocolMessage` into something that's suitable to expose to the user of the SDK
+ */
 @interface ARTDataEncoder : NSObject
 
 - (instancetype)initWithCipherParams:(ARTCipherParams *_Nullable)params logger:(ARTInternalLog *)logger error:(NSError *_Nullable*_Nullable)error;

--- a/Source/PrivateHeaders/Ably/ARTPluginDecodingContext.h
+++ b/Source/PrivateHeaders/Ably/ARTPluginDecodingContext.h
@@ -1,0 +1,17 @@
+#import <Foundation/Foundation.h>
+#import "APDecodingContext.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARTPluginDecodingContext: NSObject <APDecodingContextProtocol>
+
+- (instancetype)initWithParentID:(nullable NSString *)parentID
+              parentConnectionID:(nullable NSString *)parentConnectionID
+                 parentTimestamp:(nullable NSDate *)parentTimestamp
+                   indexInParent:(NSInteger)indexInParent NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTProtocolMessage+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTProtocolMessage+Private.h
@@ -6,6 +6,7 @@ typedef NS_OPTIONS(NSUInteger, ARTProtocolMessageFlag) {
     ARTProtocolMessageFlagHasLocalPresence = (1UL << 3),
     ARTProtocolMessageFlagTransient = (1UL << 4),
     ARTProtocolMessageFlagAttachResume = (1UL << 5),
+    ARTProtocolMessageFlagHasObjects = (1UL << 7),
     ARTProtocolMessageFlagPresence = (1UL << 16),
     ARTProtocolMessageFlagPublish = (1UL << 17),
     ARTProtocolMessageFlagSubscribe = (1UL << 18),
@@ -21,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic) BOOL ackRequired;
 
 @property (readonly, nonatomic) BOOL hasPresence;
+@property (readonly, nonatomic) BOOL hasObjects;
 @property (readonly, nonatomic) BOOL hasBacklog;
 @property (readonly, nonatomic) BOOL resumed;
 

--- a/Source/PrivateHeaders/Ably/ARTProtocolMessage+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTProtocolMessage+Private.h
@@ -9,7 +9,9 @@ typedef NS_OPTIONS(NSUInteger, ARTProtocolMessageFlag) {
     ARTProtocolMessageFlagPresence = (1UL << 16),
     ARTProtocolMessageFlagPublish = (1UL << 17),
     ARTProtocolMessageFlagSubscribe = (1UL << 18),
-    ARTProtocolMessageFlagPresenceSubscribe = (1UL << 19)
+    ARTProtocolMessageFlagPresenceSubscribe = (1UL << 19),
+    ARTProtocolMessageFlagObjectSubscribe = (1UL << 24),
+    ARTProtocolMessageFlagObjectPublish = (1UL << 25)
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Source/PrivateHeaders/Ably/ARTProtocolMessage.h
+++ b/Source/PrivateHeaders/Ably/ARTProtocolMessage.h
@@ -8,6 +8,7 @@
 @class ARTErrorInfo;
 @class ARTMessage;
 @class ARTPresenceMessage;
+@protocol APObjectMessageProtocol;
 
 /// :nodoc:
 typedef NS_ENUM(NSUInteger, ARTProtocolMessageAction) {
@@ -62,6 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, readwrite, nonatomic) ARTConnectionDetails *connectionDetails;
 @property (nullable, nonatomic) ARTAuthDetails *auth;
 @property (nonatomic, nullable) NSStringDictionary *params;
+@property (nullable, readwrite, nonatomic) NSArray<id<APObjectMessageProtocol>> *state;
 
 @end
 

--- a/Source/PrivateHeaders/Ably/ARTProtocolMessage.h
+++ b/Source/PrivateHeaders/Ably/ARTProtocolMessage.h
@@ -29,6 +29,8 @@ typedef NS_ENUM(NSUInteger, ARTProtocolMessageAction) {
     ARTProtocolMessageMessage = 15,
     ARTProtocolMessageSync = 16,
     ARTProtocolMessageAuth = 17,
+    ARTProtocolMessageObject = 19,
+    ARTProtocolMessageObjectSync = 20,
 };
 
 /// :nodoc:

--- a/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
@@ -15,6 +15,7 @@
 @class ARTRealtimePresenceInternal;
 @class ARTChannelStateChangeParams;
 @class ARTAttachRequestParams;
+@protocol APObjectMessageProtocol;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -36,6 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)canBeReattached;
 - (BOOL)shouldAttach;
 - (ARTChannelProperties *)properties_nosync;
+
+// The channel that this internal object belongs to. We need a reference to it so that we can pass it to plugins for them to handle LiveObjects protocol messages. Avoid using this property for anything else. TODO understand whether this needs to be weak in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/9
+@property (nonatomic, weak) ARTRealtimeChannel *channel_onlyForPassingToPlugins;
 
 @property (readonly, weak, nonatomic) ARTRealtimeInternal *realtime; // weak because realtime owns self
 @property (readonly, nonatomic) ARTRestChannelInternal *restChannel;
@@ -126,6 +130,10 @@ ART_EMBED_INTERFACE_EVENT_EMITTER(ARTChannelEvent, ARTChannelStateChange *)
 - (void)setPluginDataValue:(id)value forKey:(NSString *)key;
 /// Provides the implementation for `-[APPluginAPI pluginDataValueForKey:channel]`. See documentation for that method.
 - (nullable id)pluginDataValueForKey:(NSString *)key;
+
+/// Provides the implementation for `-[APPluginAPI sendStateWithObjectMessages:completion:]`. See documentation for that method.
+- (void)sendStateWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
+                         completion:(ARTCallback)completion;
 
 @end
 

--- a/Source/include/Ably/ARTRealtimeChannelOptions.h
+++ b/Source/include/Ably/ARTRealtimeChannelOptions.h
@@ -22,7 +22,15 @@ typedef NS_OPTIONS(NSUInteger, ARTChannelMode) {
     /**
          * The client can receive presence messages.
          */
-    ARTChannelModePresenceSubscribe = 1 << 19
+    ARTChannelModePresenceSubscribe = 1 << 19,
+    /**
+     * The client can receive object messages.
+     */
+    ARTChannelModeObjectSubscribe = 1 << 24,
+    /**
+     * The client can publish object messages.
+     */
+    ARTChannelModeObjectPublish = 1 << 25
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Source/include/Ably/ARTTypes.h
+++ b/Source/include/Ably/ARTTypes.h
@@ -353,13 +353,25 @@ NS_SWIFT_SENDABLE
  */
 @property (nonatomic, readonly) NSInteger presenceSubscribers;
 
+/**
+ * The number of realtime attachments permitted to publish object messages to the channel. This requires the `object-publish` capability and for a client to have specified an `ARTChannelMode` flag that includes `ARTChannelMode.ARTChannelModeObjectPublish`.
+ */
+@property (nonatomic, readonly) NSInteger objectPublishers;
+
+/**
+ * The number of realtime attachments receiving object messages on the channel. This requires the `object-subscribe` capability and for a client to have specified an `ARTChannelMode` flag that includes `ARTChannelMode.ARTChannelModeObjectSubscribe`.
+ */
+@property (nonatomic, readonly) NSInteger objectSubscribers;
+
 /// :nodoc:
 - (instancetype)initWithConnections:(NSInteger)connections
                          publishers:(NSInteger)publishers
                         subscribers:(NSInteger)subscribers
                 presenceConnections:(NSInteger)presenceConnections
                     presenceMembers:(NSInteger)presenceMembers
-                presenceSubscribers:(NSInteger)presenceSubscribers;
+                presenceSubscribers:(NSInteger)presenceSubscribers
+                   objectPublishers:(NSInteger)objectPublishers
+                  objectSubscribers:(NSInteger)objectSubscribers;
 
 @end
 

--- a/Test/Tests/RestClientChannelTests.swift
+++ b/Test/Tests/RestClientChannelTests.swift
@@ -1635,9 +1635,20 @@ class RestClientChannelTests: XCTestCase {
         let rest = ARTRest(options: options)
         let realtime = ARTRealtime(options: options)
         let channelName = test.uniqueChannelName()
-        let realtimeChannel = realtime.channels.get(channelName)
+        let channelOptions = ARTRealtimeChannelOptions()
+        channelOptions.modes = [
+            /* the default modes… */
+            .subscribe,
+            .publish,
+            .presenceSubscribe,
+            .presence,
+            /* … plus those for LiveObjects (needed for objectPublishers and objectSubscribers) */
+            .objectPublish,
+            .objectSubscribe
+        ]
+        let realtimeChannel = realtime.channels.get(channelName, options: channelOptions)
         let restChannel = rest.channels.get(channelName)
-        
+
         waitUntil(timeout: testTimeout) { done in
             realtimeChannel.presence.enter(nil) { error in
                 XCTAssertNil(error)
@@ -1672,6 +1683,8 @@ class RestClientChannelTests: XCTestCase {
                 XCTAssertEqual(details.status.occupancy.metrics.presenceMembers, 1) // CHM2c
                 XCTAssertEqual(details.status.occupancy.metrics.presenceConnections, 1) // CHM2b
                 XCTAssertEqual(details.status.occupancy.metrics.presenceSubscribers, 1) // CHM2d
+                XCTAssertEqual(details.status.occupancy.metrics.objectPublishers, 1) // CHM2g
+                XCTAssertEqual(details.status.occupancy.metrics.objectSubscribers, 1) // CHM2h
                 done()
             }
         }


### PR DESCRIPTION
**Note: This PR is based on top of #2054; please review that one first.**

This adds all of the protocol-level changes that ably-cocoa needs for LiveObjects support, and implements the related required interactions with the LiveObjects plugin. See commit messages for more details.

The interactions with the LiveObjects plugin are tested as part of the plugin in https://github.com/ably/ably-cocoa-liveobjects-plugin/pull/14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for object-based protocol messages, enabling channels to send and receive object state and sync messages.
  - Introduced new channel modes for object publishing and subscribing.
  - Added new metrics for tracking object publishers and subscribers on channels.
  - Enhanced protocol message handling to support object-related actions and state.
  - Introduced a decoding context protocol providing metadata during object message decoding.

- **Bug Fixes**
  - Channels now safely ignore object protocol messages if the LiveObjects plugin is not provided, preventing crashes or message blocking.

- **Documentation**
  - Updated developer and plugin documentation to clarify usage and integration details for object messaging and private headers.

- **Tests**
  - Added tests for handling object protocol messages and verifying channel metrics for object publishers and subscribers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->