### PR TITLE
Make OBJECT_SYNC channelSerial passed to plugin nullable

### DIFF
--- a/AblyPlugin/include/APLiveObjectsPlugin.h
+++ b/AblyPlugin/include/APLiveObjectsPlugin.h
@@ -84,7 +84,7 @@ NS_SWIFT_SENDABLE
 /// - objectMessages: The contents of the `ProtocolMessage`'s `state` property.
 /// - channel: The channel on which the `ProtocolMessage` was received.
 - (void)handleObjectSyncProtocolMessageWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
-                             protocolMessageChannelSerial:(NSString *)protocolMessageChannelSerial
+                             protocolMessageChannelSerial:(nullable NSString *)protocolMessageChannelSerial
                                                   channel:(ARTRealtimeChannel *)channel;
 
 @end


### PR DESCRIPTION
**Note: This PR is based on top of #2068; please review that one first.**

Mistake in 2df7939.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved compatibility by allowing certain parameters to accept empty values in plugin integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->