### PR TITLE
Make sure not to pass a nil channel to LiveObjects plugin

### DIFF
--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -885,8 +885,15 @@ dispatch_sync(_queue, ^{
         return;
     }
 
+    // It appears that it's possible for the ARTRealtimeChannel to become deallocated before its corresponding ARTRealtimeChannelInternal does (not sure how that works; investigate as part of https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/9); for now just make sure that we honour our contract and not pass nil to handleObjectProtocolMessageWithObjectMessages:channel:
+    ARTRealtimeChannel *channel = self.channel_onlyForPassingToPlugins;
+    if (!channel) {
+        ARTLogDebug(self.logger, @"R:%p C:%p (%@) %@", _realtime, self, self.name, @"self.channel_onlyForPassingToPlugins is nil upon receipt of OBJECT; dropping");
+        return;
+    }
+
     [self.realtime.options.liveObjectsPlugin handleObjectProtocolMessageWithObjectMessages:pm.state
-                                                                                   channel:self.channel_onlyForPassingToPlugins];
+                                                                                   channel:channel];
 }
 
 - (void)onObjectSync:(ARTProtocolMessage *)pm {
@@ -895,9 +902,16 @@ dispatch_sync(_queue, ^{
         return;
     }
 
+    // It appears that it's possible for the ARTRealtimeChannel to become deallocated before its corresponding ARTRealtimeChannelInternal does (not sure how that works; investigate as part of https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/9); for now just make sure that we honour our contract and not pass nil to handleObjectSyncProtocolMessageWithObjectMessages:channel:
+    ARTRealtimeChannel *channel = self.channel_onlyForPassingToPlugins;
+    if (!channel) {
+        ARTLogDebug(self.logger, @"R:%p C:%p (%@) %@", _realtime, self, self.name, @"self.channel_onlyForPassingToPlugins is nil upon receipt of OBJECT_SYNC; dropping");
+        return;
+    }
+
     [self.realtime.options.liveObjectsPlugin handleObjectSyncProtocolMessageWithObjectMessages:pm.state
                                                                   protocolMessageChannelSerial:pm.channelSerial
-                                                                                       channel:self.channel_onlyForPassingToPlugins];
+                                                                                       channel:channel];
 }
 
 - (void)attach {


### PR DESCRIPTION
**Note: This PR is based on top of #2071; please review that one first.**

Note that this workaround is subsequently reverted by #2073.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by ensuring messages are not processed if the related channel has been deallocated, preventing potential crashes and unexpected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->