### PR TITLE
Pass `ARTRealtimeChannelInternal` to plugins

### DIFF
--- a/Ably.podspec
+++ b/Ably.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   # - https://stackoverflow.com/questions/28425765/add-a-user-header-search-path-to-a-podspec
   # - https://stackoverflow.com/questions/58690010/including-a-directory-as-a-search-path-during-compilation-with-cocoapods
   s.pod_target_xcconfig     = {
-    'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}/AblyPlugin/include"'
+    'HEADER_SEARCH_PATHS' => ['"${PODS_TARGET_SRCROOT}/AblyPlugin/include"', '"${PODS_TARGET_SRCROOT}/AblyPlugin/PrivateHeaders"']
   }
   s.dependency 'msgpack', '0.4.0'
   s.dependency 'AblyDeltaCodec', '1.3.3'

--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -4227,6 +4227,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/Source/Private",
 					"$(PROJECT_DIR)/AblyPlugin/include",
+					"$(PROJECT_DIR)/AblyPlugin/PrivateHeaders",
 				);
 				INFOPLIST_FILE = "Source/Info-iOS.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -4257,6 +4258,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/Source/Private",
 					"$(PROJECT_DIR)/AblyPlugin/include",
+					"$(PROJECT_DIR)/AblyPlugin/PrivateHeaders",
 				);
 				INFOPLIST_FILE = "Source/Info-iOS.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -4433,6 +4435,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/include",
 					"$(PROJECT_DIR)/AblyPlugin/include",
+					"$(PROJECT_DIR)/AblyPlugin/PrivateHeaders",
 				);
 				INFOPLIST_FILE = "Source/Info-macOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -4476,6 +4479,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/include",
 					"$(PROJECT_DIR)/AblyPlugin/include",
+					"$(PROJECT_DIR)/AblyPlugin/PrivateHeaders",
 				);
 				INFOPLIST_FILE = "Source/Info-macOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -4514,6 +4518,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/include",
 					"$(PROJECT_DIR)/AblyPlugin/include",
+					"$(PROJECT_DIR)/AblyPlugin/PrivateHeaders",
 				);
 				INFOPLIST_FILE = "Source/Info-tvOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -4556,6 +4561,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/include",
 					"$(PROJECT_DIR)/AblyPlugin/include",
+					"$(PROJECT_DIR)/AblyPlugin/PrivateHeaders",
 				);
 				INFOPLIST_FILE = "Source/Info-tvOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/AblyPlugin/APPluginAPI.m
+++ b/AblyPlugin/APPluginAPI.m
@@ -2,6 +2,22 @@
 #import "ARTRealtimeChannel+Private.h"
 #import "ARTChannel+Private.h"
 #import "ARTInternalLog+APLogger.h"
+#import "ARTRealtimeChannelInternal+APRealtimeChannel.h"
+#import "ARTRealtimeInternal+APRealtimeClient.h"
+
+static ARTRealtimeChannelInternal *_internalRealtimeChannel(id<APRealtimeChannel> pluginRealtimeChannel) {
+    if (![pluginRealtimeChannel isKindOfClass:[ARTRealtimeChannelInternal class]]) {
+        [NSException raise:NSInternalInconsistencyException format:@"Expected ARTRealtimeChannelInternal, got %@", pluginRealtimeChannel];
+    }
+    return (ARTRealtimeChannelInternal *)pluginRealtimeChannel;
+}
+
+static ARTRealtimeInternal *_internalRealtimeClient(id<APRealtimeClient> pluginRealtimeClient) {
+    if (![pluginRealtimeClient isKindOfClass:[ARTRealtimeInternal class]]) {
+        [NSException raise:NSInternalInconsistencyException format:@"Expected ARTRealtimeInternal, got %@", pluginRealtimeClient];
+    }
+    return (ARTRealtimeInternal *)pluginRealtimeClient;
+}
 
 @implementation APPluginAPI
 
@@ -15,32 +31,36 @@
     return sharedInstance;
 }
 
+- (id<APRealtimeChannel>)channelForPublicRealtimeChannel:(ARTRealtimeChannel *)channel {
+    return channel.internal;
+}
+
 - (void)setPluginDataValue:(nonnull id)value
                     forKey:(nonnull NSString *)key
-                   channel:(nonnull ARTRealtimeChannel *)channel {
-    [channel.internal setPluginDataValue:value forKey:key];
+                   channel:(nonnull id<APRealtimeChannel>)channel {
+    [_internalRealtimeChannel(channel) setPluginDataValue:value forKey:key];
 }
 
 - (nullable id)pluginDataValueForKey:(nonnull NSString *)key
-                             channel:(nonnull ARTRealtimeChannel *)channel {
-    return [channel.internal pluginDataValueForKey:key];
+                             channel:(nonnull id<APRealtimeChannel>)channel {
+    return [_internalRealtimeChannel(channel) pluginDataValueForKey:key];
 }
 
-- (id<APLogger>)loggerForChannel:(ARTRealtimeChannel *)channel {
-    return channel.internal.logger;
+- (id<APLogger>)loggerForChannel:(id<APRealtimeChannel>)channel {
+    return _internalRealtimeChannel(channel).logger;
 }
 
-- (BOOL)throwIfUnpublishableStateForChannel:(ARTRealtimeChannel *)channel error:(ARTErrorInfo * _Nullable __autoreleasing *)error {
+- (BOOL)throwIfUnpublishableStateForChannel:(id<APRealtimeChannel>)channel error:(ARTErrorInfo * _Nullable __autoreleasing *)error {
     [NSException raise:NSInternalInconsistencyException format:@"Not yet implemented"];
 }
 
-- (void)sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages channel:(ARTRealtimeChannel *)channel completion:(void (^)(ARTErrorInfo * _Nonnull))completion {
-    [channel.internal sendStateWithObjectMessages:objectMessages
-                                       completion:completion];
+- (void)sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages channel:(id<APRealtimeChannel>)channel completion:(void (^)(ARTErrorInfo * _Nonnull))completion {
+    [_internalRealtimeChannel(channel) sendStateWithObjectMessages:objectMessages
+                                                        completion:completion];
 }
 
 - (void)fetchTimestampWithQueryTime:(BOOL)queryTime
-                           realtime:(ARTRealtime *)realtime
+                           realtime:(id<APRealtimeClient>)realtime
                          completion:(void (^ _Nullable)(ARTErrorInfo *_Nullable error, NSDate *_Nullable timestamp))completion {
     [NSException raise:NSInternalInconsistencyException format:@"Not yet implemented"];
 }

--- a/AblyPlugin/PrivateHeaders/ARTRealtimeChannelInternal+APRealtimeChannel.h
+++ b/AblyPlugin/PrivateHeaders/ARTRealtimeChannelInternal+APRealtimeChannel.h
@@ -1,0 +1,5 @@
+#import "ARTRealtimeChannel+Private.h"
+#import "APRealtimeChannel.h"
+
+@interface ARTRealtimeChannelInternal (APRealtimeChannel) <APRealtimeChannel>
+@end

--- a/AblyPlugin/PrivateHeaders/ARTRealtimeInternal+APRealtimeClient.h
+++ b/AblyPlugin/PrivateHeaders/ARTRealtimeInternal+APRealtimeClient.h
@@ -1,0 +1,5 @@
+#import "ARTRealtime+Private.h"
+#import "APRealtimeClient.h"
+
+@interface ARTRealtimeInternal (APRealtimeClient) <APRealtimeClient>
+@end

--- a/AblyPlugin/include/APLiveObjectsPlugin.h
+++ b/AblyPlugin/include/APLiveObjectsPlugin.h
@@ -6,6 +6,7 @@
 @protocol APLiveObjectsInternalPluginProtocol;
 @protocol APObjectMessageProtocol;
 @protocol APDecodingContextProtocol;
+@protocol APRealtimeChannel;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -31,7 +32,7 @@ NS_SWIFT_SENDABLE
 /// ably-cocoa will call this method when initializing an `ARTRealtimeChannel` instance.
 ///
 /// The plugin can use this as an opportunity to perform any initial setup of LiveObjects functionality for this channel.
-- (void)prepareChannel:(ARTRealtimeChannel *)channel;
+- (void)prepareChannel:(id<APRealtimeChannel>)channel;
 
 /// Decodes an `ObjectMessage` received over the wire.
 ///
@@ -63,7 +64,7 @@ NS_SWIFT_SENDABLE
 /// Parameters:
 /// - channel: The channel that received the `ProtocolMessage`.
 /// - hasObjects: Whether the `ProtocolMessage` has the `HAS_OBJECTS` flag set.
-- (void)onChannelAttached:(ARTRealtimeChannel *)channel
+- (void)onChannelAttached:(id<APRealtimeChannel>)channel
                hasObjects:(BOOL)hasObjects;
 
 /// Processes a received `OBJECT` `ProtocolMessage`.
@@ -74,7 +75,7 @@ NS_SWIFT_SENDABLE
 /// - objectMessages: The contents of the `ProtocolMessage`'s `state` property.
 /// - channel: The channel on which the `ProtocolMessage` was received.
 - (void)handleObjectProtocolMessageWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
-                                              channel:(ARTRealtimeChannel *)channel;
+                                              channel:(id<APRealtimeChannel>)channel;
 
 /// Processes a received `OBJECT_SYNC` `ProtocolMessage`.
 ///
@@ -85,7 +86,7 @@ NS_SWIFT_SENDABLE
 /// - channel: The channel on which the `ProtocolMessage` was received.
 - (void)handleObjectSyncProtocolMessageWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
                              protocolMessageChannelSerial:(nullable NSString *)protocolMessageChannelSerial
-                                                  channel:(ARTRealtimeChannel *)channel;
+                                                  channel:(id<APRealtimeChannel>)channel;
 
 @end
 

--- a/AblyPlugin/include/APPluginAPI.h
+++ b/AblyPlugin/include/APPluginAPI.h
@@ -5,6 +5,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol APLogger;
 @protocol APObjectMessageProtocol;
+@protocol APRealtimeChannel;
+@protocol APRealtimeClient;
 
 /// `APPluginAPIProtocol` provides a stable API (that is, one which will not introduce backwards-incompatible changes within a given major version of ably-cocoa) for Ably-authored plugins to access certain private functionality of ably-cocoa.
 ///
@@ -13,34 +15,39 @@ NS_SWIFT_NAME(PluginAPIProtocol)
 NS_SWIFT_SENDABLE
 @protocol APPluginAPIProtocol
 
+/// Returns the internal `APRealtimeChannel` that corresponds to a public `ARTRealtimeChannel`.
+///
+/// Plugins should, in general, not make use of `ARTRealtimeChannel` internally, and instead use `APRealtimeChannel`. This method is intended only to be used in plugin-authored extensions of `ARTRealtimeChannel`.
+- (id<APRealtimeChannel>)channelForPublicRealtimeChannel:(ARTRealtimeChannel *)channel;
+
 /// Allows a plugin to store arbitrary key-value data on a channel.
 ///
 /// The channel stores a strong reference to `value`.
 - (void)setPluginDataValue:(id)value
                     forKey:(NSString *)key
-                   channel:(ARTRealtimeChannel *)channel;
+                   channel:(id<APRealtimeChannel>)channel;
 
 /// Allows a plugin to retrieve arbitrary key-value data that was previously stored on a channel using `-setPluginDataValue:forKey:channel:`.
 - (nullable id)pluginDataValueForKey:(NSString *)key
-                             channel:(ARTRealtimeChannel *)channel;
+                             channel:(id<APRealtimeChannel>)channel;
 
 /// Provides plugins with access to ably-cocoa's logging functionality.
 ///
 /// - Parameter channel: The channel whose logger the returned logger should wrap.
-- (id<APLogger>)loggerForChannel:(ARTRealtimeChannel *)channel;
+- (id<APLogger>)loggerForChannel:(id<APRealtimeChannel>)channel;
 
 /// Throws an error if the channel is in a state in which a message should not be published. Copied from ably-js, not yet implemented. Will document this method properly once exact meaning decided, or may replace it with something that makes more sense for ably-cocoa.
-- (BOOL)throwIfUnpublishableStateForChannel:(ARTRealtimeChannel *)channel
+- (BOOL)throwIfUnpublishableStateForChannel:(id<APRealtimeChannel>)channel
                                       error:(ARTErrorInfo *_Nullable *_Nullable)error;
 
 /// Sends an `OBJECT` `ProtocolMessage` on a channel and indicates the result of waiting for an `ACK`. Copied from ably-js, not yet implemented. Will document this method properly once exact meaning decided, or may replace it with something that makes more sense for ably-cocoa.
 - (void)sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
-                             channel:(ARTRealtimeChannel *)channel
+                             channel:(id<APRealtimeChannel>)channel
                           completion:(void (^ _Nullable)(ARTErrorInfo *_Nullable error))completion;
 
 /// Returns the server time, as calculated from the `ARTRealtimeInstance`'s stored offset between the local clock and the server time. Copied from ably-js, not yet implemented. Will document this method once exact meaning decided, or may replace it with something that makes more sense for ably-cocoa.
 - (void)fetchTimestampWithQueryTime:(BOOL)queryTime
-                           realtime:(ARTRealtime *)realtime
+                           realtime:(id<APRealtimeClient>)realtime
                          completion:(void (^ _Nullable)(ARTErrorInfo *_Nullable error, NSDate *_Nullable timestamp))completion;
 
 @end

--- a/AblyPlugin/include/APRealtimeChannel.h
+++ b/AblyPlugin/include/APRealtimeChannel.h
@@ -1,0 +1,19 @@
+@import Foundation;
+@import Ably;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// The interface that plugins use to interact with a realtime channel.
+///
+/// This exists so that plugins do not need to make use of the public `ARTRealtimeChannel` class, which allows the internal components of ably-cocoa to continue the (existing before we introduced plugins) pattern of also not making use of this public class.
+///
+/// Note that AblyPlugin does not allow you to pass it arbitrary objects that conform to this protocol; rather you must pass it an object which it previously passed to the plugin (e.g. via `prepareChannel:`).
+NS_SWIFT_NAME(RealtimeChannel)
+NS_SWIFT_SENDABLE
+@protocol APRealtimeChannel <NSObject>
+
+@property (nonatomic, readonly) ARTRealtimeChannelState state;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AblyPlugin/include/APRealtimeClient.h
+++ b/AblyPlugin/include/APRealtimeClient.h
@@ -1,0 +1,15 @@
+@import Foundation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// The interface that plugins use to interact with a realtime client.
+///
+/// This exists so that plugins do not need to make use of the public `ARTRealtime` class, which allows the internal components of ably-cocoa to continue the (existing before we introduced plugins) pattern of also not making use of this public class.
+///
+/// Note that AblyPlugin does not allow you to pass it arbitrary objects that conform to this protocol; rather you must pass it an object which it previously passed to the plugin (e.g. via TODO we don't have an example yet; will come later).
+NS_SWIFT_NAME(RealtimeClient)
+NS_SWIFT_SENDABLE
+@protocol APRealtimeClient <NSObject>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Package.swift
+++ b/Package.swift
@@ -52,6 +52,7 @@ let package = Package(
                 .headerSearchPath("SocketRocket/Internal/Delegate"),
                 .headerSearchPath("SocketRocket/Internal/IOConsumer"),
                 .headerSearchPath("../AblyPlugin/include"),
+                .headerSearchPath("../AblyPlugin/PrivateHeaders"),
             ]
         ),
         .target(

--- a/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
@@ -41,9 +41,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)shouldAttach;
 - (ARTChannelProperties *)properties_nosync;
 
-// The channel that this internal object belongs to. We need a reference to it so that we can pass it to plugins for them to handle LiveObjects protocol messages. Avoid using this property for anything else. TODO understand whether this needs to be weak in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/9
-@property (nonatomic, weak) ARTRealtimeChannel *channel_onlyForPassingToPlugins;
-
 @property (readonly, weak, nonatomic) ARTRealtimeInternal *realtime; // weak because realtime owns self
 @property (readonly, nonatomic) ARTRestChannelInternal *restChannel;
 @property (readwrite, nonatomic, nullable) NSString *attachSerial;


### PR DESCRIPTION
**Note: This PR is based on top of https://github.com/ably/ably-cocoa/pull/2072; please review that one first.**

This undoes a change introduced in 916bf9d, in which we needed to give `ARTRealtimeChannelInternal` a reference to its public `ARTRealtimeChannel`, because the LiveObjects plugin only understood the public types. This broke the existing pattern of not referring to public types within the internals of ably-cocoa. Here we address this by instead making the plugins deal with `ARTRealtimeChannelInternal` (behind an opaque protocol), thus also making them consistent with the internals of ably-cocoa. This also allows us to undo the workaround introduced in #2072.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new protocols for realtime channel and client interactions, enabling more flexible plugin integration.
  * Added a method to map public realtime channels to their internal representations for advanced plugin operations.

* **Refactor**
  * Updated APIs and plugin interfaces to use protocol-based abstractions instead of concrete classes, improving extensibility and type safety.
  * Simplified internal channel handling by removing legacy properties and streamlining plugin interactions.

* **Chores**
  * Expanded header search paths in build configurations to support new internal interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->