### PR TITLE
Expose callback queue to plugins

### DIFF
--- a/AblyPlugin/APDefaultPublicRealtimeChannelUnderlyingObjects.m
+++ b/AblyPlugin/APDefaultPublicRealtimeChannelUnderlyingObjects.m
@@ -1,0 +1,17 @@
+#import "APDefaultPublicRealtimeChannelUnderlyingObjects.h"
+
+@implementation APDefaultPublicRealtimeChannelUnderlyingObjects
+
+@synthesize client = _client;
+@synthesize channel = _channel;
+
+- (instancetype)initWithClient:(id<APRealtimeClient>)client channel:(id<APRealtimeChannel>)channel {
+    if (self = [super init]) {
+        _client = client;
+        _channel = channel;
+    }
+
+    return self;
+}
+
+@end

--- a/AblyPlugin/APPluginAPI.m
+++ b/AblyPlugin/APPluginAPI.m
@@ -4,6 +4,7 @@
 #import "ARTInternalLog+APLogger.h"
 #import "ARTRealtimeChannelInternal+APRealtimeChannel.h"
 #import "ARTRealtimeInternal+APRealtimeClient.h"
+#import "APDefaultPublicRealtimeChannelUnderlyingObjects.h"
 
 static ARTRealtimeChannelInternal *_internalRealtimeChannel(id<APRealtimeChannel> pluginRealtimeChannel) {
     if (![pluginRealtimeChannel isKindOfClass:[ARTRealtimeChannelInternal class]]) {
@@ -31,8 +32,10 @@ static ARTRealtimeInternal *_internalRealtimeClient(id<APRealtimeClient> pluginR
     return sharedInstance;
 }
 
-- (id<APRealtimeChannel>)channelForPublicRealtimeChannel:(ARTRealtimeChannel *)channel {
-    return channel.internal;
+- (id<APPublicRealtimeChannelUnderlyingObjects>)underlyingObjectsForPublicRealtimeChannel:(ARTRealtimeChannel *)channel {
+    return [[APDefaultPublicRealtimeChannelUnderlyingObjects alloc] initWithClient:channel.realtimeInternal
+                                                                           channel:channel.internal];
+
 }
 
 - (void)setPluginDataValue:(nonnull id)value

--- a/AblyPlugin/APPluginAPI.m
+++ b/AblyPlugin/APPluginAPI.m
@@ -53,6 +53,11 @@ static ARTRealtimeInternal *_internalRealtimeClient(id<APRealtimeClient> pluginR
     return _internalRealtimeChannel(channel).logger;
 }
 
+/// Provides plugins with the queue on which all user callbacks for a given client should be called.
+- (dispatch_queue_t)callbackQueueForClient:(id<APRealtimeClient>)client {
+    return _internalRealtimeClient(client).options.dispatchQueue;
+}
+
 - (BOOL)throwIfUnpublishableStateForChannel:(id<APRealtimeChannel>)channel error:(ARTErrorInfo * _Nullable __autoreleasing *)error {
     [NSException raise:NSInternalInconsistencyException format:@"Not yet implemented"];
 }

--- a/AblyPlugin/PrivateHeaders/APDefaultPublicRealtimeChannelUnderlyingObjects.h
+++ b/AblyPlugin/PrivateHeaders/APDefaultPublicRealtimeChannelUnderlyingObjects.h
@@ -1,0 +1,13 @@
+@import Foundation;
+#import "APPublicRealtimeChannelUnderlyingObjects.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface APDefaultPublicRealtimeChannelUnderlyingObjects: NSObject <APPublicRealtimeChannelUnderlyingObjects>
+
+- (instancetype)initWithClient:(id<APRealtimeClient>)client
+                       channel:(id<APRealtimeChannel>)channel;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AblyPlugin/include/APLiveObjectsPlugin.h
+++ b/AblyPlugin/include/APLiveObjectsPlugin.h
@@ -7,6 +7,7 @@
 @protocol APObjectMessageProtocol;
 @protocol APDecodingContextProtocol;
 @protocol APRealtimeChannel;
+@protocol APRealtimeClient;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -32,7 +33,7 @@ NS_SWIFT_SENDABLE
 /// ably-cocoa will call this method when initializing an `ARTRealtimeChannel` instance.
 ///
 /// The plugin can use this as an opportunity to perform any initial setup of LiveObjects functionality for this channel.
-- (void)prepareChannel:(id<APRealtimeChannel>)channel;
+- (void)prepareChannel:(id<APRealtimeChannel>)channel client:(id<APRealtimeClient>)client;
 
 /// Decodes an `ObjectMessage` received over the wire.
 ///

--- a/AblyPlugin/include/APPluginAPI.h
+++ b/AblyPlugin/include/APPluginAPI.h
@@ -7,6 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol APObjectMessageProtocol;
 @protocol APRealtimeChannel;
 @protocol APRealtimeClient;
+@protocol APPublicRealtimeChannelUnderlyingObjects;
 
 /// `APPluginAPIProtocol` provides a stable API (that is, one which will not introduce backwards-incompatible changes within a given major version of ably-cocoa) for Ably-authored plugins to access certain private functionality of ably-cocoa.
 ///
@@ -15,10 +16,10 @@ NS_SWIFT_NAME(PluginAPIProtocol)
 NS_SWIFT_SENDABLE
 @protocol APPluginAPIProtocol
 
-/// Returns the internal `APRealtimeChannel` that corresponds to a public `ARTRealtimeChannel`.
+/// Returns the internal objects that correspond to a public `ARTRealtimeChannel`.
 ///
 /// Plugins should, in general, not make use of `ARTRealtimeChannel` internally, and instead use `APRealtimeChannel`. This method is intended only to be used in plugin-authored extensions of `ARTRealtimeChannel`.
-- (id<APRealtimeChannel>)channelForPublicRealtimeChannel:(ARTRealtimeChannel *)channel;
+- (id<APPublicRealtimeChannelUnderlyingObjects>)underlyingObjectsForPublicRealtimeChannel:(ARTRealtimeChannel *)channel;
 
 /// Allows a plugin to store arbitrary key-value data on a channel.
 ///

--- a/AblyPlugin/include/APPluginAPI.h
+++ b/AblyPlugin/include/APPluginAPI.h
@@ -37,6 +37,9 @@ NS_SWIFT_SENDABLE
 /// - Parameter channel: The channel whose logger the returned logger should wrap.
 - (id<APLogger>)loggerForChannel:(id<APRealtimeChannel>)channel;
 
+/// Provides plugins with the queue on which all user callbacks for a given client should be called.
+- (dispatch_queue_t)callbackQueueForClient:(id<APRealtimeClient>)client;
+
 /// Throws an error if the channel is in a state in which a message should not be published. Copied from ably-js, not yet implemented. Will document this method properly once exact meaning decided, or may replace it with something that makes more sense for ably-cocoa.
 - (BOOL)throwIfUnpublishableStateForChannel:(id<APRealtimeChannel>)channel
                                       error:(ARTErrorInfo *_Nullable *_Nullable)error;

--- a/AblyPlugin/include/APPublicRealtimeChannelUnderlyingObjects.h
+++ b/AblyPlugin/include/APPublicRealtimeChannelUnderlyingObjects.h
@@ -1,0 +1,18 @@
+@import Foundation;
+
+@protocol APRealtimeClient;
+@protocol APRealtimeChannel;
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(PublicRealtimeChannelUnderlyingObjects)
+NS_SWIFT_SENDABLE
+/// The `AblyPlugin` objects that back an `ARTRealtimeChannel` instance.
+@protocol APPublicRealtimeChannelUnderlyingObjects <NSObject>
+
+@property (nonatomic, readonly) id<APRealtimeClient> client;
+@property (nonatomic, readonly) id<APRealtimeChannel> channel;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -85,7 +85,7 @@
 }
 
 - (ARTRealtimeChannels *)channels {
-    return [[ARTRealtimeChannels alloc] initWithInternal:_internal.channels queuedDealloc:_dealloc];
+    return [[ARTRealtimeChannels alloc] initWithInternal:_internal.channels realtimeInternal:_internal queuedDealloc:_dealloc];
 }
 
 - (ARTAuth *)auth {

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -55,10 +55,11 @@
     });
 }
 
-- (instancetype)initWithInternal:(ARTRealtimeChannelInternal *)internal queuedDealloc:(ARTQueuedDealloc *)dealloc {
+- (instancetype)initWithInternal:(ARTRealtimeChannelInternal *)internal realtimeInternal:(ARTRealtimeInternal *)realtimeInternal queuedDealloc:(ARTQueuedDealloc *)dealloc {
     self = [super init];
     if (self) {
         _internal = internal;
+        _realtimeInternal = realtimeInternal;
         _dealloc = dealloc;
 
         // If the LiveObjects plugin has been provided, set up LiveObjects functionality for this channel.

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -38,6 +38,7 @@
 #endif
 #import "APLiveObjectsPlugin.h"
 #import "ARTRealtimeChannelInternal+APRealtimeChannel.h"
+#import "ARTRealtimeInternal+APRealtimeClient.h"
 
 @implementation ARTRealtimeChannel {
     ARTQueuedDealloc *_dealloc;
@@ -65,7 +66,7 @@
         // If the LiveObjects plugin has been provided, set up LiveObjects functionality for this channel.
         id<APLiveObjectsInternalPluginProtocol> liveObjectsPlugin = internal.realtime.options.liveObjectsPlugin;
         if (liveObjectsPlugin) {
-            [liveObjectsPlugin prepareChannel:internal];
+            [liveObjectsPlugin prepareChannel:internal client:realtimeInternal];
         }
     }
     return self;

--- a/Source/ARTRealtimeChannels.m
+++ b/Source/ARTRealtimeChannels.m
@@ -11,10 +11,11 @@
     ARTQueuedDealloc *_dealloc;
 }
 
-- (instancetype)initWithInternal:(ARTRealtimeChannelsInternal *)internal queuedDealloc:(ARTQueuedDealloc *)dealloc {
+- (instancetype)initWithInternal:(ARTRealtimeChannelsInternal *)internal realtimeInternal:(ARTRealtimeInternal *)realtimeInternal queuedDealloc:(ARTQueuedDealloc *)dealloc {
     self = [super init];
     if (self) {
         _internal = internal;
+        _realtimeInternal = realtimeInternal;
         _dealloc = dealloc;
     }
     return self;
@@ -25,11 +26,11 @@
 }
 
 - (ARTRealtimeChannel *)get:(NSString *)name {
-    return [[ARTRealtimeChannel alloc] initWithInternal:[_internal get:(NSString *)name] queuedDealloc:_dealloc];
+    return [[ARTRealtimeChannel alloc] initWithInternal:[_internal get:(NSString *)name] realtimeInternal:_realtimeInternal queuedDealloc:_dealloc];
 }
 
 - (ARTRealtimeChannel *)get:(NSString *)name options:(ARTRealtimeChannelOptions *)options {
-    return [[ARTRealtimeChannel alloc] initWithInternal:[_internal get:(NSString *)name options:options] queuedDealloc:_dealloc];
+    return [[ARTRealtimeChannel alloc] initWithInternal:[_internal get:(NSString *)name options:options] realtimeInternal:_realtimeInternal queuedDealloc:_dealloc];
 }
 
 - (void)release:(NSString *)name callback:(nullable ARTCallback)errorInfo {
@@ -42,7 +43,7 @@
 
 - (id<NSFastEnumeration>)iterate {
     return [_internal copyIntoIteratorWithMapper:^ARTRealtimeChannel *(ARTRealtimeChannelInternal *internalChannel) {
-        return [[ARTRealtimeChannel alloc] initWithInternal:internalChannel queuedDealloc:self->_dealloc];
+        return [[ARTRealtimeChannel alloc] initWithInternal:internalChannel realtimeInternal:self->_realtimeInternal queuedDealloc:self->_dealloc];
     }];
 }
 

--- a/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
@@ -140,11 +140,12 @@ ART_EMBED_INTERFACE_EVENT_EMITTER(ARTChannelEvent, ARTChannelStateChange *)
 @interface ARTRealtimeChannel ()
 
 @property (nonatomic, readonly) ARTRealtimeChannelInternal *internal;
+@property (nonatomic, readonly) ARTRealtimeInternal *realtimeInternal;
 
 - (void)internalAsync:(void (^)(ARTRealtimeChannelInternal *))use;
 - (void)internalSync:(void (^)(ARTRealtimeChannelInternal *))use;
 
-- (instancetype)initWithInternal:(ARTRealtimeChannelInternal *)internal queuedDealloc:(ARTQueuedDealloc *)dealloc;
+- (instancetype)initWithInternal:(ARTRealtimeChannelInternal *)internal realtimeInternal:(ARTRealtimeInternal *)realtimeInternal queuedDealloc:(ARTQueuedDealloc *)dealloc;
 
 @end
 

--- a/Source/PrivateHeaders/Ably/ARTRealtimeChannels+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeChannels+Private.h
@@ -34,8 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ARTRealtimeChannels ()
 
 @property (nonatomic, readonly) ARTRealtimeChannelsInternal *internal;
+@property (nonatomic, readonly) ARTRealtimeInternal *realtimeInternal;
 
-- (instancetype)initWithInternal:(ARTRealtimeChannelsInternal *)internal queuedDealloc:(ARTQueuedDealloc *)dealloc;
+- (instancetype)initWithInternal:(ARTRealtimeChannelsInternal *)internal realtimeInternal:(ARTRealtimeInternal *)realtimeInternal queuedDealloc:(ARTQueuedDealloc *)dealloc;
 
 @end
 


### PR DESCRIPTION
**Note: This PR is based on top of #2073; please review that one first.**

So that they can call their callbacks on the same queue as the rest of the SDK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new protocol for accessing underlying realtime channel objects, exposing both client and channel properties.
  * Added a method to retrieve the callback queue associated with a realtime client, allowing plugins to access the user callback execution context.

* **Improvements**
  * Enhanced plugin API to provide more granular access to underlying channel objects.
  * Updated internal channel and channels initialization to include additional context, improving extensibility for advanced integrations.
  * Updated LiveObjects plugin to require client information when preparing channels, enhancing plugin interaction capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->