### PR TITLE
Enforce calling `sendObject…` on internal queue

### DIFF
--- a/AblyPlugin/APPluginAPI.m
+++ b/AblyPlugin/APPluginAPI.m
@@ -58,6 +58,10 @@ static ARTRealtimeInternal *_internalRealtimeClient(id<APRealtimeClient> pluginR
     return _internalRealtimeClient(client).options.dispatchQueue;
 }
 
+- (dispatch_queue_t)internalQueueForClient:(id<APRealtimeClient>)client {
+    return _internalRealtimeClient(client).options.internalDispatchQueue;
+}
+
 - (BOOL)throwIfUnpublishableStateForChannel:(id<APRealtimeChannel>)channel error:(ARTErrorInfo * _Nullable __autoreleasing *)error {
     [NSException raise:NSInternalInconsistencyException format:@"Not yet implemented"];
 }

--- a/AblyPlugin/include/APPluginAPI.h
+++ b/AblyPlugin/include/APPluginAPI.h
@@ -40,11 +40,18 @@ NS_SWIFT_SENDABLE
 /// Provides plugins with the queue on which all user callbacks for a given client should be called.
 - (dispatch_queue_t)callbackQueueForClient:(id<APRealtimeClient>)client;
 
+/// Provides plugins with the queue which a given client uses to synchronize its internal state.
+///
+/// Certain `APPluginAPIProtocol` methods must be called on this queue (the method will document when this is the case).
+- (dispatch_queue_t)internalQueueForClient:(id<APRealtimeClient>)client;
+
 /// Throws an error if the channel is in a state in which a message should not be published. Copied from ably-js, not yet implemented. Will document this method properly once exact meaning decided, or may replace it with something that makes more sense for ably-cocoa.
 - (BOOL)throwIfUnpublishableStateForChannel:(id<APRealtimeChannel>)channel
                                       error:(ARTErrorInfo *_Nullable *_Nullable)error;
 
 /// Sends an `OBJECT` `ProtocolMessage` on a channel and indicates the result of waiting for an `ACK`. Copied from ably-js, not yet implemented. Will document this method properly once exact meaning decided, or may replace it with something that makes more sense for ably-cocoa.
+///
+/// This method must be called on the client's internal queue (see `-internalQueueForClient:`).
 - (void)sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
                              channel:(id<APRealtimeChannel>)channel
                           completion:(void (^ _Nullable)(ARTErrorInfo *_Nullable error))completion;

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -414,6 +414,8 @@ dispatch_sync(_queue, ^{
 
 - (void)sendStateWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
                          completion:(ARTCallback)completion {
+    dispatch_assert_queue(_queue);
+
     ARTProtocolMessage *pm = [[ARTProtocolMessage alloc] init];
     pm.action = ARTProtocolMessageObject;
     pm.channel = self.name;


### PR DESCRIPTION
We need to synchronize access to the client's internal `msgSerial` to avoid race conditions (was observing `msgSerial`s being reused).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a method for plugins to access the internal dispatch queue used by a client for synchronization.

* **Documentation**
  * Updated documentation to clarify that certain methods must be called on the client's internal queue.

* **Style**
  * Added an assertion to ensure a specific method is called on the correct internal queue, improving thread safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->