### PR TITLE
Add ability to configure plugins using `ARTClientOptions`

### DIFF
--- a/AblyPlugin/APPluginAPI.m
+++ b/AblyPlugin/APPluginAPI.m
@@ -5,6 +5,7 @@
 #import "ARTRealtimeChannelInternal+APRealtimeChannel.h"
 #import "ARTRealtimeInternal+APRealtimeClient.h"
 #import "APDefaultPublicRealtimeChannelUnderlyingObjects.h"
+#import "ARTClientOptions+Private.h"
 
 static ARTRealtimeChannelInternal *_internalRealtimeChannel(id<APRealtimeChannel> pluginRealtimeChannel) {
     if (![pluginRealtimeChannel isKindOfClass:[ARTRealtimeChannelInternal class]]) {
@@ -51,6 +52,18 @@ static ARTRealtimeInternal *_internalRealtimeClient(id<APRealtimeClient> pluginR
 
 - (id<APLogger>)loggerForChannel:(id<APRealtimeChannel>)channel {
     return _internalRealtimeChannel(channel).logger;
+}
+
+- (void)setPluginOptionsValue:(id)value forKey:(NSString *)key clientOptions:(ARTClientOptions *)options {
+    [options setPluginOptionsValue:value forKey:key];
+}
+
+- (id)pluginOptionsValueForKey:(NSString *)key clientOptions:(ARTClientOptions *)options {
+    return [options pluginOptionsValueForKey:key];
+}
+
+- (ARTClientOptions *)optionsForClient:(id<APRealtimeClient>)client {
+    return [_internalRealtimeClient(client).options copy];
 }
 
 /// Provides plugins with the queue on which all user callbacks for a given client should be called.

--- a/AblyPlugin/include/APPluginAPI.h
+++ b/AblyPlugin/include/APPluginAPI.h
@@ -32,6 +32,22 @@ NS_SWIFT_SENDABLE
 - (nullable id)pluginDataValueForKey:(NSString *)key
                              channel:(id<APRealtimeChannel>)channel;
 
+/// Allows a plugin to store arbitrary key-value data in an `ARTClientOptions`. This allows a plugin to define its own client options.
+///
+/// You would usually call this from within a plugin-defined extension of `ARTClientOptions`.
+- (void)setPluginOptionsValue:(id)value
+                       forKey:(NSString *)key
+                clientOptions:(ARTClientOptions *)options;
+
+/// Allows a plugin to retrieve arbitrary key-value data that was previously stored on an `ARTClientOptions` using `-setPluginOptionsValue:forKey:clientOptions:`.
+///
+/// You would usually call this from within a plugin-defined extension of `ARTClientOptions`.
+- (nullable id)pluginOptionsValueForKey:(NSString *)key
+                          clientOptions:(ARTClientOptions *)options;
+
+/// Retrieves a copy of the options for a client.
+- (ARTClientOptions *)optionsForClient:(id<APRealtimeClient>)client;
+
 /// Provides plugins with access to ably-cocoa's logging functionality.
 ///
 /// - Parameter channel: The channel whose logger the returned logger should wrap.

--- a/Source/ARTClientOptions.m
+++ b/Source/ARTClientOptions.m
@@ -17,6 +17,8 @@ NSString *ARTDefaultEnvironment = nil;
 
 @interface ARTClientOptions ()
 
+@property (nonatomic) NSMutableDictionary<NSString *, id> *pluginData;
+
 - (instancetype)initDefaults;
 
 @end
@@ -53,6 +55,7 @@ NSString *ARTDefaultEnvironment = nil;
     _addRequestIds = false;
     _pushRegistererDelegate = nil;
     _testOptions = [[ARTTestClientOptions alloc] init];
+    _pluginData = [[NSMutableDictionary alloc] init];
     return self;
 }
 
@@ -144,6 +147,7 @@ NSString *ARTDefaultEnvironment = nil;
     options.agents = self.agents;
     options.testOptions = self.testOptions;
     options.plugins = self.plugins;
+    options.pluginData = [self.pluginData mutableCopy];
 
     return options;
 }
@@ -238,6 +242,16 @@ NSString *ARTDefaultEnvironment = nil;
     }
 
     return [publicPlugin internalPlugin];
+}
+
+// MARK: - Options for plugins
+
+- (void)setPluginOptionsValue:(id)value forKey:(NSString *)key {
+    self.pluginData[key] = value;
+}
+
+- (id)pluginOptionsValueForKey:(NSString *)key {
+    return self.pluginData[key];
 }
 
 @end

--- a/Source/PrivateHeaders/Ably/ARTClientOptions+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTClientOptions+Private.h
@@ -25,6 +25,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// The plugin that channels should use to access LiveObjects functionality.
 @property (nullable, readonly) id<APLiveObjectsInternalPluginProtocol> liveObjectsPlugin;
 
+// MARK: - Options for plugins
+
+/// Provides the implementation for `-[APPluginAPI setPluginOptionsValue:forKey:options:]`. See documentation for that method.
+- (void)setPluginOptionsValue:(id)value forKey:(NSString *)key;
+/// Provides the implementation for `-[APPluginAPI pluginOptionsValueForKey:options:]`. See documentation for that method.
+- (nullable id)pluginOptionsValueForKey:(NSString *)key;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
We'll use this to change the garbage collection parameters in the LiveObjects tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins can store and retrieve their own key–value configuration within client options.
  * Added ability to obtain an immutable snapshot of a client’s options for safe inspection.
  * Centralized plugin option handling within client options to improve plugin ergonomics alongside existing per-channel storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->