### PR TITLE
Adds missing sendable annotations 

### DIFF
--- a/Source/include/Ably/ARTTypes.h
+++ b/Source/include/Ably/ARTTypes.h
@@ -523,13 +523,13 @@ typedef void (^ARTStatusCallback)(ARTStatus *status);
 typedef void (^ARTURLRequestCallback)(NSHTTPURLResponse *_Nullable result, NSData *_Nullable data, NSError *_Nullable error);
 
 /// :nodoc:
-typedef void (^ARTTokenDetailsCallback)(ARTTokenDetails *_Nullable result, NSError *_Nullable error);
+typedef void (NS_SWIFT_SENDABLE ^ARTTokenDetailsCallback)(ARTTokenDetails *_Nullable result, NSError *_Nullable error);
 
 /// :nodoc:
-typedef void (^ARTTokenDetailsCompatibleCallback)(id<ARTTokenDetailsCompatible> _Nullable result, NSError *_Nullable error);
+typedef void (NS_SWIFT_SENDABLE ^ARTTokenDetailsCompatibleCallback)(id<ARTTokenDetailsCompatible> _Nullable result, NSError *_Nullable error);
 
 /// :nodoc:
-typedef void (^ARTAuthCallback)(ARTTokenParams *params, ARTTokenDetailsCompatibleCallback callback);
+typedef void (NS_SWIFT_SENDABLE ^ARTAuthCallback)(ARTTokenParams *params, ARTTokenDetailsCompatibleCallback callback);
 
 /// :nodoc:
 typedef void (^ARTHTTPPaginatedCallback)(ARTHTTPPaginatedResponse *_Nullable response, ARTErrorInfo *_Nullable error);


### PR DESCRIPTION
Issue was raised on a client's support slack channel whilst they were migrating to Swift 6. This PR has been tested by them in isolation and confirmed as working. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved Swift interoperability by marking callback types as Sendable, enabling safer use with Swift Concurrency (e.g., async contexts and structured concurrency).
  - Reduces Swift compiler warnings related to non-Sendable closures and improves thread-safety guarantees when using the SDK from Swift.
  - No changes to callback parameters or runtime behavior; existing integrations continue to work without modification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->