### PR TITLE
Update for renamed LiveObjects plugin repo

### DIFF
--- a/Docs/plugins.md
+++ b/Docs/plugins.md
@@ -6,7 +6,7 @@ ably-cocoa and its plugins depend on a separate library called `_AblyPluginSuppo
 
 I will expand on this documentation once this mechanism is more mature; currently [ADR-128: Plugins for ably-cocoa SDK](https://ably.atlassian.net/wiki/spaces/ENG/pages/3838574593/ADR-128+Plugins+for+ably-cocoa+SDK) provides a decent description of our approach. The key divergence between ADR-128 and our current approach is that `_AblyPluginSupportPrivate` (called `AblyPlugin` in the ADR) is no longer part of ably-cocoa and instead lives in a separate repository. I will update that ADR or create a new one later on as part of clearing technical debt caused by this last-minute change of approach.
 
-Currently, our only plugin is for adding LiveObjects functionality. This plugin can be found at https://github.com/ably/ably-cocoa-liveobjects-plugin.
+Currently, our only plugin is for adding LiveObjects functionality. This plugin can be found at https://github.com/ably/ably-liveobjects-swift-plugin.
 
 ## Notes on `_AblyPluginSupportPrivate`
 

--- a/Source/include/Ably/ARTClientOptions.h
+++ b/Source/include/Ably/ARTClientOptions.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// A key for the `-[ARTClientOptions plugins]` property.
 typedef NSString *ARTPluginName NS_TYPED_EXTENSIBLE_ENUM;
-/// Set this key in `-[ARTClientOptions plugins]` to `AblyLiveObjects.Plugin.self` after importing `AblyLiveObjects` from the  [ably/ably-cocoa-liveobjects-plugin](https://github.com/ably/ably-cocoa-liveobjects-plugin) repository in order to enable LiveObjects functionality.
+/// Set this key in `-[ARTClientOptions plugins]` to `AblyLiveObjects.Plugin.self` after importing `AblyLiveObjects` from the  [ably/ably-liveobjects-swift-plugin](https://github.com/ably/ably-liveobjects-swift-plugin) repository in order to enable LiveObjects functionality.
 extern const ARTPluginName ARTPluginNameLiveObjects;
 
 /**
@@ -206,7 +206,7 @@ extern const ARTPluginName ARTPluginNameLiveObjects;
 ///
 /// Currently supported keys:
 ///
-/// - `ARTPluginNameLiveObjects`: Allows you to use LiveObjects functionality. Import the `AblyLiveObjects` module from the [ably/ably-cocoa-liveobjects-plugin](https://github.com/ably/ably-cocoa-liveobjects-plugin) repository and set the value for this key to `AblyLiveObjects.Plugin.self`. Use a channel's `objects` property to access its LiveObjects functionality.
+/// - `ARTPluginNameLiveObjects`: Allows you to use LiveObjects functionality. Import the `AblyLiveObjects` module from the [ably/ably-liveobjects-swift-plugin](https://github.com/ably/ably-liveobjects-swift-plugin) repository and set the value for this key to `AblyLiveObjects.Plugin.self`. Use a channel's `objects` property to access its LiveObjects functionality.
 @property (nonatomic, copy, nullable) NSDictionary<ARTPluginName, id> *plugins;
 
 @end


### PR DESCRIPTION
Also see https://github.com/ably/ably-liveobjects-swift-plugin/pull/70.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated LiveObjects plugin references to point to the Swift-based repository, ensuring links and guidance reflect the current plugin location.
  - Clarified references in user docs and API comments, including supported keys and plugin name details.
  - No changes to app behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->