### PR TITLE
Add comment stating that LiveObjects plugin key might change

### DIFF
--- a/Source/include/Ably/ARTClientOptions.h
+++ b/Source/include/Ably/ARTClientOptions.h
@@ -12,6 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// A key for the `ARTClientOptions.plugins` property.
 typedef NSString *ARTPluginName NS_TYPED_EXTENSIBLE_ENUM;
 /// Set this key in `ARTClientOptions.plugins` to `AblyLiveObjects.Plugin.self` after importing `AblyLiveObjects` from the  [ably/ably-liveobjects-swift-plugin](https://github.com/ably/ably-liveobjects-swift-plugin) repository in order to enable LiveObjects functionality.
+///
+/// - Attention: This is an experimental API and the name of this key may change in a future release within this major version.
 extern const ARTPluginName ARTPluginNameLiveObjects;
 
 /**


### PR DESCRIPTION
**Note: This PR is based on top of #2095**

There's a lot of back-and-forth about this at the moment so best cover our backs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified plugin reference notation in client options.
  - Added an explicit experimental notice for the LiveObjects plugin, signaling potential changes in a future major release.
  - No behavioral or API changes.

- Chores
  - Updated Ruby version used by tooling to 3.4.5.
  - No impact on app functionality or compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->