### PR TITLE
Add additional user info param to `ARTErrorInfo` creation

### DIFF
--- a/Source/ARTStatus.m
+++ b/Source/ARTStatus.m
@@ -25,16 +25,37 @@ NSInteger getStatusFromCode(NSInteger code) {
     return [ARTErrorInfo createWithCode:code status:getStatusFromCode(code) message:message requestId:requestId];
 }
 
++ (ARTErrorInfo *)createWithCode:(NSInteger)code message:(NSString *)message requestId:(nullable NSString *)requestId additionalUserInfo:(nullable NSDictionary<NSString *, id> *)additionalUserInfo {
+    return [ARTErrorInfo createWithCode:code status:getStatusFromCode(code) message:message requestId:requestId additionalUserInfo:additionalUserInfo];
+}
+
 + (ARTErrorInfo *)createWithCode:(NSInteger)code message:(NSString *)message {
     return [ARTErrorInfo createWithCode:code status:getStatusFromCode(code) message:message requestId:nil];
 }
 
++ (ARTErrorInfo *)createWithCode:(NSInteger)code message:(NSString *)message additionalUserInfo:(nullable NSDictionary<NSString *, id> *)additionalUserInfo {
+    return [ARTErrorInfo createWithCode:code status:getStatusFromCode(code) message:message requestId:nil additionalUserInfo:additionalUserInfo];
+}
+
++ (ARTErrorInfo *)createWithCode:(NSInteger)code status:(NSInteger)status message:(NSString *)message additionalUserInfo:(nullable NSDictionary<NSString *, id> *)additionalUserInfo {
+    return [ARTErrorInfo createWithCode:code status:status message:message requestId:nil additionalUserInfo:additionalUserInfo];
+}
+
 + (ARTErrorInfo *)createWithCode:(NSInteger)code status:(NSInteger)status message:(NSString *)message requestId:(nullable NSString *)requestId {
+    return [ARTErrorInfo createWithCode:code status:status message:message requestId:requestId additionalUserInfo:nil];
+}
+
++ (ARTErrorInfo *)createWithCode:(NSInteger)code status:(NSInteger)status message:(NSString *)message requestId:(nullable NSString *)requestId additionalUserInfo:(nullable NSDictionary<NSString *, id> *)additionalUserInfo {
     NSMutableDictionary *userInfo = [NSMutableDictionary new];
     userInfo[ARTErrorInfoStatusCodeKey] = [NSNumber numberWithInteger:status];
     userInfo[NSLocalizedDescriptionKey] = message;
     userInfo[ARTErrorInfoRequestIdKey] = requestId;
-    
+
+    // Add any additional userInfo values
+    if (additionalUserInfo) {
+        [userInfo addEntriesFromDictionary:additionalUserInfo];
+    }
+
     return [[ARTErrorInfo alloc] initWithDomain:ARTAblyErrorDomain code:code userInfo:userInfo];
 }
 

--- a/Source/include/Ably/ARTStatus.h
+++ b/Source/include/Ably/ARTStatus.h
@@ -226,7 +226,13 @@ FOUNDATION_EXPORT NSString *const ARTAblyMessageNoMeansToRenewToken;
 + (ARTErrorInfo *)createWithCode:(NSInteger)code message:(NSString *)message;
 
 /// :nodoc:
++ (ARTErrorInfo *)createWithCode:(NSInteger)code message:(NSString *)message additionalUserInfo:(nullable NSDictionary<NSString *, id> *)additionalUserInfo;
+
+/// :nodoc:
 + (ARTErrorInfo *)createWithCode:(NSInteger)code status:(NSInteger)status message:(NSString *)message;
+
+/// :nodoc:
++ (ARTErrorInfo *)createWithCode:(NSInteger)code status:(NSInteger)status message:(NSString *)message additionalUserInfo:(nullable NSDictionary<NSString *, id> *)additionalUserInfo;
 
 /// :nodoc:
 + (ARTErrorInfo *)createFromNSError:(NSError *)error;
@@ -238,7 +244,13 @@ FOUNDATION_EXPORT NSString *const ARTAblyMessageNoMeansToRenewToken;
 + (ARTErrorInfo *)createWithCode:(NSInteger)code message:(NSString *)message requestId:(nullable NSString *)requestId;
 
 /// :nodoc:
++ (ARTErrorInfo *)createWithCode:(NSInteger)code message:(NSString *)message requestId:(nullable NSString *)requestId additionalUserInfo:(nullable NSDictionary<NSString *, id> *)additionalUserInfo;
+
+/// :nodoc:
 + (ARTErrorInfo *)createWithCode:(NSInteger)code status:(NSInteger)status message:(NSString *)message requestId:(nullable NSString *)requestId;
+
+/// :nodoc:
++ (ARTErrorInfo *)createWithCode:(NSInteger)code status:(NSInteger)status message:(NSString *)message requestId:(nullable NSString *)requestId additionalUserInfo:(nullable NSDictionary<NSString *, id> *)additionalUserInfo;
 
 /// :nodoc:
 + (ARTErrorInfo *)createFromNSException:(NSException *)error requestId:(nullable NSString *)requestId;


### PR DESCRIPTION
**Note: This PR is based on top of #2100; please review that one first.**

Will use this in LiveObjects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced error creation with optional request IDs and extra metadata for richer diagnostics.
  - Added helpers to build errors from system errors and exceptions.
  - Introduced a utility to generate unknown errors and to wrap existing errors with additional context.

- Refactor
  - Standardized error description behavior, aligning string output with default formatting and improving consistency in logs and UI displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->