### PR TITLE
Unpin ably-cocoa-plugin-support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,8 @@ ably-cocoa allows users to pass in Ably-authored plugins via the `ARTClientOptio
 
 For each release, the following needs to be done:
 
+* Confirm that none of our `Package.swift` dependencies are specified using a fixed `.revision`.
+    * The dependency that is most likely to be using a fixed revision is [ably-cocoa-plugin-support](https://github.com/ably/ably-cocoa-plugin-support); make a new release of that library if needed.
 * Create a new branch `release/x.x.x` (where `x.x.x` is the new version number) from the `main` branch
 * Run `make bump_[major|minor|patch]` to bump the new version number. This will create a Git commit, push it to origin: `git push -u origin release/x.x.x`
 * Go to [Github releases](https://github.com/ably/ably-cocoa/releases) and press the `Draft a new release` button. Choose your new branch as a target

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/ably/ably-cocoa-plugin-support",
         "state": {
           "branch": null,
-          "revision": "2ce1058ed4430cc3563dcead0299e92a81d2774b",
-          "version": null
+          "revision": "8db4632b0664b7272d54f7b612ddad0a18d1758f",
+          "version": "0.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         .package(name: "msgpack", url: "https://github.com/rvi/msgpack-objective-C", from: "0.4.0"),
         .package(name: "AblyDeltaCodec", url: "https://github.com/ably/delta-codec-cocoa", from: "1.3.3"),
-        .package(name: "ably-cocoa-plugin-support", url: "https://github.com/ably/ably-cocoa-plugin-support", .revision("2ce1058ed4430cc3563dcead0299e92a81d2774b")),
+        .package(name: "ably-cocoa-plugin-support", url: "https://github.com/ably/ably-cocoa-plugin-support", from: "0.2.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Forgot to do this before the 1.2.45 release, as I said I would in 8dde3e8.

Using a fixed revision breaks the build for libraries that depend on ably-cocoa; e.g. ably-chat-swift CI package resolution started to break upon upgrading to ably-cocoa 1.2.45, with the error:

> 'ably-cocoa' >= 1.2.45 cannot be used because package 'ably-cocoa' is
> required using a stable-version but 'ably-cocoa' depends on an
> unstable-version package 'ably-cocoa-plugin-support' and no versions of
> 'ably-cocoa' match the requirement 1.2.46..<2.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release checklist to ensure dependencies aren’t pinned to fixed revisions and clarified guidance for handling version locks during releases.

* **Chores**
  * Switched a plugin support dependency from a fixed commit to a semantic version (0.2.0) and refreshed resolved packages.
  * Aligns dependency management with the release process for improved stability and predictability.
  * No functional changes or user-facing behavior expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->