### PR TITLE
Expose wrapper SDK proxy channel's underlying channel

### DIFF
--- a/Source/ARTWrapperSDKProxyRealtimeChannel.m
+++ b/Source/ARTWrapperSDKProxyRealtimeChannel.m
@@ -9,7 +9,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ARTWrapperSDKProxyRealtimeChannel ()
 
-@property (nonatomic, readonly) ARTRealtimeChannel *underlyingChannel;
 @property (nonatomic, readonly) ARTWrapperSDKProxyOptions *proxyOptions;
 
 @end

--- a/Source/include/Ably/ARTWrapperSDKProxyRealtimeChannel.h
+++ b/Source/include/Ably/ARTWrapperSDKProxyRealtimeChannel.h
@@ -18,6 +18,9 @@ NS_SWIFT_SENDABLE
 
 - (instancetype)init NS_UNAVAILABLE;
 
+/// The channel that this `ARTWrapperSDKProxyRealtimeChannel` proxies.
+@property (nonatomic, readonly) ARTRealtimeChannel *underlyingChannel;
+
 @property (readonly) ARTWrapperSDKProxyRealtimePresence *presence;
 
 @property (readonly) ARTWrapperSDKProxyRealtimeAnnotations *annotations;


### PR DESCRIPTION
We need this to populate the `Room.channel` property in Chat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Exposed the underlying realtime channel via a new read-only property on the wrapper’s realtime channel proxy, enabling direct access for advanced use cases (e.g., leveraging lower-level channel capabilities).
  - No changes required for existing integrations; this is an additive, non-breaking enhancement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->