### PR TITLE
Remove `UIDevice` access

### DIFF
--- a/Source/ARTLocalDevice.m
+++ b/Source/ARTLocalDevice.m
@@ -67,18 +67,8 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
 + (instancetype)deviceWithStorage:(id<ARTDeviceStorage>)storage logger:(nullable ARTInternalLog *)logger {
     ARTLocalDevice *device = [[ARTLocalDevice alloc] initWithStorage:storage logger:logger];
     device.platform = ARTDevicePlatform;
-    #if TARGET_OS_IOS
-    switch ([[UIDevice currentDevice] userInterfaceIdiom]) {
-        case UIUserInterfaceIdiomPad:
-            device.formFactor = @"tablet";
-        case UIUserInterfaceIdiomCarPlay:
-            device.formFactor = @"car";
-        default:
-            device.formFactor = ARTDeviceFormFactor;
-    }
-    #else
+    // TODO: Set this based on the UIDevice's userInterfaceIdiom (https://github.com/ably/ably-cocoa/issues/2132)
     device.formFactor = ARTDeviceFormFactor;
-    #endif
     device.push.recipient[@"transportType"] = ARTDevicePushTransportType;
 
     NSString *deviceId = [storage objectForKey:ARTDeviceIdKey];


### PR DESCRIPTION
All of UIDevice's API is marked as `@MainActor` but we're accessing it from the `deviceAccessQueue`. This appears to be causing intermittent hangs in the Chat integration tests (see https://github.com/ably/ably-chat-swift/issues/295); adding logging to those tests shows that the fetch of the device's `userInterfaceIdiom` sometimes never completes.

I tried to add a `dispatch_sync` onto the main queue to access the `UIDevice` (see #2131) but this introduced a deadlock in CI (which might be similar to what was happening when accessing `UIDevice` off the main queue, not sure):

- main thread in `ARTChannels` `getChannel`, on `dispatch_sync` to internal queue (the tests fetching a room)
- device access queue in `formFactor` method, on `dispatch_sync` to main queue
- internal queue in `device_nosync`, on `dispatch_sync` to device access queue

i.e. main waiting on internal waiting on deviceAccess waiting on main.

I don't yet have a good idea for a reliable way for us to synchronously access `UIDevice`. So let's just get rid of our access of it for now. This sounds like a behavioural change but it actually isn't due to bug #2132, in which the lack of `break` statements in the `userInterfaceIdiom` `switch` statement means that we weren't making use of its value anyway. But we should revisit #2132 sometime and try to figure out how we can restore the `userInterfaceIdiom` fetch without the hang.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated device detection logic to improve form factor determination across different device types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->