### PR TITLE
[ECO-5633] Avoid parsing an http body error if response is not from Ably

### DIFF
--- a/Source/ARTJsonLikeEncoder.m
+++ b/Source/ARTJsonLikeEncoder.m
@@ -1129,11 +1129,12 @@
                                      status:[(statusNumber ?: @(statusCode)) intValue]
                                     message:message ?: [NSString stringWithFormat:@"HTTP request failed with status code %ld", statusCode]];
     } else {
-        // We expect `decodedError` as a dictionary from Ably REST API, but in case user sets custom authUrl in the auth options, it can be anything
-        // We'll address this in an upcoming proper fix for https://github.com/ably/ably-cocoa/issues/2135
-        return [ARTErrorInfo createWithCode:statusCode * 100
-                                     status:statusCode
-                                    message:[NSString stringWithFormat:@"HTTP request failed with status code %ld", statusCode]];
+        // We expect `decodedError` as a dictionary from Ably REST API
+        // In case it's something else we set the decoding error
+        *error = [ARTErrorInfo createWithCode:ARTClientCodeErrorInvalidType
+                                       status:0
+                                      message:[NSString stringWithFormat:@"Failed to decode error dictionary from the provided error data."]];
+        return nil;
     }
 }
 

--- a/Source/PrivateHeaders/Ably/ARTErrorInfo+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTErrorInfo+Private.h
@@ -12,4 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 #endif
 
+// Gets an HTTP status code from error code by taking first three digits. Doesn't perform any checks if the result is a valid status code.
+NSInteger ARTHttpStatusCodeFromErrorCode(ARTErrorCode errorCode);
+
 NS_ASSUME_NONNULL_END

--- a/Source/include/Ably/ARTStatus.h
+++ b/Source/include/Ably/ARTStatus.h
@@ -232,6 +232,9 @@ FOUNDATION_EXPORT NSString *const ARTAblyMessageNoMeansToRenewToken;
 + (ARTErrorInfo *)createWithCode:(NSInteger)code status:(NSInteger)status message:(NSString *)message;
 
 /// :nodoc:
++ (ARTErrorInfo *)createWithCode:(NSInteger)code status:(NSInteger)status message:(nullable NSString *)message underlyingError:(nullable NSError *)error;
+
+/// :nodoc:
 + (ARTErrorInfo *)createWithCode:(NSInteger)code status:(NSInteger)status message:(NSString *)message additionalUserInfo:(nullable NSDictionary<NSString *, id> *)additionalUserInfo;
 
 /// :nodoc:
@@ -250,7 +253,7 @@ FOUNDATION_EXPORT NSString *const ARTAblyMessageNoMeansToRenewToken;
 + (ARTErrorInfo *)createWithCode:(NSInteger)code status:(NSInteger)status message:(NSString *)message requestId:(nullable NSString *)requestId;
 
 /// :nodoc:
-+ (ARTErrorInfo *)createWithCode:(NSInteger)code status:(NSInteger)status message:(NSString *)message requestId:(nullable NSString *)requestId additionalUserInfo:(nullable NSDictionary<NSString *, id> *)additionalUserInfo;
++ (ARTErrorInfo *)createWithCode:(NSInteger)code status:(NSInteger)status message:(NSString *)message requestId:(nullable NSString *)requestId additionalUserInfo:(nullable NSDictionary<NSString *, id> *)additionalUserInfo underlyingError:(nullable NSError *)underlyingError;
 
 /// :nodoc:
 + (ARTErrorInfo *)createFromNSException:(NSException *)error requestId:(nullable NSString *)requestId;

--- a/Test/AblyTests/Tests/UtilitiesTests.swift
+++ b/Test/AblyTests/Tests/UtilitiesTests.swift
@@ -239,7 +239,7 @@ class UtilitiesTests: XCTestCase {
         }
     }
 
-    func test__Utilities__JSON_Encoder__should_decode_rest_error_response_with_only_error_field() throws {
+    func test__Utilities__JSON_Encoder__should_not_decode_rest_http_error_if_it_doesnt_contains_error_dictionary_under_error_key() throws {
         let test = Test()
         beforeEach__Utilities__JSON_Encoder()
 
@@ -263,15 +263,14 @@ class UtilitiesTests: XCTestCase {
                 guard let error = error as? ARTErrorInfo else {
                     fail("Should be ARTErrorInfo"); done(); return
                 }
-                XCTAssertTrue(error.code == 40400)
-                XCTAssertTrue(error.statusCode == 404)
-                XCTAssertTrue(error.message == "HTTP request failed with status code 404")
+                XCTAssertTrue(error.code == ARTClientCodeError.invalidType.rawValue)
+                XCTAssertTrue(error.message == "Failed to decode error dictionary from the provided error data.")
                 done()
             })
         }
     }
 
-    func test__Utilities__JSON_Encoder__should_decode_rest_error_response_with_complete_error_info() throws {
+    func test__Utilities__JSON_Encoder__should_decode_rest_http_error_if_it_contains_error_dictionary_under_error_key() throws {
         let test = Test()
         beforeEach__Utilities__JSON_Encoder()
 


### PR DESCRIPTION
Closes #2135 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling with better error messages and accurate HTTP status code mapping.
  * Enhanced underlying error propagation for authentication and connection failures.
  * Better handling of malformed server responses and edge cases.

* **Tests**
  * Added authentication error scenario test coverage.
  * Updated error handling tests for improved validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->