### PR TITLE
Set immediateReconnectionDelay to 1 second

### DIFF
--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -258,7 +258,7 @@ typedef NS_ENUM(NSUInteger, ARTNetworkState) {
         _pendingAuthorizations = [NSMutableArray array];
         _connection = [[ARTConnectionInternal alloc] initWithRealtime:self logger:self.logger];
         _connectionStateTtl = [ARTDefault connectionStateTtl];
-        _immediateReconnectionDelay = 0.1;
+        _immediateReconnectionDelay = 1.0;
         const id<ARTRetryDelayCalculator> connectRetryDelayCalculator = [[ARTBackoffRetryDelayCalculator alloc] initWithInitialRetryTimeout:options.disconnectedRetryTimeout
                                                                                                                  jitterCoefficientGenerator:options.testOptions.jitterCoefficientGenerator];
         _connectRetryState = [[ARTConnectRetryState alloc] initWithRetryDelayCalculator:connectRetryDelayCalculator


### PR DESCRIPTION
Set _immediateReconnectionDelay to 1 second, because it is short enough for the user not to notice it and is long enough for the hardware to digest quick iteration over fallback hosts.

This will ease the effect of a proxy connection drop until proper solution implemented (see https://github.com/ably/ably-cocoa/issues/2142).