### PR TITLE
Add plugin API for fetching server time

### DIFF
--- a/Docs/plugins.md
+++ b/Docs/plugins.md
@@ -12,7 +12,8 @@ Currently, our only plugin is for adding LiveObjects functionality. This plugin 
 
 - Everything in ably-cocoa that depends on `_AblyPluginSupportPrivate` is gated behind `#ifdef ABLY_SUPPORTS_PLUGINS`, which is only defined in SPM builds. This is so as not to affect the non-SPM builds (i.e. Xcode, CocoaPods), which do not have access to `_AblyPluginSupportPrivate`.
 - ably-cocoa provides an implementation of `_AblyPluginSupportPrivate`'s `APPluginAPI` protocol, which is the interface that plugins use to access ably-cocoa's internals. On library initialization, it registers this implementation with `APDependencyStore`, from where plugins can subsequetly fetch it.
-- Currently, the plan is to test all the LiveObjects functionality within the LiveObjects plugin repository, so ably-cocoa does not contain any tests for the plugins mechanism.
+- There are some tests for the `APPluginAPI` implementation in `PluginAPITests.swift` (with only partial coverage at the moment).
+- Currently, the plan is to test all the LiveObjects functionality within the LiveObjects plugin repository, so the ably-cocoa tests do not import the LiveObjects plugin.
 - The underscore and `Private` are to reduce the chances of the user accidentally importing it into their project.
 - `_AblyPluginSupportPrivate` can not refer to any of ably-cocoa's types (since SPM forbids circular dependencies) and so it contains various types that duplicate ably-cocoa's public types. These fall into two categories:
   - enums e.g. `APRealtimeChannelState`, which are an exact copy of the corresponding ably-cocoa enum (in this example, `ARTRealtimeChannelState`)

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/ably/ably-cocoa-plugin-support",
         "state": {
           "branch": null,
-          "revision": "8db4632b0664b7272d54f7b612ddad0a18d1758f",
-          "version": "0.2.0"
+          "revision": "37ad19df2cc6063c74ec88ecefc2ddf491db5ebf",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
         .package(name: "AblyDeltaCodec", url: "https://github.com/ably/delta-codec-cocoa", from: "1.3.5"),
         .package(name: "Nimble", url: "https://github.com/quick/nimble", from: "11.2.2"),
         // Be sure to use `exact` here and not `from`; SPM does not have any special handling of 0.x versions and will resolve 'from: "0.2.0"' to anything less than 1.0.0. (BTW, our version of SPM manifest doesn't seem to have `exact`; this closed range equivalent is what Claude says I should use.)
-        .package(name: "ably-cocoa-plugin-support", url: "https://github.com/ably/ably-cocoa-plugin-support", "0.2.0"..."0.2.0"),
+        // TODO: Unpin before next release
+        .package(name: "ably-cocoa-plugin-support", url: "https://github.com/ably/ably-cocoa-plugin-support", .revision("37ad19df2cc6063c74ec88ecefc2ddf491db5ebf"))
     ],
     targets: [
         .target(
@@ -60,6 +61,7 @@ let package = Package(
                 .byName(name: "AblyTesting"),
                 .byName(name: "AblyTestingObjC"),
                 .byName(name: "Nimble"),
+                .product(name: "_AblyPluginSupportPrivate", package: "ably-cocoa-plugin-support")
             ],
             path: "Test/AblyTests",
             resources: [

--- a/Source/ARTPluginAPI.m
+++ b/Source/ARTPluginAPI.m
@@ -165,6 +165,14 @@ static ARTLogLevel _convertPluginLogLevel(APLogLevel pluginLogLevel) {
     return _convertOurRealtimeChannelState(internalChannel.state_nosync);
 }
 
+- (void)nosync_fetchServerTimeForClient:(id<APRealtimeClient>)client
+                             completion:(void (^)(NSDate * _Nullable, id<APPublicErrorInfo> _Nullable))completion {
+    ARTRealtimeInternal *internalRealtimeClient = _internalRealtimeClient(client);
+    dispatch_assert_queue(internalRealtimeClient.queue);
+
+    [internalRealtimeClient.auth fetchServerTimeWithCompletion:completion];
+}
+
 - (void)log:(NSString *)message
         withLevel:(APLogLevel)level
         file:(const char *)fileName

--- a/Source/PrivateHeaders/Ably/ARTAuth+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTAuth+Private.h
@@ -36,6 +36,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)createTokenRequest:(void (^)(ARTTokenRequest *_Nullable tokenRequest, NSError *_Nullable error))callback;
 
+/// Provides the implementation for `-[ARTPluginAPI nosync_fetchServerTimeForClient:completion:]`. See documentation for that method in `APPluginAPIProtocol`.
+- (void)fetchServerTimeWithCompletion:(void (^ _Nullable)(NSDate *_Nullable serverTime, ARTErrorInfo *_Nullable error))completion;
+
 @end
 
 /// Messages related to the ARTAuth

--- a/Test/AblyTests/Tests/PluginAPITests.swift
+++ b/Test/AblyTests/Tests/PluginAPITests.swift
@@ -1,0 +1,44 @@
+import Ably.Private
+import XCTest
+import _AblyPluginSupportPrivate
+import Nimble
+
+class PluginAPITests: XCTestCase {
+    func test_fetchServerTime() throws {
+        // Given: A realtime client
+        let test = Test()
+        let options = try AblyTests.commonAppSetup(for: test)
+
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        var serverTimeRequestCount = 0
+        let rest = client.internal.rest
+        let hook = rest.testSuite_injectIntoMethod(after: #selector(rest._time(withWrapperSDKAgents:completion:))) {
+            serverTimeRequestCount += 1
+        }
+        defer { hook.remove() }
+
+        let pluginAPI = DependencyStore.sharedInstance().fetchPluginAPI()
+        let pluginRealtimeClient = client.internal as! _AblyPluginSupportPrivate.RealtimeClient
+
+        let internalQueue = client.internal.queue
+
+        // When: We call nosync_fetchServerTime twice on the plugin API
+
+        for _ in (1...2) {
+            waitUntil(timeout: testTimeout) { done in
+                internalQueue.async {
+                    pluginAPI.nosync_fetchServerTime(for: pluginRealtimeClient) { serverTime, error in
+                        // Then: Both attempts succeed, and the server time is fetched from the REST API on the first attempt but not on the second
+                        dispatchPrecondition(condition: .onQueue(internalQueue))
+                        XCTAssertNil(error)
+                        XCTAssertNotNil(serverTime)
+                        XCTAssertEqual(serverTimeRequestCount, 1)
+                        done()
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements the API added in https://github.com/ably/ably-cocoa-plugin-support/pull/4.

Relates to https://github.com/ably/ably-liveobjects-swift-plugin/issues/50.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin API: fetch server time for a client with caching to avoid duplicate remote requests.

* **Documentation**
  * Clarified plugin docs: current test coverage and notes about duplicated private-interface types and usage guidance.

* **Chores**
  * Updated plugin-support dependency pin.

* **Tests**
  * Added tests validating server-time retrieval and that multiple calls trigger only a single remote request.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->