### PR TITLE
Implement plugin API for getting `CONNECTED` `connectionDetails`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/ably/ably-cocoa-plugin-support",
         "state": {
           "branch": null,
-          "revision": "37ad19df2cc6063c74ec88ecefc2ddf491db5ebf",
+          "revision": "c034504a5ef426f64e7b27534e86a0c547f3b1e8",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(name: "Nimble", url: "https://github.com/quick/nimble", from: "11.2.2"),
         // Be sure to use `exact` here and not `from`; SPM does not have any special handling of 0.x versions and will resolve 'from: "0.2.0"' to anything less than 1.0.0. (BTW, our version of SPM manifest doesn't seem to have `exact`; this closed range equivalent is what Claude says I should use.)
         // TODO: Unpin before next release
-        .package(name: "ably-cocoa-plugin-support", url: "https://github.com/ably/ably-cocoa-plugin-support", .revision("37ad19df2cc6063c74ec88ecefc2ddf491db5ebf"))
+        .package(name: "ably-cocoa-plugin-support", url: "https://github.com/ably/ably-cocoa-plugin-support", .revision("c034504a5ef426f64e7b27534e86a0c547f3b1e8"))
     ],
     targets: [
         .target(

--- a/Source/ARTConnectionDetails.m
+++ b/Source/ARTConnectionDetails.m
@@ -9,7 +9,8 @@
                   maxInboundRate:(NSInteger)maxInboundRate
               connectionStateTtl:(NSTimeInterval)connectionStateTtl
                         serverId:(NSString *)serverId
-                 maxIdleInterval:(NSTimeInterval)maxIdleInterval {
+                 maxIdleInterval:(NSTimeInterval)maxIdleInterval
+            objectsGCGracePeriod:(nullable NSNumber *)objectsGCGracePeriod {
     if (self = [super init]) {
         _clientId = clientId;
         _connectionKey = connectionKey;
@@ -19,6 +20,7 @@
         _connectionStateTtl = connectionStateTtl;
         _serverId = serverId;
         _maxIdleInterval = maxIdleInterval;
+        _objectsGCGracePeriod = objectsGCGracePeriod;
     }
     return self;
 }

--- a/Source/ARTJsonLikeEncoder.m
+++ b/Source/ARTJsonLikeEncoder.m
@@ -952,6 +952,13 @@
     if (!input) {
         return nil;
     }
+
+    NSNumber *objectsGCGracePeriod = nil;
+    // RTO10b3 implies this may be absent
+    if ([input valueForKey:@"objectsGCGracePeriod"]) {
+        objectsGCGracePeriod = @(millisecondsToTimeInterval([input artInteger:@"objectsGCGracePeriod"]));
+    }
+
     return [[ARTConnectionDetails alloc] initWithClientId:[input artString:@"clientId"]
                                             connectionKey:[input artString:@"connectionKey"]
                                            maxMessageSize:[input artInteger:@"maxMessageSize"]
@@ -959,7 +966,8 @@
                                            maxInboundRate:[input artInteger:@"maxInboundRate"]
                                        connectionStateTtl:millisecondsToTimeInterval([input artInteger:@"connectionStateTtl"])
                                                  serverId:[input artString:@"serverId"]
-                                          maxIdleInterval:millisecondsToTimeInterval([input artInteger:@"maxIdleInterval"])];
+                                          maxIdleInterval:millisecondsToTimeInterval([input artInteger:@"maxIdleInterval"])
+                                     objectsGCGracePeriod:objectsGCGracePeriod];
 }
 
 - (ARTChannelMetrics *)channelMetricsFromDictionary:(NSDictionary *)input {

--- a/Source/ARTPluginAPI.m
+++ b/Source/ARTPluginAPI.m
@@ -7,6 +7,7 @@
 #import "ARTPublicRealtimeChannelUnderlyingObjects.h"
 #import "ARTClientOptions+Private.h"
 #import "ARTErrorInfo+Private.h"
+#import "ARTConnectionDetails+Private.h"
 
 static ARTErrorInfo *_ourPublicErrorInfo(id<APPublicErrorInfo> pluginPublicErrorInfo) {
     if (![pluginPublicErrorInfo isKindOfClass:[ARTErrorInfo class]]) {
@@ -171,6 +172,13 @@ static ARTLogLevel _convertPluginLogLevel(APLogLevel pluginLogLevel) {
     dispatch_assert_queue(internalRealtimeClient.queue);
 
     [internalRealtimeClient.auth fetchServerTimeWithCompletion:completion];
+}
+
+- (id<APConnectionDetailsProtocol>)nosync_latestConnectionDetailsForClient:(id<APRealtimeClient>)client {
+    ARTRealtimeInternal *internalRealtimeClient = _internalRealtimeClient(client);
+    dispatch_assert_queue(internalRealtimeClient.queue);
+
+    return internalRealtimeClient.latestConnectionDetails;
 }
 
 - (void)log:(NSString *)message

--- a/Source/PrivateHeaders/Ably/ARTConnectionDetails+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTConnectionDetails+Private.h
@@ -1,5 +1,14 @@
 #import "ARTConnectionDetails.h"
 
+#ifdef ABLY_SUPPORTS_PLUGINS
+@import _AblyPluginSupportPrivate;
+#endif
+
+#ifdef ABLY_SUPPORTS_PLUGINS
+@interface ARTConnectionDetails () <APConnectionDetailsProtocol>
+@end
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ARTConnectionDetails ()

--- a/Source/PrivateHeaders/Ably/ARTConnectionDetails.h
+++ b/Source/PrivateHeaders/Ably/ARTConnectionDetails.h
@@ -51,6 +51,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (readonly, nonatomic) NSTimeInterval maxIdleInterval;
 
+/// If the `objectsGCGracePeriod` is present in the `ConnectionDetails`, this contains an `NSNumber` wrapping an `NSTimeInterval` containing its value in seconds.
+@property (readonly, nonatomic, nullable) NSNumber *objectsGCGracePeriod;
+
 /// :nodoc:
 - (instancetype)initWithClientId:(NSString *_Nullable)clientId
                    connectionKey:(NSString *_Nullable)connectionKey
@@ -59,7 +62,8 @@ NS_ASSUME_NONNULL_BEGIN
                   maxInboundRate:(NSInteger)maxInboundRate
               connectionStateTtl:(NSTimeInterval)connectionStateTtl
                         serverId:(NSString *)serverId
-                 maxIdleInterval:(NSTimeInterval)maxIdleInterval;
+                 maxIdleInterval:(NSTimeInterval)maxIdleInterval
+            objectsGCGracePeriod:(nullable NSNumber *)objectsGCGracePeriod;
 
 NS_ASSUME_NONNULL_END
 

--- a/Source/PrivateHeaders/Ably/ARTRealtime+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtime+Private.h
@@ -53,6 +53,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly, nonatomic) dispatch_queue_t queue;
 
+/// The `connectionDetails` from the latest `CONNECTED` `ProtocolMessage` that we received (`nil` if it did not contain a `connectionDetails`).
+///
+/// Provides the implementation for `-[ARTPluginAPI nosync_latestConnectionDetailsForClient:]`. See documentation for that method in `APPluginAPIProtocol`.
+@property (nullable, readonly, nonatomic) ARTConnectionDetails *latestConnectionDetails;
+
 - (void)timeWithWrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
                       completion:(ARTDateTimeCallback)callback;
 

--- a/Test/AblyTests/Test Utilities/TestUtilities.swift
+++ b/Test/AblyTests/Test Utilities/TestUtilities.swift
@@ -1389,7 +1389,7 @@ class TestProxyTransport: ARTWebSocketTransport {
         msg.action = .connected
         msg.connectionId = "x-xxxxxxxx"
         msg.connectionKey = "xxxxxxx-xxxxxxxxxxxxxx-xxxxxxxx"
-        msg.connectionDetails = ARTConnectionDetails(clientId: clientId, connectionKey: "a8c10!t-3D0O4ejwTdvLkl-b33a8c10", maxMessageSize: 16384, maxFrameSize: 262144, maxInboundRate: 250, connectionStateTtl: 60, serverId: "testServerId", maxIdleInterval: 15000)
+        msg.connectionDetails = ARTConnectionDetails(clientId: clientId, connectionKey: "a8c10!t-3D0O4ejwTdvLkl-b33a8c10", maxMessageSize: 16384, maxFrameSize: 262144, maxInboundRate: 250, connectionStateTtl: 60, serverId: "testServerId", maxIdleInterval: 15000, objectsGCGracePeriod: 86_400_000)
         super.receive(msg)
     }
 


### PR DESCRIPTION
**Note: This PR is based on top of #2149; please review that one first.**

Implements the API added in https://github.com/ably/ably-cocoa-plugin-support/pull/5.

Relates to https://github.com/ably/ably-liveobjects-swift-plugin/issues/32.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an objects garbage-collection grace period field to connection details.
  * Plugin API exposes latest connection details and real-time now notifies plugins on connection updates.

* **Chores**
  * Pinned dependency revision updated.

* **Tests**
  * Added tests and mocks verifying connection details propagation (including the new grace period) and latest-connection-details behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->