### PR TITLE
Make default `ARTMessage.action` explicit

### DIFF
--- a/Source/ARTMessage.m
+++ b/Source/ARTMessage.m
@@ -12,6 +12,8 @@
         self.name = [name copy];
         if (data) {
             self.data = data;
+            // The `action` property is meant to be optional so that it is absent on user-instantiated messages. However, we misunderstood this when implementing this property. So now we have to set a default value which, as the documentation says, is ignored (currently this is because we don't populate `action` on _any_ outbound `ProtocolMessage`; when we start doing this for realtime edits and deletes we'll have to make sure that we find some way to ignore the user-specified value; either by skipping it somehow or by just always sending MESSAGE_CREATE for publishes, which Simon said should be OK). Internal discussion: https://ably-real-time.slack.com/archives/CURL4U2FP/p1764676336838699
+            self.action = ARTMessageActionCreate;
             self.encoding = @"";
         }
     }

--- a/Source/include/Ably/ARTMessage.h
+++ b/Source/include/Ably/ARTMessage.h
@@ -53,6 +53,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, readwrite, nonatomic) NSString *name;
 
 /// The action type of the message, one of the `ARTMessageAction` enum values.
+///
+/// - Note: A message that you create via the ``initWithName:data:`` or ``initWithName:data:clientId:`` initializers will have an `action` of ``ARTMessageAction/ARTMessageActionCreate``. However, the value of this property will be ignored when you pass this message to the SDK (e.g. when publishing the message).
 @property (readwrite, nonatomic) ARTMessageAction action;
 
 /// This message's unique serial (an identifier that will be the same in all future updates of this message).


### PR DESCRIPTION
This is not a functional change, because the property was defaulting to zero which is `ARTMessageActionCreate` anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Messages created via the public initializers now reliably get a default action value when data is provided.

* **Documentation**
  * Clarified docs describing initialization behavior and the default action assigned for messages created with those initializers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->