### PR TITLE
[ECO-5633] Refactor `executeRequest`

### DIFF
--- a/Source/ARTAuth.m
+++ b/Source/ARTAuth.m
@@ -260,6 +260,7 @@ NS_ASSUME_NONNULL_END
     NSURL *url = [self buildURL:options withParams:params];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     request.HTTPMethod = options.authMethod;
+    [request setTimeoutInterval:_options.httpRequestTimeout];
 
     // HTTP Header Fields
     if ([options isMethodPOST]) {
@@ -370,7 +371,7 @@ art_dispatch_async(_queue, ^{
 
         ARTLogDebug(self.logger, @"RS:%p using authUrl (%@ %@)", _rest, request.HTTPMethod, request.URL);
 
-        task = [_rest executeRequest:request withAuthOption:ARTAuthenticationOff wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+        task = [_rest executeExternalRequest:request completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
             if (error) {
                 checkerCallback(nil, error);
             } else {
@@ -508,7 +509,7 @@ art_dispatch_async(_queue, ^{
     [request setValue:[encoder mimeType] forHTTPHeaderField:@"Accept"];
     [request setValue:[encoder mimeType] forHTTPHeaderField:@"Content-Type"];
 
-    return [_rest executeRequest:request withAuthOption:ARTAuthenticationOff wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    return [_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOff wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             callback(nil, error);
         } else {

--- a/Source/ARTHTTPPaginatedResponse.m
+++ b/Source/ARTHTTPPaginatedResponse.m
@@ -93,7 +93,7 @@
                 callback:(ARTHTTPPaginatedCallback)callback {
     ARTLogDebug(logger, @"HTTP Paginated request: %@", request);
 
-    [rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error && ![error.domain isEqualToString:ARTAblyErrorDomain]) {
             callback(nil, [ARTErrorInfo createFromNSError:error]);
             return;

--- a/Source/ARTPaginatedResult.m
+++ b/Source/ARTPaginatedResult.m
@@ -147,7 +147,7 @@
 + (void)executePaginated:(ARTRestInternal *)rest withRequest:(NSMutableURLRequest *)request andResponseProcessor:(ARTPaginatedResultResponseProcessor)responseProcessor wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents logger:(ARTInternalLog *)logger callback:(void (^)(ARTPaginatedResult<id> *_Nullable result, ARTErrorInfo *_Nullable error))callback {
     ARTLogDebug(logger, @"Paginated request: %@", request);
 
-    [rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             callback(nil, [ARTErrorInfo createFromNSError:error]);
         } else {

--- a/Source/ARTPushActivationStateMachine.m
+++ b/Source/ARTPushActivationStateMachine.m
@@ -197,7 +197,7 @@ art_dispatch_async(_queue, ^{
         [request setValue:[[self->_rest defaultEncoder] mimeType] forHTTPHeaderField:@"Content-Type"];
 
         ARTLogDebug(self->_logger, @"%@: device registration with request %@", NSStringFromClass(self.class), request);
-        [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+        [self->_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
             if (error) {
                 ARTLogError(self->_logger, @"%@: device registration failed (%@)", NSStringFromClass(self.class), error.localizedDescription);
                 [self sendEvent:[ARTPushActivationEventGettingDeviceRegistrationFailed newWithError:[ARTErrorInfo createFromNSError:error]]];
@@ -263,7 +263,7 @@ art_dispatch_async(_queue, ^{
     [request setDeviceAuthentication:local];
 
     ARTLogDebug(_logger, @"%@: update device with request %@", NSStringFromClass(self.class), request);
-    [_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             ARTLogError(self->_logger, @"%@: update device failed (%@)", NSStringFromClass(self.class), error.localizedDescription);
             [self sendEvent:[ARTPushActivationEventSyncRegistrationFailed newWithError:[ARTErrorInfo createFromNSError:error]]];
@@ -311,7 +311,7 @@ art_dispatch_async(_queue, ^{
         [request setDeviceAuthentication:local];
 
         ARTLogDebug(self->_logger, @"%@: sync device with request %@", NSStringFromClass(self.class), request);
-        [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+        [self->_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
             if (error) {
                 ARTLogError(self->_logger, @"%@: device registration failed (%@)", NSStringFromClass(self.class), error.localizedDescription);
                 [self sendEvent:[ARTPushActivationEventSyncRegistrationFailed newWithError:[ARTErrorInfo createFromNSError:error]]];
@@ -366,7 +366,7 @@ art_dispatch_async(_queue, ^{
     [request setDeviceAuthentication:local];
 
     ARTLogDebug(_logger, @"%@: device deregistration with request %@", NSStringFromClass(self.class), request);
-    [_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             // RSH3d2c1: ignore unauthorized or invalid credentials errors
             if (response.statusCode == 401 || error.code == 40005) {

--- a/Source/ARTPushAdmin.m
+++ b/Source/ARTPushAdmin.m
@@ -84,7 +84,7 @@
             [request setValue:[[self->_rest defaultEncoder] mimeType] forHTTPHeaderField:@"Content-Type"];
 
             ARTLogDebug(self->_logger, @"push notification to a single device %@", request);
-        [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+            [self->_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
                 if (error) {
                     ARTLogError(self->_logger, @"%@: push notification to a single device failed (%@)", NSStringFromClass(self.class), error.localizedDescription);
                     if (callback) callback([ARTErrorInfo createFromNSError:error]);

--- a/Source/ARTPushChannel.m
+++ b/Source/ARTPushChannel.m
@@ -130,7 +130,7 @@ art_dispatch_async(_queue, ^{
     [request setDeviceAuthentication:deviceId localDevice:device];
 
     ARTLogDebug(self->_logger, @"subscribe notifications for device %@ in channel %@", deviceId, self->_channel.name);
-    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self->_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             ARTLogError(self->_logger, @"%@: subscribe notifications for device %@ in channel %@ failed (%@)", NSStringFromClass(self.class), deviceId, self->_channel.name, error.localizedDescription);
         }
@@ -164,7 +164,7 @@ art_dispatch_async(_queue, ^{
     [request setValue:[[self->_rest defaultEncoder] mimeType] forHTTPHeaderField:@"Content-Type"];
 
     ARTLogDebug(self->_logger, @"subscribe notifications for clientId %@ in channel %@", clientId, self->_channel.name);
-    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self->_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             ARTLogError(self->_logger, @"%@: subscribe notifications for clientId %@ in channel %@ failed (%@)", NSStringFromClass(self.class), clientId, self->_channel.name, error.localizedDescription);
         }
@@ -201,7 +201,7 @@ art_dispatch_async(_queue, ^{
     [request setDeviceAuthentication:deviceId localDevice:device];
 
     ARTLogDebug(self->_logger, @"unsubscribe notifications for device %@ in channel %@", deviceId, self->_channel.name);
-    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self->_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             ARTLogError(self->_logger, @"%@: unsubscribe notifications for device %@ in channel %@ failed (%@)", NSStringFromClass(self.class), deviceId, self->_channel.name, error.localizedDescription);
         }
@@ -236,7 +236,7 @@ art_dispatch_async(_queue, ^{
     request.HTTPMethod = @"DELETE";
 
     ARTLogDebug(self->_logger, @"unsubscribe notifications for clientId %@ in channel %@", clientId, self->_channel.name);
-    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self->_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             ARTLogError(self->_logger, @"%@: unsubscribe notifications for clientId %@ in channel %@ failed (%@)", NSStringFromClass(self.class), clientId, self->_channel.name, error.localizedDescription);
         }

--- a/Source/ARTPushChannelSubscriptions.m
+++ b/Source/ARTPushChannelSubscriptions.m
@@ -91,7 +91,7 @@
         [request setDeviceAuthentication:channelSubscription.deviceId localDevice:local];
         
         ARTLogDebug(self->_logger, @"save channel subscription with request %@", request);
-        [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+        [self->_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
             if (response.statusCode == 200 /*Ok*/ || response.statusCode == 201 /*Created*/) {
                 ARTLogDebug(self->_logger, @"channel subscription saved successfully");
                 callback(nil);
@@ -209,7 +209,7 @@
 #endif
     
     ARTLogDebug(_logger, @"remove channel subscription with request %@", request);
-    [_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (response.statusCode == 200 /*Ok*/ || response.statusCode == 204 /*not returning any content*/) {
             ARTLogDebug(self->_logger, @"%@: channel subscription removed successfully", NSStringFromClass(self.class));
             callback(nil);

--- a/Source/ARTPushDeviceRegistrations.m
+++ b/Source/ARTPushDeviceRegistrations.m
@@ -92,7 +92,7 @@ art_dispatch_async(_queue, ^{
     [request setDeviceAuthentication:deviceDetails.id localDevice:local logger:self->_logger];
 
     ARTLogDebug(self->_logger, @"save device with request %@", request);
-    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self->_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (response.statusCode == 200 /*OK*/) {
             NSError *decodeError = nil;
             ARTDeviceDetails *deviceDetails = [[self->_rest defaultEncoder] decodeDeviceDetails:data error:&decodeError];
@@ -140,7 +140,7 @@ art_dispatch_async(_queue, ^{
     [request setDeviceAuthentication:deviceId localDevice:local logger:self->_logger];
 
     ARTLogDebug(self->_logger, @"get device with request %@", request);
-    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self->_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (response.statusCode == 200 /*OK*/) {
             NSError *decodeError = nil;
             ARTDeviceDetails *device = [self->_rest.encoders[response.MIMEType] decodeDeviceDetails:data error:&decodeError];
@@ -213,7 +213,7 @@ art_dispatch_async(_queue, ^{
     [request setValue:[[self->_rest defaultEncoder] mimeType] forHTTPHeaderField:@"Content-Type"];
 
     ARTLogDebug(self->_logger, @"remove device with request %@", request);
-    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self->_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (response.statusCode == 200 /*Ok*/ || response.statusCode == 204 /*not returning any content*/) {
             ARTLogDebug(self->_logger, @"%@: save device successfully", NSStringFromClass(self.class));
             callback(nil);
@@ -258,7 +258,7 @@ art_dispatch_async(_queue, ^{
     [request setDeviceAuthentication:[params objectForKey:@"deviceId"] localDevice:local];
 
     ARTLogDebug(self->_logger, @"remove devices with request %@", request);
-    [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self->_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (response.statusCode == 200 /*Ok*/ || response.statusCode == 204 /*not returning any content*/) {
             ARTLogDebug(self->_logger, @"%@: remove devices successfully", NSStringFromClass(self.class));
             callback(nil);

--- a/Source/ARTRestAnnotations.m
+++ b/Source/ARTRestAnnotations.m
@@ -202,10 +202,10 @@ art_dispatch_async(_queue, ^{
                 self->_channel.rest, self->_channel, self->_channel.name,
                 [[NSString alloc] initWithData:encodedAnnotation encoding:NSUTF8StringEncoding]);
     
-    [self->_channel.rest executeRequest:request
-                         withAuthOption:ARTAuthenticationOn
-                       wrapperSDKAgents:nil
-                             completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self->_channel.rest executeAblyRequest:request
+                             withAuthOption:ARTAuthenticationOn
+                           wrapperSDKAgents:nil
+                                 completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (callback) {
             ARTErrorInfo *errorInfo = nil;
             if (error) {

--- a/Source/ARTRestChannel.m
+++ b/Source/ARTRestChannel.m
@@ -260,7 +260,7 @@ art_dispatch_sync(_queue, ^{
         
         ARTLogDebug(self.logger, @"RS:%p C:%p (%@) channel details request %@", self->_rest, self, self.name, request);
         
-        [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse * _Nullable response, NSData * _Nullable data, NSError * _Nullable error) {
+        [self->_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse * _Nullable response, NSData * _Nullable data, NSError * _Nullable error) {
             
             if (response.statusCode == 200 /*OK*/) {
                 NSError *decodeError = nil;
@@ -390,7 +390,7 @@ art_dispatch_sync(_queue, ^{
         
         ARTLogDebug(self.logger, @"RS:%p C:%p (%@) post message %@", self->_rest, self, self.name, [[NSString alloc] initWithData:encodedMessage ?: [NSData data] encoding:NSUTF8StringEncoding]);
         
-        [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+        [self->_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:nil completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
             if (callback) {
                 ARTErrorInfo *errorInfo;
                 if (self->_rest.options.addRequestIds) {
@@ -514,7 +514,7 @@ art_dispatch_sync(_queue, ^{
         NSString *logOperation = isDelete ? @"delete" : @"update";
         ARTLogDebug(self.logger, @"RS:%p C:%p (%@) %@ message %@", self->_rest, self, self.name, logOperation, [[NSString alloc] initWithData:requestBodyData ?: [NSData data] encoding:NSUTF8StringEncoding]);
         
-        [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+        [self->_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
             if (callback) {
                 ARTErrorInfo *errorInfo;
                 if (self->_rest.options.addRequestIds) {
@@ -569,7 +569,7 @@ art_dispatch_sync(_queue, ^{
         
         ARTLogDebug(self.logger, @"RS:%p C:%p (%@) get message with serial %@", self->_rest, self, self.name, serial);
         
-        [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+        [self->_rest executeAblyRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
             if (error) {
                 ARTErrorInfo *errorInfo;
                 if (self->_rest.options.addRequestIds) {

--- a/Source/PrivateHeaders/Ably/ARTRest+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRest+Private.h
@@ -71,16 +71,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 // MARK: ARTHTTPExecutor
 
-- (nullable NSObject<ARTCancellable> *)executeRequest:(NSURLRequest *)request
-                                     wrapperSDKAgents:(nullable NSDictionary<NSString *, NSString *> *)wrapperSDKAgents
-                                           completion:(nullable ARTURLRequestCallback)callback;
+- (nullable NSObject<ARTCancellable> *)executeExternalRequest:(NSURLRequest *)request
+                                                   completion:(nullable ARTURLRequestCallback)callback;
 
 // MARK: Internal
 
-- (nullable NSObject<ARTCancellable> *)executeRequest:(NSMutableURLRequest *)request
-                                       withAuthOption:(ARTAuthentication)authOption
-                                     wrapperSDKAgents:(nullable NSDictionary<NSString *, NSString *> *)wrapperSDKAgents
-                                           completion:(ARTURLRequestCallback)callback;
+- (nullable NSObject<ARTCancellable> *)executeAblyRequest:(NSMutableURLRequest *)request
+                                           withAuthOption:(ARTAuthentication)authOption
+                                         wrapperSDKAgents:(nullable NSDictionary<NSString *, NSString *> *)wrapperSDKAgents
+                                               completion:(ARTURLRequestCallback)callback;
+
+- (nullable NSObject<ARTCancellable> *)executeAblyRequest:(NSURLRequest *)request
+                                         wrapperSDKAgents:(nullable NSDictionary<NSString *, NSString *> *)wrapperSDKAgents
+                                               completion:(nullable ARTURLRequestCallback)callback;
 
 - (nullable NSObject<ARTCancellable> *)internetIsUp:(void (^)(BOOL isUp))cb;
 

--- a/Test/AblyTests/Tests/AuthTests.swift
+++ b/Test/AblyTests/Tests/AuthTests.swift
@@ -592,6 +592,7 @@ class AuthTests: XCTestCase {
                     fail("ErrorInfo is nil"); done(); return
                 }
                 XCTAssertEqual(errorInfo.code, ARTErrorCode.authConfiguredProviderFailure.intValue)
+                XCTAssertTrue(errorInfo.description().contains("Invalid request: body param is required")) // see https://github.com/ably/ably-cocoa/issues/2135
                 done()
             }
             realtime.connect()

--- a/Test/AblyTests/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/AblyTests/Tests/RealtimeClientConnectionTests.swift
@@ -5351,7 +5351,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                     "Accept": "application/json",
                     "Content-Type": "application/json",
                 ]
-                client.internal.rest.execute(request, withAuthOption: .on, wrapperSDKAgents: nil, completion: { _, _, err in
+                client.internal.rest.executeAblyRequest(request, withAuthOption: .on, wrapperSDKAgents: nil, completion: { _, _, err in
                     if let err = err {
                         fail("\(err)")
                     }
@@ -5377,7 +5377,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                     let request = NSMutableURLRequest(url: URL(string: "/channels/\(channel.name)/messages")!)
                     request.httpMethod = "GET"
                     request.allHTTPHeaderFields = ["Accept": "application/json"]
-                    client.internal.rest.execute(request, withAuthOption: .on, wrapperSDKAgents: nil, completion: { _, data, err in
+                    client.internal.rest.executeAblyRequest(request, withAuthOption: .on, wrapperSDKAgents: nil, completion: { _, data, err in
                         if let err = err {
                             fail("\(err)")
                             done()
@@ -5441,7 +5441,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                     "Accept": "application/json",
                     "Content-Type": "application/json",
                 ]
-                restPublishClient.internal.execute(request, withAuthOption: .on, wrapperSDKAgents: nil, completion: { _, _, err in
+                restPublishClient.internal.executeAblyRequest(request, withAuthOption: .on, wrapperSDKAgents: nil, completion: { _, _, err in
                     if let err = err {
                         fail("\(err)")
                     }
@@ -5507,7 +5507,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                     let request = NSMutableURLRequest(url: URL(string: "/channels/\(restPublishChannel.name)/messages")!)
                     request.httpMethod = "GET"
                     request.allHTTPHeaderFields = ["Accept": "application/json"]
-                    restRetrieveClient.internal.execute(request, withAuthOption: .on, wrapperSDKAgents: nil, completion: { _, data, err in
+                    restRetrieveClient.internal.executeAblyRequest(request, withAuthOption: .on, wrapperSDKAgents: nil, completion: { _, data, err in
                         if let err = err {
                             fail("\(err)")
                             done()

--- a/Test/AblyTests/Tests/RestClientTests.swift
+++ b/Test/AblyTests/Tests/RestClientTests.swift
@@ -1797,7 +1797,7 @@ class RestClientTests: XCTestCase {
         let request = URLRequest(url: URL(string: "https://www.example.com")!)
         waitUntil(timeout: testTimeout) { done in
             let rest = ARTRest(key: "xxxx:xxxx")
-            rest.internal.execute(request, wrapperSDKAgents:nil, completion: { response, _, error in
+            rest.internal.executeAblyRequest(request, wrapperSDKAgents:nil, completion: { response, _, error in
                 guard let contentType = response?.allHeaderFields["Content-Type"] as? String else {
                     fail("Response should have a Content-Type"); done(); return
                 }

--- a/Test/AblyTests/Tests/UtilitiesTests.swift
+++ b/Test/AblyTests/Tests/UtilitiesTests.swift
@@ -257,9 +257,9 @@ class UtilitiesTests: XCTestCase {
             ]
         )
         
-        let request = URLRequest(url: URL(string: "https://www.example.com")!)
+        let request = URLRequest(url: URL(string: "https://www.example.com")!) // this should be an Ably address, but we use random since the response is simulated
         waitUntil(timeout: testTimeout) { done in
-            rest.internal.execute(request, wrapperSDKAgents:nil, completion: { response, _, error in
+            rest.internal.executeAblyRequest(request, wrapperSDKAgents:nil, completion: { response, _, error in
                 guard let error = error as? ARTErrorInfo else {
                     fail("Should be ARTErrorInfo"); done(); return
                 }
@@ -292,9 +292,9 @@ class UtilitiesTests: XCTestCase {
             ]
         )
         
-        let request = URLRequest(url: URL(string: "https://www.example.com")!)
+        let request = URLRequest(url: URL(string: "https://www.example.com")!) // this should be an Ably address, but we use random since the response is simulated
         waitUntil(timeout: testTimeout) { done in
-            rest.internal.execute(request, wrapperSDKAgents:nil, completion: { response, _, error in
+            rest.internal.executeAblyRequest(request, wrapperSDKAgents:nil, completion: { response, _, error in
                 guard let error = error as? ARTErrorInfo else {
                     fail("Should be ARTErrorInfo"); done(); return
                 }


### PR DESCRIPTION
Closes #2135 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Per-request HTTP timeouts and a unified request pipeline for consistent request preparation and handling.
  * Normalized error responses, clarified token-renewal retry behavior, and improved host fallback/retry resilience.
  * Callbacks now receive consistent, structured error information across REST flows.

* **Bug Fixes**
  * Prevented post-failure continuation in a push registration error path to avoid duplicate processing.

* **Tests**
  * Updated tests for the new request pipeline and added assertions for specific auth error descriptions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->