### PR TITLE
Include `action` in wire-encoded `ARTMessage`

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -316,6 +316,9 @@
 		21B4A7BC2E560F8000687F68 /* ARTErrorInfo+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 21B4A7BB2E560F8000687F68 /* ARTErrorInfo+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21B4A7BD2E560F8000687F68 /* ARTErrorInfo+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 21B4A7BB2E560F8000687F68 /* ARTErrorInfo+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21B4A7BE2E560F8000687F68 /* ARTErrorInfo+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 21B4A7BB2E560F8000687F68 /* ARTErrorInfo+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		21D04A722EE9AA4A00BD59DD /* ARTMessage+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 21D04A712EE9AA4A00BD59DD /* ARTMessage+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		21D04A732EE9AA4A00BD59DD /* ARTMessage+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 21D04A712EE9AA4A00BD59DD /* ARTMessage+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		21D04A742EE9AA4A00BD59DD /* ARTMessage+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 21D04A712EE9AA4A00BD59DD /* ARTMessage+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21E1C0E52A0DC47400A5DB65 /* ARTWebSocketFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 21E1C0E42A0DC47400A5DB65 /* ARTWebSocketFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21E1C0E62A0DC47400A5DB65 /* ARTWebSocketFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 21E1C0E42A0DC47400A5DB65 /* ARTWebSocketFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21E1C0E72A0DC47400A5DB65 /* ARTWebSocketFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 21E1C0E42A0DC47400A5DB65 /* ARTWebSocketFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1214,6 +1217,7 @@
 		21AC0CD02D4AA3200030BD23 /* ARTWrapperSDKProxyRealtimeChannel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWrapperSDKProxyRealtimeChannel.m; sourceTree = "<group>"; };
 		21AC0CD12D4AA3200030BD23 /* ARTWrapperSDKProxyRealtimeChannels.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWrapperSDKProxyRealtimeChannels.m; sourceTree = "<group>"; };
 		21B4A7BB2E560F8000687F68 /* ARTErrorInfo+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTErrorInfo+Private.h"; path = "PrivateHeaders/Ably/ARTErrorInfo+Private.h"; sourceTree = "<group>"; };
+		21D04A712EE9AA4A00BD59DD /* ARTMessage+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTMessage+Private.h"; path = "PrivateHeaders/Ably/ARTMessage+Private.h"; sourceTree = "<group>"; };
 		21E1C0E42A0DC47400A5DB65 /* ARTWebSocketFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTWebSocketFactory.h; path = PrivateHeaders/Ably/ARTWebSocketFactory.h; sourceTree = "<group>"; };
 		21E1C0E82A0DC5E600A5DB65 /* ARTWebSocketFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTWebSocketFactory.m; sourceTree = "<group>"; };
 		21E5D87E2D5E3EC300526C4C /* ARTChannelProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTChannelProtocol.h; path = include/Ably/ARTChannelProtocol.h; sourceTree = "<group>"; };
@@ -1904,6 +1908,7 @@
 				EB0505FB1C5BD7C4006BA7E2 /* ARTBaseMessage+Private.h */,
 				96BF61631A35CDE1004CF2B3 /* ARTBaseMessage.m */,
 				D746AE361BBC3201003ECEF8 /* ARTMessage.h */,
+				21D04A712EE9AA4A00BD59DD /* ARTMessage+Private.h */,
 				D746AE371BBC3201003ECEF8 /* ARTMessage.m */,
 				D746AE261BBB61C9003ECEF8 /* ARTPresence.h */,
 				D746AE271BBB61C9003ECEF8 /* ARTPresence.m */,
@@ -2127,6 +2132,7 @@
 				21088DC32A5354F10033C722 /* ARTConnectRetryState.h in Headers */,
 				EB5E058D1C77027600A48B39 /* ARTCrypto+Private.h in Headers */,
 				2132C2F529D5BE05000C4355 /* ARTRetrySequence.h in Headers */,
+				21D04A732EE9AA4A00BD59DD /* ARTMessage+Private.h in Headers */,
 				D72C67DF201AB74000978EBB /* ARTPushActivationStateMachine+Private.h in Headers */,
 				D7DC8AF11C6AA0C8005AF165 /* ARTDefault+Private.h in Headers */,
 				961343D81A42E0B7006DC822 /* ARTClientOptions.h in Headers */,
@@ -2499,6 +2505,7 @@
 				D710D4D921949BF9008F54AD /* ARTQueuedMessage.h in Headers */,
 				D710D61F21949DEC008F54AD /* ARTNSHTTPURLResponse+ARTPaginated.h in Headers */,
 				84B18ACE2EE233C7003768C1 /* ARTDictionarySerializable.h in Headers */,
+				21D04A742EE9AA4A00BD59DD /* ARTMessage+Private.h in Headers */,
 				D710D69F21949F0D008F54AD /* ARTJsonLikeEncoder.h in Headers */,
 				2105ED1B29E722DD00DE6D67 /* ARTInternalLogCore+Testing.h in Headers */,
 				5CC1D9C52E7C25A2005DC3ED /* ARTMessageAnnotations.h in Headers */,
@@ -2710,6 +2717,7 @@
 				D710D62B21949DED008F54AD /* ARTNSHTTPURLResponse+ARTPaginated.h in Headers */,
 				D710D6A121949F0E008F54AD /* ARTJsonLikeEncoder.h in Headers */,
 				84B18ACF2EE233C7003768C1 /* ARTDictionarySerializable.h in Headers */,
+				21D04A722EE9AA4A00BD59DD /* ARTMessage+Private.h in Headers */,
 				D710D4AD21949AE0008F54AD /* ARTRestChannel.h in Headers */,
 				2105ED1C29E722DD00DE6D67 /* ARTInternalLogCore+Testing.h in Headers */,
 				5CC1D9C22E7C25A2005DC3ED /* ARTMessageAnnotations.h in Headers */,

--- a/Source/ARTJsonLikeEncoder.m
+++ b/Source/ARTJsonLikeEncoder.m
@@ -3,6 +3,7 @@
 #import "ARTJsonLikeEncoder.h"
 
 #import "ARTMessage.h"
+#import "ARTMessage+Private.h"
 #import "ARTPresence.h"
 #import "ARTPresenceMessage.h"
 #import "ARTAnnotation.h"
@@ -405,6 +406,23 @@
     }
 }
 
+- (int)intFromMessageAction:(ARTMessageAction)action
+{
+    // TM5
+    switch (action) {
+        case ARTMessageActionCreate:
+            return 0;
+        case ARTMessageActionUpdate:
+            return 1;
+        case ARTMessageActionDelete:
+            return 2;
+        case ARTMessageActionMeta:
+            return 3;
+        case ARTMessageActionMessageSummary:
+            return 4;
+    }
+}
+
 - (ARTPresenceMessage *)presenceMessageFromDictionary:(NSDictionary *)input {
     ARTLogVerbose(_logger, @"RS:%p ARTJsonLikeEncoder<%@>: presenceMessageFromDictionary %@", _rest, [_delegate formatAsString], input);
     if (![input isKindOfClass:[NSDictionary class]]) {
@@ -499,6 +517,11 @@
 
     if (message.name) {
         [output setObject:message.name forKey:@"name"];
+    }
+
+    if (message.actionIsInternallySet) {
+        int action = [self intFromMessageAction:message.action];
+        [output setObject:[NSNumber numberWithInt:action] forKey:@"action"];
     }
 
     if (message.extras) {

--- a/Source/ARTMessage.m
+++ b/Source/ARTMessage.m
@@ -4,6 +4,7 @@
 #import "ARTBaseMessage+Private.h"
 #import "ARTNSArray+ARTFunctional.h"
 #import "ARTInternalLog.h"
+#import "ARTMessage+Private.h"
 
 @implementation ARTMessage
 
@@ -12,7 +13,7 @@
         self.name = [name copy];
         if (data) {
             self.data = data;
-            // The `action` property is meant to be optional so that it is absent on user-instantiated messages. However, we misunderstood this when implementing this property. So now we have to set a default value which, as the documentation says, is ignored (currently this is because we don't populate `action` on _any_ outbound `ProtocolMessage`; when we start doing this for realtime edits and deletes we'll have to make sure that we find some way to ignore the user-specified value; either by skipping it somehow or by just always sending MESSAGE_CREATE for publishes, which Simon said should be OK). Internal discussion: https://ably-real-time.slack.com/archives/CURL4U2FP/p1764676336838699
+            // The `action` property is meant to be optional so that it is absent on user-instantiated messages. However, we misunderstood this when implementing this property. So now we have to set a default value which, as the documentation says, is ignored (see the `actionIsInternallySet` property).
             self.action = ARTMessageActionCreate;
             self.encoding = @"";
         }
@@ -47,6 +48,7 @@
     message.serial = self.serial;
     message.version = self.version;
     message.annotations = self.annotations;
+    message.actionIsInternallySet = self.actionIsInternallySet;
     return message;
 }
 

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -141,5 +141,6 @@ framework module Ably {
         header "ARTErrorInfo+Private.h"
         header "ARTDictionarySerializable.h"
         header "ARTMessageOperation+Private.h"
+        header "ARTMessage+Private.h"
     }
 }

--- a/Source/PrivateHeaders/Ably/ARTMessage+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTMessage+Private.h
@@ -1,0 +1,18 @@
+#import <Ably/ARTMessage.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARTMessage ()
+
+/**
+ * Whether the `action` property has been set by the internals of the SDK.
+ *
+ * This property defaults to `NO`, indicating that the `action` property is either the default value or has been set by the user. As described in the documentation for `action`, this means that the SDK should ignore the value of this property. In particular, it should not populate this property when sending this message over the wire.
+ *
+ * - Note: If we had a separate `WireMessage` type instead of using `ARTMessage` as both our internal and external representation of a message, then we wouldn't need this mechanism. But we don't.
+ */
+@property (nonatomic) BOOL actionIsInternallySet;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/include/module.modulemap
+++ b/Source/include/module.modulemap
@@ -141,5 +141,6 @@ module Ably {
         header "../PrivateHeaders/Ably/ARTErrorInfo+Private.h"
         header "../PrivateHeaders/Ably/ARTDictionarySerializable.h"
         header "../PrivateHeaders/Ably/ARTMessageOperation+Private.h"
+        header "../PrivateHeaders/Ably/ARTMessage+Private.h"
     }
 }


### PR DESCRIPTION
We'll need this for the upcoming realtime edits / deletes work (in which we'll publish an `ARTMessage` with a specific `action`).

(Depending on when the edits / deletes stuff becomes ready to implement, might just end up incorporating this in the PR for that work, but wanted to have this somewhere in case I end up not being the one to implement that since I'm going on holiday soon.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced message action handling with improved internal state tracking.
  * Updated message action encoding to use integer representation for better data serialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->