### PR TITLE
[ECO-5669] Missing parameter in getMessageVersionsWithSerial

### DIFF
--- a/Source/ARTChannel.m
+++ b/Source/ARTChannel.m
@@ -176,6 +176,13 @@
 }
 
 - (void)getMessageVersionsWithSerial:(NSString *)serial
+                              params:(nullable NSDictionary<NSString *, ARTStringifiable *> *)params
+                    wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                            callback:(ARTPaginatedMessagesCallback)callback {
+    NSAssert(false, @"-[%@ %@] should always be overriden.", self.class, NSStringFromSelector(_cmd));
+}
+
+- (void)getMessageVersionsWithSerial:(NSString *)serial
                     wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
                             callback:(ARTPaginatedMessagesCallback)callback {
     NSAssert(false, @"-[%@ %@] should always be overriden.", self.class, NSStringFromSelector(_cmd));

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -156,8 +156,12 @@
     [_internal getMessageWithSerial:serial wrapperSDKAgents:nil callback:callback];
 }
 
+- (void)getMessageVersionsWithSerial:(NSString *)serial params:(nullable NSDictionary<NSString *, ARTStringifiable *> *)params callback:(ARTPaginatedMessagesCallback)callback {
+    [_internal getMessageVersionsWithSerial:serial params:params wrapperSDKAgents:nil callback:callback];
+}
+
 - (void)getMessageVersionsWithSerial:(NSString *)serial callback:(ARTPaginatedMessagesCallback)callback {
-    [_internal getMessageVersionsWithSerial:serial wrapperSDKAgents:nil callback:callback];
+    [_internal getMessageVersionsWithSerial:serial params:nil wrapperSDKAgents:nil callback:callback];
 }
 
 - (void)history:(ARTPaginatedMessagesCallback)callback {
@@ -487,8 +491,11 @@ art_dispatch_sync(_queue, ^{
     [self.restChannel getMessageWithSerial:serial wrapperSDKAgents:wrapperSDKAgents callback:callback];
 }
 
-- (void)getMessageVersionsWithSerial:(NSString *)serial wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents callback:(ARTPaginatedMessagesCallback)callback {
-    [self.restChannel getMessageVersionsWithSerial:serial wrapperSDKAgents:wrapperSDKAgents callback:callback];
+- (void)getMessageVersionsWithSerial:(NSString *)serial
+                              params:(nullable NSDictionary<NSString *, ARTStringifiable *> *)params
+                    wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                            callback:(ARTPaginatedMessagesCallback)callback {
+    [self.restChannel getMessageVersionsWithSerial:serial params:params wrapperSDKAgents:wrapperSDKAgents callback:callback];
 }
 
 - (void)publishProtocolMessage:(ARTProtocolMessage *)pm callback:(ARTStatusCallback)cb {

--- a/Source/ARTRestChannel.m
+++ b/Source/ARTRestChannel.m
@@ -113,8 +113,12 @@
     [_internal getMessageWithSerial:serial wrapperSDKAgents:nil callback:callback];
 }
 
+- (void)getMessageVersionsWithSerial:(NSString *)serial params:(nullable NSDictionary<NSString *, ARTStringifiable *> *)params callback:(ARTPaginatedMessagesCallback)callback {
+    [_internal getMessageVersionsWithSerial:serial params:params wrapperSDKAgents:nil callback:callback];
+}
+
 - (void)getMessageVersionsWithSerial:(NSString *)serial callback:(ARTPaginatedMessagesCallback)callback {
-    [_internal getMessageVersionsWithSerial:serial wrapperSDKAgents:nil callback:callback];
+    [_internal getMessageVersionsWithSerial:serial params:nil wrapperSDKAgents:nil callback:callback];
 }
 
 - (void)history:(ARTPaginatedMessagesCallback)callback {
@@ -624,6 +628,7 @@ art_dispatch_sync(_queue, ^{
 
 // RSL14
 - (void)getMessageVersionsWithSerial:(NSString *)serial
+                              params:(nullable NSDictionary<NSString *, ARTStringifiable *> *)params
                     wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
                             callback:(ARTPaginatedMessagesCallback)callback {
     if (callback) {
@@ -638,6 +643,14 @@ art_dispatch_sync(_queue, ^{
     art_dispatch_async(_queue, ^{
         NSString *messagePath = [NSString stringWithFormat:@"messages/%@/versions", [serial stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]]];
         NSURLComponents *components = [[NSURLComponents alloc] initWithURL:[NSURL URLWithString:[self->_basePath stringByAppendingPathComponent:messagePath]] resolvingAgainstBaseURL:YES];
+        
+        if (params && params.count > 0) {
+            NSMutableArray<NSURLQueryItem *> *queryItems = [NSMutableArray array];
+            for (NSString *key in params) {
+                [queryItems addObject:[NSURLQueryItem queryItemWithName:key value:params[key].stringValue]];
+            }
+            components.queryItems = queryItems;
+        }
         
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[components URL]];
         request.HTTPMethod = @"GET";

--- a/Source/ARTWrapperSDKProxyRealtimeChannel.m
+++ b/Source/ARTWrapperSDKProxyRealtimeChannel.m
@@ -129,8 +129,16 @@ NS_ASSUME_NONNULL_END
                                           callback:callback];
 }
 
+- (void)getMessageVersionsWithSerial:(nonnull NSString *)serial params:(nullable NSDictionary<NSString *, ARTStringifiable *> *)params callback:(nonnull ARTPaginatedMessagesCallback)callback {
+    [self.underlyingChannel.internal getMessageVersionsWithSerial:serial
+                                                           params:params
+                                                 wrapperSDKAgents:self.proxyOptions.agents
+                                                         callback:callback];
+}
+
 - (void)getMessageVersionsWithSerial:(nonnull NSString *)serial callback:(nonnull ARTPaginatedMessagesCallback)callback {
     [self.underlyingChannel.internal getMessageVersionsWithSerial:serial
+                                                           params:nil
                                                  wrapperSDKAgents:self.proxyOptions.agents
                                                          callback:callback];
 }

--- a/Source/PrivateHeaders/Ably/ARTChannel.h
+++ b/Source/PrivateHeaders/Ably/ARTChannel.h
@@ -62,6 +62,11 @@ NS_SWIFT_SENDABLE
                     callback:(ARTMessageErrorCallback)callback;
 
 - (void)getMessageVersionsWithSerial:(NSString *)serial
+                              params:(nullable NSDictionary<NSString *, ARTStringifiable *> *)params
+                    wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
+                            callback:(ARTPaginatedMessagesCallback)callback;
+
+- (void)getMessageVersionsWithSerial:(NSString *)serial
                     wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
                             callback:(ARTPaginatedMessagesCallback)callback;
 

--- a/Source/include/Ably/ARTChannelProtocol.h
+++ b/Source/include/Ably/ARTChannelProtocol.h
@@ -108,6 +108,17 @@ NS_ASSUME_NONNULL_BEGIN
  * Retrieves all historical versions of a specific message, ordered by version. This includes the original message and all subsequent updates or delete operations.
  *
  * @param serial A serial identifier string of the message whose versions are to be retrieved.
+ * @param params Optional parameters sent as part of the query string.
+ * @param callback A callback which, upon success, will contain an `ARTPaginatedResult` object containing an array of `ARTMessage` objects representing all versions of the message. Upon failure, the callback will contain an `ARTErrorInfo` object which explains the error.
+ */
+- (void)getMessageVersionsWithSerial:(NSString *)serial
+                              params:(nullable NSDictionary<NSString *, ARTStringifiable *> *)params
+                            callback:(ARTPaginatedMessagesCallback)callback;
+
+/**
+ * Retrieves all historical versions of a specific message, ordered by version. This includes the original message and all subsequent updates or delete operations.
+ *
+ * @param serial A serial identifier string of the message whose versions are to be retrieved.
  * @param callback A callback which, upon success, will contain an `ARTPaginatedResult` object containing an array of `ARTMessage` objects representing all versions of the message. Upon failure, the callback will contain an `ARTErrorInfo` object which explains the error.
  */
 - (void)getMessageVersionsWithSerial:(NSString *)serial callback:(ARTPaginatedMessagesCallback)callback;


### PR DESCRIPTION
Closes #2167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for optional query parameters when retrieving message versions, enabling enhanced filtering and customization of version retrieval requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->