### PR TITLE
[ECO-5657] Make both ARTMessageAnnotations and ARTMessageVersion sendable

### DIFF
--- a/Source/ARTMessageAnnotations.m
+++ b/Source/ARTMessageAnnotations.m
@@ -4,16 +4,19 @@
 @implementation ARTMessageAnnotations
 
 - (instancetype)init {
+    return [self initWithSummary:nil];
+}
+
+- (instancetype)initWithSummary:(nullable ARTJsonObject *)summary {
     self = [super init];
     if (self) {
-        _summary = nil;
+        _summary = summary;
     }
     return self;
 }
 
 - (id)copyWithZone:(NSZone *)zone {
-    ARTMessageAnnotations *annotations = [[[self class] allocWithZone:zone] init];
-    annotations.summary = self.summary;
+    ARTMessageAnnotations *annotations = [[[self class] allocWithZone:zone] initWithSummary:self.summary];
     return annotations;
 }
 
@@ -24,9 +27,7 @@
 }
 
 + (instancetype)createFromDictionary:(NSDictionary<NSString *, id> *)jsonObject {
-    ARTMessageAnnotations *annotations = [[ARTMessageAnnotations alloc] init];
-    annotations.summary = [jsonObject objectForKey:@"summary"];
-    return annotations;
+    return [[ARTMessageAnnotations alloc] initWithSummary:[jsonObject objectForKey:@"summary"]];
 }
 
 - (NSString *)description {

--- a/Source/ARTMessageVersion.m
+++ b/Source/ARTMessageVersion.m
@@ -6,25 +6,31 @@
 @implementation ARTMessageVersion
 
 - (instancetype)init {
+    return [self initWithSerial:nil timestamp:nil clientId:nil descriptionText:nil metadata:nil];
+}
+
+- (instancetype)initWithSerial:(nullable NSString *)serial
+                     timestamp:(nullable NSDate *)timestamp
+                      clientId:(nullable NSString *)clientId
+               descriptionText:(nullable NSString *)descriptionText
+                      metadata:(nullable NSDictionary<NSString *, NSString *> *)metadata {
     self = [super init];
     if (self) {
-        _serial = nil;
-        _timestamp = nil;
-        _clientId = nil;
-        _descriptionText = nil;
-        _metadata = nil;
+        _serial = serial;
+        _timestamp = timestamp;
+        _clientId = clientId;
+        _descriptionText = descriptionText;
+        _metadata = metadata;
     }
     return self;
 }
 
 - (id)copyWithZone:(NSZone *)zone {
-    ARTMessageVersion *version = [[[self class] allocWithZone:zone] init];
-    version.serial = self.serial;
-    version.timestamp = self.timestamp;
-    version.clientId = self.clientId;
-    version.descriptionText = self.descriptionText;
-    version.metadata = self.metadata;
-    return version;
+    return [[self.class allocWithZone:zone] initWithSerial:self.serial
+                                                 timestamp:self.timestamp
+                                                  clientId:self.clientId
+                                           descriptionText:self.descriptionText
+                                                  metadata:self.metadata];
 }
 
 - (void)writeToDictionary:(NSMutableDictionary<NSString *, id> *)dictionary {
@@ -46,18 +52,17 @@
 }
 
 + (instancetype)createFromDictionary:(NSDictionary<NSString *, id> *)jsonObject {
-    ARTMessageVersion *version = [[ARTMessageVersion alloc] init];
-    version.serial = [jsonObject artString:@"serial"];
-    version.timestamp = [jsonObject artTimestamp:@"timestamp"];
-    version.clientId = [jsonObject artString:@"clientId"];
-    version.descriptionText = [jsonObject artString:@"description"];
-
     id metadata = jsonObject[@"metadata"];
+    NSDictionary<NSString *, NSString *> *metadataDict = nil;
     if (metadata && [metadata isKindOfClass:[NSDictionary class]]) {
-        version.metadata = metadata;
+        metadataDict = metadata;
     }
-
-    return version;
+    
+    return [[ARTMessageVersion alloc] initWithSerial:[jsonObject artString:@"serial"]
+                                           timestamp:[jsonObject artTimestamp:@"timestamp"]
+                                            clientId:[jsonObject artString:@"clientId"]
+                                     descriptionText:[jsonObject artString:@"description"]
+                                            metadata:metadataDict];
 }
 
 - (NSString *)description {

--- a/Source/include/Ably/ARTMessageAnnotations.h
+++ b/Source/include/Ably/ARTMessageAnnotations.h
@@ -6,10 +6,18 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Contains annotations summary for a message. The keys of the dict are annotation types, and the values are aggregated summaries for that annotation type.
  */
+NS_SWIFT_SENDABLE
 @interface ARTMessageAnnotations : NSObject
 
 /// An annotations summary for the message. The keys of the dict are annotation types, and the values are aggregated summaries for that annotation type.
-@property (nonatomic, copy, nullable) ARTJsonObject *summary;
+@property (nonatomic, readonly, nullable) ARTJsonObject *summary;
+
+/**
+ * Initializes an `ARTMessageAnnotations` with all properties.
+ *
+ * @param summary An annotations summary for the message. The keys of the dict are annotation types, and the values are aggregated summaries for that annotation type.
+ */
+- (instancetype)initWithSummary:(nullable ARTJsonObject *)summary;
 
 @end
 

--- a/Source/include/Ably/ARTMessageVersion.h
+++ b/Source/include/Ably/ARTMessageVersion.h
@@ -6,22 +6,38 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Contains version information for a message, including operation metadata.
  */
+NS_SWIFT_SENDABLE
 @interface ARTMessageVersion : NSObject
 
 /// The serial of the message version.
-@property (nullable, readwrite, nonatomic) NSString *serial;
+@property (nullable, readonly, nonatomic) NSString *serial;
 
 /// The timestamp of the message version.
-@property (nullable, readwrite, nonatomic) NSDate *timestamp;
+@property (nullable, readonly, nonatomic) NSDate *timestamp;
 
 /// The client ID associated with this version.
-@property (nullable, readwrite, nonatomic) NSString *clientId;
+@property (nullable, readonly, nonatomic) NSString *clientId;
 
 /// A description of the operation performed.
-@property (nullable, readwrite, nonatomic) NSString *descriptionText;
+@property (nullable, readonly, nonatomic) NSString *descriptionText;
 
 /// Metadata associated with the operation.
-@property (nullable, readwrite, nonatomic) NSDictionary<NSString *, NSString *> *metadata;
+@property (nullable, readonly, nonatomic) NSDictionary<NSString *, NSString *> *metadata;
+
+/**
+ * Initializes an `ARTMessageVersion` with all properties.
+ *
+ * @param serial The serial of the message version.
+ * @param timestamp The timestamp of the message version.
+ * @param clientId The client ID associated with this version.
+ * @param descriptionText A description of the operation performed.
+ * @param metadata Metadata associated with the operation.
+ */
+- (instancetype)initWithSerial:(nullable NSString *)serial
+                     timestamp:(nullable NSDate *)timestamp
+                      clientId:(nullable NSString *)clientId
+               descriptionText:(nullable NSString *)descriptionText
+                      metadata:(nullable NSDictionary<NSString *, NSString *> *)metadata;
 
 @end
 


### PR DESCRIPTION
Closes #2155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Swift concurrency safety for message annotations and versions.
  * Message annotation and version objects are now immutable after creation.
  * New initializers allow creating messages/versions with serials, timestamps, client IDs, descriptions, metadata, and summaries.
  * Added a factory to construct message annotations from dictionary data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->