### PR TITLE
Use EditorConfig for linting trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig: https://EditorConfig.org
+root = true
+
+# Swift and Objective-C files only
+[*.{swift,m,h}]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  editorconfig:
+    name: EditorConfig
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up editorconfig-checker
+        uses: editorconfig-checker/action-editorconfig-checker@main
+
+      - name: Run editorconfig-checker
+        run: editorconfig-checker

--- a/Ably-SoakTest-AppUITests/SoakTest.swift
+++ b/Ably-SoakTest-AppUITests/SoakTest.swift
@@ -21,9 +21,9 @@ class SoakTest: XCTestCase {
 
     func testSoak() {
         ARTHttp.setURLSessionClass(SoakTestURLSession.self)
-        
+
         var shouldStop = DispatchQueue(label: "io.ably.soakTest.shouldStop").syncValue(false)
-        
+
         for i in (0 ..< concurrentConnections) {
             let queue = DispatchQueue(label: "io.ably.soakTest.\(i)")
             let internalQueue = DispatchQueue(label: "io.ably.soakTest.internal.\(i)")
@@ -54,9 +54,9 @@ class SoakTest: XCTestCase {
                 channelsOperations(realtime: realtime, queue: queue)
             }
         }
-        
+
         Thread.sleep(forTimeInterval: runTime)
-        
+
         shouldStop.set(true)
     }
 }
@@ -111,7 +111,7 @@ func realtimeOperations(realtime: ARTRealtime, queue: DispatchQueue, shouldStop:
             realtime.close()
         }
     }
-    
+
     queue.afterSeconds(between: 0.1 ... 3.0) {
         realtime.ping { error in
             print("pinged; error: \(String(describing: error))")
@@ -127,19 +127,19 @@ func channelsOperations(realtime: ARTRealtime, queue: DispatchQueue) {
         channelsOperations(realtime: realtime, queue: queue)
 
         let channel = realtime.channels.get("channel.\(Int((0 ... 100).randomWithin()))")
-        
+
         queue.afterSeconds(between: 0.1 ... 1) {
             channel.attach { error in
                 print("\(channel.name): attached; error: \(String(describing: error))")
             }
         }
-        
+
         queue.afterSeconds(between: 0.1 ... 60) {
             channel.detach { error in
                 print("\(channel.name): detached; error: \(String(describing: error))")
             }
         }
-        
+
         queue.afterSeconds(between: 0.3 ... 2) {
             channel.subscribe { message in
                 print("\(channel.name): got message: \(message)")
@@ -151,27 +151,27 @@ func channelsOperations(realtime: ARTRealtime, queue: DispatchQueue) {
                     print("\(channel.name): got message ack; error: \(String(describing: error))")
             }
         }
-        
+
         queue.afterSeconds(between: 0.3 ... 2) {
             channel.presence.subscribe { message in
                 print("\(channel.name): got presence message: \(message)")
             }
         }
-        
+
         queue.afterSeconds(between: 0.5 ... 3) {
             presenceCycle(channel: channel, queue: queue)
         }
-        
+
         queue.afterSeconds(between: 0.1 ... 1) {
             realtime.channels.exists(channel.name)
         }
-        
+
         queue.afterSeconds(between: 0.1 ... 2) {
             realtime.channels.release(channel.name) { error in
                 print("\(channel.name): released; error: \(String(describing: error))")
             }
         }
-        
+
         if true.times(1, outOf: 10) {
             for channel in realtime.channels {
                 _ = channel

--- a/Ably-SoakTest-AppUITests/SoakTestReachability.swift
+++ b/Ably-SoakTest-AppUITests/SoakTestReachability.swift
@@ -19,15 +19,15 @@ class SoakTestReachability : NSObject, ARTReachability {
         super.init()
         waitAndToggle()
     }
-    
+
     func listen(forHost host: String, callback: @escaping (Bool) -> Void) {
         self.callback = callback
     }
-    
+
     func off() {
         self.callback = nil
     }
-    
+
     func waitAndToggle() {
         queue.afterSeconds(between: (0.1 ... 60.0 * 5)) {
             self.isReachable = !self.isReachable
@@ -35,7 +35,7 @@ class SoakTestReachability : NSObject, ARTReachability {
             if let callback = self.callback {
                 callback(self.isReachable)
             }
-            
+
             self.waitAndToggle()
         }
     }

--- a/Ably-SoakTest-AppUITests/SoakTestURLSession.swift
+++ b/Ably-SoakTest-AppUITests/SoakTestURLSession.swift
@@ -16,7 +16,7 @@ class SoakTestURLSession : NSObject, ARTURLSession {
     required init(_ queue: DispatchQueue) {
         self.queue = queue
     }
-    
+
     func get(_ request: URLRequest, completion callback: @escaping (HTTPURLResponse?, Data?, Error?) -> Void) -> ARTCancellable & NSObjectProtocol {
         let cancellable = CancellableInQueue(queue: queue)
         cancellables.append(cancellable)
@@ -25,17 +25,17 @@ class SoakTestURLSession : NSObject, ARTURLSession {
             if cancellable.cancelled {
                 return
             }
-            
+
             if request.url?.host != "fakeauth.com" {
                 callback(nil, nil, "SoakTestURLSession: unexpected URL: \(String(describing: request.url))".asError())
                 return
             }
-            
+
             if true.times(1, outOf: 20) {
                 callback(nil, nil, fakeError)
                 return
             }
-            
+
             let data = try! jsonEncoder.encode(ARTTokenDetails(
                 token: "fakeToken",
                 expires: Date(timeIntervalSinceNow: (0.5 ... 30.0).randomWithin()),
@@ -43,7 +43,7 @@ class SoakTestURLSession : NSObject, ARTURLSession {
                 capability: nil,
                 clientId: nil
             ))
-            
+
             callback(HTTPURLResponse.init(
                 url: request.url!,
                 mimeType: "application/json",
@@ -51,10 +51,10 @@ class SoakTestURLSession : NSObject, ARTURLSession {
                 textEncodingName: nil
             ), data, nil)
         }
-        
+
         return cancellable
     }
-    
+
     func finishTasksAndInvalidate() {
         for cancellable in cancellables {
             cancellable.cancel()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,18 @@ ably-cocoa allows users to pass in Ably-authored plugins via the `ARTClientOptio
 
 - In Objective-C code, use `art_dispatch_sync` and `art_dispatch_async` instead of `dispatch_sync` and `dispatch_async`, for more debuggable handling of the case in which we accidentally submit to a `nil` queue.
 
+## Linting
+
+Source files must comply with the rules defined in `.editorconfig` (enforced by CI).
+
+Many text editors — including Xcode, if the "Prefer settings from .editorconfig files" setting is switched on — can automatically follow these rules.
+
+To check compliance locally, install `editorconfig-checker` (`brew install editorconfig-checker`) and run:
+
+```bash
+make lint
+```
+
 ## Release Process
 
 For each release, the following needs to be done:

--- a/Examples/AblyPush/AblyLocationPush/LocationPushService.swift
+++ b/Examples/AblyPush/AblyLocationPush/LocationPushService.swift
@@ -62,20 +62,20 @@ class LocationPushService: NSObject, CLLocationPushServiceExtension, CLLocationM
             try! newData.write(to: url)
         }
     }
-    
+
     func serviceExtensionWillTerminate() {
         // Called just before the extension will be terminated by the system.
         self.completion?()
     }
 
     // MARK: - CLLocationManagerDelegate methods
-    
+
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         // Process the location(s) as needed
         print("Locations received: \(locations)")
         self.completion?()
     }
-    
+
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
         print("Location manager failed: \(error)")
         self.completion?()

--- a/Examples/AblyPush/AblyPushExample/App.swift
+++ b/Examples/AblyPush/AblyPushExample/App.swift
@@ -3,9 +3,9 @@ import SwiftUI
 
 @main
 struct AblyCocoaAPNSExampleApp: App {
-    
+
     @UIApplicationDelegateAdaptor private var appDelegate: AppDelegate
-    
+
     var body: some Scene {
         WindowGroup {
             ContentView()
@@ -14,19 +14,19 @@ struct AblyCocoaAPNSExampleApp: App {
 }
 
 class AppDelegate: NSObject, UIApplicationDelegate {
-    
+
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         AblyHelper.shared.defaultDeviceToken = deviceToken.deviceTokenString
         ARTPush.didRegisterForRemoteNotifications(withDeviceToken: deviceToken, realtime: AblyHelper.shared.realtime)
     }
-    
+
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         ARTPush.didFailToRegisterForRemoteNotificationsWithError(error, realtime: AblyHelper.shared.realtime)
     }
 }
 
 extension Data {
-    
+
     var deviceTokenString: String {
         var result = ""
         for byte in self {

--- a/Examples/AblyPush/AblyPushExample/Buttons/PushButton.swift
+++ b/Examples/AblyPush/AblyPushExample/Buttons/PushButton.swift
@@ -7,10 +7,10 @@ struct PushButton: View {
     let action: () -> Void
     let isButtonEnabled: Bool // is the button enabled
     let isActive: Bool // is the action in it's on or off state
-    
+
     let activeColor = Color(red: 1.00, green: 0.33, blue: 0.09)
     let inActiveColor = Color(red: 0.00, green: 0.56, blue: 0.02)
-    
+
     init(
         isButtonEnabled: Bool,
         systemImage: String,
@@ -42,11 +42,11 @@ struct PushButton: View {
         .tint(isActive ? activeColor : inActiveColor)
         .disabled(!isButtonEnabled)
         .animation(.easeInOut, value: isButtonEnabled)
-        
+
         if #available(iOS 17.0, *) {
             return button.contentTransition(.symbolEffect(.replace))
         }
-        
+
         return button
     }
 }

--- a/Examples/AblyPush/AblyPushExample/Buttons/StatelessButton.swift
+++ b/Examples/AblyPush/AblyPushExample/Buttons/StatelessButton.swift
@@ -6,9 +6,9 @@ struct StatelessButton: View {
     let title: String
     let backgroundColor: Color
     let action: () -> Void
-    
+
     @State var taps: Int = 0 // purely to trigger animation on every tap
-    
+
     init(
         isButtonEnabled: Bool,
         systemImage: String,
@@ -22,7 +22,7 @@ struct StatelessButton: View {
         self.backgroundColor = backgroundColor
         self.action = action
     }
-    
+
     var body: some View {
         let button = Button {
             action()
@@ -38,11 +38,11 @@ struct StatelessButton: View {
         .tint(backgroundColor)
         .disabled(!isButtonEnabled)
         .animation(.easeInOut, value: isButtonEnabled)
-        
+
         if #available(iOS 17.0, *) {
             return button.symbolEffect(.bounce.down, value: taps)
         }
-        
+
         return button
     }
 }

--- a/Examples/AblyPush/AblyPushExample/ContentView.swift
+++ b/Examples/AblyPush/AblyPushExample/ContentView.swift
@@ -7,12 +7,12 @@ struct ContentView: View {
     @State var showDeviceDetailsAlert = false
     @State var deviceDetails: ARTDeviceDetails?
     @State var deviceDetailsError: ARTErrorInfo?
-    
+
     @State var showDeviceTokensAlert = false
     @State var defaultDeviceToken: String?
     @State var locationDeviceToken: String?
     @State var deviceTokensError: ARTErrorInfo?
-    
+
     var body: some View {
         NavigationView {
             VStack {
@@ -21,7 +21,7 @@ struct ContentView: View {
                     .aspectRatio(contentMode: .fit)
                     .frame(height: 44)
                     .padding()
-                                       
+
                 PushButton(
                     isButtonEnabled: true, // Button to toggle push activation is always enabled
                     systemImage: ablyHelper.isPushActivated ? "bell.slash" : "bell",
@@ -54,7 +54,7 @@ struct ContentView: View {
                     }
                     return Alert(title: Text("Push activation"), message: Text("Success"))
                 }
-                
+
                 HStack {
                     let backgroundColor = Color(red: 0.40, green: 0.44, blue: 0.52)
                     StatelessButton(
@@ -81,7 +81,7 @@ struct ContentView: View {
                     )
                 }
                 .fixedSize(horizontal: false, vertical: true)
-                
+
                 .alert(isPresented: $showDeviceDetailsAlert) {
                     if deviceDetails != nil {
                         return Alert(title: Text("Device Details"), message: Text("\(deviceDetails!)"))
@@ -142,14 +142,14 @@ struct ContentView: View {
                     )
                 }
                 .fixedSize(horizontal: false, vertical: true)
-                
+
                 HStack {
                     StatelessButton(
                         isButtonEnabled: ablyHelper.isPushActivated && ablyHelper.isSubscribedToExampleChannel1,
                         systemImage: "paperplane.circle.fill",
                         title: "Send Push to \(Channel.exampleChannel1.rawValue)",
                         action: {
-                            AblyHelper.shared.sendPushToChannel(.exampleChannel1)    
+                            AblyHelper.shared.sendPushToChannel(.exampleChannel1)
                         }
                     )
                     StatelessButton(

--- a/Examples/Tests/TestsTests/TestsTests.swift
+++ b/Examples/Tests/TestsTests/TestsTests.swift
@@ -57,7 +57,7 @@ class TestsTests: XCTestCase {
             client.close()
             receiveExpectation.fulfill()
         }
-        
+
         client.channels.get("test").publish(nil, data: "Get this!")
 
         self.waitForExpectations(timeout: 10, handler: nil)

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,12 @@ update: \
 	submodules \
 	update_carthage_dependencies
 
+## -- Linting --
+
+## [Lint] Check EditorConfig compliance
+lint:
+	editorconfig-checker
+
 ## -- Source Code Tasks --
 
 ## Update Git submodules

--- a/Source/ARTAuth.m
+++ b/Source/ARTAuth.m
@@ -197,7 +197,7 @@ NS_ASSUME_NONNULL_END
     } else {
         [ARTException raise:@"ARTAuthException" format:@"Could not setup authentication method with given options."];
     }
-    
+
     if ([options.clientId isEqual:@"*"]) {
         [ARTException raise:@"ARTAuthException" format:@"Invalid clientId: cannot contain only a wilcard \"*\"."];
     }
@@ -300,7 +300,7 @@ NS_ASSUME_NONNULL_END
         if (self.tokenDetails.expires == nil) {
             return YES;
         }
-        
+
         // RSA4b1: Only check expiry client-side if local clock has been adjusted.
         // If it hasn't, assume the token remains valid.
         if (![self hasTimeOffset]) {
@@ -347,7 +347,7 @@ art_dispatch_async(_queue, ^{
         callback(nil, [ARTErrorInfo createWithCode:ARTStateRequestTokenFailed message:ARTAblyMessageNoMeansToRenewToken]);
         return nil;
     }
-    
+
     const ARTTokenDetailsCallback checkerCallback = ^(ARTTokenDetails *tokenDetails, NSError *error) {
         if (error) {
             if (error.code == NSURLErrorTimedOut) {
@@ -400,13 +400,13 @@ art_dispatch_async(_queue, ^{
                     [tokenDetailsCompat toTokenDetails:[self toAuth] callback:callback];
                 }
             }, &safeCallback);
-            
+
             const ARTAuthCallback userCallback = ^(ARTTokenParams *tokenParams, ARTTokenDetailsCompatibleCallback callback) {
                 art_dispatch_async(self->_userQueue, ^{
                     replacedOptions.authCallback(tokenParams, callback);
                 });
             };
-            
+
             tokenDetailsFactory = ^(ARTTokenParams *tokenParams, ARTTokenDetailsCallback callback) {
                 userCallback(tokenParams, ^(id<ARTTokenDetailsCompatible> tokenDetailsCompat, NSError *error) {
                     art_dispatch_async(self->_queue, ^{
@@ -495,7 +495,7 @@ art_dispatch_async(_queue, ^{
 
     NSURL *requestUrl = [NSURL URLWithString:[NSString stringWithFormat:@"/keys/%@/requestToken?format=%@", tokenRequest.keyName, [encoder formatAsString]]
                                relativeToURL:_rest.baseUrl];
-    
+
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestUrl];
     request.HTTPMethod = @"POST";
 
@@ -582,7 +582,7 @@ art_dispatch_async(_queue, ^{
                 callback(tokenDetails, nil);
             }
         };
-        
+
         void (^const failureCallbackBlock)(NSError *) = ^(NSError *error) {
             ARTLogVerbose(self.logger, @"RS:%p ARTAuthInternal [authorize.%@]: failure callback: %@ with token details %@", self->_rest, authorizeId, error, tokenDetails);
             if (callback) {
@@ -685,7 +685,7 @@ art_dispatch_async(_queue, ^{
     if (currentTokenParams.capability) {
         // Validate: Capability JSON text
         NSError *errorCapability = nil;
-        
+
         [NSJSONSerialization JSONObjectWithData:[currentTokenParams.capability dataUsingEncoding:NSUTF8StringEncoding] options:0 error:&errorCapability];
 
         if (errorCapability) {

--- a/Source/ARTAuthOptions.m
+++ b/Source/ARTAuthOptions.m
@@ -20,7 +20,7 @@ NSString *const ARTAuthOptionsMethodDefault = @"GET";
             [ARTException raise:@"Invalid key" format:@"%@ should be of the form <keyName>:<keySecret>", key];
         }
         else if (key != nil) {
-            _key = [key copy];            
+            _key = [key copy];
         }
         return [self initDefaults];
     }
@@ -52,7 +52,7 @@ NSString *const ARTAuthOptionsMethodDefault = @"GET";
 
 - (id)copyWithZone:(NSZone *)zone {
     ARTAuthOptions *options = [[[self class] allocWithZone:zone] init];
-    
+
     options.key = self.key;
     options.token = self.token;
     options.tokenDetails = self.tokenDetails;
@@ -94,7 +94,7 @@ NSString *const ARTAuthOptionsMethodDefault = @"GET";
 
 - (ARTAuthOptions *)mergeWith:(ARTAuthOptions *)precedenceOptions {
     ARTAuthOptions *merged = [self copy];
-    
+
     if (precedenceOptions.key)
         merged.key = precedenceOptions.key;
     if (precedenceOptions.authCallback)

--- a/Source/ARTChannel.m
+++ b/Source/ARTChannel.m
@@ -63,7 +63,7 @@
 - (void)recreateDataEncoderWith:(ARTCipherParams*)cipher {
     NSError *error = nil;
     _dataEncoder = [[ARTDataEncoder alloc] initWithCipherParams:cipher logger:self.logger error:&error];
-    
+
     if (error != nil) {
         ARTLogWarn(_logger, @"creating ARTDataEncoder: %@", error);
         _dataEncoder = [[ARTDataEncoder alloc] initWithCipherParams:nil logger:self.logger error:nil];
@@ -122,7 +122,7 @@
         if (resultCallback) resultCallback(nil, [ARTErrorInfo createFromNSError:error]);
         return;
     }
-    
+
     // Checked after encoding, so that the client can receive callback with encoding errors
     if ([self exceedMaxSize:@[message]]) {
         ARTErrorInfo *sizeError = [ARTErrorInfo createWithCode:ARTErrorMaxMessageLengthExceeded
@@ -132,7 +132,7 @@
         }
         return;
     }
-    
+
     [self internalPostMessages:messagesWithDataEncoded callback:resultCallback];
 }
 
@@ -155,14 +155,14 @@
     for (ARTMessage *message in messages) {
         [messagesWithDataEncoded addObject:[self encodeMessageIfNeeded:message error:&error]];
     }
-    
+
     if (error) {
         if (resultCallback) {
             resultCallback(nil, [ARTErrorInfo createFromNSError:error]);
         }
         return;
     }
-    
+
     // Checked after encoding, so that the client can receive callback with encoding errors
     if ([self exceedMaxSize:messages]) {
         ARTErrorInfo *sizeError = [ARTErrorInfo createWithCode:ARTErrorMaxMessageLengthExceeded
@@ -172,7 +172,7 @@
         }
         return;
     }
-    
+
     [self internalPostMessages:messagesWithDataEncoded callback:resultCallback];
 }
 

--- a/Source/ARTClientInformation.m
+++ b/Source/ARTClientInformation.m
@@ -18,7 +18,7 @@ static inline UInt32 conformVersionComponent(const NSInteger component) {
 
 + (NSDictionary<NSString *, NSString *> *)agents {
     NSMutableDictionary<NSString *, NSString *> *const result = [NSMutableDictionary dictionary];
-    
+
     [result addEntriesFromDictionary:[self platformAgent]];
     [result addEntriesFromDictionary:[self libraryAgent]];
 
@@ -27,11 +27,11 @@ static inline UInt32 conformVersionComponent(const NSInteger component) {
 
 + (NSString *)agentIdentifierWithAdditionalAgents:(nullable NSDictionary<NSString *, NSString *> *const)additionalAgents {
     NSMutableDictionary<NSString *, NSString *> *const agents = [self.agents mutableCopy];
-    
+
     for (NSString *const additionalAgentName in additionalAgents) {
         agents[additionalAgentName] = additionalAgents[additionalAgentName];
     }
-    
+
     return [self agentIdentifierForAgents:agents];
 }
 
@@ -48,7 +48,7 @@ static inline UInt32 conformVersionComponent(const NSInteger component) {
             [components addObject:[NSString stringWithFormat:@"%@/%@", name, version]];
         }
     }
-        
+
     return [components componentsJoinedByString:@" "];
 }
 
@@ -62,11 +62,11 @@ static inline UInt32 conformVersionComponent(const NSInteger component) {
 
 + (NSDictionary<NSString *, NSString *> *)platformAgent {
     NSString *const osName = [self osName];
-    
+
     if (osName == nil) {
         return @{};
     }
-    
+
     return @{ osName: [self osVersionString] };
 }
 

--- a/Source/ARTClientOptions.m
+++ b/Source/ARTClientOptions.m
@@ -89,7 +89,7 @@ NSString *ARTDefaultEnvironment = nil;
     if ([_environment isEqualToString:ARTDefaultProduction]) {
         return [ARTDefault realtimeHost];
     }
-    
+
     return self.hasEnvironment ? [self host:[ARTDefault realtimeHost] forEnvironment:_environment] : [ARTDefault realtimeHost];
 }
 
@@ -138,7 +138,7 @@ NSString *ARTDefaultEnvironment = nil;
     options.httpOpenTimeout = self.httpOpenTimeout;
     options.fallbackRetryTimeout = self.fallbackRetryTimeout;
     options->_fallbackHosts = self.fallbackHosts; //ignore setter
-    
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     options->_fallbackHostsUseDefault = self.fallbackHostsUseDefault; //ignore setter

--- a/Source/ARTConnection.m
+++ b/Source/ARTConnection.m
@@ -133,23 +133,23 @@
 }
 
 - (NSString *)id {
-    __block NSString *ret;   
+    __block NSString *ret;
 art_dispatch_sync(_queue, ^{
     ret = [self id_nosync];
 });
     return ret;
-} 
+}
 
 - (NSString *)key {
-    __block NSString *ret;   
+    __block NSString *ret;
 art_dispatch_sync(_queue, ^{
     ret = [self key_nosync];
 });
     return ret;
-} 
+}
 
 - (ARTRealtimeConnectionState)state {
-    __block ARTRealtimeConnectionState ret;   
+    __block ARTRealtimeConnectionState ret;
 art_dispatch_sync(_queue, ^{
     ret = [self state_nosync];
 });
@@ -157,7 +157,7 @@ art_dispatch_sync(_queue, ^{
 }
 
 - (ARTErrorInfo *)errorReason {
-    __block ARTErrorInfo *ret;   
+    __block ARTErrorInfo *ret;
 art_dispatch_sync(_queue, ^{
     ret = [self errorReason_nosync];
 });
@@ -190,11 +190,11 @@ art_dispatch_sync(_queue, ^{
 
 - (NSString *)id_nosync {
     return _id;
-} 
+}
 
 - (NSString *)key_nosync {
     return _key;
-} 
+}
 
 - (NSInteger)maxMessageSize {
     if (_maxMessageSize)
@@ -276,14 +276,14 @@ art_dispatch_sync(_queue, ^{
     if (_key == nil || IsInactiveConnectionState(_state)) { // RTN16g2
         return nil;
     }
-    
+
     NSMutableDictionary<NSString *, NSString *> *channelSerials = [NSMutableDictionary new];
     for (ARTRealtimeChannelInternal *const channel in _realtime.channels.nosyncIterable) {
         if (channel.state_nosync == ARTRealtimeChannelAttached) {
             channelSerials[channel.name] = channel.channelSerial;
         }
     }
-    
+
     ARTConnectionRecoveryKey *const recoveryKey = [[ARTConnectionRecoveryKey alloc] initWithConnectionKey:_key
                                                                                                 msgSerial:_realtime.msgSerial
                                                                                            channelSerials:channelSerials];
@@ -339,7 +339,7 @@ art_dispatch_sync(_queue, ^{
         @"connectionKey": _connectionKey,
         @"channelSerials": _channelSerials
     };
-    
+
     NSData *const jsonData = [NSJSONSerialization dataWithJSONObject:object
                                                              options:0
                                                                error:&error];
@@ -348,23 +348,23 @@ art_dispatch_sync(_queue, ^{
                                        reason:[NSString stringWithFormat:@"%@: This JSON serialization should pass without errors.", self.class]
                                      userInfo:nil];
     }
-    
+
     return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
 }
 
 + (ARTConnectionRecoveryKey *)fromJsonString:(NSString *)json error:(NSError **)errorPtr {
     NSData *const jsonData = [json dataUsingEncoding:NSUTF8StringEncoding];
-    
+
     NSError *error = nil;
     NSDictionary *const object = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
-    
+
     if (error) {
         if (errorPtr) {
             *errorPtr = error;
         }
         return nil;
     }
-    
+
     return [[ARTConnectionRecoveryKey alloc] initWithConnectionKey:[object valueForKey:@"connectionKey"]
                                                          msgSerial:[[object valueForKey:@"msgSerial"] longLongValue]
                                                     channelSerials:[object valueForKey:@"channelSerials"]];

--- a/Source/ARTDataEncoder.m
+++ b/Source/ARTDataEncoder.m
@@ -138,7 +138,7 @@
         [self setDeltaCodecBase:data identifier:identifier];
         return [[ARTDataEncoderOutput alloc] initWithData:data encoding:encoding errorInfo:nil];
     }
-    
+
     ARTErrorInfo *errorInfo = nil;
     NSArray *encodings = [encoding componentsSeparatedByString:@"/"];
     NSString *outputEncoding = [NSString stringWithString:encoding];
@@ -222,7 +222,7 @@
             break;
         }
     }
-    
+
     return [[ARTDataEncoderOutput alloc] initWithData:data
                                              encoding:outputEncoding
                                             errorInfo:errorInfo];

--- a/Source/ARTDefault.m
+++ b/Source/ARTDefault.m
@@ -32,7 +32,7 @@ static NSInteger _maxSandboxMessageSize = 16384;
         prefix = [NSString stringWithFormat:@"%@-", environment];
         suffix = @"-fallback";
     }
-    
+
     return [fallbacks artMap:^NSString *(NSString * fallback) {
         return [NSString stringWithFormat:@"%@%@%@.ably-realtime.com", prefix, fallback, suffix];
     }];

--- a/Source/ARTEventEmitter.m
+++ b/Source/ARTEventEmitter.m
@@ -134,7 +134,7 @@
         NSAssert(false, @"timer is already running");
     }
     _timerIsRunning = true;
-    
+
     __weak ARTEventListener *weakSelf = self;
     _work = artDispatchScheduled(_timeoutDeadline, [_eventHandler queue], ^{
         [weakSelf timeout];
@@ -347,7 +347,7 @@
             });
         };
     }
-    
+
     __block ARTEventListener *listener;
 art_dispatch_sync(_queue, ^{
     listener = [super on:event callback:cb];
@@ -364,7 +364,7 @@ art_dispatch_sync(_queue, ^{
             });
         };
     }
-    
+
     __block ARTEventListener *listener;
 art_dispatch_sync(_queue, ^{
     listener = [super on:cb];

--- a/Source/ARTJsonLikeEncoder.m
+++ b/Source/ARTJsonLikeEncoder.m
@@ -330,7 +330,7 @@
     if (!message.version.timestamp) { // TM2s2
         message.version.timestamp = message.timestamp;
     }
-    
+
     id annotations = input[@"annotations"];
     if (annotations && [annotations isKindOfClass:[NSDictionary class]]) {
         message.annotations = [ARTMessageAnnotations createFromDictionary:annotations];
@@ -343,7 +343,7 @@
         // TM8a
         message.annotations.summary = @{};
     }
-    
+
     return message;
 }
 
@@ -351,7 +351,7 @@
     if (![input isKindOfClass:[NSArray class]]) {
         return nil;
     }
-    
+
     NSMutableArray *output = [NSMutableArray array];
     for (NSDictionary *item in input) {
         ARTMessage *message = [self messageFromDictionary:item protocolMessage:protocolMessage];
@@ -439,13 +439,13 @@
     message.encoding = [input artString:@"encoding"];
     message.clientId = [input artString:@"clientId"];
     message.timestamp = [input artTimestamp:@"timestamp"];
-    
+
     int action = [[input artNumber:@"action"] intValue];
-    
+
     message.action = [self presenceActionFromInt:action];
-    
+
     message.connectionId = [input artString:@"connectionId"];
-    
+
     return message;
 }
 
@@ -453,7 +453,7 @@
     if (![input isKindOfClass:[NSArray class]]) {
         return nil;
     }
-    
+
     NSMutableArray *output = [NSMutableArray array];
     for (NSDictionary *item in input) {
         ARTPresenceMessage *message = [self presenceMessageFromDictionary:item];
@@ -490,7 +490,7 @@
     if (![input isKindOfClass:[NSArray class]]) {
         return nil;
     }
-    
+
     NSMutableArray *output = [NSMutableArray array];
     for (NSDictionary *item in input) {
         ARTAnnotation *annotation = [self annotationFromDictionary:item];
@@ -566,7 +566,7 @@
 
 - (NSDictionary *)annotationToDictionary:(ARTAnnotation *)annotation {
     NSMutableDictionary *output = [NSMutableDictionary dictionary];
-    
+
     // Only encode fields that exist in ARTOutboundAnnotation (RSAN1a2)
     if (annotation.id) {
         [output setObject:annotation.id forKey:@"id"];
@@ -589,11 +589,11 @@
     if (annotation.clientId) {
         [output setObject:annotation.clientId forKey:@"clientId"];
     }
-    
+
     if (annotation.data) {
         [self writeData:annotation.data encoding:annotation.encoding toDictionary:output];
     }
-    
+
     if (annotation.name) {
         [output setObject:annotation.name forKey:@"name"];
     }
@@ -715,46 +715,46 @@
 
 - (NSArray *)messagesToArray:(NSArray *)messages {
     NSMutableArray *output = [NSMutableArray array];
-    
+
     for (ARTMessage *message in messages) {
         NSDictionary *item = [self messageToDictionary:message];
         [output addObject:item];
     }
-    
+
     return output;
 }
 
 - (NSArray *)annotationsToArray:(NSArray *)annotations {
     NSMutableArray *output = [NSMutableArray array];
-    
+
     for (ARTAnnotation *annotation in annotations) {
         NSDictionary *item = [self annotationToDictionary:annotation];
         [output addObject:item];
     }
-    
+
     return output;
 }
 
 - (NSDictionary *)presenceMessageToDictionary:(ARTPresenceMessage *)message {
     NSMutableDictionary *output = [NSMutableDictionary dictionary];
-    
+
     if (message.timestamp) {
         [output setObject:[message.timestamp artToNumberMs] forKey:@"timestamp"];
     }
-    
+
     if (message.clientId) {
         [output setObject:message.clientId forKey:@"clientId"];
     }
-    
+
     if (message.data) {
         [self writeData:message.data encoding:message.encoding toDictionary:output];
     }
     if(message.connectionId) {
         [output setObject:message.connectionId forKey:@"connectionId"];
     }
-    
+
     int action = [self intFromPresenceMessageAction:message.action];
-    
+
     [output setObject:[NSNumber numberWithInt:action] forKey:@"action"];
     ARTLogVerbose(_logger, @"RS:%p ARTJsonLikeEncoder<%@>: presenceMessageToDictionary %@", _rest, [_delegate formatAsString], output);
     return output;
@@ -762,7 +762,7 @@
 
 - (NSArray *)presenceMessagesToArray:(NSArray *)messages {
     NSMutableArray *output = [NSMutableArray array];
-    
+
     for (ARTPresenceMessage *message in messages) {
         NSDictionary *item = [self presenceMessageToDictionary:message];
         [output addObject:item];
@@ -789,7 +789,7 @@
     if (message.messages) {
         output[@"messages"] = [self messagesToArray:message.messages];
     }
-    
+
     if (message.presence) {
         output[@"presence"] = [self presenceMessagesToArray:message.presence];
     }
@@ -826,11 +826,11 @@
 
 - (ARTTokenDetails *)tokenFromDictionary:(NSDictionary *)input error:(NSError * __autoreleasing *)error {
     ARTLogVerbose(_logger, @"RS:%p ARTJsonLikeEncoder<%@>: tokenFromDictionary %@", _rest, [_delegate formatAsString], input);
-    
+
     if (![input isKindOfClass:[NSDictionary class]]) {
         return nil;
     }
-    
+
     NSDictionary *jsonError = [input artDictionary:@"error"];
     if (jsonError) {
         ARTLogError(_logger, @"RS:%p ARTJsonLikeEncoder<%@>: tokenFromDictionary error %@", _rest, [_delegate formatAsString], jsonError);
@@ -844,19 +844,19 @@
         return nil;
     }
     error = nil;
-    
+
     NSString *token = [input artString:@"token"];
     NSNumber *expiresTimeInterval = [input objectForKey:@"expires"];
     NSDate *expires = expiresTimeInterval != nil ? [NSDate dateWithTimeIntervalSince1970:millisecondsToTimeInterval(expiresTimeInterval.doubleValue)] : nil;
     NSNumber *issuedInterval = [input objectForKey:@"issued"];
     NSDate *issued = issuedInterval != nil ? [NSDate dateWithTimeIntervalSince1970:millisecondsToTimeInterval(issuedInterval.doubleValue)] : nil;
-    
+
     return [[ARTTokenDetails alloc] initWithToken:token
                                               expires:expires
                                                issued:issued
                                            capability:[input artString:@"capability"]
                                              clientId:[input artString:@"clientId"]];
-    
+
 }
 
 - (NSDictionary *)tokenRequestToDictionary:(ARTTokenRequest *)tokenRequest {
@@ -944,7 +944,7 @@
     if (tokenDetails.clientId) {
         dictionary[@"clientId"] = tokenDetails.clientId;
     }
-    
+
     return dictionary;
 }
 
@@ -1039,7 +1039,7 @@
     if (![input isKindOfClass:[NSDictionary class]]) {
         return nil;
     }
-    
+
     ARTProtocolMessage *message = [[ARTProtocolMessage alloc] init];
     message.action = (ARTProtocolMessageAction)[[input artNumber:@"action"] intValue];
     message.count = [[input artNumber:@"count"] intValue];
@@ -1147,9 +1147,9 @@
     if (![input isKindOfClass:[NSArray class]]) {
         return nil;
     }
-    
+
     NSMutableArray *output = [NSMutableArray array];
-    
+
     for (NSDictionary *item in input) {
         if (![item isKindOfClass:[NSDictionary class]]) {
             return nil;
@@ -1160,7 +1160,7 @@
         }
         [output addObject:statsItem];
     }
-    
+
     return output;
 }
 
@@ -1169,7 +1169,7 @@
     if (![input isKindOfClass:[NSDictionary class]]) {
         return nil;
     }
-    
+
     return [[ARTStats alloc] initWithAll:[self statsMessageTypesFromDictionary:[input objectForKey:@"all"]]
                                  inbound:[self statsMessageTrafficFromDictionary:[input objectForKey:@"inbound"]]
                                 outbound:[self statsMessageTrafficFromDictionary:[input objectForKey:@"outbound"]]
@@ -1188,15 +1188,15 @@
     if (![input isKindOfClass:[NSDictionary class]]) {
         return [ARTStatsMessageTypes empty];
     }
-    
+
     ARTStatsMessageCount *all = [self statsMessageCountFromDictionary:[input objectForKey:@"all"]];
     ARTStatsMessageCount *messages = [self statsMessageCountFromDictionary:[input objectForKey:@"messages"]];
     ARTStatsMessageCount *presence = [self statsMessageCountFromDictionary:[input objectForKey:@"presence"]];
-    
+
     if (all || messages || presence) {
         return [[ARTStatsMessageTypes alloc] initWithAll:all messages:messages presence:presence];
     }
-    
+
     return [ARTStatsMessageTypes empty];
 }
 
@@ -1204,10 +1204,10 @@
     if (![input isKindOfClass:[NSDictionary class]]) {
         return [ARTStatsMessageCount empty];
     }
-    
+
     NSNumber *count = [input artTyped:[NSNumber class] key:@"count"];
     NSNumber *data = [input artTyped:[NSNumber class] key:@"data"];
-    
+
     return [[ARTStatsMessageCount alloc] initWithCount:count.doubleValue data:data.doubleValue];
 }
 
@@ -1215,19 +1215,19 @@
     if (![input isKindOfClass:[NSDictionary class]]) {
         return [ARTStatsMessageTraffic empty];
     }
-    
+
     ARTStatsMessageTypes *all = [self statsMessageTypesFromDictionary:[input objectForKey:@"all"]];
     ARTStatsMessageTypes *realtime = [self statsMessageTypesFromDictionary:[input objectForKey:@"realtime"]];
     ARTStatsMessageTypes *rest = [self statsMessageTypesFromDictionary:[input objectForKey:@"rest"]];
     ARTStatsMessageTypes *webhook = [self statsMessageTypesFromDictionary:[input objectForKey:@"webhook"]];
-    
+
     if (all || realtime || rest || webhook) {
         return [[ARTStatsMessageTraffic alloc] initWithAll:all
                                                   realtime:realtime
                                                       rest:rest
                                                    webhook:webhook];
     }
-    
+
     return [ARTStatsMessageTraffic empty];
 }
 
@@ -1235,15 +1235,15 @@
     if (![input isKindOfClass:[NSDictionary class]]) {
         return [ARTStatsConnectionTypes empty];
     }
-    
+
     ARTStatsResourceCount *all = [self statsResourceCountFromDictionary:[input objectForKey:@"all"]];
     ARTStatsResourceCount *plain = [self statsResourceCountFromDictionary:[input objectForKey:@"plain"]];
     ARTStatsResourceCount *tls = [self statsResourceCountFromDictionary:[input objectForKey:@"tls"]];
-    
+
     if (all || plain || tls) {
         return [[ARTStatsConnectionTypes alloc] initWithAll:all plain:plain tls:tls];
     }
-    
+
     return [ARTStatsConnectionTypes empty];
 }
 
@@ -1251,13 +1251,13 @@
     if (![input isKindOfClass:[NSDictionary class]]) {
         return [ARTStatsResourceCount empty];
     }
-    
+
     NSNumber *opened = [input artTyped:[NSNumber class] key:@"opened"];
     NSNumber *peak = [input artTyped:[NSNumber class] key:@"peak"];
     NSNumber *mean = [input artTyped:[NSNumber class] key:@"mean"];
     NSNumber *min = [input artTyped:[NSNumber class] key:@"min"];
     NSNumber *refused = [input artTyped:[NSNumber class] key:@"refused"];
-    
+
     return [[ARTStatsResourceCount alloc] initWithOpened:opened.doubleValue
                                                     peak:peak.doubleValue
                                                     mean:mean.doubleValue
@@ -1291,11 +1291,11 @@
     if (![input isKindOfClass:[NSDictionary class]]) {
         return [ARTStatsRequestCount empty];
     }
-    
+
     NSNumber *succeeded = [input artTyped:[NSNumber class] key:@"succeeded"];
     NSNumber *failed = [input artTyped:[NSNumber class] key:@"failed"];
     NSNumber *refused = [input artTyped:[NSNumber class] key:@"refused"];
-    
+
     return [[ARTStatsRequestCount alloc] initWithSucceeded:succeeded.doubleValue
                                                     failed:failed.doubleValue
                                                    refused:refused.doubleValue];
@@ -1306,16 +1306,16 @@
     if (![input isKindOfClass:[NSDictionary class]]) {
         return [ARTStatsPushCount empty];
     }
-    
+
     NSNumber *messages = [input artNumber:@"messages"];
     NSNumber *direct = [input artNumber:@"directPublishes"];
-    
+
     NSDictionary *notifications = input[@"notifications"];
     NSNumber *succeeded = [notifications artNumber:@"successful"];
     NSNumber *invalid = [notifications artNumber:@"invalid"];
     NSNumber *attempted = [notifications artNumber:@"attempted"];
     NSNumber *failed = [notifications artNumber:@"failed"];
-    
+
     return [[ARTStatsPushCount alloc] initWithSucceeded:succeeded.integerValue
                                                 invalid:invalid.integerValue
                                               attempted:attempted.integerValue

--- a/Source/ARTLocalDevice.m
+++ b/Source/ARTLocalDevice.m
@@ -59,7 +59,7 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
 - (void)generateAndPersistPairOfDeviceIdAndSecret {
     self.id = [self.class generateId];
     self.secret = [self.class generateSecret];
-    
+
     [_storage setObject:self.id forKey:ARTDeviceIdKey];
     [_storage setSecret:self.secret forDevice:self.id];
 }
@@ -73,7 +73,7 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
 
     NSString *deviceId = [storage objectForKey:ARTDeviceIdKey];
     NSString *deviceSecret = deviceId == nil ? nil : [storage secretForDevice:deviceId];
-    
+
     if (deviceId == nil || deviceSecret == nil) {
         [device generateAndPersistPairOfDeviceIdAndSecret]; // Should be removed later once spec issue #180 resolved.
     }
@@ -97,7 +97,7 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
         ARTAPNSDeviceDefaultTokenType,
         ARTAPNSDeviceLocationTokenType
     ];
-    
+
     for (NSString *tokenType in supportedTokenTypes) {
         NSString *token = [ARTLocalDevice apnsDeviceTokenOfType:tokenType fromStorage:storage];
         [device setAPNSDeviceToken:token tokenType:tokenType];
@@ -108,11 +108,11 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
 - (void)setupDetailsWithClientId:(NSString *)clientId {
     NSString *deviceId = self.id;
     NSString *deviceSecret = self.secret;
-    
+
     if (deviceId == nil || deviceSecret == nil) {
         [self generateAndPersistPairOfDeviceIdAndSecret];
     }
-    
+
     self.clientId = clientId;
     [_storage setObject:clientId forKey:ARTClientIdKey];
 }
@@ -120,7 +120,7 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
 - (void)resetDetails {
     // Should be replaced later to resetting device's id/secret once spec issue #180 resolved.
     [self generateAndPersistPairOfDeviceIdAndSecret];
-    
+
     self.clientId = nil;
     [_storage setObject:nil forKey:ARTClientIdKey];
     [self setAndPersistIdentityTokenDetails:nil];

--- a/Source/ARTMessage.m
+++ b/Source/ARTMessage.m
@@ -92,9 +92,9 @@ NSString *ARTMessageActionToStr(ARTMessageAction action) {
         }
         return nil;
     }
-    
+
     ARTMessage *message = [jsonEncoder messageFromDictionary:jsonObject protocolMessage:nil];
-    
+
     NSError *decodeError = nil;
     message = [message decodeWithEncoder:decoder error:&decodeError];
     if (decodeError != nil) {
@@ -122,9 +122,9 @@ NSString *ARTMessageActionToStr(ARTMessageAction action) {
         }
         return nil;
     }
-    
+
     NSArray<ARTMessage *> *messages = [jsonEncoder messagesFromArray:jsonArray protocolMessage:nil];
-    
+
     NSMutableArray<ARTMessage *> *decodedMessages = [NSMutableArray array];
     for (ARTMessage *message in messages) {
         NSError *decodeError = nil;

--- a/Source/ARTNSError+ARTUtils.m
+++ b/Source/ARTNSError+ARTUtils.m
@@ -6,7 +6,7 @@
 + (NSError *)copyFromError:(NSError *)error withRequestId:(nullable NSString *)requestId {
     NSMutableDictionary *mutableInfo = [NSMutableDictionary dictionaryWithDictionary:error.userInfo];
     mutableInfo[ARTErrorInfoRequestIdKey] = requestId;
-    
+
     return [NSError errorWithDomain:error.domain code:error.code userInfo:mutableInfo];
 }
 

--- a/Source/ARTNSMutableURLRequest+ARTUtils.m
+++ b/Source/ARTNSMutableURLRequest+ARTUtils.m
@@ -7,11 +7,11 @@
     if(components == nil) {
         return;
     }
-    
+
     NSMutableArray<NSURLQueryItem *> *mutableQueryItems = [NSMutableArray arrayWithArray:components.queryItems];
     [mutableQueryItems addObject:item];
     components.queryItems = mutableQueryItems;
-    
+
     NSURL *modifiedURL = components.URL;
     if (modifiedURL != nil) {
         self.URL = modifiedURL;
@@ -21,7 +21,7 @@
 - (void)replaceHostWith:(NSString *)host {
     NSURLComponents *components = [NSURLComponents componentsWithURL:self.URL resolvingAgainstBaseURL:YES];
     components.host = host;
-    
+
     if(components != nil) {
         self.URL = components.URL;
     }

--- a/Source/ARTNSURL+ARTUtils.m
+++ b/Source/ARTNSURL+ARTUtils.m
@@ -5,7 +5,7 @@
 + (NSURL *)copyFromURL:(NSURL *)url withHost:(NSString *)host {
     NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:YES];
     components.host = host;
-    
+
     return components.URL;
 }
 

--- a/Source/ARTOSReachability.m
+++ b/Source/ARTOSReachability.m
@@ -39,7 +39,7 @@ static void ARTOSReachability_Callback(SCNetworkReachabilityRef target, SCNetwor
 
     // This strategy is taken from Mike Ash's book "The Complete Friday Q&A: Volume III".
     // Article: https://www.mikeash.com/pyblog/friday-qa-2013-06-14-reachability.html
-    
+
     __weak ARTOSReachability *weakSelf = self;
     void (^callbackBlock)(SCNetworkReachabilityFlags) = ^(SCNetworkReachabilityFlags flags) {
         ARTOSReachability *strongSelf = weakSelf;
@@ -53,9 +53,9 @@ static void ARTOSReachability_Callback(SCNetworkReachabilityRef target, SCNetwor
             });
         }
     };
-    
+
     _reachabilityRef = SCNetworkReachabilityCreateWithName(NULL, [host UTF8String]);
-    
+
     SCNetworkReachabilityContext context = {
         .version = 0,
         .info = (__bridge void *)(callbackBlock),

--- a/Source/ARTOutboundAnnotation.m
+++ b/Source/ARTOutboundAnnotation.m
@@ -12,7 +12,7 @@
     // (RSAN1a3) - The SDK must validate that the user supplied `type` (All other fields are optional)
     // (TAN2k) type string: a string indicating the type of the annotation, handled opaquely by the SDK
     NSAssert(type, @"ARTOutboundAnnotation: No annotation `type` provided");
-    
+
     if (self = [super init]) {
         _id = annotationId;
         _type = type;

--- a/Source/ARTPaginatedResult.m
+++ b/Source/ARTPaginatedResult.m
@@ -53,15 +53,15 @@
         _initializedViaInit = NO;
 
         _items = items;
-        
+
         _relFirst = relFirst;
-        
+
         _relCurrent = relCurrent;
-        
+
         _relNext = relNext;
         _hasNext = !!relNext;
         _isLast = !_hasNext;
-        
+
         _rest = rest;
         _userQueue = rest.userQueue;
         _queue = rest.queue;
@@ -82,7 +82,7 @@
         // make our own.
         _dealloc = [[ARTQueuedDealloc alloc] init:_rest queue:_queue];
     }
-    
+
     return self;
 }
 
@@ -109,7 +109,7 @@
 
 - (void)first:(void (^)(ARTPaginatedResult<id> *_Nullable result, ARTErrorInfo *_Nullable error))callback {
     [self initializedViaInitCheck];
-    
+
     if (callback) {
         void (^userCallback)(ARTPaginatedResult<id> *_Nullable result, ARTErrorInfo *_Nullable error) = callback;
         callback = ^(ARTPaginatedResult<id> *_Nullable result, ARTErrorInfo *_Nullable error) {
@@ -124,7 +124,7 @@
 
 - (void)next:(void (^)(ARTPaginatedResult<id> *_Nullable result, ARTErrorInfo *_Nullable error))callback {
     [self initializedViaInitCheck];
-    
+
     if (callback) {
         void (^userCallback)(ARTPaginatedResult<id> *_Nullable result, ARTErrorInfo *_Nullable error) = callback;
         callback = ^(ARTPaginatedResult<id> *_Nullable result, ARTErrorInfo *_Nullable error) {

--- a/Source/ARTPush.m
+++ b/Source/ARTPush.m
@@ -159,7 +159,7 @@
         [NSException raise:NSInternalInconsistencyException
                     format:@"_activationMachine already set."];
     }
-    
+
     _activationMachine = [[ARTPushActivationStateMachine alloc] initWithRest:self->_rest delegate:delegate logger:_logger];
     return _activationMachine;
 }
@@ -169,15 +169,15 @@
         [NSException raise:NSInternalInconsistencyException
                     format:@"Failed to immediately acquire lock for internal testing purposes."];
     }
-    
+
     ARTPushActivationStateMachine *const machine = _activationMachine;
     if (!machine) {
         [NSException raise:NSInternalInconsistencyException
                     format:@"There is no activation machine for internal testing purposes."];
     }
-    
+
     [_activationMachineLock unlock];
-    
+
     return machine;
 }
 

--- a/Source/ARTPushActivationState.m
+++ b/Source/ARTPushActivationState.m
@@ -97,7 +97,7 @@ ARTPushActivationState *validateAndSync(ARTPushActivationStateMachine *machine, 
         } else {
             [machine syncDevice];
         }
-        
+
         return [ARTPushActivationStateWaitingForRegistrationSync newWithMachine:machine logger:logger fromEvent:event];
     } else if ([local apnsDeviceToken]) {
         [machine sendEvent:[ARTPushActivationEventGotPushDeviceDetails new]];

--- a/Source/ARTPushChannelSubscriptions.m
+++ b/Source/ARTPushChannelSubscriptions.m
@@ -72,13 +72,13 @@
             });
         };
     }
-    
+
 #if TARGET_OS_IOS
     ARTLocalDevice *local = _rest.device;
 #else
     ARTLocalDevice *local = nil;
 #endif
-    
+
     art_dispatch_async(_queue, ^{
         NSURLComponents *components = [[NSURLComponents alloc] initWithURL:[NSURL URLWithString:@"/push/channelSubscriptions"] resolvingAgainstBaseURL:NO];
         if (self->_rest.options.pushFullWait) {
@@ -89,7 +89,7 @@
         request.HTTPBody = [[self->_rest defaultEncoder] encodePushChannelSubscription:channelSubscription error:nil];
         [request setValue:[[self->_rest defaultEncoder] mimeType] forHTTPHeaderField:@"Content-Type"];
         [request setDeviceAuthentication:channelSubscription.deviceId localDevice:local];
-        
+
         ARTLogDebug(self->_logger, @"save channel subscription with request %@", request);
         [self->_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
             if (response.statusCode == 200 /*Ok*/ || response.statusCode == 201 /*Created*/) {
@@ -119,12 +119,12 @@
             });
         };
     }
-    
+
     art_dispatch_async(_queue, ^{
         NSURLComponents *components = [[NSURLComponents alloc] initWithURL:[NSURL URLWithString:@"/push/channels"] resolvingAgainstBaseURL:NO];
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[components URL]];
         request.HTTPMethod = @"GET";
-        
+
         ARTPaginatedResultResponseProcessor responseProcessor = ^(NSHTTPURLResponse *response, NSData *data, NSError **error) {
             return [self->_rest.encoders[response.MIMEType] decode:data error:error];
         };
@@ -141,13 +141,13 @@
             });
         };
     }
-    
+
     art_dispatch_async(_queue, ^{
         NSURLComponents *components = [[NSURLComponents alloc] initWithURL:[NSURL URLWithString:@"/push/channelSubscriptions"] resolvingAgainstBaseURL:NO];
         components.queryItems = [params art_asURLQueryItems];
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[components URL]];
         request.HTTPMethod = @"GET";
-        
+
         ARTPaginatedResultResponseProcessor responseProcessor = ^(NSHTTPURLResponse *response, NSData *data, NSError **error) {
             return [self->_rest.encoders[response.MIMEType] decodePushChannelSubscriptions:data error:error];
         };
@@ -164,7 +164,7 @@
             });
         };
     }
-    
+
     art_dispatch_async(_queue, ^{
         if ((subscription.deviceId && subscription.clientId) || (!subscription.deviceId && !subscription.clientId)) {
             callback([ARTErrorInfo createWithCode:0 message:@"ARTChannelSubscription cannot be for both a deviceId and a clientId"]);
@@ -190,7 +190,7 @@
             });
         };
     }
-    
+
     art_dispatch_async(_queue, ^{
         [self _removeWhere:params wrapperSDKAgents:wrapperSDKAgents callback:callback];
     });
@@ -207,7 +207,7 @@
 #if TARGET_OS_IOS
     [request setDeviceAuthentication:[params objectForKey:@"deviceId"] localDevice:_rest.device_nosync];
 #endif
-    
+
     ARTLogDebug(_logger, @"remove channel subscription with request %@", request);
     [_rest executeRequest:request withAuthOption:ARTAuthenticationOn wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (response.statusCode == 200 /*Ok*/ || response.statusCode == 204 /*not returning any content*/) {

--- a/Source/ARTRealtimeAnnotations.m
+++ b/Source/ARTRealtimeAnnotations.m
@@ -118,7 +118,7 @@
             });
         };
     }
-    
+
     // RSAN1a1: Message object must contain a populated serial field
     if (messageSerial == nil) {
         if (callback) {
@@ -126,7 +126,7 @@
         }
         return;
     }
-    
+
     // Convert ARTOutboundAnnotation to ARTAnnotation for internal processing
     ARTAnnotation *annotation = [[ARTAnnotation alloc] initWithId:nil
                                                            action:action // RSAN1c1
@@ -149,11 +149,11 @@ art_dispatch_sync(_queue, ^{
         }
         return;
     }
-    
+
     // Validate annotation size against connection's maxMessageSize
     NSInteger annotationSize = [annotationToPublish annotationSize];
     NSInteger maxSize = self.realtime.connection.maxMessageSize;
-    
+
     if (annotationSize > maxSize) {
         if (callback) {
             callback([ARTErrorInfo createWithCode:ARTErrorMaxMessageLengthExceeded
@@ -161,7 +161,7 @@ art_dispatch_sync(_queue, ^{
         }
         return;
     }
-    
+
     // RTAN1c
     ARTProtocolMessage *pm = [[ARTProtocolMessage alloc] init];
     pm.action = ARTProtocolMessageAnnotation;
@@ -187,7 +187,7 @@ art_dispatch_sync(_queue, ^{
     }
 
     __block ARTEventListener *listener = nil;
-    
+
 art_dispatch_sync(_queue, ^{
     ARTRealtimeChannelOptions *options = self->_channel.getOptions_nosync;
     BOOL attachOnSubscribe = options != nil ? options.attachOnSubscribe : true;

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -800,12 +800,12 @@ art_dispatch_sync(_queue, ^{
     }
     // RTL15a
     self.attachSerial = message.channelSerial;
-    
+
     // RTL15b
     if (message.channelSerial) {
         self.channelSerial = message.channelSerial;
     }
-    
+
     // RTL4m
     self.modes = message.channelModes;
 
@@ -954,7 +954,7 @@ art_dispatch_sync(_queue, ^{
 
         ++i;
     }
-    
+
     // RTL15b
     if (pm.channelSerial) {
         self.channelSerial = pm.channelSerial;
@@ -1227,7 +1227,7 @@ art_dispatch_sync(_queue, ^{
         [self performTransitionToState:ARTRealtimeChannelAttached withParams:params];
         [self->_detachedEventEmitter emit:nil with:errorInfo];
     }] startTimer];
-    
+
     if (self.presence.syncInProgress_nosync) {
         [self.presence failsSync:[ARTErrorInfo createWithCode:ARTErrorChannelOperationFailed message:@"channel is being DETACHED"]];
     }

--- a/Source/ARTRealtimePresence.m
+++ b/Source/ARTRealtimePresence.m
@@ -179,13 +179,13 @@ typedef NS_ENUM(NSUInteger, ARTPresenceSyncState) {
     NSMutableArray<ARTQueuedMessage *> *_pendingPresence;
     ARTEventEmitter<ARTEvent *, ARTPresenceMessage *> *_eventEmitter;
     ARTDataEncoder *_dataEncoder;
-    
+
     ARTPresenceSyncState _syncState;
     ARTEventEmitter<ARTEvent * /*ARTSyncState*/, id> *_syncEventEmitter;
-    
+
     NSMutableDictionary<NSString *, ARTPresenceMessage *> *_members; // RTP2
     NSMutableDictionary<NSString *, ARTPresenceMessage *> *_internalMembers; // RTP17h
-    
+
     NSMutableDictionary<NSString *, ARTPresenceMessage *> *_beforeSyncMembers; // RTP19
 }
 
@@ -725,7 +725,7 @@ art_dispatch_sync(_queue, ^{
         if (!member.connectionId) {
             member.connectionId = message.connectionId;
         }
-        
+
         [self processMember:member];
 
         ++i;
@@ -769,9 +769,9 @@ art_dispatch_sync(_queue, ^{
                 NSString *message = [NSString stringWithFormat:@"Re-entering member \"%@\" is failed with code %ld (%@)", member.memberKey, (long)error.code, error.message];
                 ARTErrorInfo *reenterError = [ARTErrorInfo createWithCode:ARTErrorUnableToAutomaticallyReEnterPresenceChannel message:message];
                 ARTChannelStateChange *stateChange = [[ARTChannelStateChange alloc] initWithCurrent:self->_channel.state_nosync previous:self->_channel.state_nosync event:ARTChannelEventUpdate reason:reenterError resumed:true]; // RTP17e
-                
+
                 [self->_channel emit:stateChange.event with:stateChange];
-                
+
                 ARTLogWarn(self.logger, @"RT:%p C:%p (%@) Re-entering member \"%@\" is failed with code %ld (%@)", self->_realtime, self->_channel, self->_channel.name, member.memberKey, (long)error.code, error.message);
             }
             else {
@@ -812,7 +812,7 @@ art_dispatch_sync(_queue, ^{
                 break;
         }
     }
-    
+
     BOOL memberUpdated = false;
     switch (message.action) {
         case ARTPresenceEnter:
@@ -846,12 +846,12 @@ art_dispatch_sync(_queue, ^{
     if ([msg1 isSynthesized] || [msg2 isSynthesized]) { // RTP2b1
         return !msg1.timestamp || msg1.timestamp.timeIntervalSince1970 >= msg2.timestamp.timeIntervalSince1970;
     }
-    
+
     NSInteger msg1Serial = [msg1 msgSerialFromId];
     NSInteger msg1Index = [msg1 indexFromId];
     NSInteger msg2Serial = [msg2 msgSerialFromId];
     NSInteger msg2Index = [msg2 indexFromId];
-    
+
     // RTP2b2
     if (msg1Serial == msg2Serial) {
         return msg1Index > msg2Index;

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -249,7 +249,7 @@ NS_ASSUME_NONNULL_END
                             wrapperSDKAgents:(nullable NSDictionary<NSString *, NSString *> *)wrapperSDKAgents
                                   completion:(ARTURLRequestCallback)callback {
     request.URL = [NSURL URLWithString:request.URL.relativeString relativeToURL:self.baseUrl];
-    
+
     switch (authOption) {
         case ARTAuthenticationOff:
             return [self executeRequest:request wrapperSDKAgents:wrapperSDKAgents completion:callback];
@@ -346,7 +346,7 @@ NS_ASSUME_NONNULL_END
                                   completion:(ARTURLRequestCallback)callback {
     NSString *requestId = nil;
     __block ARTFallback *blockFallbacks = fallbacks;
-    
+
     if ([request isKindOfClass:[NSMutableURLRequest class]]) {
         NSMutableURLRequest *mutableRequest = (NSMutableURLRequest *)request;
         [mutableRequest setAcceptHeader:self.defaultEncoder encoders:self.encoders];
@@ -359,7 +359,7 @@ NS_ASSUME_NONNULL_END
         if (_options.clientId && !self.auth.isTokenAuth) {
             [mutableRequest setValue:encodeBase64(_options.clientId) forHTTPHeaderField:@"X-Ably-ClientId"];
         }
-        
+
         if (_options.addRequestIds) {
             if (fallbacks != nil) {
                 requestId = originalRequestId;
@@ -367,16 +367,16 @@ NS_ASSUME_NONNULL_END
                 NSString *randomId = [NSUUID new].UUIDString;
                 requestId = [[randomId dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:0];
             }
-            
+
             [mutableRequest appendQueryItem:[NSURLQueryItem queryItemWithName:@"request_id" value:requestId]];
         }
-        
+
         // RSC15f - reset the successed fallback host on fallbackRetryTimeout expiration
         // change URLRequest host from `fallback host` to `default host`
         //
         if (self.currentFallbackHost != nil && self.fallbackRetryExpiration != nil && [[self.continuousClock now] isAfter:self.fallbackRetryExpiration]) {
             ARTLogDebug(self.logger, @"RS:%p fallbackRetryExpiration ids expired, reset `prioritizedHost` and `currentFallbackHost`", self);
-            
+
             self.currentFallbackHost = nil;
             self.prioritizedHost = nil;
             [mutableRequest replaceHostWith:_options.restHost];
@@ -438,7 +438,7 @@ NS_ASSUME_NONNULL_END
                                              message:[[NSString alloc] initWithData:data ?: [NSData data] encoding:NSUTF8StringEncoding]
                                            requestId:requestId];
             }
-            
+
         } else {
             // Response Status Code < 400 and no errors
             if (error == nil && self.currentFallbackHost != nil) {
@@ -446,7 +446,7 @@ NS_ASSUME_NONNULL_END
                 self.prioritizedHost = self.currentFallbackHost;
             }
         }
-        
+
         if (retries < self->_options.httpMaxRetryCount && [self shouldRetryWithFallback:request response:response error:error]) {
             if (!blockFallbacks) {
                 NSArray *hosts = [ARTFallbackHosts hostsFromOptions:self->_options];
@@ -456,7 +456,7 @@ NS_ASSUME_NONNULL_END
                 NSString *host = [blockFallbacks popFallbackHost];
                 if (host != nil) {
                     ARTLogDebug(self.logger, @"RS:%p host is down; retrying request at %@", self, host);
-                    
+
                     self.currentFallbackHost = host;
                     NSMutableURLRequest *newRequest = [request copy];
                     [newRequest setValue:host forHTTPHeaderField:@"Host"];
@@ -556,7 +556,7 @@ NS_ASSUME_NONNULL_END
     request.HTTPMethod = @"GET";
     NSString *accept = [[_encoders.allValues valueForKeyPath:@"mimeType"] componentsJoinedByString:@","];
     [request setValue:accept forHTTPHeaderField:@"Accept"];
-    
+
     return [self executeRequest:request withAuthOption:ARTAuthenticationOff wrapperSDKAgents:wrapperSDKAgents completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             callback(nil, error);
@@ -583,7 +583,7 @@ NS_ASSUME_NONNULL_END
 wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
        callback:(ARTHTTPPaginatedCallback)callback
           error:(NSError **)errorPtr {
-    
+
     if (callback) {
         void (^userCallback)(ARTHTTPPaginatedResponse *, ARTErrorInfo *) = callback;
         callback = ^(ARTHTTPPaginatedResponse *r, ARTErrorInfo *e) {
@@ -739,7 +739,7 @@ wrapperSDKAgents:(nullable NSStringDictionary *)wrapperSDKAgents
     ARTPaginatedResultResponseProcessor responseProcessor = ^(NSHTTPURLResponse *response, NSData *data, NSError **errorPtr) {
         return [self.encoders[response.MIMEType] decodeStats:data error:errorPtr];
     };
-    
+
 art_dispatch_async(_queue, ^{
     [ARTPaginatedResult executePaginated:self withRequest:request andResponseProcessor:responseProcessor wrapperSDKAgents:wrapperSDKAgents logger:self.logger callback:callback];
 });
@@ -753,7 +753,7 @@ art_dispatch_async(_queue, ^{
 - (NSURL *)getBaseUrl {
     NSURLComponents *components = [_options restUrlComponents];
     NSString *prioritizedHost = self.prioritizedHost; // Important to use the property, not the variable; it's atomic!
-    if (prioritizedHost) { 
+    if (prioritizedHost) {
         components.host = prioritizedHost;
     }
     return components.URL;
@@ -763,11 +763,11 @@ art_dispatch_async(_queue, ^{
     if (value == nil) {
         _fallbackRetryExpiration = nil;
     }
-    
+
     if ([_currentFallbackHost isEqual:value]) {
         return;
     }
-    
+
     _currentFallbackHost = value;
 
     ARTContinuousClockInstant *const now = [self.continuousClock now];
@@ -794,11 +794,11 @@ art_dispatch_async(_queue, ^{
 + (dispatch_queue_t)deviceAccessQueue {
     static dispatch_queue_t queue;
     static dispatch_once_t onceToken;
-    
+
     dispatch_once(&onceToken, ^{
         queue = dispatch_queue_create("io.ably.deviceAccess", DISPATCH_QUEUE_SERIAL);
     });
-    
+
     return queue;
 }
 
@@ -845,7 +845,7 @@ static BOOL sharedDeviceNeedsLoading_onlyAccessOnDeviceAccessQueue = YES;
 - (void)setAndPersistAPNSDeviceTokenData:(NSData *)deviceTokenData tokenType:(NSString *)tokenType {
     NSString *deviceToken = deviceTokenData.deviceTokenString;
     ARTLogInfo(self.logger, @"ARTRest: device token: %@ of type: `%@`", deviceToken, tokenType);
-    
+
     NSString *currentDeviceToken = [ARTLocalDevice apnsDeviceTokenOfType:tokenType fromStorage:self.storage];
     if ([currentDeviceToken isEqualToString:deviceToken]) {
         // Already stored.
@@ -854,7 +854,7 @@ static BOOL sharedDeviceNeedsLoading_onlyAccessOnDeviceAccessQueue = YES;
 
     [self.device_nosync setAndPersistAPNSDeviceToken:deviceToken tokenType:tokenType];
     ARTLogDebug(self.logger, @"ARTRest: device token stored");
-    
+
     [self.push getActivationMachine:^(ARTPushActivationStateMachine *_Nullable stateMachine) {
         [stateMachine sendEvent:[ARTPushActivationEventGotPushDeviceDetails new]];
     }];

--- a/Source/ARTStatus.m
+++ b/Source/ARTStatus.m
@@ -67,11 +67,11 @@ NSInteger getStatusFromCode(NSInteger code) {
     if ([error isKindOfClass:[ARTErrorInfo class]]) {
         return (ARTErrorInfo *)error;
     }
-    
+
     NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:error.userInfo];
     userInfo[ARTErrorInfoOriginalDomainKey] = error.domain;
     userInfo[ARTErrorInfoRequestIdKey] = error.requestId;
-    
+
     return [[ARTErrorInfo alloc] initWithDomain:ARTAblyErrorDomain code:error.code userInfo:userInfo];
 }
 
@@ -142,7 +142,7 @@ NSInteger getStatusFromCode(NSInteger code) {
     if (self.statusCode == 0 ) {
         return nil;
     }
-    
+
     return [@"https://help.ably.io/error/" stringByAppendingFormat:@"%lld", (long long)self.statusCode];
 }
 

--- a/Source/ARTSummaryTypes.m
+++ b/Source/ARTSummaryTypes.m
@@ -12,7 +12,7 @@
     return [self initWithTotal:total clientIds:clientIds clipped:NO];
 }
 
-- (instancetype)initWithTotal:(NSInteger)total 
+- (instancetype)initWithTotal:(NSInteger)total
                     clientIds:(NSArray<NSString *> *)clientIds
                       clipped:(BOOL)clipped {
     self = [super init];
@@ -28,15 +28,15 @@
     if (![dictionary isKindOfClass:[NSDictionary class]]) {
         return nil;
     }
-    
+
     NSInteger total = [dictionary artInteger:@"total"];
     NSArray *clientIdsArray = [dictionary artArray:@"clientIds"];
     BOOL clipped = [dictionary artBoolean:@"clipped"];
-    
+
     if (!clientIdsArray) {
         return nil;
     }
-    
+
     // Validate that all items in the array are strings
     NSMutableArray<NSString *> *validatedClientIds = [NSMutableArray array];
     for (id item in clientIdsArray) {
@@ -46,8 +46,8 @@
             return nil; // Invalid data type in array
         }
     }
-    
-    return [self initWithTotal:total 
+
+    return [self initWithTotal:total
                      clientIds:[validatedClientIds copy]
                        clipped:clipped];
 }
@@ -69,7 +69,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"<%@: %p> { total: %ld, clientIds: %@, clipped: %@ }", 
+    return [NSString stringWithFormat:@"<%@: %p> { total: %ld, clientIds: %@, clipped: %@ }",
             self.class, self, (long)self.total, self.clientIds, @(self.clipped)];
 }
 
@@ -84,7 +84,7 @@
     return [self initWithTotal:total clientIds:clientIds clipped:NO totalUnidentified:0 totalClientIds:clientIds.count];
 }
 
-- (instancetype)initWithTotal:(NSInteger)total 
+- (instancetype)initWithTotal:(NSInteger)total
                     clientIds:(NSDictionary<NSString *, NSNumber *> *)clientIds
                       clipped:(BOOL)clipped
             totalUnidentified:(NSInteger)totalUnidentified
@@ -104,24 +104,24 @@
     if (![dictionary isKindOfClass:[NSDictionary class]]) {
         return nil;
     }
-    
+
     NSInteger total = [dictionary artInteger:@"total"];
     NSDictionary *clientIdsDict = [dictionary artDictionary:@"clientIds"];
     BOOL clipped = [dictionary artBoolean:@"clipped"];
     NSInteger totalUnidentified = [dictionary artInteger:@"totalUnidentified"];
     NSInteger totalClientIds = [dictionary artInteger:@"totalClientIds"];
-    
+
     if (!clientIdsDict) {
         return nil;
     }
-    
+
     // Validate that all values in the dictionary are numbers
     NSMutableDictionary<NSString *, NSNumber *> *validatedClientIds = [NSMutableDictionary dictionary];
     for (NSString *key in clientIdsDict) {
         if (![key isKindOfClass:[NSString class]]) {
             return nil; // Invalid key type
         }
-        
+
         id value = clientIdsDict[key];
         if ([value isKindOfClass:[NSNumber class]]) {
             validatedClientIds[key] = value;
@@ -138,8 +138,8 @@
             return nil; // Invalid value type
         }
     }
-    
-    return [self initWithTotal:total 
+
+    return [self initWithTotal:total
                      clientIds:[validatedClientIds copy]
                        clipped:clipped
              totalUnidentified:totalUnidentified
@@ -159,15 +159,15 @@
 }
 
 - (id)copyWithZone:(NSZone *)zone {
-    return [[ARTSummaryClientIdCounts allocWithZone:zone] initWithTotal:self.total 
-                                                              clientIds:self.clientIds 
-                                                                clipped:self.clipped 
-                                                      totalUnidentified:self.totalUnidentified 
+    return [[ARTSummaryClientIdCounts allocWithZone:zone] initWithTotal:self.total
+                                                              clientIds:self.clientIds
+                                                                clipped:self.clipped
+                                                      totalUnidentified:self.totalUnidentified
                                                          totalClientIds:self.totalClientIds];
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"<%@: %p> { total: %ld, clientIds: %@, clipped: %@, totalUnidentified: %ld, totalClientIds: %ld }", 
+    return [NSString stringWithFormat:@"<%@: %p> { total: %ld, clientIds: %@, clipped: %@, totalUnidentified: %ld, totalClientIds: %ld }",
             self.class, self, (long)self.total, self.clientIds, @(self.clipped), (long)self.totalUnidentified, (long)self.totalClientIds];
 }
 
@@ -190,7 +190,7 @@
     if (![dictionary isKindOfClass:[NSDictionary class]]) {
         return nil;
     }
-    
+
     NSInteger total = [dictionary artInteger:@"total"];
     return [self initWithTotal:total];
 }

--- a/Source/ARTTokenParams.m
+++ b/Source/ARTTokenParams.m
@@ -61,7 +61,7 @@
 
 - (NSMutableArray *)toArray {
     NSMutableArray *params = [[NSMutableArray alloc] init];
-    
+
     if (self.clientId)
         [params addObject:[NSURLQueryItem queryItemWithName:@"clientId" value:self.clientId]];
     if (self.ttl != nil)
@@ -70,13 +70,13 @@
         [params addObject:[NSURLQueryItem queryItemWithName:@"capability" value:self.capability]];
     if (self.timestamp)
         [params addObject:[NSURLQueryItem queryItemWithName:@"timestamp" value:[NSString stringWithFormat:@"%llu", dateToMilliseconds(self.timestamp)]]];
-    
+
     return params;
 }
 
 - (NSMutableDictionary<NSString *, NSString *> *)toDictionary {
     NSMutableDictionary<NSString *, NSString *> *const params = [NSMutableDictionary new];
-    
+
     if (self.clientId)
         params[@"clientId"] = self.clientId;
     if (self.ttl != nil)
@@ -85,14 +85,14 @@
         params[@"capability"] = self.capability;
     if (self.timestamp)
         params[@"timestamp"] = [NSString stringWithFormat:@"%llu", dateToMilliseconds(self.timestamp)];
-    
+
     return params;
 }
 
 - (NSArray *)toArrayWithUnion:(NSArray *)items {
     NSMutableArray *tokenParams = [self toArray];
     BOOL add = YES;
-    
+
     for (NSURLQueryItem *item in items) {
         for (NSURLQueryItem *param in tokenParams) {
             // Check if exist
@@ -106,14 +106,14 @@
         }
         add = YES;
     }
-    
+
     return tokenParams;
 }
 
 - (NSStringDictionary *)toDictionaryWithUnion:(NSArray<NSURLQueryItem *> *const)items {
     NSMutableDictionary<NSString *, NSString *> *const tokenParams = [self toDictionary];
     BOOL add = YES;
-    
+
     for (NSURLQueryItem *item in items) {
         for (NSString *key in tokenParams.allKeys) {
             // Check if exist
@@ -127,7 +127,7 @@
         }
         add = YES;
     }
-    
+
     return [tokenParams copy]; // immutable
 }
 
@@ -136,9 +136,9 @@ static NSString *hmacForDataAndKey(NSData *data, NSData *key) {
     const void *cData = [data bytes];
     size_t keyLen = [key length];
     size_t dataLen = [data length];
-    
+
     unsigned char hmac[CC_SHA256_DIGEST_LENGTH];
-    
+
     CCHmac(kCCHmacAlgSHA256, cKey, keyLen, cData, dataLen, hmac);
     NSData *mac = [[NSData alloc] initWithBytes:hmac length:sizeof(hmac)];
     NSString *str = [mac base64EncodedStringWithOptions:0];

--- a/Source/ARTTokenRequest.m
+++ b/Source/ARTTokenRequest.m
@@ -50,7 +50,7 @@
 
     NSNumber *ttlNumber = [dict artNumber:@"ttl"];
     tokenRequest.ttl = ttlNumber != nil ? [NSNumber numberWithDouble:millisecondsToTimeInterval([ttlNumber unsignedLongLongValue])] : nil;
-    
+
     return tokenRequest;
 }
 

--- a/Source/ARTTypes.m
+++ b/Source/ARTTypes.m
@@ -158,7 +158,7 @@ NSString *ARTRealtimeConnectionEventToStr(ARTRealtimeConnectionEvent event) {
                 presenceSubscribers:(NSInteger)presenceSubscribers
                    objectPublishers:(NSInteger)objectPublishers
                   objectSubscribers:(NSInteger)objectSubscribers {
-    
+
     if (self = [super init]) {
         _connections = connections;
         _publishers = publishers;
@@ -393,7 +393,7 @@ NSString *ARTChannelEventToStr(ARTChannelEvent event) {
 
 @implementation ARTCancellableFromCallback {
     id _lock;
-    
+
     // _callback will be nil once either cancel or invoke has been called on
     // this instance.
     volatile ARTResultCallback _callback;
@@ -409,17 +409,17 @@ NSString *ARTChannelEventToStr(ARTChannelEvent event) {
     if (!self) {
         return nil;
     }
-    
+
     _lock = [NSObject new];
     _callback = callback;
-    
+
     __weak ARTCancellableFromCallback * _cancellable = self;
     _wrapper = ^(const id result, NSError *const error) {
         // _cancellable is a weak self so may, legitimately, be nil now.
         ARTCancellableFromCallback *const cancellable = _cancellable;
         [cancellable invokeWithResult:result error:error];
     };
-    
+
     return self;
 }
 
@@ -431,12 +431,12 @@ NSString *ARTChannelEventToStr(ARTChannelEvent event) {
 
 -(void)invokeWithResult:(const id)result error:(NSError *const)error {
     ARTResultCallback callback;
-    
+
     @synchronized (_lock) {
         callback = _callback;
         _callback = nil;
     }
-    
+
     if (callback) {
         callback(result, error);
     }
@@ -499,7 +499,7 @@ NSObject<ARTCancellable> * artCancellableFromCallback(const ARTResultCallback ca
     if (!wrapper) {
         [NSException raise:NSInternalInconsistencyException format:@"wrapper is nil."];
     }
-    
+
     ARTCancellableFromCallback *const cancellable =
         [[ARTCancellableFromCallback alloc] initWithCallback:callback];
     *wrapper = cancellable.wrapper;

--- a/Source/ARTWebSocketTransport.m
+++ b/Source/ARTWebSocketTransport.m
@@ -148,7 +148,7 @@ NS_ASSUME_NONNULL_END
 
 - (NSURL *)setupWebSocket:(NSDictionary<NSString *, NSURLQueryItem *> *)params withOptions:(ARTClientOptions *)options resumeKey:(NSString *)resumeKey {
     __block NSMutableDictionary<NSString*, NSURLQueryItem*> *queryItems = [params mutableCopy];
-    
+
     // ClientID
     if (options.clientId) {
         [queryItems addValueAsURLQueryItem:options.clientId forKey:@"clientId"];
@@ -176,7 +176,7 @@ NS_ASSUME_NONNULL_END
     }
 
     [queryItems addValueAsURLQueryItem:[ARTDefault apiVersion] forKey:@"v"];
-    
+
     // Lib
     [queryItems addValueAsURLQueryItem:[ARTClientInformation agentIdentifierWithAdditionalAgents:options.agents] forKey:@"agent"];
 
@@ -186,7 +186,7 @@ NS_ASSUME_NONNULL_END
             [queryItems addValueAsURLQueryItem:obj.stringValue forKey:key];
         }];
     }
-    
+
     // URL
     NSURLComponents *urlComponents = [NSURLComponents componentsWithString:@"/"];
     urlComponents.queryItems = [queryItems allValues];

--- a/Source/ARTWrapperSDKProxyRealtimeAnnotations.m
+++ b/Source/ARTWrapperSDKProxyRealtimeAnnotations.m
@@ -24,11 +24,11 @@ NS_ASSUME_NONNULL_END
     return self;
 }
 
-- (ARTEventListener *)subscribe:(ARTAnnotationCallback)callback { 
+- (ARTEventListener *)subscribe:(ARTAnnotationCallback)callback {
     return [self.underlyingRealtimeAnnotations subscribe:callback];
 }
 
-- (ARTEventListener *)subscribe:(NSString *)type callback:(ARTAnnotationCallback)callback { 
+- (ARTEventListener *)subscribe:(NSString *)type callback:(ARTAnnotationCallback)callback {
     return [self.underlyingRealtimeAnnotations subscribe:type callback:callback];
 }
 
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_END
     [self.underlyingRealtimeAnnotations unsubscribe:listener];
 }
 
-- (void)unsubscribe:(NSString *)type listener:(ARTEventListener *)listener { 
+- (void)unsubscribe:(NSString *)type listener:(ARTEventListener *)listener {
     [self.underlyingRealtimeAnnotations unsubscribe:type listener:listener];
 }
 

--- a/Source/ARTWrapperSDKProxyRealtimeChannel.m
+++ b/Source/ARTWrapperSDKProxyRealtimeChannel.m
@@ -112,7 +112,7 @@ NS_ASSUME_NONNULL_END
     [self.underlyingChannel publish:name data:data extras:extras callback:callback];
 }
 
-- (void)getMessageWithSerial:(nonnull NSString *)serial callback:(nonnull ARTMessageErrorCallback)callback { 
+- (void)getMessageWithSerial:(nonnull NSString *)serial callback:(nonnull ARTMessageErrorCallback)callback {
     [self.underlyingChannel.internal getMessageWithSerial:serial
                                          wrapperSDKAgents:self.proxyOptions.agents
                                                  callback:callback];

--- a/Source/SocketRocket/Internal/Security/ARTSRPinningSecurityPolicy.h
+++ b/Source/SocketRocket/Internal/Security/ARTSRPinningSecurityPolicy.h
@@ -15,7 +15,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/** 
+/**
  * NOTE: While publicly, SocketRocket does not support configuring the security policy with pinned certificates,
  * it is still possible to manually construct a security policy of this class. If you do this, note that you may
  * be open to MitM attacks, and we will not support any issues you may have. Dive at your own risk.

--- a/Source/include/Ably/ARTChannels.h
+++ b/Source/include/Ably/ARTChannels.h
@@ -33,7 +33,7 @@ NS_SWIFT_SENDABLE
  *
  * @param name The channel name.
  * @param options An `ARTChannelOptions` object.
- * 
+ *
  * @return A `ARTRestChannel` or `ARTRealtimeChannel` object.
  */
 - (ChannelType)get:(NSString *)name options:(ARTChannelOptions *)options;

--- a/Source/include/Ably/ARTDefault.h
+++ b/Source/include/Ably/ARTDefault.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  When the client is in the `ARTRealtimeConnectionState.ARTRealtimeDisconnected` state, once this TTL has passed, the client should change the state to the `ARTRealtimeConnectionState.ARTRealtimeSuspended` state signifying that the state is now lost i.e. channels need to be reattached manually.
- 
+
  Note that this default is override by any `ARTConnectionDetails.connectionStateTtl` of the `ARTProtocolMessageConnected` of the `ARTProtocolMessage`.
  */
 + (NSTimeInterval)connectionStateTtl;

--- a/Source/include/Ably/ARTSummaryTypes.h
+++ b/Source/include/Ably/ARTSummaryTypes.h
@@ -25,7 +25,7 @@ NS_SWIFT_SENDABLE
  * @param clientIds Array of client ID strings
  * @param clipped Whether the data is clipped
  */
-- (instancetype)initWithTotal:(NSInteger)total 
+- (instancetype)initWithTotal:(NSInteger)total
                     clientIds:(NSArray<NSString *> *)clientIds
                       clipped:(BOOL)clipped;
 
@@ -60,7 +60,7 @@ NS_SWIFT_SENDABLE
  * @param totalUnidentified Total unidentified annotations
  * @param totalClientIds Total unique client IDs
  */
-- (instancetype)initWithTotal:(NSInteger)total 
+- (instancetype)initWithTotal:(NSInteger)total
                     clientIds:(NSDictionary<NSString *, NSNumber *> *)clientIds
                       clipped:(BOOL)clipped
             totalUnidentified:(NSInteger)totalUnidentified

--- a/Test/AblyTestingObjC/Dependencies/steipete/Aspects.h
+++ b/Test/AblyTestingObjC/Dependencies/steipete/Aspects.h
@@ -11,7 +11,7 @@ typedef NS_OPTIONS(NSUInteger, AspectOptions) {
     AspectPositionAfter   = 0,            /// Called after the original implementation (default)
     AspectPositionInstead = 1,            /// Will replace the original implementation.
     AspectPositionBefore  = 2,            /// Called before the original implementation.
-    
+
     AspectOptionAutomaticRemoval = 1 << 3 /// Will remove the hook after the first execution.
 };
 

--- a/Test/AblyTestingObjC/Dependencies/steipete/Aspects.m
+++ b/Test/AblyTestingObjC/Dependencies/steipete/Aspects.m
@@ -843,24 +843,24 @@ static void aspect_deregisterTrackedSelector(id self, SEL selector) {
     if (numberOfArguments > 1) {
         [blockInvocation setArgument:&info atIndex:1];
     }
-    
+
 	void *argBuf = NULL;
     for (NSUInteger idx = 2; idx < numberOfArguments; idx++) {
         const char *type = [originalInvocation.methodSignature getArgumentTypeAtIndex:idx];
 		NSUInteger argSize;
 		NSGetSizeAndAlignment(type, &argSize, NULL);
-        
+
 		if (!(argBuf = reallocf(argBuf, argSize))) {
             AspectLogError(@"Failed to allocate memory for block invocation.");
 			return NO;
 		}
-        
+
 		[originalInvocation getArgument:argBuf atIndex:idx];
 		[blockInvocation setArgument:argBuf atIndex:idx];
     }
-    
+
     [blockInvocation invokeWithTarget:self.block];
-    
+
     if (argBuf != NULL) {
         free(argBuf);
     }

--- a/Test/AblyTests/Test Utilities/JSON.swift
+++ b/Test/AblyTests/Test Utilities/JSON.swift
@@ -18,36 +18,36 @@ enum JSONUtility {
     private static var decoder: JSONDecoder  {
         let jsonDecoder = JSONDecoder()
         jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
-        
+
         return jsonDecoder
     }
-    
+
     private static var encoder: JSONEncoder {
         let jsonEncoder = JSONEncoder()
-        
+
         return jsonEncoder
     }
-    
+
     static func decode<T: Codable>(path: String) throws -> T {
         let url = URL(fileURLWithPath: path)
-        
+
         return try decode(url: url)
     }
-    
+
     static func decode<T: Codable>(url: URL) throws -> T {
         let data = try Data(contentsOf: url)
-        
+
         return try decode(data: data)
     }
-    
+
     static func decode<T: Codable>(data: Data) throws -> T {
         try decoder.decode(T.self, from: data)
     }
-    
+
     static func encode(_ model: Encodable) throws -> Data {
         try encoder.encode(model)
     }
-    
+
     static func serialize(_ object: Any) throws -> Data {
         if #available(iOS 11.0, *) {
             return try JSONSerialization.data(withJSONObject: object, options: .sortedKeys)
@@ -55,7 +55,7 @@ enum JSONUtility {
             return try JSONSerialization.data(withJSONObject: object)
         }
     }
-    
+
     static func toJSONString( _ object: Any, encoding: String.Encoding = .utf8) throws -> String {
         let data = try serialize(object)
 
@@ -65,7 +65,7 @@ enum JSONUtility {
 
         return string
     }
-    
+
     static func codableToDictionary( _ model: Codable) throws -> [String: Any] {
         let data = try encode(model)
 
@@ -75,12 +75,12 @@ enum JSONUtility {
 
         return object
     }
-    
+
     static func jsonObject<T: Any>(data: Data?) throws -> T {
         guard let data else {
             throw Error.dataArgumentIsNil
         }
-        
+
         guard let object = try JSONSerialization.jsonObject(with: data) as? T else {
             throw Error.serializedObjectIsNotOfExpectedType
         }

--- a/Test/AblyTests/Test Utilities/MockDeviceStorage.swift
+++ b/Test/AblyTests/Test Utilities/MockDeviceStorage.swift
@@ -2,7 +2,7 @@
 import Ably
 
 class MockDeviceStorage: NSObject, ARTDeviceStorage {
-    
+
     private let accessQueue = DispatchQueue(label: "io.ably.MockDeviceStorage")
 
     var keysRead: [String] = []

--- a/Test/AblyTests/Test Utilities/TestProxyTransportFactory.swift
+++ b/Test/AblyTests/Test Utilities/TestProxyTransportFactory.swift
@@ -19,7 +19,7 @@ class TestProxyTransportFactory: RealtimeTransportFactory {
         )
 
         transportCreatedEvent?(testProxyTransport)
-        
+
         return testProxyTransport
     }
 }

--- a/Test/AblyTests/Test Utilities/TestUtilities.swift
+++ b/Test/AblyTests/Test Utilities/TestUtilities.swift
@@ -15,16 +15,16 @@ class AblyTestsConfiguration: NSObject, XCTestObservation {
         super.init()
         XCTestObservationCenter.shared.addTestObserver(self)
     }
-    
+
     private var performedPreFirstTestCaseSetup = false
-    
+
     func testCaseWillStart(_ testCase: XCTestCase) {
         if !performedPreFirstTestCaseSetup {
             preFirstTestCaseSetup()
             performedPreFirstTestCaseSetup = true
         }
     }
-    
+
     private func preFirstTestCaseSetup() {
         // This is code that, when we were using the Quick testing
         // framework, was inside a `configuration.beforeSuite` hook,
@@ -63,7 +63,7 @@ class AblyTests {
     class func msgpackToData(_ data: Data) -> Data {
         let decoded = try! ARTMsgPackEncoder().decode(data)
         let encoded = try! ARTJsonEncoder().encode(decoded)
-        
+
         return encoded
     }
 
@@ -129,7 +129,7 @@ class AblyTests {
 
             app = try JSONUtility.jsonObject(data: responseData)
             testApplication = app
-            
+
             if debug {
                 print(app)
             }
@@ -316,7 +316,7 @@ class AblyTests {
         }
 
     }
-    
+
     class func loadCryptoTestRawData(_ fileName: String) -> (key: Data, iv: Data, jsonItems: [CryptoData.Item]) {
         let file = testResourcesPath + fileName + ".json";
         let json: CryptoData = try! JSONUtility.decode(path: pathForTestResource(file))
@@ -326,7 +326,7 @@ class AblyTests {
 
         return (keyData, ivData, json.items)
     }
-    
+
     class func loadCryptoTestData(_ fileName: String) -> (key: Data, iv: Data, items: [CryptoTestItem]) {
         let (keyData, ivData, jsonItems) = loadCryptoTestRawData(fileName)
         let items = jsonItems.map{ $0 }.map(CryptoTestItem.init)
@@ -373,7 +373,7 @@ class SynchronousHTTPClient: NSObject, URLSessionDelegate, URLSessionTaskDelegat
             callbackResponse = response
             callbackError = error
             requestCompleted = true
-        }) 
+        })
         task.resume()
 
         while !requestCompleted {
@@ -604,9 +604,9 @@ func getJWTToken(for test: Test, invalid: Bool = false, expiresIn: Int = 3600, c
         URLQueryItem(name: "capability", value: capability),
         URLQueryItem(name: "jwtType", value: jwtType),
         URLQueryItem(name: "encrypted", value: String(encrypted)),
-        URLQueryItem(name: "environment", value: getEnvironment()) 
+        URLQueryItem(name: "environment", value: getEnvironment())
     ]
-    
+
     let request = NSMutableURLRequest(url: urlComponents!.url!)
     let (responseData, _) = try SynchronousHTTPClient().perform(request)
     return String(data: responseData, encoding: String.Encoding.utf8)
@@ -625,7 +625,7 @@ public func delay(_ seconds: TimeInterval, closure: @escaping () -> Void) {
 }
 
 public func getEnvironment() -> String {
-    let b = Bundle(for: AblyTests.self)    
+    let b = Bundle(for: AblyTests.self)
     guard let env = b.infoDictionary!["ABLY_ENV"] as? String, env.count > 0 else {
         return "sandbox"
     }
@@ -672,23 +672,23 @@ enum Result<T> {
 func extractURL(_ request: URLRequest?) -> Result<URL> {
     guard let request = request
         else { return Result(error: "No request found") }
-    
+
     guard let url = request.url
         else { return Result(error: "Request has no URL defined") }
-    
+
     return Result.success(Box(url))
 }
 
 func extractBodyAsJSON(_ request: URLRequest?) -> Result<NSDictionary> {
     guard let request = request
         else { return Result(error: "No request found") }
-    
+
     guard let bodyData = request.httpBody
         else { return Result(error: "No HTTPBody") }
-    
+
     guard let json = try? JSONSerialization.jsonObject(with: bodyData, options: .mutableLeaves)
         else { return Result(error: "Invalid json") }
-    
+
     guard let httpBody = json as? NSDictionary
         else { return Result(error: "HTTPBody has invalid format") }
 
@@ -923,7 +923,7 @@ struct ErrorSimulator {
     var statusCode: Int = 401
     var shouldPerformRequest: Bool = false
     let stubData: Data?
-    
+
     init(value: Int, description: String, statusCode: Int, shouldPerformRequest: Bool, stubData: Data?) {
         self.value = value
         self.description = description
@@ -931,7 +931,7 @@ struct ErrorSimulator {
         self.shouldPerformRequest = shouldPerformRequest
         self.stubData = stubData
     }
-    
+
     init(value: Int, description: String, statusCode: Int, shouldPerformRequest: Bool, stubDataDict: [String: Any]? = nil) {
         self.value = value
         self.description = description
@@ -951,7 +951,7 @@ struct ErrorSimulator {
             self.stubData = jsonObject.data()
         }
     }
-    
+
     func stubResponse(_ url: URL) -> HTTPURLResponse? {
         return HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: "HTTP/1.1", headerFields: [
             "Content-Length": String(stubData?.count ?? 0),
@@ -980,7 +980,7 @@ class MockHTTPExecutor: NSObject, ARTHTTPExecutor {
 
     func execute(_ request: URLRequest, completion callback: ((HTTPURLResponse?, Data?, Error?) -> Void)? = nil) -> (ARTCancellable & NSObjectProtocol)? {
         self.requests.append(request)
-        
+
         if let simulatedError = errorSimulator, var _ = request.url {
             defer { errorSimulator = nil }
             callback?(nil, nil, simulatedError)
@@ -1109,7 +1109,7 @@ class TestProxyHTTPExecutor: NSObject, ARTHTTPExecutor {
             else {
                 callback?(simulatedError.stubResponse(requestURL), simulatedError.stubData, nil)
                 return nil
-            }            
+            }
         }
 
         let task = http.execute(request, completion: { response, data, error in
@@ -1272,7 +1272,7 @@ class TestProxyTransport: ARTWebSocketTransport {
             self.replacingAcksWithNacks = nil
         }
     }
-    
+
     func emulateTokenRevokationBeforeConnected() {
         setBeforeIncomingMessageModifier { protocolMessage in
             if protocolMessage.action == .connected {
@@ -1462,7 +1462,7 @@ extension Sequence where Iterator.Element == Data {
         let msgPackEncoder = ARTMsgPackEncoder()
         return map({ try! msgPackEncoder.decode($0) as! T })
     }
-    
+
 }
 
 func + <K,V> (left: Dictionary<K,V>, right: Dictionary<K,V>?) -> Dictionary<K,V> {
@@ -1547,7 +1547,7 @@ extension Data {
 
         return result.uppercased()
     }
-    
+
 }
 
 extension NSData {
@@ -1603,15 +1603,15 @@ extension String {
 }
 
 extension ARTRealtime {
-    
+
     var transportFactory: TestProxyTransportFactory? {
         self.internal.options.testOptions.transportFactory as? TestProxyTransportFactory
     }
-    
+
     func simulateLostConnection() {
         self.internal.onDisconnected()
     }
-    
+
     func simulateLostConnectionAndState() {
         //1. Abruptly disconnect
         //2. Change the `Connection#id` and `Connection#key` before the client
@@ -1641,7 +1641,7 @@ extension ARTRealtime {
             reachability.simulate(false)
         }
     }
-    
+
     func simulateNoInternetConnection(during timeout: TimeInterval? = nil) {
         guard let transportFactory = self.transportFactory else {
             fatalError("Expected test TestProxyTransportFactory")
@@ -1662,14 +1662,14 @@ extension ARTRealtime {
             reachability.simulate(true)
         }
     }
-    
+
     func simulateRestoreInternetConnection(after seconds: TimeInterval? = nil) {
         guard let transportFactory = self.transportFactory else {
             fatalError("Expected test TestProxyTransportFactory")
         }
         simulateRestoreInternetConnection(after: seconds, transportFactory: transportFactory)
     }
-    
+
     @discardableResult
     func waitUntilConnected() -> Bool {
         var connected = false
@@ -1681,11 +1681,11 @@ extension ARTRealtime {
         }
         return connected
     }
-    
+
     func waitForPendingMessages() {
         expect(self.internal.pendingMessages).toEventually(haveCount(0),timeout: testTimeout)
     }
-    
+
     func overrideConnectionStateTTL(_ ttl: TimeInterval) -> HookToken {
         return self.internal.testSuite_injectIntoMethod(before: NSSelectorFromString("connectionStateTtl")) {
             self.internal.connectionStateTtl = ttl
@@ -1699,7 +1699,7 @@ extension ARTRealtime {
         }
         self.connection.off()
     }
-    
+
     func requestPresenceSyncForChannel(_ channel: ARTRealtimeChannel) {
         let syncMessage = ARTProtocolMessage()
         syncMessage.action = .sync
@@ -1968,7 +1968,7 @@ extension HTTPURLResponse {
         //of the private NSDictionary subclass in CFNetwork directly
         return allHeaderFields as NSDictionary
     }
-    
+
     /**
      The value which corresponds to the given header
      field. Note that, in keeping with the HTTP RFC, HTTP header field
@@ -2037,7 +2037,7 @@ extension DispatchTimeInterval {
             fatalError("Unhandled DispatchTimeInterval unit.")
         }
     }
-    
+
     /// Return a new dispatch time interval computed from this one, incremented by the supplied amount, to no less than millisecond precision.
     func incremented(by interval: TimeInterval) -> DispatchTimeInterval {
         // interval is a TimeInterval which is a Double which is in SECONDS
@@ -2063,7 +2063,7 @@ extension DispatchTimeInterval {
 }
 
 extension ARTErrorCode {
-    
+
     var intValue: NSInteger {
         return NSInteger(rawValue)
     }

--- a/Test/AblyTests/Tests/ARTDefaultTests.swift
+++ b/Test/AblyTests/Tests/ARTDefaultTests.swift
@@ -3,7 +3,7 @@ import XCTest
 import Ably.ARTDefault // System under Test
 
 class ARTDefaultTests: XCTestCase {
-    
+
     func testVersions() {
         XCTAssertEqual(ARTDefault.apiVersion(), "5")
         XCTAssertEqual(ARTDefault.libraryVersion(), "1.2.57")

--- a/Test/AblyTests/Tests/AuthTests.swift
+++ b/Test/AblyTests/Tests/AuthTests.swift
@@ -137,9 +137,9 @@ class AuthTests: XCTestCase {
                 done()
             }
         }
-        
+
         let url = try XCTUnwrap(testHTTPExecutor.requests.first?.url, "No request url found")
-        
+
         XCTAssertEqual(url.scheme, "http", "No HTTP support")
     }
 
@@ -158,7 +158,7 @@ class AuthTests: XCTestCase {
         }
 
         let url = try XCTUnwrap(testHTTPExecutor.requests.first?.url, "No request url found")
-        
+
         XCTAssertEqual(url.scheme, "https", "No HTTPS support")
     }
 
@@ -598,7 +598,7 @@ class AuthTests: XCTestCase {
         }
 
         let errorInfo = try XCTUnwrap(realtime.connection.errorReason, "ErrorInfo is empty")
-        
+
         XCTAssertEqual(errorInfo.code, ARTErrorCode.authConfiguredProviderFailure.intValue)
         expect(errorInfo.message).to(contain("body param is required"))
     }
@@ -665,9 +665,9 @@ class AuthTests: XCTestCase {
         }
 
         expect(realtime.connection.state).toEventually(equal(ARTRealtimeConnectionState.disconnected), timeout: testTimeout)
-        
+
         let errorInfo = try XCTUnwrap(realtime.connection.errorReason, "ErrorInfo is empty")
-        
+
         XCTAssertEqual(errorInfo.code, ARTErrorCode.authConfiguredProviderFailure.intValue)
         expect(errorInfo.message).to(contain("hostname could not be found"))
     }
@@ -700,7 +700,7 @@ class AuthTests: XCTestCase {
         realtime.internal.transport?.receive(authMessage)
 
         expect(realtime.connection.errorReason).toEventuallyNot(beNil(), timeout: testTimeout)
-        
+
         let errorInfo = try XCTUnwrap(realtime.connection.errorReason, "ErrorInfo is empty")
 
         XCTAssertEqual(errorInfo.code, ARTErrorCode.authConfiguredProviderFailure.intValue)
@@ -787,7 +787,7 @@ class AuthTests: XCTestCase {
         realtime.internal.transport?.receive(authMessage)
 
         expect(realtime.connection.errorReason).toEventuallyNot(beNil(), timeout: testTimeout)
-        
+
         let errorInfo = try XCTUnwrap(realtime.connection.errorReason, "ErrorInfo is empty")
 
         XCTAssertEqual(errorInfo.code, ARTErrorCode.authConfiguredProviderFailure.intValue)
@@ -867,7 +867,7 @@ class AuthTests: XCTestCase {
         }
 
         expect(realtime.connection.errorReason).toEventuallyNot(beNil(), timeout: testTimeout)
-        
+
         let errorInfo = try XCTUnwrap(realtime.connection.errorReason, "ErrorInfo is empty")
 
         XCTAssertEqual(errorInfo.code, ARTErrorCode.authConfiguredProviderFailure.intValue)
@@ -903,9 +903,9 @@ class AuthTests: XCTestCase {
                 done()
             }
         }
-        
+
         let request = try XCTUnwrap(testHTTPExecutor.requests.first, "No request found")
-        
+
         switch extractBodyAsMsgPack(request) {
         case let .failure(error):
             XCTFail(error)
@@ -940,10 +940,10 @@ class AuthTests: XCTestCase {
                 }
             }
         }
-        
+
         let transport = try XCTUnwrap(client.internal.transport as? TestProxyTransport, "Transport is nil")
         let connectedMessage = try XCTUnwrap(transport.protocolMessagesReceived.filter({ $0.action == .connected }).last, "No CONNECTED protocol action received")
-        
+
         // CONNECTED ProtocolMessage
         XCTAssertEqual(connectedMessage.connectionDetails!.clientId, expectedClientId)
     }
@@ -1055,7 +1055,7 @@ class AuthTests: XCTestCase {
         let request = rest.auth.internal.buildRequest(options, with: tokenParams)
 
         let query = try XCTUnwrap(request.url?.query, "URL is empty")
-        
+
         expect(query).to(haveParam("capability", withValue: "%7B%22*%22:%5B%22*%22%5D%7D"))
         expect(query).to(haveParam("timestamp", withValue: "1475965860000"))
     }
@@ -1082,9 +1082,9 @@ class AuthTests: XCTestCase {
                 done()
             }
         }
-        
+
         let request = try XCTUnwrap(testHTTPExecutor.requests.first, "No request found")
-        
+
         switch extractBodyAsMsgPack(request) {
         case let .failure(error):
             fail(error)
@@ -1114,9 +1114,9 @@ class AuthTests: XCTestCase {
                 done()
             }
         }
-        
+
         let request = try XCTUnwrap(testHTTPExecutor.requests.first, "No request found")
-        
+
         switch extractBodyAsMsgPack(request) {
         case let .failure(error):
             fail(error)
@@ -1563,7 +1563,7 @@ class AuthTests: XCTestCase {
                 done()
             })
         }
-        
+
         let testTokenRequest = try XCTUnwrap(tokenRequest, "TokenRequest is empty")
         let jsonTokenRequest = try XCTUnwrap(createJsonEncoder().encode(testTokenRequest), "Invalid TokenRequest")
 
@@ -1621,7 +1621,7 @@ class AuthTests: XCTestCase {
 
         let url = try XCTUnwrap(request.url, "Request is invalid")
         let urlComponents = try XCTUnwrap(NSURLComponents(url: url, resolvingAgainstBaseURL: false), "invalid URL: \(url)")
-        
+
         XCTAssertEqual(urlComponents.scheme, "http")
         XCTAssertEqual(urlComponents.host, "auth.ably.io")
         guard let queryItems = urlComponents.queryItems else {
@@ -2541,7 +2541,7 @@ class AuthTests: XCTestCase {
 
         // Check that token exists
         XCTAssertEqual(rest.auth.internal.method, ARTAuthMethod.token)
-        
+
         let firstTokenDetails = try XCTUnwrap(rest.auth.tokenDetails, "TokenDetails is nil")
         XCTAssertNotNil(firstTokenDetails.token)
 
@@ -2554,7 +2554,7 @@ class AuthTests: XCTestCase {
 
         // Check that token has not changed
         XCTAssertEqual(rest.auth.internal.method, ARTAuthMethod.token)
-        
+
         let secondTokenDetails = try XCTUnwrap(rest.auth.tokenDetails, "TokenDetails is nil")
         XCTAssertTrue(firstTokenDetails === secondTokenDetails)
 
@@ -3000,7 +3000,7 @@ class AuthTests: XCTestCase {
 
     func test__107__authorize__should_adhere_to_all_requirements_relating_to__authUrl_with_json() throws {
         let test = Test()
-        
+
         let tokenDetails = try XCTUnwrap(getTestTokenDetails(for: test), "TokenDetails is empty")
         let tokenDetailsData = try XCTUnwrap(createJsonEncoder().encode(tokenDetails), "Couldn't encode token details")
         let tokenDetailsJSON = try XCTUnwrap(String(data: tokenDetailsData, encoding: .utf8), "JSON TokenDetails is empty")
@@ -4459,7 +4459,7 @@ class AuthTests: XCTestCase {
         let test = Test()
         var originalTokenRequest: ARTTokenRequest!
         let tmpRest = ARTRest(options: try AblyTests.commonAppSetup(for: test))
-        
+
         let channelName = test.uniqueChannelName()
         waitUntil(timeout: testTimeout) { done in
             let tokenParams = ARTTokenParams()
@@ -4499,10 +4499,10 @@ class AuthTests: XCTestCase {
                 done()
             }
         }
-        
+
         let requestUrl = try XCTUnwrap(testHttpExecutor.requests.first?.url, "No request url found")
         let tokenDetails = try XCTUnwrap(rest.internal.auth.tokenDetails, "Should have token details")
-        
+
         XCTAssertEqual(requestUrl.host, "auth-test.ably.cocoa")
         XCTAssertEqual(tokenDetails.clientId, originalTokenRequest.clientId)
         XCTAssertNotNil(tokenDetails.token)

--- a/Test/AblyTests/Tests/ClientInformationTests.swift
+++ b/Test/AblyTests/Tests/ClientInformationTests.swift
@@ -2,15 +2,15 @@ import XCTest
 import Ably
 
 final class ClientInformationTests: XCTestCase {
-    
+
     // CR2, CR2a
     func testAgents() {
         let agents = ARTClientInformation.agents
-        
+
         XCTAssertEqual(agents.keys.count, 2)
-        
+
         XCTAssertEqual(agents["ably-cocoa"], "1.2.57")
-        
+
         #if os(iOS)
         XCTAssertTrue(agents.keys.contains("iOS"))
         #elseif os(tvOS)
@@ -23,31 +23,31 @@ final class ClientInformationTests: XCTestCase {
         #error("Building for unknown OS")
         #endif
     }
-    
+
     // CR3, CR3b
     func testAgentIdentifierWithAdditionalAgents_withNilAdditionalAgents() {
         let expectedIdentifier = [
             "ably-cocoa/1.2.57",
             ARTDefault.platformAgent()
         ].sorted().joined(separator: " ")
-        
+
         XCTAssertEqual(ARTClientInformation.agentIdentifier(withAdditionalAgents: nil), expectedIdentifier)
     }
-    
+
     // CR3, CR3b, CR3c
     func testAgentIdentifierWithAdditionalAgents_withNonNilAdditionalAgents() {
         let additionalAgents = [
             "demolib": "0.0.1",
             "morelib": ARTClientInformationAgentNotVersioned
         ]
-        
+
         let expectedIdentifier = [
             "ably-cocoa/1.2.57",
             "demolib/0.0.1",
             "morelib",
             ARTDefault.platformAgent()
         ].sorted().joined(separator: " ")
-        
+
         XCTAssertEqual(ARTClientInformation.agentIdentifier(withAdditionalAgents: additionalAgents), expectedIdentifier)
     }
 }

--- a/Test/AblyTests/Tests/CryptoTests.swift
+++ b/Test/AblyTests/Tests/CryptoTests.swift
@@ -163,7 +163,7 @@ class CryptoTests: XCTestCase {
                 let encrypted = try XCTUnwrap(decoded.encode(with: encrypter, error: &error) as? ARTMessage)
                 XCTAssertNil(error)
                 XCTAssertNotNil(encrypted)
-                
+
                 XCTAssertEqual(encrypted, encryptedFixture)
             }
 
@@ -200,43 +200,43 @@ class CryptoTests: XCTestCase {
             try test__should_decrypt_messages_as_expected_in_the_fixtures()
         }
     }
-    
+
     func reusableTestsTestManualDecryption(fileName: String, expectedEncryptedEncoding: String, keyLength: UInt) throws {
         let (key, iv, jsonItems) = AblyTests.loadCryptoTestRawData(fileName)
         let decoder = ARTDataEncoder(cipherParams: nil, logger: .init(core: MockInternalLogCore()), error: nil)
         let cipherParams = ARTCipherParams(algorithm: "aes", key: key as ARTCipherKeyCompatible, iv: iv)
         let channelOptions = ARTChannelOptions(cipher: cipherParams)
-        
+
         func extractMessage(_ rawFixture: CryptoData.Item.Encoded) -> ARTMessage {
             let msg = ARTMessage(name: rawFixture.name, data: rawFixture.data)
             msg.encoding = rawFixture.encoding
             return msg
         }
-        
+
         // one by one
         for jsonItem in jsonItems {
             let fixture = extractMessage(jsonItem.encoded)
             let encryptedFixture = jsonItem.encrypted
             expect(encryptedFixture.encoding).to(endWith("\(expectedEncryptedEncoding)/base64"))
-            
+
             var error: NSError?
             let decoded = fixture.decode(with: decoder, error: &error) as! ARTMessage
             XCTAssertNil(error)
             XCTAssertNotNil(decoded)
-            
+
             let rawDictionary = try XCTUnwrap(JSONUtility.codableToDictionary(encryptedFixture))
             let decrypted = try XCTUnwrap(ARTMessage.fromEncoded(rawDictionary, channelOptions: channelOptions))
             XCTAssertNotNil(decrypted)
-            
+
             XCTAssertEqual(decrypted, decoded)
         }
-        
+
         // a bunch at once
         let encryptedFixtures = try jsonItems.map { try XCTUnwrap(JSONUtility.codableToDictionary($0.encrypted)) }
 
         let decryptedArray = try XCTUnwrap(ARTMessage.fromEncodedArray(encryptedFixtures, channelOptions: channelOptions))
         XCTAssertEqual(decryptedArray.count, jsonItems.count)
-        
+
         for i in 0..<jsonItems.count {
             let fixture = extractMessage(jsonItems[i].encoded)
 
@@ -244,7 +244,7 @@ class CryptoTests: XCTestCase {
             let decoded = fixture.decode(with: decoder, error: &error) as! ARTMessage
             XCTAssertNil(error)
             XCTAssertNotNil(decoded)
-            
+
             let decrypted = decryptedArray[i]
             XCTAssertEqual(decrypted, decoded)
         }
@@ -273,11 +273,11 @@ class CryptoTests: XCTestCase {
     func test__014__Crypto__with_fixtures_from_crypto_data_256_json__should_decrypt_messages_as_expected_in_the_fixtures() throws {
         try reusableTestsWrapper__Crypto__with_fixtures_from_crypto_data_256_json__reusableTestsTestFixture(testCase: .should_decrypt_messages_as_expected_in_the_fixtures)
     }
-    
+
     func test__015__Crypto__with_fixtures_from_crypto_data_128_json__manual_decrypt_messages_as_expected_in_the_fixtures() throws {
         try reusableTestsTestManualDecryption(fileName: "crypto-data-128", expectedEncryptedEncoding: "cipher+aes-128-cbc", keyLength: 128)
     }
-    
+
     func test__016__Crypto__with_fixtures_from_crypto_data_256_json__manual_decrypt_messages_as_expected_in_the_fixtures() throws {
         try reusableTestsTestManualDecryption(fileName: "crypto-data-256", expectedEncryptedEncoding: "cipher+aes-256-cbc", keyLength: 256)
     }

--- a/Test/AblyTests/Tests/GCDTests.swift
+++ b/Test/AblyTests/Tests/GCDTests.swift
@@ -4,13 +4,13 @@ import Ably.Private
 class GCDTests: XCTestCase {
     func testScheduledBlockHandleDerefsBlockAfterInvoke() {
         let invokedExpectation = self.expectation(description: "scheduled block invoked")
-        
+
         // retain counter: 1
         var object = NSObject()
-        
+
         // store reference for above weakified
         weak var weakObject = object
-        
+
         // prepare schedule block
         var scheduledBlock: ARTScheduledBlockHandle? = artDispatchScheduled(0, .main) { [object] in
             // retain counter +1 -> sum: 2
@@ -20,9 +20,9 @@ class GCDTests: XCTestCase {
 
         // invoke block
         _ = scheduledBlock
-        
+
         waitForExpectations(timeout: 2, handler: nil)
-        
+
         // destroy block reference
         // `object` retain counter -1, sum: 1
         scheduledBlock = nil
@@ -30,7 +30,7 @@ class GCDTests: XCTestCase {
         // assign new object to old variable
         // at this point old `object` should be destroyed, retain counter: -1, sum: 0 -> Destroy
         object = NSObject()
-        
+
         // check if old `object` reference was destroyed
         XCTAssertNil(weakObject)
     }

--- a/Test/AblyTests/Tests/PushAdminTests.swift
+++ b/Test/AblyTests/Tests/PushAdminTests.swift
@@ -398,10 +398,10 @@ class PushAdminTests: XCTestCase {
                 done()
             }
         }
-        
+
         let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
-        
+
         XCTAssertEqual(authorization, testIdentityTokenDetails.token.base64Encoded())
     }
 
@@ -419,7 +419,7 @@ class PushAdminTests: XCTestCase {
 
         let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
-        
+
         XCTAssertEqual(authorization, localDevice.secret)
     }
 
@@ -527,7 +527,7 @@ class PushAdminTests: XCTestCase {
                 done()
             }
         }
-        
+
         let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
 
         XCTAssertEqual(request.httpMethod, "PUT")
@@ -561,10 +561,10 @@ class PushAdminTests: XCTestCase {
                 done()
             }
         }
-        
+
         let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
-        
+
         XCTAssertEqual(request.httpMethod, "PUT")
         XCTAssertEqual(authorization, testIdentityTokenDetails.token.base64Encoded())
     }
@@ -586,7 +586,7 @@ class PushAdminTests: XCTestCase {
 
         let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
-        
+
         XCTAssertEqual(request.httpMethod, "PUT")
         XCTAssertEqual(authorization, localDevice.secret)
     }
@@ -625,7 +625,7 @@ class PushAdminTests: XCTestCase {
                 done()
             }
         }
-        
+
         let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
 
         XCTAssertEqual(request.httpMethod, "DELETE")
@@ -751,7 +751,7 @@ class PushAdminTests: XCTestCase {
 
         let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
-        
+
         XCTAssertEqual(authorization, testIdentityTokenDetails.token.base64Encoded())
     }
 
@@ -772,7 +772,7 @@ class PushAdminTests: XCTestCase {
 
         let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
-        
+
         XCTAssertEqual(authorization, localDevice.secret)
     }
 
@@ -833,7 +833,7 @@ class PushAdminTests: XCTestCase {
         }
 
         let request = try XCTUnwrap(testProxyHTTPExecutor.requests.first, "No request found")
-        
+
         XCTAssertEqual(request.httpMethod, "DELETE")
         XCTAssertNil(request.allHTTPHeaderFields?["X-Ably-DeviceToken"])
         XCTAssertNil(request.allHTTPHeaderFields?["X-Ably-DeviceSecret"])
@@ -879,7 +879,7 @@ class PushAdminTests: XCTestCase {
 
         let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceToken"]
-        
+
         XCTAssertEqual(authorization, testIdentityTokenDetails.token.base64Encoded())
     }
 
@@ -900,7 +900,7 @@ class PushAdminTests: XCTestCase {
 
         let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
         let authorization = request.allHTTPHeaderFields?["X-Ably-DeviceSecret"]
-        
+
         XCTAssertEqual(authorization, localDevice.secret)
     }
 

--- a/Test/AblyTests/Tests/PushChannelTests.swift
+++ b/Test/AblyTests/Tests/PushChannelTests.swift
@@ -238,7 +238,7 @@ class PushChannelTests: XCTestCase {
         let request = try XCTUnwrap(testEnvironment.mockHttpExecutor.requests.first, "should have a \"/push/channelSubscriptions\" request")
         let url = try XCTUnwrap(request.url, "No request url found")
         let query = try XCTUnwrap(url.query, "should have a query")
-        
+
         XCTAssertEqual(request.httpMethod, "DELETE")
         expect(url.absoluteString).to(contain("/push/channelSubscriptions"))
         expect(query).to(haveParam("clientId", withValue: rest.device.clientId!))

--- a/Test/AblyTests/Tests/PushTests.swift
+++ b/Test/AblyTests/Tests/PushTests.swift
@@ -16,7 +16,7 @@ class PushTests: XCTestCase {
         static let tokenData = Data(base64Encoded: tokenBase64, options: [])!
         static let tokenString = tokenData.map { String(format: "%02x", $0) }.joined()
     }
-    
+
     enum TestLocationDeviceToken {
         static let tokenBase64 = "bG9jYXRpb24gZGV2aWNlIHRva2Vu"
         static let tokenData = Data(base64Encoded: tokenBase64, options: [])!
@@ -207,7 +207,7 @@ class PushTests: XCTestCase {
         let expectedDeviceTokenKey = "ARTAPNSDeviceToken-default" // ARTAPNSDeviceTokenKeyOfType(nil)
         expect(storage.keysWritten.keys).to(contain([expectedDeviceTokenKey]))
         XCTAssertEqual(storage.keysWritten.at(expectedDeviceTokenKey)?.value as? String, expectedDeviceToken)
-        
+
         let expectedLocationDeviceTokenKey = "ARTAPNSDeviceToken-location" // ARTAPNSDeviceTokenKeyOfType("location")
         expect(storage.keysWritten.keys).to(contain([expectedLocationDeviceTokenKey]))
         XCTAssertEqual(storage.keysWritten.at(expectedLocationDeviceTokenKey)?.value as? String, expectedLocationDeviceToken)
@@ -239,7 +239,7 @@ class PushTests: XCTestCase {
 
         let rest = ARTRest(key: "fake:key")
         rest.internal.storage = storage
-        
+
         storage.simulateOnNextRead(string: "testId", for: ARTDeviceIdKey)
         storage.simulateOnNextRead(string: "testSecret", for: ARTDeviceSecretKey)
         storage.simulateOnNextRead(string: testToken, for: ARTAPNSDeviceTokenKey)
@@ -295,7 +295,7 @@ class PushTests: XCTestCase {
 
         XCTAssertNil(realtime.device.clientId)
         XCTAssertNil(storage.keysWritten[ARTClientIdKey] as? String)
-        
+
         waitUntil(timeout: testTimeout) { done in
             realtime.connection.once(.connected) { _ in
                 done()
@@ -449,7 +449,7 @@ class PushTests: XCTestCase {
         pushRegistererDelegate = nil
         XCTAssertNil(rest.internal.options.pushRegistererDelegate)
     }
-    
+
     func test__016__activate_should_call_registerForAPNS_while_transition_from_not_activated() {
         var registerForAPNSMethodWasCalled = false
 
@@ -473,7 +473,7 @@ class PushTests: XCTestCase {
     }
 
     // RSH8i
-    
+
     func test__017__LocalDevice__must_verify_the_validity_of_saved_push_details_and_update_if_needed_on_the_Ably_server_by_triggering_GotPushDeviceDetails() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
@@ -530,7 +530,7 @@ class PushTests: XCTestCase {
             let expectedTokenString = pushDict.value(forKeyPath: "recipient.apnsDeviceTokens.default") as? String
             XCTAssertEqual(expectedTokenString, testDeviceToken)
         }
-        
+
         let updateRequest = mockHttpExecutor.requests.filter { req in
             req.httpMethod == "PATCH" && req.url!.path.hasPrefix("/push/deviceRegistrations/")
         }.first
@@ -546,7 +546,7 @@ class PushTests: XCTestCase {
             XCTAssertEqual(expectedTokenString, TestDeviceToken.tokenString)
         }
     }
-    
+
     func test__018__LocalDevice__when_alternative_device_token_available_update_push_details_on_the_Ably_server_by_triggering_GotPushDeviceDetails() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
@@ -564,11 +564,11 @@ class PushTests: XCTestCase {
         let testDeviceToken = "xxxx-xxxx-xxxx-xxxx-xxxx"
         rest.device.setAndPersistAPNSDeviceToken(testDeviceToken)
         defer { rest.device.setAndPersistAPNSDeviceToken(nil) }
-        
+
         func requestLocationDeviceToken() {
             ARTPush.didRegisterForLocationNotifications(withDeviceToken: TestLocationDeviceToken.tokenData, rest: rest)
         }
-        
+
         waitUntil(timeout: testTimeout) { done in
             pushRegistererDelegate.onDidActivateAblyPush = { _ in
                 requestLocationDeviceToken()
@@ -578,7 +578,7 @@ class PushTests: XCTestCase {
             }
             rest.push.activate()
         }
-        
+
         let registerRequest = mockHttpExecutor.requests.filter { req in
             req.httpMethod == "POST" && req.url!.path == "/push/deviceRegistrations"
         }.first
@@ -593,7 +593,7 @@ class PushTests: XCTestCase {
             let expectedTokenString = pushDict.value(forKeyPath: "recipient.apnsDeviceTokens.default") as? String
             XCTAssertEqual(expectedTokenString, testDeviceToken)
         }
-        
+
         let updateRequest = mockHttpExecutor.requests.filter { req in
             req.httpMethod == "PATCH" && req.url!.path.hasPrefix("/push/deviceRegistrations/")
         }.first

--- a/Test/AblyTests/Tests/RealtimeAnnotationsTests.swift
+++ b/Test/AblyTests/Tests/RealtimeAnnotationsTests.swift
@@ -12,34 +12,34 @@ class RealtimeAnnotationsTests: XCTestCase {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         options.testOptions.channelNamePrefix = nil
-        
+
         // Create realtime client
         let realtimeClient = ARTRealtime(options: options)
         defer { realtimeClient.dispose(); realtimeClient.close() }
-        
+
         // Channel name and options
         let channelName = test.uniqueChannelName(prefix: "mutable:")
         let channelOptions = ARTRealtimeChannelOptions()
         channelOptions.modes = [.publish, .subscribe, .annotationPublish, .annotationSubscribe]
-        
+
         // Get realtime channel with options
         let realtimeChannel = realtimeClient.channels.get(channelName, options: channelOptions)
-        
+
         // Message and annotation to track
         var receivedMessage: ARTMessage!
         var receivedSummary: ARTMessage!
         var createdAnnotation: ARTAnnotation!
-        
+
         // Filtered by type annotations subscription callback calls counter
         var filteredCallbackCalls = 0
-        
+
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(3, done: done)
-            
+
             // Publish a message to annotate
             let message = ARTMessage(name: "test", data: "test message")
             realtimeChannel.publish([message])
-            
+
             // Subscribe to messages
             realtimeChannel.subscribe { message in
                 if message.action == .create {
@@ -65,55 +65,55 @@ class RealtimeAnnotationsTests: XCTestCase {
                 else if message.action == .messageSummary {
                     receivedSummary = message
                     realtimeChannel.unsubscribe()
-                    
+
                     // Verify summary properties
                     XCTAssertEqual(receivedSummary.action, .messageSummary)
                     XCTAssertEqual(receivedSummary.serial, receivedMessage.serial)
                     XCTAssertEqual(receivedSummary.annotations?.summary?.count, 1)
-                    
+
                     partialDone()
                 }
             }
-            
+
             // RTAN4: Subscribe to annotations
             realtimeChannel.annotations.subscribe { annotation in
                 // only interested in the first annotation which is with action `create` (testing RTAN5 along the way)
                 realtimeChannel.annotations.unsubscribe()
-                
+
                 createdAnnotation = annotation
-                
+
                 // Verify annotation properties
                 XCTAssertEqual(annotation.action, .create)
                 XCTAssertEqual(annotation.messageSerial, receivedMessage.serial)
                 XCTAssertEqual(annotation.type, "reaction:multiple.v1")
                 XCTAssertEqual(annotation.name, "👍")
                 XCTAssertEqual(annotation.count?.intValue, 10)
-                
+
                 // Verify it matches the message
                 XCTAssertEqual(annotation.messageSerial, receivedMessage.serial)
-                
+
                 partialDone()
             }
-            
+
             // RTAN4c
             realtimeChannel.annotations.subscribe("reaction:multiple.v1") { annotation in
                 XCTAssertEqual(annotation.type, "reaction:multiple.v1")
                 filteredCallbackCalls += 1
             }
-            
+
             // RTAN4c
             realtimeChannel.annotations.subscribe("reaction:distinct.v1") { annotation in
                 XCTFail("Callback shouldn't be called for this type.")
             }
         }
-        
+
         XCTAssertEqual(filteredCallbackCalls, 1)
-        
+
         guard let createdAnnotation else {
             XCTFail("Annotation should not be nil")
             return
         }
-        
+
         // RTAN2: Now delete the annotation
         waitUntil(timeout: testTimeout) { done in
             let deleteAnnotation = ARTOutboundAnnotation(
@@ -130,24 +130,24 @@ class RealtimeAnnotationsTests: XCTestCase {
                 done()
             }
         }
-        
+
         // After the annotations are published (and received via realtime), check it through the rest request:
-        
+
         guard let messageSerial = receivedMessage.serial else {
             XCTFail("Message serial should not be nil")
             return
         }
-        
+
         // Comment form ably-js 'annotations.test.js':
         // > Temporary anti-flake measure; can be removed after summary loop implements
         // > annotation resume (CHA-887)
         sleep(2)
-        
+
         waitUntil(timeout: testTimeout) { done in
             // RTAN3
             realtimeChannel.annotations.getForMessageSerial(messageSerial, query: .init()) { paginatedResult, error in
                 XCTAssertNil(error)
-                
+
                 guard let annotations = paginatedResult?.items, annotations.count == 2 else {
                     XCTFail("Should contain two annotations.")
                     return
@@ -156,42 +156,42 @@ class RealtimeAnnotationsTests: XCTestCase {
                 XCTAssertEqual(annotations[0].type, "reaction:multiple.v1")
                 XCTAssertEqual(annotations[0].name, "👍")
                 XCTAssertEqual(annotations[0].count?.intValue, 10)
-                
+
                 XCTAssertEqual(annotations[1].action, .delete)
                 XCTAssertEqual(annotations[1].type, "reaction:multiple.v1")
                 XCTAssertEqual(annotations[1].name, "👍")
                 XCTAssertEqual(annotations[1].count?.intValue, 10)
-                
+
                 done()
             }
         }
     }
-    
+
     // RTAN4e
     func test__if_annotation_subscribe_mode_is_missing_from_channel_options_then_subscription_will_not_work() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         options.testOptions.channelNamePrefix = nil
-        
+
         // Create realtime client
         let realtimeClient = ARTRealtime(options: options)
         defer { realtimeClient.dispose(); realtimeClient.close() }
-        
+
         // Channel name and options
         let channelName = test.uniqueChannelName(prefix: "mutable:")
         let channelOptions = ARTRealtimeChannelOptions()
         channelOptions.modes = [.publish, .subscribe, .annotationPublish] // miss `annotationSubscribe`
-        
+
         // Get realtime channel with options
         let realtimeChannel = realtimeClient.channels.get(channelName, options: channelOptions)
-        
+
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(3, done: done)
-            
+
             // Publish a message to annotate
             let message = ARTMessage(name: "test", data: "test message")
             realtimeChannel.publish([message])
-            
+
             // Subscribe to messages
             realtimeChannel.subscribe { message in
                 if message.action == .create {
@@ -205,7 +205,7 @@ class RealtimeAnnotationsTests: XCTestCase {
                         data: nil,
                         extras: nil
                     )
-                    
+
                     // RTAN1
                     realtimeChannel.annotations.publish(for: message, annotation: annotation) { error in
                         XCTAssertNil(error)
@@ -217,13 +217,13 @@ class RealtimeAnnotationsTests: XCTestCase {
                     partialDone()
                 }
             }
-            
+
             var callbackCalls = 0
-            
+
             realtimeChannel.annotations.subscribe { annotation in
                 callbackCalls += 1
             }
-            
+
             // wait for possible annotations callback call
             delay(1.5) {
                 XCTAssertEqual(callbackCalls, 0, "Annotation callback should not be called")
@@ -231,25 +231,25 @@ class RealtimeAnnotationsTests: XCTestCase {
             }
         }
     }
-    
+
     // RTAN1a
     func test__publish_annotation_exceeding_max_message_size() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         options.testOptions.channelNamePrefix = nil
-        
+
         // Create realtime client
         let realtimeClient = ARTRealtime(options: options)
         defer { realtimeClient.dispose(); realtimeClient.close() }
-        
+
         // Channel name and options
         let channelName = test.uniqueChannelName(prefix: "mutable:")
         let channelOptions = ARTRealtimeChannelOptions()
         channelOptions.modes = [.publish, .subscribe, .annotationPublish, .annotationSubscribe]
-        
+
         // Get channel with options
         let channel = realtimeClient.channels.get(channelName, options: channelOptions)
-        
+
         // Wait for the channel to be ready
         waitUntil(timeout: testTimeout) { done in
             channel.once(.attached) { _ in
@@ -257,10 +257,10 @@ class RealtimeAnnotationsTests: XCTestCase {
             }
             channel.attach()
         }
-        
+
         // Create an annotation with a large name field that exceeds maxMessageSize
         let largeString = String(repeating: "f", count: realtimeClient.connection.maxMessageSize + 100)
-        
+
         waitUntil(timeout: testTimeout) { done in
             // Create annotation with large name
             let annotation = ARTOutboundAnnotation(
@@ -272,7 +272,7 @@ class RealtimeAnnotationsTests: XCTestCase {
                 data: nil,
                 extras: nil
             )
-            
+
             // Try to publish the annotation - should fail with 40009
             channel.annotations.publish(forMessageSerial: "test", annotation: annotation) { error in
                 XCTAssertNotNil(error)

--- a/Test/AblyTests/Tests/RealtimeClientChannelTests.swift
+++ b/Test/AblyTests/Tests/RealtimeClientChannelTests.swift
@@ -161,9 +161,9 @@ class RealtimeClientChannelTests: XCTestCase {
         let options = try AblyTests.commonAppSetup(for: test)
         let client1 = AblyTests.newRealtime(options).client
         defer { client1.dispose(); client1.close() }
-        
+
         let roomName = test.uniqueChannelName(prefix: "room")
-        
+
         let channel1 = client1.channels.get(roomName)
 
         waitUntil(timeout: testTimeout) { done in
@@ -543,14 +543,14 @@ class RealtimeClientChannelTests: XCTestCase {
             channel.attach()
         }
     }
-    
+
     // RTL2f (connection recovery case)
     func test__011b__Channel__EventEmitter__channel_states_and_events__ChannelStateChange_will_contain_a_resumed_boolean_attribute_with_value__true__if_the_bit_flag_RESUMED_was_included_for_recovered_connection() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        
+
         let channelName = test.uniqueChannelName()
         let channel = client.channels.get(channelName)
 
@@ -567,12 +567,12 @@ class RealtimeClientChannelTests: XCTestCase {
             channel.attach()
             channel.publish(nil, data: "A message")
         }
-        
+
         options.recover = client.connection.createRecoveryKey()
-        
+
         let recoveredClient = ARTRealtime(options: options)
         defer { recoveredClient.dispose(); recoveredClient.close() }
-        
+
         let recoveredChannel = recoveredClient.channels.get(channelName)
 
         waitUntil(timeout: testTimeout) { done in
@@ -588,7 +588,7 @@ class RealtimeClientChannelTests: XCTestCase {
             recoveredChannel.attach()
         }
     }
-    
+
     // RTL3
 
     // RTL3a
@@ -729,13 +729,13 @@ class RealtimeClientChannelTests: XCTestCase {
         defer { client.dispose(); client.close() }
         client.internal.setReachabilityClass(TestReachability.self)
         let channel = client.channels.get(test.uniqueChannelName())
-        
+
         client.connect()
         expect(client.connection.state).toEventually(equal(.connected), timeout: testTimeout)
-        
+
         channel.attach()
         expect(channel.state).toEventually(equal(.attached), timeout: testTimeout)
-        
+
         waitUntil(timeout: testTimeout) { done in
             channel.publish(nil, data: "message") { error in
                 XCTAssertNil(error)
@@ -851,7 +851,7 @@ class RealtimeClientChannelTests: XCTestCase {
         // forced SUSPENDED message, not by a DETACHED.
         let transport = client.internal.transport as! TestProxyTransport
         transport.actionsIgnored += [.detached]
-        
+
         var channel0Name = ""
         for i in 0 ..< 100 { // We need a few channels to trigger iterator invalidation.
             let channelName = test.uniqueChannelName(prefix: "channel\(i)")
@@ -910,12 +910,12 @@ class RealtimeClientChannelTests: XCTestCase {
                 done()
             }
         }
-        
+
         XCTAssertEqual(channel.state, ARTRealtimeChannelState.attaching)
-        
+
         let transport = client.internal.transport as! TestProxyTransport
         transport.actionsIgnored += [.attached]
-        
+
         waitUntil(timeout: testTimeout) { done in
             let splitDone = AblyTests.splitDone(2, done: done)
             var wasSuspended = false
@@ -965,7 +965,7 @@ class RealtimeClientChannelTests: XCTestCase {
             }
             client.connect()
         }
-        
+
         let oldConnectionId = client.connection.id
 
         waitUntil(timeout: testTimeout) { done in
@@ -1286,7 +1286,7 @@ class RealtimeClientChannelTests: XCTestCase {
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
         XCTAssertEqual(transport.protocolMessagesReceived.filter { $0.action == .attached }.count, 1)
     }
-    
+
     // RTL4c1
     func test__202__Channel__attach__protocol_message_channelSerial_must_be_set_to_channelSerial_of_the_most_recent_protocol_message_or_omitted_if_no_previous_protocol_message_received() throws {
         let test = Test()
@@ -1294,7 +1294,7 @@ class RealtimeClientChannelTests: XCTestCase {
         options.autoConnect = false
         let transportFactory = TestProxyTransportFactory()
         options.testOptions.transportFactory = transportFactory
-        
+
         let client = ARTRealtime(options: options)
         client.internal.setReachabilityClass(TestReachability.self)
         client.connect()
@@ -1305,18 +1305,18 @@ class RealtimeClientChannelTests: XCTestCase {
             let protocolAttachMessagesSent = transport.protocolMessagesSent.filter { $0.action == .attach }
             return try XCTUnwrap(protocolAttachMessagesSent.last)
         }
-        
+
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-        
+
         let channel = client.channels.get(test.uniqueChannelName())
         channel.attach()
 
         expect(channel.state).to(equal(ARTRealtimeChannelState.attaching))
-        
+
         let firstProtocolAttachMessage = try latestAttachProtocolMessage()
         expect(firstProtocolAttachMessage.channelSerial).to(beNil())
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-        
+
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(2, done: done)
             channel.subscribe { message in
@@ -1329,14 +1329,14 @@ class RealtimeClientChannelTests: XCTestCase {
             }
         }
         expect(channel.internal.channelSerial).toEventuallyNot(beNil())
-        
+
         client.simulateNoInternetConnection(transportFactory: transportFactory)
         client.simulateRestoreInternetConnection(after: 0.1, transportFactory: transportFactory)
-        
+
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.disconnected), timeout: testTimeout)
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-        
+
         let secondProtocolAttachMessage = try latestAttachProtocolMessage()
         expect(secondProtocolAttachMessage.channelSerial).to(equal(channel.internal.channelSerial))
     }
@@ -2129,7 +2129,7 @@ class RealtimeClientChannelTests: XCTestCase {
         let data = ["value": 1]
 
         let channelName = test.uniqueChannelName()
-        
+
         let rest = ARTRest(options: try AblyTests.commonAppSetup(for: test))
         let restChannel = rest.channels.get(channelName)
 
@@ -2236,12 +2236,12 @@ class RealtimeClientChannelTests: XCTestCase {
     func test__069__Channel__publish__should_invoke_callback__for_all_messages_published() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
-        
+
         let channelToSucceedName = test.uniqueChannelName(prefix: "channelToSucceed")
         let channelToFailName = test.uniqueChannelName(prefix: "channelToFail")
-        
+
         options.token = try getTestToken(for: test, key: options.key, capability: "{ \"\(options.testOptions.channelNamePrefix!)-\(channelToSucceedName)\":[\"subscribe\", \"publish\"], \"\(options.testOptions.channelNamePrefix!)-\(channelToFailName)\":[\"subscribe\"] }")
-        
+
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
 
@@ -3053,13 +3053,13 @@ class RealtimeClientChannelTests: XCTestCase {
         channel.subscribe { _ in }
         XCTAssertEqual(channel.state, ARTRealtimeChannelState.attaching)
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-        
+
         // Detaching
         channel.detach()
         channel.subscribe { _ in }
         XCTAssertEqual(channel.state, ARTRealtimeChannelState.detaching)
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-        
+
         // Detached
         channel.detach()
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
@@ -3072,7 +3072,7 @@ class RealtimeClientChannelTests: XCTestCase {
         let test = Test()
         let client = ARTRealtime(options: try AblyTests.commonAppSetup(for: test))
         defer { client.dispose(); client.close() }
-        
+
         let channelOptions = ARTRealtimeChannelOptions()
         channelOptions.attachOnSubscribe = false
         let channel = client.channels.get(test.uniqueChannelName(), options: channelOptions)
@@ -3122,10 +3122,10 @@ class RealtimeClientChannelTests: XCTestCase {
         let channelOptions = ARTRealtimeChannelOptions()
         channelOptions.attachOnSubscribe = false
         let channel = client.channels.get(test.uniqueChannelName(), options: channelOptions)
-        
+
         channel.internal.onError(AblyTests.newErrorProtocolMessage())
         XCTAssertEqual(channel.state, ARTRealtimeChannelState.failed)
-        
+
         channel.subscribe(attachCallback: { _ in
             fail("Attach callback should not be called.")
         }) { _ in }
@@ -3381,7 +3381,7 @@ class RealtimeClientChannelTests: XCTestCase {
         defer { client2.close() }
 
         let channelName = test.uniqueChannelName()
-        
+
         let channel1 = client1.channels.get(channelName)
         channel1.attach()
         expect(channel1.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
@@ -3478,7 +3478,7 @@ class RealtimeClientChannelTests: XCTestCase {
 
         let client2 = ARTRealtime(options: options)
         defer { client2.close() }
-        
+
         let channelName = test.uniqueChannelName()
 
         let channel1 = client1.channels.get(channelName)
@@ -3584,12 +3584,12 @@ class RealtimeClientChannelTests: XCTestCase {
 
             // Inject additional ATTACHED action with an error
             client.internal.transport?.receive(attachedMessageWithError)
-            
+
             let attachedMessage = ARTProtocolMessage()
             attachedMessage.action = .attached
             attachedMessage.channel = channel.name
             attachedMessage.flags = 4 // resume
-            
+
             // Inject another ATTACHED action with resume flag, should not generate neither .attached nor .update events
             client.internal.transport?.receive(attachedMessage)
         }
@@ -3792,11 +3792,11 @@ class RealtimeClientChannelTests: XCTestCase {
             channel.attach()
         }
     }
-    
+
     // RTL13b, RTB1
     func test__131b__Channel__if_the_channel_receives_a_server_initiated_DETACHED_message_and_if_the_attempt_to_reattach_fails_then_the_channel_will_transition_to_SUSPENDED_state_with_periodic_reattach_with_channelRetryTimeout() throws {
         let test = Test()
-        
+
         // Given...
 
         /* ...a Realtime client, configured with a realtimeRequestTimeout of 1 second and a channelRetryTimeout of 1 second...
@@ -4013,9 +4013,9 @@ class RealtimeClientChannelTests: XCTestCase {
 
         XCTAssertEqual(channel.state, ARTRealtimeChannelState.failed)
     }
-    
+
     // RTL15
-    
+
     // RTL15a/RTL15b
     func test__200__channel_serial_is_updated_whenever_a_protocol_message_with_either_message_presence_or_attached_actions_is_received_in_a_channel() throws {
         let test = Test()
@@ -4023,11 +4023,11 @@ class RealtimeClientChannelTests: XCTestCase {
         let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(test.uniqueChannelName())
-        
+
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
 
         let transport = try XCTUnwrap(client.internal.transport as? TestProxyTransport)
-        
+
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(3, done: done)
             channel.attach { error in
@@ -4038,7 +4038,7 @@ class RealtimeClientChannelTests: XCTestCase {
                     expect(attachMessage.channelSerial).to(equal(channel.properties.channelSerial)) // RTL15b
                 }
                 partialDone()
-                
+
                 channel.subscribe { message in
                     let messageMessage = transport.protocolMessagesReceived.filter { $0.action == .message }[0]
                     if messageMessage.channelSerial != nil {
@@ -4094,32 +4094,32 @@ class RealtimeClientChannelTests: XCTestCase {
         let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(test.uniqueChannelName())
-        
+
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-        
+
         // Case for detached
         channel.attach()
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
         expect(channel.internal.channelSerial).toNot(beNil())
-        
+
         channel.detach()
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
         expect(channel.internal.channelSerial).to(beNil())
-        
+
         // Case for suspended
         channel.attach()
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
         expect(channel.internal.channelSerial).toNot(beNil())
-        
+
         channel.internal.setSuspended(.init(state: .ok))
         expect(channel.state).to(equal(ARTRealtimeChannelState.suspended))
         expect(channel.internal.channelSerial).to(beNil())
-        
+
         // Case for failed
         channel.attach()
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
         expect(channel.internal.channelSerial).toNot(beNil())
-        
+
         channel.internal.setFailed(.init(state: .ok))
         expect(channel.state).to(equal(ARTRealtimeChannelState.failed))
         expect(channel.internal.channelSerial).to(beNil())
@@ -4366,7 +4366,7 @@ class RealtimeClientChannelTests: XCTestCase {
         XCTAssertEqual(lastAttach.flags & subscribeFlag, subscribeFlag)
         XCTAssertEqual(lastAttach.params, channelOptions.params)
     }
-    
+
     func test__Channel_options__setOptions__shouldUpdateOptionsOfRestChannel() throws {
         let test = Test()
         let client = AblyTests.newRealtime(try AblyTests.commonAppSetup(for: test)).client
@@ -4378,7 +4378,7 @@ class RealtimeClientChannelTests: XCTestCase {
                 done()
             }
         }
-        
+
         var restChannelSetOptions: ARTChannelOptions?
         let token = channel.internal.restChannel.testSuite_getArgument(from: #selector(ARTRestChannelInternal.setOptions_nosync(_:)), at: 0) { arg in
             guard let optionsArg = arg as? ARTChannelOptions else {
@@ -4388,16 +4388,16 @@ class RealtimeClientChannelTests: XCTestCase {
             restChannelSetOptions = optionsArg
         }
         defer { token.remove() }
-        
+
         let channelOptions = ARTRealtimeChannelOptions(cipherKey: ARTCrypto.generateRandomKey() as NSData)
-        
+
         waitUntil(timeout: testTimeout) { done in
             channel.setOptions(channelOptions) { error in
                 XCTAssertNil(error)
                 done()
             }
         }
-        
+
         XCTAssertTrue(restChannelSetOptions === channelOptions)
     }
 
@@ -4592,7 +4592,7 @@ class RealtimeClientChannelTests: XCTestCase {
             }
         }
     }
-    
+
     // TB1
     func test__140__ChannelOptions__options_provided_when_instantiating_a_channel_should_be_frozen() throws {
         let test = Test()
@@ -4600,37 +4600,37 @@ class RealtimeClientChannelTests: XCTestCase {
         options.autoConnect = false
         let realtime = AblyTests.newRealtime(options).client
         defer { realtime.dispose(); realtime.close() }
-        
+
         let (keyData, ivData, _) = AblyTests.loadCryptoTestData("crypto-data-128")
         let cipherParams = ARTCipherParams(algorithm: "aes", key: keyData as ARTCipherKeyCompatible, iv: ivData)
-        
+
         let channelOptions = ARTRealtimeChannelOptions()
-        
+
         // not frozen
         channelOptions.cipher = cipherParams
         channelOptions.modes = [.publish]
         channelOptions.params = ["rewind": "1"]
-        
+
         _ = realtime.channels.get(test.uniqueChannelName(), options: channelOptions)
-        
+
         let exception1 = tryInObjC {
             channelOptions.cipher = cipherParams // frozen
         }
         XCTAssertNotNil(exception1)
         XCTAssertEqual(exception1!.name, NSExceptionName.objectInaccessibleException)
-        
+
         let exception2 = tryInObjC {
             channelOptions.modes = [.publish] // frozen
         }
         XCTAssertNotNil(exception2)
         XCTAssertEqual(exception2!.name, NSExceptionName.objectInaccessibleException)
-        
+
         let exception3 = tryInObjC {
             channelOptions.params = ["rewind": "1"] // frozen
         }
         XCTAssertNotNil(exception3)
         XCTAssertEqual(exception3!.name, NSExceptionName.objectInaccessibleException)
-        
+
         let exception4 = tryInObjC {
             channelOptions.attachOnSubscribe = false // frozen
         }
@@ -4691,7 +4691,7 @@ class RealtimeClientChannelTests: XCTestCase {
         let receivedMessage = try receivedMessageDataGatherer.waitForData(timeout: testTimeout)
         XCTAssertEqual(receivedMessage.name, "foo")
     }
-    
+
     // RTL4m
     func test__141__ChannelOptions__on_ATTACHED_should_decode_flags_into_array_of_channel_modes() throws {
         // Given: A realtime channel and a protocol message with channel modes
@@ -4702,7 +4702,7 @@ class RealtimeClientChannelTests: XCTestCase {
         defer { realtime.dispose(); realtime.close() }
 
         let channel = realtime.channels.get("test")
-        
+
         // Then: The modes property should be accessible and initially 0
         XCTAssertEqual(channel.modes, ARTChannelMode(rawValue: 0))
 
@@ -4718,10 +4718,10 @@ class RealtimeClientChannelTests: XCTestCase {
             ARTChannelMode.presence.rawValue | // the first mode
             ARTChannelMode.subscribe.rawValue // mode
         )
-        
+
         // When: setAttached is called with the protocol message
         channel.internal.setAttached(protocolMessage)
-        
+
         // Then: The modes property should be set from the protocol message and contain only channel modes
         XCTAssertEqual(channel.modes, [.presence, .subscribe])
     }

--- a/Test/AblyTests/Tests/RealtimeClientConnectionTests.swift
+++ b/Test/AblyTests/Tests/RealtimeClientConnectionTests.swift
@@ -97,7 +97,7 @@ private let fixtures: [String: Any] = try! JSONUtility.jsonObject(
 
 private func expectDataToMatch(_ message: ARTMessage, _ fixtureMessage: Any) {
     let dictionaryValue = fixtureMessage as! [String: Any]
-    
+
     switch dictionaryValue["expectedType"] as! String {
     case "string":
         XCTAssertEqual(message.data as? NSString, dictionaryValue["expectedValue"] as? NSString)
@@ -503,7 +503,7 @@ class RealtimeClientConnectionTests: XCTestCase {
 
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        
+
         var events: [ARTRealtimeConnectionState] = []
 
         waitUntil(timeout: testTimeout) { done in
@@ -525,7 +525,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         XCTAssertEqual(events.count, 1)
         XCTAssertEqual(events[0].rawValue, ARTRealtimeConnectionState.connecting.rawValue, "Should be CONNECTING state")
     }
-    
+
     // RTN4b
     func test__022__Connection__event_emitter__should_emit_states_on_a_new_connection() throws {
         let test = Test()
@@ -899,7 +899,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     func test__030__Connection__ACK_and_NACK__should_expect_either_an_ACK_or_NACK_to_confirm__message_failure() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
-        
+
         let channelName = test.uniqueChannelName()
         options.token = try getTestToken(for: test, key: options.key, capability: "{ \"\(options.testOptions.channelNamePrefix!)-\(channelName)\":[\"subscribe\"] }")
         options.autoConnect = false
@@ -1360,18 +1360,18 @@ class RealtimeClientConnectionTests: XCTestCase {
 
         XCTAssertEqual(ids.count, max)
     }
-    
+
     // RTN8c, RTN9c (connection's `id` and `key` respectively)
-    
+
     func test__139__Connection__connection_id_and_key__should_be_nil_when_sdk_is_in_CLOSING_and_CLOSED_states() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        
+
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(3, done: done)
-            
+
             client.connection.on { stateChange in
                 expect(stateChange.reason).to(beNil())
                 if stateChange.current == .connected {
@@ -1393,16 +1393,16 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
         }
     }
-    
+
     func test__140__Connection__connection_id_and_key__should_be_nil_when_sdk_is_in_SUSPENDED_state() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        
+
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(2, done: done)
-            
+
             client.connection.on { stateChange in
                 expect(stateChange.reason).to(beNil())
                 if stateChange.current == .connected {
@@ -1419,7 +1419,7 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
         }
     }
-    
+
     func test__141__Connection__connection_id_and_key__should_be_nil_when_sdk_is_in_FAILED_state() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
@@ -1428,7 +1428,7 @@ class RealtimeClientConnectionTests: XCTestCase {
 
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(2, done: done)
-            
+
             client.connection.on { stateChange in
                 expect(stateChange.reason).to(beNil())
                 if stateChange.current == .connected {
@@ -2229,9 +2229,9 @@ class RealtimeClientConnectionTests: XCTestCase {
                 jitterCoefficients: jitterCoefficients
             ).prefix(numberOfRetriesToWaitFor + 1 /* The +1 can be removed after #1782 is fixed; see note below */)
         )
-        
+
         var expectedRetryDelays = [TimeInterval]()
-        
+
         if useFallbacks {
             // https://ably-real-time.slack.com/archives/CURL4U2FP/p1742211172312389?thread_ts=1741387920.007779&cid=CURL4U2FP
             /* Owen Pearson:
@@ -2252,7 +2252,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         } else {
             expectedRetryDelays = backoffJitterRetryDelays
         }
-        
+
         let timesNeededToObserveRetries = expectedRetryDelays.map { retryDelay in
             extraTimeNeededToObserveEachRetry
             + retryDelay // waiting for retry to occur
@@ -2598,7 +2598,7 @@ class RealtimeClientConnectionTests: XCTestCase {
     }
 
     // RTN15c
-    
+
     // RTN15c6 (attaching)
     func test__068a__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__CONNECTED_ProtocolMessage_with_the_same_connectionId_as_the_current_client__and_no_error() throws {
         let test = Test()
@@ -2607,7 +2607,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(test.uniqueChannelName())
         channel.attach()
-        
+
         XCTAssertTrue(client.waitUntilConnected())
         let expectedConnectionId = client.connection.id
 
@@ -2615,10 +2615,10 @@ class RealtimeClientConnectionTests: XCTestCase {
         XCTAssertEqual((transport.protocolMessagesSent.filter { $0.action == .attach }).count, 1)
 
         client.internal.onDisconnected()
-        
+
         channel.publish(nil, data: "queued message")
         expect(client.internal.queuedMessages).toEventually(haveCount(1), timeout: testTimeout)
-        
+
         XCTAssertEqual(channel.state, ARTRealtimeChannelState.attaching, "Channel should be still attaching.")
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -2631,10 +2631,10 @@ class RealtimeClientConnectionTests: XCTestCase {
                 done()
             }
         }
-        
+
         expect(client.internal.queuedMessages).toEventually(haveCount(0), timeout: testTimeout) // RTL6c2
     }
-    
+
     // RTN15c6 (attached, detaching)
     func test__068b__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__CONNECTED_ProtocolMessage_with_the_same_connectionId_as_the_current_client__and_no_error() throws {
         let test = Test()
@@ -2645,7 +2645,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         let channel2 = client.channels.get(test.uniqueChannelName(prefix: "second_"))
         channel1.attach()
         channel2.attach()
-        
+
         XCTAssertTrue(client.waitUntilConnected())
         expect(channel1.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
         expect(channel2.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
@@ -2653,15 +2653,15 @@ class RealtimeClientConnectionTests: XCTestCase {
 
         let transport = client.internal.transport as! TestProxyTransport
         XCTAssertEqual((transport.protocolMessagesSent.filter { $0.action == .attach }).count, 2, "Should contain 2 attach messages.") // for channel 1 and 2
-        
+
         channel2.detach()
         XCTAssertEqual(channel2.state, ARTRealtimeChannelState.detaching)
-        
+
         client.internal.onDisconnected()
-        
+
         channel1.publish(nil, data: "queued message")
         expect(client.internal.queuedMessages).toEventually(haveCount(1), timeout: testTimeout)
-        
+
         XCTAssertEqual(channel1.state, ARTRealtimeChannelState.attached, "Channel should be still attached.")
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
@@ -2675,10 +2675,10 @@ class RealtimeClientConnectionTests: XCTestCase {
                 done()
             }
         }
-        
+
         expect(client.internal.queuedMessages).toEventually(haveCount(0), timeout: testTimeout) // RTL6c2
     }
-    
+
     // RTN15c6 (suspended)
     func test__068c__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__CONNECTED_ProtocolMessage_with_the_same_connectionId_as_the_current_client__and_no_error() throws {
         let test = Test()
@@ -2687,22 +2687,22 @@ class RealtimeClientConnectionTests: XCTestCase {
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(test.uniqueChannelName())
         channel.attach()
-        
+
         XCTAssertTrue(client.waitUntilConnected())
         let expectedConnectionId = client.connection.id
 
         let transport = client.internal.transport as! TestProxyTransport
         transport.actionsIgnored += [.attached]
         XCTAssertEqual((transport.protocolMessagesSent.filter { $0.action == .attach }).count, 1)
-        
+
         XCTAssertEqual(channel.state, ARTRealtimeChannelState.attaching)
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.suspended), timeout: testTimeout)
-        
+
         client.internal.onDisconnected()
-        
+
         channel.publish(nil, data: "queued message")
         XCTAssertEqual(client.internal.queuedMessages.count, 0) // should fail message immidiatly if channel is suspended
-        
+
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
                 let transport = client.internal.transport as! TestProxyTransport
@@ -2716,7 +2716,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
     }
-    
+
     // RTN15c7
     func test__069__Connection__connection_failures_once_CONNECTED__System_s_response_to_a_resume_request__CONNECTED_ProtocolMessage_with_the_different_connectionId_than_the_current_client_and_an_non_fatal_error() throws {
         let test = Test()
@@ -2750,9 +2750,9 @@ class RealtimeClientConnectionTests: XCTestCase {
                 }
             }
         }
-        
+
         expect(client.internal.msgSerial).to(equal(0))
-        
+
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(2, done: done)
             client.connection.once(.connected) { stateChange in
@@ -2820,7 +2820,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         let restOptions = try AblyTests.clientOptions(for: test, key: options.key!)
         restOptions.testOptions.channelNamePrefix = options.testOptions.channelNamePrefix
         let rest = ARTRest(options: restOptions)
-        
+
         let channelName = test.uniqueChannelName()
         let channel = client.channels.get(channelName)
         waitUntil(timeout: testTimeout) { done in
@@ -2888,7 +2888,7 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
         }
     }
-    
+
     // RTN15d
     func test__065__Connection__connection_failures_once_CONNECTED__should_recover_from_disconnection_and_messages_should_be_delivered_once_the_connection_is_resumed() throws {
         let test = Test()
@@ -2896,7 +2896,7 @@ class RealtimeClientConnectionTests: XCTestCase {
 
         let client1 = ARTRealtime(options: options)
         defer { client1.close() }
-        
+
         let channelName = test.uniqueChannelName()
         let channel1 = client1.channels.get(channelName)
 
@@ -3264,7 +3264,7 @@ class RealtimeClientConnectionTests: XCTestCase {
 
         let clientSend = ARTRealtime(options: options)
         defer { clientSend.close() }
-        
+
         let channelName = test.uniqueChannelName()
         let channelSend = clientSend.channels.get(channelName)
 
@@ -3334,14 +3334,14 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
         }
     }
-    
+
     // RTN16g
     func test__110__Connection__Connection_recovery__connection_recovery_key_is_correctly_constructed_from_defined_parts() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
-        
+
         let firstChannelName = test.uniqueChannelName()
         let secondChannelName = test.uniqueChannelName()
         let thirdChannelName = test.uniqueChannelName()
@@ -3377,22 +3377,22 @@ class RealtimeClientConnectionTests: XCTestCase {
                 partialDone()
             }
         }
-        
+
         let thirdChannel = client.channels.get(thirdChannelName)
         thirdChannel.detach()
-        
+
         guard let recoveryKeyString = client.connection.createRecoveryKey() else {
             fail("recoveryKeyString shouldn't be null")
             return
         }
-        
+
         let recoveryKey = try! ARTConnectionRecoveryKey.fromJsonString(recoveryKeyString)
         expect(recoveryKey).toNot(beNil())
         expect(recoveryKey.connectionKey).to(equal(client.connection.key))
         expect(recoveryKey.channelSerials.count).to(equal(2))
-        
+
         XCTAssertNil(recoveryKey.channelSerials.first(where: { $0.key == thirdChannelSerial }))
-        
+
         recoveryKey.channelSerials.keys.forEach { key in
             let serial = recoveryKey.channelSerials[key]
             expect(serial).toNot(beNil())
@@ -3404,19 +3404,19 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
         expect(recoveryKey.msgSerial).to(equal(client.internal.msgSerial))
     }
-    
+
     // RTN16g1
     func test__111__Connection__Connection_recovery__connection_recovery_key_is_properly_serializing_any_unicode_channel_name() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
-        
+
         let sanskritChannelName = "channel_खगौघाङचिच्छौजाझाञ्ज्ञोऽटौठीडडण्ढणः।"
         let koreanChannelName = "channel_키스의고유조건은"
         var firstChannelSerial: String?
         var secondChannelSerial: String?
-        
+
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(4, done: done)
             client.connection.once(.connected) { stateChange in
@@ -3428,7 +3428,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                 let secondChannel = client.channels.get(koreanChannelName)
                 secondChannel.on(.attached) {_ in
                     secondChannelSerial = secondChannel.internal.channelSerial
-                    
+
                     secondChannel.publish(nil, data: "message") { error in
                         expect(error).to(beNil())
                         partialDone()
@@ -3440,12 +3440,12 @@ class RealtimeClientConnectionTests: XCTestCase {
                 partialDone()
             }
         }
-       
+
         guard let recoveryKeyString = client.connection.createRecoveryKey() else {
             fail("recoveryKeyString shouldn't be null")
             return
         }
-        
+
         let recoveryKey = try! ARTConnectionRecoveryKey.fromJsonString(recoveryKeyString)
         expect(recoveryKey).toNot(beNil())
         expect(recoveryKey.connectionKey).to(equal(client.connection.key))
@@ -3461,14 +3461,14 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
         expect(recoveryKey.msgSerial).to(equal(client.internal.msgSerial))
     }
-    
+
     // RTN16g2 - closing, closed
     func test__112__Connection__Connection_recovery__connection_recovery_key_is_null_when_connection_is_in_invalid_state() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
-        
+
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(2, done: done)
             client.connection.once(.connected) { stateChange in
@@ -3492,7 +3492,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = try AblyTests.commonAppSetup(for: test)
         let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
-        
+
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
                 expect(client.connection.createRecoveryKey()).notTo(beNil())
@@ -3504,14 +3504,14 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
         }
     }
-    
+
     // RTN16g2 - failed
     func test__114__Connection__Connection_recovery__connection_recovery_key_is_null_when_connection_is_in_failed_state() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
-        
+
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connected) { stateChange in
                 expect(client.connection.createRecoveryKey()).notTo(beNil())
@@ -3532,7 +3532,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         defer { client.dispose(); client.close() }
 
         var recoveryKey: ARTConnectionRecoveryKey!
-        
+
         waitUntil(timeout: testTimeout) { done in
             publishFirstTestMessage(client, channelName: test.uniqueChannelName(), completion: { error in
                 XCTAssertNil(error)
@@ -3546,7 +3546,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         let recoverClient = AblyTests.newRealtime(options).client
         expect(recoverClient.internal.msgSerial).to(equal(recoveryKey.msgSerial))
     }
-    
+
     // RTN16j
     func test__086__Connection__Connection_recovery__library_should_create_channel_with_corresponding_serial_in_given_recovery_key() throws {
         let test = Test()
@@ -3554,7 +3554,7 @@ class RealtimeClientConnectionTests: XCTestCase {
 
         let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
-        
+
         let channelName = test.uniqueChannelName()
         var expectedChannelSerial: String?
         waitUntil(timeout: testTimeout) { done in
@@ -3572,25 +3572,25 @@ class RealtimeClientConnectionTests: XCTestCase {
 
         let recoverOptions = options
         recoverOptions.recover = client.connection.createRecoveryKey()
-        
+
         let recoveredClient = AblyTests.newRealtime(recoverOptions).client
         defer { recoveredClient.dispose(); recoveredClient.close() }
         expect(recoveredClient.connection.state).toEventually(equal(.connected), timeout: testTimeout)
-        
+
         XCTAssertTrue(recoveredClient.channels.exists(channelName))
         let recoveredChannel = recoveredClient.channels.get(channelName)
         expect(recoveredChannel.internal.channelSerial).to(equal(expectedChannelSerial))
     }
-  
+
     // RTN16k
     func test__090__Connection__Connection_recovery__library_provides_additional_querystring_when_recover_is_provided() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         options.autoConnect = false
-        
+
         let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
-        
+
         func recoverQueryPart(_ query: String) -> String? {
             let parts = query.components(separatedBy: "&")
             let recoverPart = parts.filter({ part in
@@ -3598,7 +3598,7 @@ class RealtimeClientConnectionTests: XCTestCase {
             }).first
             return recoverPart
         }
-        
+
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connecting) {_ in
                 guard let webSocketTransport = client.internal.transport as? ARTWebSocketTransport else {
@@ -3620,7 +3620,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         recoverOptions.autoConnect = false
         let recoverClient = AblyTests.newRealtime(recoverOptions).client
         defer { recoverClient.dispose(); recoverClient.close() }
-        
+
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(3, done: done)
             recoverClient.connection.once(.connecting) {_ in
@@ -3661,16 +3661,16 @@ class RealtimeClientConnectionTests: XCTestCase {
         let options = try AblyTests.commonAppSetup(for: test)
         let client = AblyTests.newRealtime(options).client
         expect(client.internal.connection.state).toEventually(equal(.connected), timeout: testTimeout)
-        
+
         let recoverOptions = try AblyTests.commonAppSetup(for: test)
         recoverOptions.recover = client.connection.createRecoveryKey()
-        
+
         let key = recoverOptions.key
         // set the key to nil so that the client can't sign further token requests
         recoverOptions.key = nil
         let tokenDetails = try getTestTokenDetails(for: test, key: key, ttl: 30.0)
         recoverOptions.token = tokenDetails.token
-        
+
         let recoverClient = AblyTests.newRealtime(recoverOptions).client
         defer { recoverClient.dispose(); recoverClient.close() }
 
@@ -3688,26 +3688,26 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
         }
     }
-    
+
     // RTN16l for (RTN15c5 + RTN15h2 success)
     func test__200b__Connection__Connection_recovery__failures_system_response_to_unrecoverable_token_error() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = AblyTests.newRealtime(options).client
         expect(client.internal.connection.state).toEventually(equal(.connected), timeout: testTimeout)
-        
+
         let recoverOptions = try AblyTests.commonAppSetup(for: test)
         recoverOptions.recover = client.connection.createRecoveryKey()
-        
+
         let tokenDetails = try getTestTokenDetails(for: test, key: recoverOptions.key, ttl: 30.0)
         recoverOptions.token = tokenDetails.token
-        
+
         let recoverClient = AblyTests.newRealtime(recoverOptions).client
         defer { recoverClient.dispose(); recoverClient.close() }
 
         let transport = recoverClient.internal.transport as! TestProxyTransport
         transport.emulateTokenRevokationBeforeConnected()
-        
+
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(2, done: done)
             recoverClient.connection.once(.disconnected) { stateChange in
@@ -3719,20 +3719,20 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
         }
     }
-    
+
     // RTN16l for (RTN15c5 + RTN15h2 failure)
     func test__200c__Connection__Connection_recovery__failures_system_response_to_unrecoverable_token_error() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = AblyTests.newRealtime(options).client
         expect(client.internal.connection.state).toEventually(equal(.connected), timeout: testTimeout)
-        
+
         let recoverOptions = try AblyTests.commonAppSetup(for: test)
         recoverOptions.recover = client.connection.createRecoveryKey()
-        
+
         let tokenDetails = try getTestTokenDetails(for: test, key: recoverOptions.key, ttl: 30.0)
         recoverOptions.token = tokenDetails.token
-        
+
         let recoverClient = AblyTests.newRealtime(recoverOptions, onTransportCreated: { transport in
             (transport as! TestProxyTransport).emulateTokenRevokationBeforeConnected()
         }).client
@@ -3753,26 +3753,26 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
         }
     }
-    
+
     // RTN16l for (RTN15c7)
     func test__201__Connection__Connection_recovery__failures_once_CONNECTED__System_s_response_to_a_resume_request__CONNECTED_ProtocolMessage_with_the_different_connectionId_than_the_current_client_and_an_non_fatal_error() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = AblyTests.newRealtime(options).client
         defer { client.dispose(); client.close() }
-        
+
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-        
+
         let expectedConnectionId = client.connection.id
-        
+
         let recoverOptions = try AblyTests.commonAppSetup(for: test)
         recoverOptions.recover = client.connection.createRecoveryKey()
         recoverOptions.autoConnect = false
         let recoverClient = AblyTests.newRealtime(recoverOptions).client
         defer { recoverClient.dispose(); recoverClient.close() }
-        
+
         waitUntil(timeout: testTimeout) { done in
-            
+
             recoverClient.connection.once(.connecting) { _ in
                 let transport = recoverClient.internal.transport as! TestProxyTransport
                 transport.setBeforeIncomingMessageModifier { protocolMessage in
@@ -3781,39 +3781,39 @@ class RealtimeClientConnectionTests: XCTestCase {
                     return protocolMessage
                 }
             }
-            
+
             recoverClient.connection.once(.connected) { stateChange in
                 expect(stateChange.reason?.message).to(equal("Injected error"))
                 expect(recoverClient.connection.errorReason).to(beIdenticalTo(stateChange.reason))
                 let transport = recoverClient.internal.transport as! TestProxyTransport
-                
+
                 let connectedPM = transport.protocolMessagesReceived.filter { $0.action == .connected }[0]
                 expect(connectedPM.connectionId).toNot(equal(expectedConnectionId))
                 expect(recoverClient.connection.id).toNot(equal(expectedConnectionId))
                 done()
             }
-            
+
             recoverClient.connect()
         }
     }
-    
+
     // RTN16l (for RTN15c4)
     func test__202__Connection__Connection_recovery__failures_with_any_other_fatal_error_in_the_connection() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = AblyTests.newRealtime(options).client
         expect(client.internal.connection.state).toEventually(equal(.connected), timeout: testTimeout)
-        
+
         let recoverOptions = try AblyTests.commonAppSetup(for: test)
         recoverOptions.recover = client.connection.createRecoveryKey()
         recoverOptions.autoConnect = false
-        
+
         let tokenDetails = try getTestTokenDetails(for: test, key: recoverOptions.key, ttl: 30.0)
         recoverOptions.token = tokenDetails.token
-        
+
         let recoverClient = AblyTests.newRealtime(recoverOptions).client
         defer { recoverClient.dispose(); recoverClient.close() }
-        
+
         waitUntil(timeout: testTimeout) { done in
             recoverClient.connection.once(.connecting) { _ in
                 let transport = recoverClient.internal.transport as! TestProxyTransport
@@ -3838,7 +3838,7 @@ class RealtimeClientConnectionTests: XCTestCase {
             recoverClient.connect()
         }
     }
-    
+
     // RTN17
 
     // RTN17b1 (host)
@@ -3889,7 +3889,7 @@ class RealtimeClientConnectionTests: XCTestCase {
 
         XCTAssertEqual(urlConnections.count, 1)
     }
-    
+
     // RTN17b1 (port)
     func test__086b__Connection__Host_Fallback__failing_connections_with_custom_port_should_result_in_an_error_immediately() {
         let test = Test()
@@ -3938,7 +3938,7 @@ class RealtimeClientConnectionTests: XCTestCase {
 
         XCTAssertEqual(urlConnections.count, 1)
     }
-    
+
     // RTN17b1 (tlsPort)
     func test__086c__Connection__Host_Fallback__failing_connections_with_custom_tlsPort_should_result_in_an_error_immediately() {
         let test = Test()
@@ -4051,7 +4051,7 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
             urlConnections.append(url)
         }
-        
+
         let allHostsCount = options.fallbackHosts!.count + 1 // + default host
 
         waitUntil(timeout: testTimeout) { done in
@@ -4069,7 +4069,7 @@ class RealtimeClientConnectionTests: XCTestCase {
             XCTAssertTrue(NSRegularExpression.match(connection.absoluteString, pattern: "//[f-j].ably-realtime.com"))
         }
     }
-    
+
     // RTN17b3
     @available(*, deprecated, message: "This test is marked as deprecated so as to not trigger a compiler warning for using the -ARTClientOptions.fallbackHostsUseDefault property. Remove this deprecation when removing the property.")
     func test__089b__Connection__Host_Fallback__applies_when_deprecated_fallbackHostsUseDefault_option_is_set_to_true() {
@@ -4266,7 +4266,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         transportFactory.fakeNetworkResponse = .hostUnreachable
 
         let hostPrefixes = Array("abcde")
-        
+
         let extractHostname = { (url: URL) in
             if options.hasEnvironmentDifferentThanProduction {
                 NSRegularExpression.extract(url.absoluteString, pattern: "\(options.environment!)-[\(hostPrefixes.first!)-\(hostPrefixes.last!)]-fallback.ably-realtime.com")
@@ -4274,10 +4274,10 @@ class RealtimeClientConnectionTests: XCTestCase {
                 NSRegularExpression.extract(url.absoluteString, pattern: "[\(hostPrefixes.first!)-\(hostPrefixes.last!)].ably-realtime.com")
             }
         }
-        
+
         var urls = [URL]()
         let expectedFallbackHosts = Array(expectedHostOrder.map { ARTDefault.fallbackHosts(withEnvironment: options.environment)[$0] })
-        
+
         transportFactory.networkConnectEvent = { transport, url in
             if client.internal.transport !== transport {
                 return
@@ -4299,7 +4299,7 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
             client.connect()
         }
-        
+
         var resultFallbackHosts = [String]()
         var gotInternetIsUpCheck = false
         for url in urls {
@@ -4318,12 +4318,12 @@ class RealtimeClientConnectionTests: XCTestCase {
 
         XCTAssertEqual(resultFallbackHosts, expectedFallbackHosts)
     }
-    
+
     func test__092__Connection__Host_Fallback__should_retry_hosts_in_random_order_after_checkin_if_an_internet_connection_is_available_prod() {
         let test = Test()
         _test__092__Connection__Host_Fallback__should_retry_hosts_in_random_order_after_checkin_if_an_internet_connection_is_available(env: nil, test: test)
     }
-    
+
     func test__092__Connection__Host_Fallback__should_retry_hosts_in_random_order_after_checkin_if_an_internet_connection_is_available_sandbox() {
         let test = Test()
         _test__092__Connection__Host_Fallback__should_retry_hosts_in_random_order_after_checkin_if_an_internet_connection_is_available(env: "sandbox", test: test)
@@ -4401,9 +4401,9 @@ class RealtimeClientConnectionTests: XCTestCase {
         let extractHostname = { (url: URL) in
             NSRegularExpression.extract(url.absoluteString, pattern: "[\(hostPrefixes.first!)-\(hostPrefixes.last!)].ably-realtime.com")
         }
-        
+
         var urls = [URL]()
-        
+
         transportFactory.networkConnectEvent = { transport, url in
             if client.internal.transport !== transport {
                 return
@@ -4425,7 +4425,7 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
             client.connect()
         }
-        
+
         var resultFallbackHosts = [String]()
         var gotInternetIsUpCheck = false
         for url in urls {
@@ -4596,19 +4596,19 @@ class RealtimeClientConnectionTests: XCTestCase {
             client.internal.onDisconnected()
         }
     }
-    
+
     // RTN19a2 (for resume success)
     func test__103b__Connection__Transport_disconnected_side_effects_message_serial_for_pending_message_must_remain_the_same_that_is_awaiting_a_ACK_NACK() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = AblyTests.newRealtime(options).client
-       
+
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(test.uniqueChannelName())
         let transport = client.internal.transport as! TestProxyTransport
-        
+
         var connectionId: String?
-        
+
         waitUntil(timeout: testTimeout) { done in
             channel.attach { _ in
                 let connectedPM = transport.protocolMessagesReceived.filter { $0.action == .connected }[0]
@@ -4616,7 +4616,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                 done()
             }
         }
-        
+
         waitUntil(timeout: testTimeout) { done in
             // send messages to increase msgSerial above zero
             let partialDone = AblyTests.splitDone(2, done: done)
@@ -4641,7 +4641,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                     fail("Transport is nil"); done(); return
                 }
                 expect(newTransport).toNot(beIdenticalTo(transport))
-               
+
                 let msgSerial1 = transport.protocolMessagesSent.filter { $0.action == .message }[2].msgSerial
                 let msgSerial2 = newTransport.protocolMessagesSent.filter { $0.action == .message }[0].msgSerial
                 XCTAssertEqual(msgSerial1, 2)
@@ -4649,7 +4649,7 @@ class RealtimeClientConnectionTests: XCTestCase {
 
                 done()
             }
-            
+
             client.connection.once(.connected) { stateChange in
                 // Ensure same connection id and no error
                 let transport = client.internal.transport as! TestProxyTransport
@@ -4660,19 +4660,19 @@ class RealtimeClientConnectionTests: XCTestCase {
             client.internal.onDisconnected()
         }
     }
-    
+
     // RTN19a2 (for resume failure)
     func test__103c__Connection__Transport_disconnected_side_effects_message_must_be_assigned_a_new_msgSerial_from_the_internal_msgSerial() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = AblyTests.newRealtime(options).client
-       
+
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(test.uniqueChannelName())
         let transport = client.internal.transport as! TestProxyTransport
-        
+
         var connectionId: String?
-        
+
         waitUntil(timeout: testTimeout) { done in
             channel.attach { _ in
                 let connectedPM = transport.protocolMessagesReceived.filter { $0.action == .connected }[0]
@@ -4680,7 +4680,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                 done()
             }
         }
-        
+
         waitUntil(timeout: testTimeout) { done in
             // send messages to increase msgSerial above zero
             let partialDone = AblyTests.splitDone(2, done: done)
@@ -4705,7 +4705,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                     fail("Transport is nil"); done(); return
                 }
                 expect(newTransport).toNot(beIdenticalTo(transport))
-               
+
                 let msgSerial1 = transport.protocolMessagesSent.filter { $0.action == .message }[2].msgSerial
                 let msgSerial2 = newTransport.protocolMessagesSent.filter { $0.action == .message }[0].msgSerial
                 XCTAssertEqual(msgSerial1, 0)
@@ -4713,7 +4713,7 @@ class RealtimeClientConnectionTests: XCTestCase {
 
                 done()
             }
-            
+
             client.connection.once(.connected) { stateChange in
                 // Ensure different connection id and error
                 let transport = client.internal.transport as! TestProxyTransport
@@ -4915,7 +4915,7 @@ class RealtimeClientConnectionTests: XCTestCase {
             client.connect()
         }
     }
-    
+
     // RTN20c
     func test__106_b__Connection__Operating_System_events_for_network_internet_connectivity_changes__should_restart_the_pending_connection_attempt_if_the_operating_system_indicates_that_the_underlying_internet_connection_is_now_available_when_CONNECTING() throws {
         let test = Test()
@@ -4927,13 +4927,13 @@ class RealtimeClientConnectionTests: XCTestCase {
         let client = ARTRealtime(options: options)
         client.internal.setReachabilityClass(TestReachability.self)
         defer { client.dispose(); client.close() }
-        
+
         var reconnectMethodCallCount = 0
         let hook = client.internal.testSuite_injectIntoMethod(after: #selector(client.internal.transportReconnectWithExistingParameters)) {
             reconnectMethodCallCount += 1
         }
         defer { hook.remove() }
-        
+
         waitUntil(timeout: testTimeout) { done in
             client.connection.once(.connecting) { _ in
                 guard let reachability = client.internal.reachability as? TestReachability else {
@@ -4955,21 +4955,21 @@ class RealtimeClientConnectionTests: XCTestCase {
             }
             client.connect()
         }
-        
+
         // Now check that reconnect will not happen if reachability haven't reported "unreachable" before
-        
+
         let options2 = try AblyTests.commonAppSetup(for: test)
         options2.autoConnect = false
         let client2 = ARTRealtime(options: options2)
         client2.internal.setReachabilityClass(TestReachability.self)
         defer { client2.dispose(); client2.close() }
-        
+
         reconnectMethodCallCount = 0
         let hook2 = client2.internal.testSuite_injectIntoMethod(after: #selector(client2.internal.transportReconnectWithExistingParameters)) {
             reconnectMethodCallCount += 1
         }
         defer { hook2.remove() }
-        
+
         waitUntil(timeout: testTimeout) { done in
             client2.connection.once(.connecting) { _ in
                 guard let reachability = client2.internal.reachability as? TestReachability else {
@@ -4995,7 +4995,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.testOptions.transportFactory = TestProxyTransportFactory()
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        
+
         let channelName = test.uniqueChannelName()
         let channel = client.channels.get(channelName)
 
@@ -5077,7 +5077,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         options.token = try getTestToken(for: test, key: options.key!, ttl: 5.0)
         let client = ARTRealtime(options: options)
         defer { client.dispose(); client.close() }
-        
+
         let channelName = test.uniqueChannelName()
         let channel = client.channels.get(channelName)
 
@@ -5331,9 +5331,9 @@ class RealtimeClientConnectionTests: XCTestCase {
         if channel.state != .attached {
             return
         }
-        
+
         let messages = fixtures["messages"] as! [[String: Any]]
-        
+
         for fixtureMessage in messages {
             var receivedMessage: ARTMessage?
 
@@ -5373,7 +5373,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                     }
 
                     sleep(1) // give realtime some time to store messages so they appear in the GET request below
-                    
+
                     let request = NSMutableURLRequest(url: URL(string: "/channels/\(channel.name)/messages")!)
                     request.httpMethod = "GET"
                     request.allHTTPHeaderFields = ["Accept": "application/json"]
@@ -5417,7 +5417,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
 
         let messages = fixtures["messages"] as! [[String: Any]]
-        
+
         for fixtureMessage in messages {
             waitUntil(timeout: testTimeout) { done in
                 let partlyDone = AblyTests.splitDone(2, done: done)
@@ -5472,7 +5472,7 @@ class RealtimeClientConnectionTests: XCTestCase {
         }
 
         let messages = fixtures["messages"] as! [[String: Any]]
-        
+
         for fixtureMessage in messages {
             var data: AnyObject
             if let expectedType = fixtureMessage["expectedType"] as? String, expectedType == "binary" {
@@ -5483,7 +5483,7 @@ class RealtimeClientConnectionTests: XCTestCase {
 
             for restPublishChannel in [restPublishChannelMsgPack, restPublishChannelJSON] {
                 var receivedMessage: ARTMessage?
-                
+
                 waitUntil(timeout: testTimeout) { done in
                     let partialDone = AblyTests.splitDone(2, done: done)
                     realtimeChannel.subscribe("event") { message in
@@ -5502,7 +5502,7 @@ class RealtimeClientConnectionTests: XCTestCase {
                 }
 
                 sleep(1) // give realtime some time to store messages so they appear in the GET request below
-                
+
                 waitUntil(timeout: testTimeout) { done in
                     let request = NSMutableURLRequest(url: URL(string: "/channels/\(restPublishChannel.name)/messages")!)
                     request.httpMethod = "GET"

--- a/Test/AblyTests/Tests/RealtimeClientPresenceTests.swift
+++ b/Test/AblyTests/Tests/RealtimeClientPresenceTests.swift
@@ -79,12 +79,12 @@ private func attachAndWaitForInitialPresenceSyncToComplete(client: ARTRealtime, 
             done()
         }
     }
-    
+
     let transport = client.internal.transport as! TestProxyTransport
-    
+
     let attachedProtocolMessage = transport.protocolMessagesReceived.first { $0.action == .attached }
     XCTAssertNotNil(attachedProtocolMessage)
-    
+
     if ARTProtocolMessageFlag(rawValue: UInt(attachedProtocolMessage!.flags)).contains(.presence) {
         expect(channel.presence.syncComplete).toEventually(beTrue(), timeout: testTimeout)
     }
@@ -163,7 +163,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         guard let transport = client.internal.transport as? TestProxyTransport else {
             fail("TestProxyTransport is not set"); return
         }
-        
+
         // Before starting artificial SYNC process we should wait for the initial one completed:
         expect(channel.internal.presence.syncInProgress).toEventually(beFalse(), timeout: testTimeout)
         expect(channel.internal.presence.members).to(beEmpty())
@@ -401,7 +401,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         let options = try AblyTests.commonAppSetup(for: test)
         var clientSource: ARTRealtime!
         defer { clientSource.dispose(); clientSource.close() }
-        
+
         let channelName = test.uniqueChannelName()
         clientSource = AblyTests.addMembersSequentiallyToChannel(channelName, members: 250, options: options)
 
@@ -442,7 +442,7 @@ class RealtimeClientPresenceTests: XCTestCase {
 
         let client1 = AblyTests.newRealtime(options).client
         defer { client1.close() }
-        
+
         let channelName = test.uniqueChannelName()
         let channel1 = client1.channels.get(channelName)
         // We want to make sure that the ENTER presence action that we publish
@@ -630,7 +630,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         let options = try AblyTests.commonAppSetup(for: test)
         let client1 = AblyTests.newRealtime(options).client
         defer { client1.dispose(); client1.close() }
-        
+
         let channelName = test.uniqueChannelName()
         let channel1 = client1.channels.get(channelName)
 
@@ -666,7 +666,7 @@ class RealtimeClientPresenceTests: XCTestCase {
             XCTAssertFalse(channel2.presence.syncComplete)
             XCTAssertEqual(channel2.internal.presence.members.count, 0)
         }
-        
+
         expect(channel2.presence.syncComplete).toEventually(beTrue(), timeout: testTimeout)
         XCTAssertEqual(channel2.internal.presence.members.count, 2)
     }
@@ -708,19 +708,19 @@ class RealtimeClientPresenceTests: XCTestCase {
     }
 
     // RTP5f
-    
+
     func test__023__Presence__Channel_state_change_side_effects__channel_enters_the_SUSPENDED_state__members_map_is_preserved_and_only_members_that_changed_between_ATTACHED_states_should_result_in_presence_events() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let channelName = test.uniqueChannelName()
-        
+
         let clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 2, options: options)
         defer { clientMembers.dispose(); clientMembers.close() }
-        
+
         options.clientId = "leaves"
         let leavesClient = AblyTests.newRealtime(options).client
         defer { leavesClient.dispose(); leavesClient.close() }
-        
+
         options.clientId = "main"
         options.disconnectedRetryTimeout = 0.5
         options.suspendedRetryTimeout = 1.0
@@ -730,16 +730,16 @@ class RealtimeClientPresenceTests: XCTestCase {
             mainClient.dispose()
             mainClient.close()
         }
-        
+
         // Move to SUSPENDED
         let ttlHookToken = mainClient.overrideConnectionStateTTL(1.0)
         defer { ttlHookToken.remove() }
-        
+
         let leavesChannel = leavesClient.channels.get(channelName)
         let mainChannel = mainClient.channels.get(channelName)
-        
+
         var oldConnectionId = ""
-        
+
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(4, done: done)
             mainChannel.presence.subscribe { message in
@@ -762,9 +762,9 @@ class RealtimeClientPresenceTests: XCTestCase {
                 partialDone()
             }
         }
-        
+
         mainChannel.presence.unsubscribe()
-        
+
         waitUntil(timeout: testTimeout) { done in
             mainChannel.presence.get { members, error in
                 XCTAssertNil(error)
@@ -776,9 +776,9 @@ class RealtimeClientPresenceTests: XCTestCase {
                 done()
             }
         }
-        
+
         var presenceEvents = [ARTPresenceMessage]()
-        
+
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(4, done: done)
             mainChannel.presence.subscribe { presence in
@@ -809,17 +809,17 @@ class RealtimeClientPresenceTests: XCTestCase {
         XCTAssertEqual(presenceEvents.count, 1)
         XCTAssertEqual(presenceEvents[0].action, ARTPresenceAction.leave)
         XCTAssertEqual(presenceEvents[0].clientId, "leaves")
-        
+
         mainChannel.presence.unsubscribe()
-        
+
         guard let transport = mainClient.internal.transport as? TestProxyTransport else {
             fail("TestProxyTransport is not set"); return
         }
-        
+
         // Same can be achieved with sleep for more than 15 seconds for the Realtime to send synthesised presence LEAVE
         // for the mainClient's original connection after not receiving a heartbeat.
         transport.receive(AblyTests.newPresenceProtocolMessage(id: "\(mainChannel.internal.connectionId):0:0", channel: mainChannel.name, action: .leave, clientId: mainClient.clientId!, connectionId: oldConnectionId))
-        
+
         waitUntil(timeout: testTimeout) { done in
             mainChannel.presence.get { members, error in
                 XCTAssertNil(error)
@@ -831,7 +831,7 @@ class RealtimeClientPresenceTests: XCTestCase {
                 done()
             }
         }
-        
+
         mainChannel.internalSync { _internal in
             XCTAssertEqual(_internal.presence.members.count, 3) // "main", "user1", "user2"
             XCTAssertEqual(_internal.presence.internalMembers.count, 1) // "main"
@@ -848,7 +848,7 @@ class RealtimeClientPresenceTests: XCTestCase {
 
         let client1 = ARTRealtime(options: options)
         defer { client1.dispose(); client1.close() }
-        
+
         let channelName = test.uniqueChannelName()
         let channel1 = client1.channels.get(channelName)
 
@@ -898,13 +898,13 @@ class RealtimeClientPresenceTests: XCTestCase {
         channel.presence.subscribe { _ in }
         XCTAssertEqual(channel.state, ARTRealtimeChannelState.attaching)
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-        
+
         // Detaching
         channel.detach()
         channel.presence.subscribe { _ in }
         XCTAssertEqual(channel.state, ARTRealtimeChannelState.detaching)
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
-        
+
         // Detached
         channel.detach()
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
@@ -917,7 +917,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         let test = Test()
         let client = ARTRealtime(options: try AblyTests.commonAppSetup(for: test))
         defer { client.dispose(); client.close() }
-        
+
         let channelOptions = ARTRealtimeChannelOptions()
         channelOptions.attachOnSubscribe = false
         let channel = client.channels.get(test.uniqueChannelName(), options: channelOptions)
@@ -935,7 +935,7 @@ class RealtimeClientPresenceTests: XCTestCase {
             }
         }
     }
-    
+
     // RTP6d
     func test__027__Presence__subscribe__should_result_in_an_error_if_the_channel_is_in_the_FAILED_state_and_options_attachOnSubscribe_is_true() throws {
         let test = Test()
@@ -955,7 +955,7 @@ class RealtimeClientPresenceTests: XCTestCase {
             })
         }
     }
-    
+
     // RTP6e
     func test__027b__Presence__subscribe__should_not_result_in_an_error_if_the_channel_is_in_the_FAILED_state_and_options_attachOnSubscribe_is_false() throws {
         let test = Test()
@@ -965,10 +965,10 @@ class RealtimeClientPresenceTests: XCTestCase {
         let channelOptions = ARTRealtimeChannelOptions()
         channelOptions.attachOnSubscribe = false
         let channel = client.channels.get(test.uniqueChannelName(), options: channelOptions)
-        
+
         channel.internal.onError(AblyTests.newErrorProtocolMessage())
         XCTAssertEqual(channel.state, ARTRealtimeChannelState.failed)
-        
+
         channel.presence.subscribe(attachCallback: { _ in
             fail("Attach callback should not be called.")
         }) { _ in }
@@ -1012,7 +1012,7 @@ class RealtimeClientPresenceTests: XCTestCase {
 
         let client1 = ARTRealtime(options: options)
         defer { client1.close() }
-        
+
         let channelName = test.uniqueChannelName()
         let channel1 = client1.channels.get(channelName)
 
@@ -1054,7 +1054,7 @@ class RealtimeClientPresenceTests: XCTestCase {
 
         let client1 = ARTRealtime(options: options)
         defer { client1.dispose(); client1.close() }
-        
+
         let channelName = test.uniqueChannelName()
         let channel1 = client1.channels.get(channelName)
 
@@ -1092,14 +1092,14 @@ class RealtimeClientPresenceTests: XCTestCase {
         let client2 = ARTRealtime(options: options)
         let channel1 = client1.channels.get(channelName)
         let channel2 = client2.channels.get(channelName)
-        
+
         defer {
             client1.dispose(); client1.close()
             client2.dispose(); client2.close()
             expect(client1.connection.state).toEventually(equal(.closed), timeout: testTimeout)
             expect(client2.connection.state).toEventually(equal(.closed), timeout: testTimeout)
         }
-        
+
         waitUntil(timeout: testTimeout) { done in
             channel1.presence.subscribe(.enter) { _ in
                 fail("shouldn't be called")
@@ -1160,9 +1160,9 @@ class RealtimeClientPresenceTests: XCTestCase {
         let client = ARTRealtime(options: try AblyTests.commonAppSetup(for: test))
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(test.uniqueChannelName())
-        
+
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected))
-        
+
         waitUntil(timeout: testTimeout) { done in
             channel.presence.enter(nil) { error in
                 XCTAssertEqual(error?.code, Int(ARTState.noClientId.rawValue))
@@ -1170,7 +1170,7 @@ class RealtimeClientPresenceTests: XCTestCase {
             }
         }
     }
-    
+
     // RTP8j
     func test__033__Presence__enter__should_result_in_an_error_immediately_if_the_connection_state_is_connected_and_the_client_is_wildcard() throws {
         let test = Test()
@@ -1179,9 +1179,9 @@ class RealtimeClientPresenceTests: XCTestCase {
         options.clientId = "*"
         defer { client.dispose(); client.close() }
         let channel = client.channels.get(test.uniqueChannelName())
-        
+
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected))
-        
+
         waitUntil(timeout: testTimeout) { done in
             channel.presence.enter(nil) { error in
                 XCTAssertEqual(error?.code, Int(ARTState.noClientId.rawValue))
@@ -1507,7 +1507,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         let options = try AblyTests.commonAppSetup(for: test)
         var clientSecondary: ARTRealtime!
         defer { clientSecondary.dispose(); clientSecondary.close() }
-        
+
         let channelName = test.uniqueChannelName()
         clientSecondary = AblyTests.addMembersSequentiallyToChannel(channelName, members: 100, options: options)
 
@@ -1769,7 +1769,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         guard let transport = client.internal.transport as? TestProxyTransport else {
             fail("TestProxyTransport is not set"); return
         }
-        
+
         var leaveEvents = [ARTPresenceMessage]()
         channel.presence.subscribe(.leave) { message in
             leaveEvents.append(message)
@@ -1923,9 +1923,9 @@ class RealtimeClientPresenceTests: XCTestCase {
         guard let transport = client.internal.transport as? TestProxyTransport else {
             fail("TestProxyTransport is not set"); return
         }
-        
+
         var leaveMessage: ARTProtocolMessage!
-        
+
         let hook = channel.presence.internal.testSuite_injectIntoMethod(before: #selector(ARTRealtimePresenceInternal.endSync)) {
             if leaveMessage != nil {
                 transport.receive(leaveMessage)
@@ -1935,7 +1935,7 @@ class RealtimeClientPresenceTests: XCTestCase {
             }
         }
         defer { hook.remove() }
-        
+
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(2, done: done)
 
@@ -1946,7 +1946,7 @@ class RealtimeClientPresenceTests: XCTestCase {
 
             channel.attach { error in
                 XCTAssertNil(error)
-                
+
                 // Initialize a fabricated Presence message to inject it before second sync ends
                 leaveMessage = ARTProtocolMessage()
                 leaveMessage.action = .presence
@@ -1959,7 +1959,7 @@ class RealtimeClientPresenceTests: XCTestCase {
             }
         }
         channel.presence.unsubscribe()
-        
+
         expect(channel.internal.presence.syncInProgress).toEventually(beFalse(), timeout: testTimeout)
         expect(channel.internal.presence.members.filter { _, presence in presence.action == .leave }).to(beEmpty())
         expect(channel.internal.presence.members.filter { _, presence in presence.action == .absent }).to(beEmpty())
@@ -2442,7 +2442,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         options.clientId = "john"
         let client1 = AblyTests.newRealtime(options).client
         defer { client1.close() }
-        
+
         let channelName = test.uniqueChannelName()
         let channel1 = client1.channels.get(channelName)
         // We want to make sure that the ENTER presence action that we publish
@@ -2479,7 +2479,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         options.clientId = "john"
         let client1 = ARTRealtime(options: options)
         defer { client1.close() }
-        
+
         let channelName = test.uniqueChannelName()
         let channel1 = client1.channels.get(channelName)
 
@@ -2694,7 +2694,7 @@ class RealtimeClientPresenceTests: XCTestCase {
             }
         }
     }
-    
+
     // RTP17i, RTP17g
     func test__200__Presence__PresenceMap_should_perform_re_entry_whenever_a_channel_moves_into_the_attached_state_and_presence_message_consists_of_enter_action_with_client_id_and_data() throws {
         let test = Test()
@@ -2704,7 +2704,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         defer { client.dispose(); client.close() }
 
         let channel = client.channels.get(test.uniqueChannelName())
-        
+
         var firstMsgId = ""
         var secondMsgId = ""
         let firstClient = "client1"
@@ -2738,32 +2738,32 @@ class RealtimeClientPresenceTests: XCTestCase {
             channel.presence.enterClient(secondClient, data: secondClientData)
         }
         channel.presence.unsubscribe()
-        
+
         expect(channel.internal.presence.internalMembers).to(haveCount(2))
-        
+
         // All pending messages should complete (receive ACK or NACK) before disconnect for valid count of transport.protocolMessagesSent
         client.waitForPendingMessages()
         client.simulateLostConnection()
-        
+
         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-        
+
         // RTP17i
-        
+
         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
         expect(channel.internal.presence.internalMembers).to(haveCount(2))
-        
+
         let newTransport = client.internal.transport as! TestProxyTransport
         expect(newTransport).toNot(beIdenticalTo(transport))
 
         var sentPresenceMessages = newTransport.protocolMessagesSent.filter({ $0.action == .presence }).compactMap { $0.presence?.first }
-        
+
         expect(sentPresenceMessages).to(haveCount(2))
 
         let client1PresenceMessage = try XCTUnwrap(sentPresenceMessages.first(where: { $0.clientId == firstClient }))
         let client2PresenceMessage = try XCTUnwrap(sentPresenceMessages.first(where: { $0.clientId == secondClient }))
-        
+
         // RTP17i - already attached with resume flag set
-        
+
         let attachedMessage = ARTProtocolMessage()
         attachedMessage.action = .attached
         attachedMessage.channel = channel.name
@@ -2774,13 +2774,13 @@ class RealtimeClientPresenceTests: XCTestCase {
         expect(sentPresenceMessages).to(haveCount(2)) // no changes in sentPresenceMessages => no presense messages sent
 
         // RTP17g
-        
+
         expect(client1PresenceMessage.id).to(equal(firstMsgId))
         expect(client2PresenceMessage.id).to(equal(secondMsgId))
-        
+
         expect(client1PresenceMessage.action).to(equal(ARTPresenceAction.enter))
         expect(client2PresenceMessage.action).to(equal(ARTPresenceAction.enter))
-        
+
         expect(client1PresenceMessage.data as? String).to(equal(firstClientData))
         expect(client2PresenceMessage.data as? String).to(equal(secondClientData))
     }
@@ -3310,7 +3310,7 @@ class RealtimeClientPresenceTests: XCTestCase {
 
         var clientMembers: ARTRealtime?
         defer { clientMembers?.dispose(); clientMembers?.close() }
-        
+
         let channelName = test.uniqueChannelName()
         clientMembers = AblyTests.addMembersSequentiallyToChannel(channelName, members: 120, options: options)
 
@@ -3396,7 +3396,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         let channel = client.channels.get(channelName)
         channel.attach()
         expect(channel.internal.presence.syncInProgress).toEventually(beTrue(), timeout: testTimeout)
-        
+
         waitUntil(timeout: testTimeout) { done in
             let query = ARTRealtimePresenceQuery()
             XCTAssertTrue(query.waitForSync)
@@ -3420,7 +3420,7 @@ class RealtimeClientPresenceTests: XCTestCase {
         let options = try AblyTests.commonAppSetup(for: test)
         var clientSecondary: ARTRealtime!
         defer { clientSecondary.dispose(); clientSecondary.close() }
-        
+
         let channelName = test.uniqueChannelName()
         clientSecondary = AblyTests.addMembersSequentiallyToChannel(channelName, members: 150, options: options)
 
@@ -3433,7 +3433,7 @@ class RealtimeClientPresenceTests: XCTestCase {
 
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(2, done: done)
-            
+
             let transport = client.internal.transport as! TestProxyTransport
             var alreadySawSync = false
             transport.setBeforeIncomingMessageModifier { message in
@@ -3674,7 +3674,7 @@ class RealtimeClientPresenceTests: XCTestCase {
 
         let expectedData = ["x", "y"]
         let expectedPattern = "^user(\\d+)$"
-        
+
         let channelName = test.uniqueChannelName()
         clientSecondary = AblyTests.addMembersSequentiallyToChannel(channelName, members: 150, data: expectedData as AnyObject?, options: options)
 

--- a/Test/AblyTests/Tests/RealtimeClientTests.swift
+++ b/Test/AblyTests/Tests/RealtimeClientTests.swift
@@ -218,7 +218,7 @@ class RealtimeClientTests: XCTestCase {
                     fail("Transport should be of type ARTWebSocketTransport"); done()
                     return
                 }
-                
+
                 if let absoluteString = webSocketTransport.websocketURL?.absoluteString {
                     XCTAssertTrue(absoluteString.contains("tpBool=true"))
                     XCTAssertTrue(absoluteString.contains("tpInt=12"))
@@ -258,7 +258,7 @@ class RealtimeClientTests: XCTestCase {
         defer { client.dispose(); client.close() }
 
         let channelName = test.uniqueChannelName()
-        
+
         client.channels.get(channelName).subscribe { _ in
             // Attached
         }
@@ -1280,7 +1280,7 @@ class RealtimeClientTests: XCTestCase {
             }
         }
     }
-    
+
     // https://github.com/ably/ably-cocoa/issues/577
     func test__005__RealtimeClient__background_behaviour() {
         let test = Test()
@@ -1521,7 +1521,7 @@ class RealtimeClientTests: XCTestCase {
         defer { client.dispose(); client.close() }
 
         let channelName = test.uniqueChannelName()
-        
+
         var received = false
         client.channels.get(channelName).subscribe { _ in
             received = true
@@ -1549,7 +1549,7 @@ class RealtimeClientTests: XCTestCase {
         let channel = client.channels.get(test.uniqueChannelName())
         let messages = buildMessagesThatExceedMaxMessageSize()
         defer { client.dispose(); client.close() }
-        
+
         waitUntil(timeout: testTimeout, action: { done in
             // Wait for connected so that maxMessageSize is loaded from connection details
             client.connection.once(.connected) { _ in
@@ -1568,7 +1568,7 @@ class RealtimeClientTests: XCTestCase {
         let client = ARTRealtime(options: options)
         let channel = client.channels.get(test.uniqueChannelName())
         defer { client.dispose(); client.close() }
-        
+
         waitUntil(timeout: testTimeout, action: { done in
             client.connection.once(.connected) { _ in
                 channel.presence.enter(presenceData, callback: { err in
@@ -1586,7 +1586,7 @@ class RealtimeClientTests: XCTestCase {
         let client = ARTRealtime(options: options)
         let channel = client.channels.get(test.uniqueChannelName())
         defer { client.dispose(); client.close() }
-        
+
         waitUntil(timeout: testTimeout, action: { done in
             client.connection.once(.connected) { _ in
                 channel.presence.leave(presenceData, callback: { err in
@@ -1604,7 +1604,7 @@ class RealtimeClientTests: XCTestCase {
         let client = ARTRealtime(options: options)
         let channel = client.channels.get(test.uniqueChannelName())
         defer { client.dispose(); client.close() }
-        
+
         waitUntil(timeout: testTimeout, action: { done in
             client.connection.once(.connected) { _ in
                 channel.presence.update(presenceData, callback: { err in
@@ -1622,7 +1622,7 @@ class RealtimeClientTests: XCTestCase {
         let client = ARTRealtime(options: options)
         let channel = client.channels.get(test.uniqueChannelName())
         defer { client.dispose(); client.close() }
-        
+
         waitUntil(timeout: testTimeout, action: { done in
             client.connection.once(.connected) { _ in
                 channel.presence.updateClient(clientId, data: presenceData, callback: { err in
@@ -1640,7 +1640,7 @@ class RealtimeClientTests: XCTestCase {
         let client = ARTRealtime(options: options)
         let channel = client.channels.get(test.uniqueChannelName())
         defer { client.dispose(); client.close() }
-        
+
         waitUntil(timeout: testTimeout, action: { done in
             client.connection.once(.connected) { _ in
                 channel.presence.leaveClient(clientId, data: presenceData, callback: { err in

--- a/Test/AblyTests/Tests/RestAnnotationsTests.swift
+++ b/Test/AblyTests/Tests/RestAnnotationsTests.swift
@@ -10,25 +10,25 @@ class RestAnnotationsTests: XCTestCase {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         options.testOptions.channelNamePrefix = nil
-        
+
         // Create realtime client
         let realtimeClient = ARTRealtime(options: options)
         defer { realtimeClient.dispose(); realtimeClient.close() }
-        
+
         // Create rest client
         let restClient = ARTRest(options: options)
-        
+
         // Channel name and options
         let channelName = test.uniqueChannelName(prefix: "mutable:")
         let channelOptions = ARTRealtimeChannelOptions()
         channelOptions.modes = [.publish, .subscribe, .annotationPublish, .annotationSubscribe]
-        
+
         // Get realtime channel with options
         let realtimeChannel = realtimeClient.channels.get(channelName, options: channelOptions)
-        
+
         // Get rest channel
         let restChannel = restClient.channels.get(channelName)
-        
+
         // Message and annotation to track
         var receivedMessage: ARTMessage!
         var receivedSummary: ARTMessage!
@@ -36,7 +36,7 @@ class RestAnnotationsTests: XCTestCase {
 
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(4, done: done)
-            
+
             // Subscribe to messages
             realtimeChannel.subscribe { message in
                 if message.action == .create {
@@ -52,7 +52,7 @@ class RestAnnotationsTests: XCTestCase {
                         data: nil,
                         extras: nil
                     )
-                    
+
                     // RSAN1
                     restChannel.annotations.publish(for: message, annotation: annotation) { error in
                         XCTAssertNil(error)
@@ -62,36 +62,36 @@ class RestAnnotationsTests: XCTestCase {
                 else if message.action == .messageSummary {
                     receivedSummary = message
                     realtimeChannel.unsubscribe()
-                    
+
                     // Verify summary properties
                     XCTAssertEqual(receivedSummary.action, .messageSummary)
                     XCTAssertEqual(receivedSummary.serial, receivedMessage.serial)
                     XCTAssertEqual(receivedSummary.annotations?.summary?.count, 1)
-                    
+
                     partialDone()
                 }
             }
-            
+
             // Subscribe to annotations
             realtimeChannel.annotations.subscribe { annotation in
                 // only interested in the first annotation which is with action `create`
                 realtimeChannel.annotations.unsubscribe()
-                
+
                 createdAnnotation = annotation
-                
+
                 // Verify annotation properties
                 XCTAssertEqual(annotation.action, .create)
                 XCTAssertEqual(annotation.messageSerial, receivedMessage.serial)
                 XCTAssertEqual(annotation.type, "reaction:multiple.v1")
                 XCTAssertEqual(annotation.name, "👍")
                 XCTAssertEqual(annotation.count?.intValue, 10)
-                
+
                 // Verify it matches the message
                 XCTAssertEqual(annotation.messageSerial, receivedMessage.serial)
-                
+
                 partialDone()
             }
-            
+
             // Wait for channel to be attached before publishing
             realtimeChannel.once(.attached) { stateChange in
                 // Publish a message
@@ -101,7 +101,7 @@ class RestAnnotationsTests: XCTestCase {
             }
             realtimeChannel.attach()
         }
-        
+
         // RSAN2: Now delete the annotation
         waitUntil(timeout: testTimeout) { done in
             let deleteAnnotation = ARTOutboundAnnotation(
@@ -118,24 +118,24 @@ class RestAnnotationsTests: XCTestCase {
                 done()
             }
         }
-        
+
         // After the annotations are published (and received via realtime), check it through the rest request:
-        
+
         guard let messageSerial = receivedMessage.serial else {
             XCTFail("Message serial should not be nil")
             return
         }
-        
+
         // Comment form ably-js 'annotations.test.js':
         // > Temporary anti-flake measure; can be removed after summary loop implements
         // > annotation resume (CHA-887)
         sleep(2)
-        
+
         waitUntil(timeout: testTimeout) { done in
             // RSAN3
             restChannel.annotations.getForMessageSerial(messageSerial, query: .init()) { paginatedResult, error in
                 XCTAssertNil(error)
-                
+
                 guard let annotations = paginatedResult?.items, annotations.count == 2 else {
                     XCTFail("Should contain two annotations.")
                     return
@@ -144,49 +144,49 @@ class RestAnnotationsTests: XCTestCase {
                 XCTAssertEqual(annotations[0].type, "reaction:multiple.v1")
                 XCTAssertEqual(annotations[0].name, "👍")
                 XCTAssertEqual(annotations[0].count?.intValue, 10)
-                
+
                 XCTAssertEqual(annotations[1].action, .delete)
                 XCTAssertEqual(annotations[1].type, "reaction:multiple.v1")
                 XCTAssertEqual(annotations[1].name, "👍")
                 XCTAssertEqual(annotations[1].count?.intValue, 10)
-                
+
                 done()
             }
         }
     }
-    
+
     // RSAN1c4
     func test__idempotent_publishing_should_publish_annotation_with_implicit_id_only_once() throws {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         options.testOptions.channelNamePrefix = nil
         options.idempotentRestPublishing = true // for visibility, true by default
-        
+
         // Create realtime client
         let realtimeClient = ARTRealtime(options: options)
         defer { realtimeClient.dispose(); realtimeClient.close() }
-        
+
         // Create rest client
         let restClient = ARTRest(options: options)
-        
+
         // Channel name and options
         let channelName = test.uniqueChannelName(prefix: "mutable:")
         let channelOptions = ARTRealtimeChannelOptions()
         channelOptions.modes = [.publish, .subscribe, .annotationPublish, .annotationSubscribe]
-        
+
         // Get realtime channel with options
         let realtimeChannel = realtimeClient.channels.get(channelName, options: channelOptions)
-        
+
         // Get rest channel
         let restChannel = restClient.channels.get(channelName)
-        
+
         // Message and annotation to track
         var receivedMessage: ARTMessage!
         var createdAnnotation: ARTAnnotation!
 
         waitUntil(timeout: testTimeout) { done in
             let partialDone = AblyTests.splitDone(3, done: done)
-            
+
             // Subscribe to messages
             realtimeChannel.subscribe { message in
                 if message.action == .create {
@@ -202,7 +202,7 @@ class RestAnnotationsTests: XCTestCase {
                         data: nil,
                         extras: nil
                     )
-                    
+
                     // RSAN1
                     restChannel.annotations.publish(for: receivedMessage, annotation: annotation) { error in
                         XCTAssertNil(error)
@@ -210,11 +210,11 @@ class RestAnnotationsTests: XCTestCase {
                     }
                 }
             }
-            
+
             // Subscribe to annotations
             realtimeChannel.annotations.subscribe { annotation in
                 createdAnnotation = annotation
-                
+
                 // Verify annotation properties
                 XCTAssertNotNil(annotation.id)
                 XCTAssertEqual(annotation.action, .create)
@@ -223,10 +223,10 @@ class RestAnnotationsTests: XCTestCase {
                 XCTAssertEqual(annotation.name, "👍")
                 XCTAssertEqual(annotation.count?.intValue, 10)
                 XCTAssertEqual(annotation.messageSerial, receivedMessage.serial)
-                
+
                 partialDone()
             }
-            
+
             // Wait for channel to be attached before publishing
             realtimeChannel.once(.attached) { stateChange in
                 // Publish a message
@@ -236,7 +236,7 @@ class RestAnnotationsTests: XCTestCase {
             }
             realtimeChannel.attach()
         }
-        
+
         // RSAN1c4: Now publish the created annotation again (to verify idempotent publishing)
         waitUntil(timeout: testTimeout) { done in
             // Convert the received ARTAnnotation to ARTOutboundAnnotation for publishing with the same ID
@@ -254,24 +254,24 @@ class RestAnnotationsTests: XCTestCase {
                 done()
             }
         }
-        
+
         // After the annotations are published (and received via realtime), check it through the rest request:
-        
+
         guard let messageSerial = receivedMessage.serial else {
             XCTFail("Message serial should not be nil")
             return
         }
-        
+
         // Comment form ably-js 'annotations.test.js':
         // > Temporary anti-flake measure; can be removed after summary loop implements
         // > annotation resume (CHA-887)
         sleep(2)
-        
+
         waitUntil(timeout: testTimeout) { done in
             // RSAN3
             restChannel.annotations.getForMessageSerial(messageSerial, query: .init()) { paginatedResult, error in
                 XCTAssertNil(error)
-                
+
                 guard let annotations = paginatedResult?.items, annotations.count == 1 else {
                     XCTFail("Should contain only one annotation.")
                     return
@@ -281,12 +281,12 @@ class RestAnnotationsTests: XCTestCase {
                 XCTAssertEqual(annotations[0].type, "reaction:multiple.v1")
                 XCTAssertEqual(annotations[0].name, "👍")
                 XCTAssertEqual(annotations[0].count?.intValue, 10)
-                
+
                 done()
             }
         }
     }
-    
+
     // RSAN1a4
     func test__publish_annotation_exceeding_max_message_size() throws {
         let test = Test()
@@ -295,9 +295,9 @@ class RestAnnotationsTests: XCTestCase {
 
         let restClient = ARTRest(options: options)
         let channel = restClient.channels.get(test.uniqueChannelName(prefix: "mutable:"))
-        
+
         let largeString = String(repeating: "f", count: ARTDefault.maxMessageSize() + 100) // Create a string larger than maxMessageSize
-        
+
         waitUntil(timeout: testTimeout) { done in
             // Create an annotation with the large string as name
             let annotation = ARTOutboundAnnotation(
@@ -309,7 +309,7 @@ class RestAnnotationsTests: XCTestCase {
                 data: nil,
                 extras: nil
             )
-            
+
             // Try to publish the annotation
             channel.annotations.publish(forMessageSerial: "test", annotation: annotation) { error in
                 // Verify error code and message

--- a/Test/AblyTests/Tests/RestClientChannelTests.swift
+++ b/Test/AblyTests/Tests/RestClientChannelTests.swift
@@ -90,17 +90,17 @@ private func testSupportsAESEncryptionWithKeyLength(_ encryptionKeyLength: UInt,
 struct ExpectedModel: Codable, Equatable {
     var data: String?
     let encoding: String?
-    
+
     static func with(_ object: Any) -> Self {
         do {
             let data = try JSONUtility.serialize(object)
-            
+
             return try JSONUtility.decode(data: data)
         } catch {
             fatalError("\(error)")
         }
     }
-    
+
     static func ==(lhs: Self, rhs: Self) -> Bool {
         lhs.data == rhs.data && lhs.encoding == rhs.encoding
     }
@@ -153,7 +153,7 @@ class RestClientChannelTests: XCTestCase {
         var publishedMessage: ARTMessage?
 
         let channel = testEnvironment.client.channels.get(test.uniqueChannelName())
-        
+
         channel.publish(PublishArgs.name, data: PublishArgs.data) { error in
             publishError = error
             channel.history { result, _ in
@@ -176,7 +176,7 @@ class RestClientChannelTests: XCTestCase {
         var publishedMessage: ARTMessage?
 
         let channel = testEnvironment.client.channels.get(test.uniqueChannelName())
-        
+
         channel.publish(PublishArgs.name, data: nil) { error in
             publishError = error
             channel.history { result, _ in
@@ -199,7 +199,7 @@ class RestClientChannelTests: XCTestCase {
         var publishedMessage: ARTMessage?
 
         let channel = testEnvironment.client.channels.get(test.uniqueChannelName())
-        
+
         channel.publish(nil, data: PublishArgs.data) { error in
             publishError = error
             channel.history { result, _ in
@@ -222,7 +222,7 @@ class RestClientChannelTests: XCTestCase {
         var publishedMessage: ARTMessage?
 
         let channel = testEnvironment.client.channels.get(test.uniqueChannelName())
-        
+
         waitUntil(timeout: testTimeout) { done in
             channel.publish(nil, data: nil) { error in
                 publishError = error
@@ -246,7 +246,7 @@ class RestClientChannelTests: XCTestCase {
         var publishedMessage: ARTMessage?
 
         let channel = testEnvironment.client.channels.get(test.uniqueChannelName())
-        
+
         waitUntil(timeout: testTimeout) { done in
             channel.publish([ARTMessage(name: PublishArgs.name, data: PublishArgs.data)]) { error in
                 publishError = error
@@ -281,9 +281,9 @@ class RestClientChannelTests: XCTestCase {
             ARTMessage(name: "bar", data: "foo"),
             ARTMessage(name: "bat", data: "baz"),
         ]
-        
+
         let channel = client.channels.get(test.uniqueChannelName())
-        
+
         channel.publish(messages) { error in
             publishError = error
             client.internal.httpExecutor = oldExecutor
@@ -390,7 +390,7 @@ class RestClientChannelTests: XCTestCase {
         let realtime = ARTRealtime(options: options)
 
         let chanelName = test.uniqueChannelName(prefix: "ch1")
-        
+
         let subscriber = realtime.channels.get(chanelName)
         subscriber.attach()
         waitUntil(timeout: testTimeout) { done in
@@ -423,7 +423,7 @@ class RestClientChannelTests: XCTestCase {
         let realtime = ARTRealtime(options: options)
 
         let chanelName = test.uniqueChannelName(prefix: "ch1")
-        
+
         let subscriber = realtime.channels.get(chanelName)
         subscriber.attach()
         waitUntil(timeout: testTimeout) { done in
@@ -454,7 +454,7 @@ class RestClientChannelTests: XCTestCase {
         let realtime = ARTRealtime(options: options)
 
         let chanelName = test.uniqueChannelName(prefix: "ch1")
-        
+
         let subscriber = realtime.channels.get(chanelName)
         subscriber.attach()
         waitUntil(timeout: testTimeout) { done in
@@ -486,7 +486,7 @@ class RestClientChannelTests: XCTestCase {
         let realtime = ARTRealtime(options: options)
 
         let chanelName = test.uniqueChannelName(prefix: "ch1")
-        
+
         let subscriber = realtime.channels.get(chanelName)
         subscriber.attach()
         waitUntil(timeout: testTimeout) { done in
@@ -681,7 +681,7 @@ class RestClientChannelTests: XCTestCase {
 
         let arrayValue: [[String: Any]] = try XCTUnwrap(JSONUtility.jsonObject(data: AblyTests.msgpackToData(encodedBody)))
         let id = arrayValue.first?["id"] as? String
-        
+
         assertMessagePayloadId(id: id, expectedSerial: "0")
         XCTAssertNil(message.id)
     }
@@ -753,7 +753,7 @@ class RestClientChannelTests: XCTestCase {
 
         let arrayValue: [[String: Any]] = try XCTUnwrap(JSONUtility.jsonObject(data: AblyTests.msgpackToData(encodedBody)))
         let id = arrayValue.first?["id"] as? String
-        
+
         XCTAssertEqual(id, "123")
     }
 
@@ -883,7 +883,7 @@ class RestClientChannelTests: XCTestCase {
         ]
 
         let channel = client.channels.get(test.uniqueChannelName())
-        
+
         waitUntil(timeout: testTimeout) { done in
             channel.publish(messages) { error in
                 XCTAssertNotNil(error)
@@ -1298,12 +1298,12 @@ class RestClientChannelTests: XCTestCase {
             TestCase(value: array, expected: .with(["data": try JSONUtility.toJSONString(array), "encoding": "json"])),
             TestCase(value: binaryData, expected: .with(["data": binaryData.toBase64, "encoding": "base64"])),
         ]
-        
+
         client.internal.options.idempotentRestPublishing = false
         client.internal.httpExecutor = testHTTPExecutor
 
         let channel = client.channels.get(test.uniqueChannelName())
-        
+
         validCases.forEach { caseTest in
             waitUntil(timeout: testTimeout) { done in
                 channel.publish(nil, data: caseTest.value) { error in
@@ -1312,7 +1312,7 @@ class RestClientChannelTests: XCTestCase {
                         XCTFail("HTTPBody is nil")
                         done(); return
                     }
-                    
+
                     let jsonData = AblyTests.msgpackToData(httpBody)
                     var model: ExpectedModel? = nil
                     do {
@@ -1361,7 +1361,7 @@ class RestClientChannelTests: XCTestCase {
         client.internal.httpExecutor = testHTTPExecutor
 
         let channel = client.channels.get(test.uniqueChannelName())
-        
+
         encodingCases.forEach { caseItem in
             waitUntil(timeout: testTimeout) { done in
                 channel.publish(nil, data: caseItem.value, callback: { error in
@@ -1370,14 +1370,14 @@ class RestClientChannelTests: XCTestCase {
                         XCTFail("HTTPBody is nil")
                         done(); return
                     }
-                    
+
                     var model: ExpectedModel? = nil
                     do {
                         model = try JSONUtility.decode(data: AblyTests.msgpackToData(httpBody))
                     } catch {
                         XCTFail("\(error)")
                     }
-                    
+
                     XCTAssertEqual(model?.encoding, caseItem.expected.encoding)
                     done()
                 })
@@ -1393,9 +1393,9 @@ class RestClientChannelTests: XCTestCase {
         let testHTTPExecutor = testEnvironment.testHTTPExecutor
 
         client.internal.httpExecutor = testHTTPExecutor
-        
+
         let channel = client.channels.get(test.uniqueChannelName())
-        
+
         waitUntil(timeout: testTimeout) { done in
             channel.publish(nil, data: binaryData, callback: { error in
                 XCTAssertNil(error)
@@ -1420,9 +1420,9 @@ class RestClientChannelTests: XCTestCase {
         let testHTTPExecutor = testEnvironment.testHTTPExecutor
 
         client.internal.httpExecutor = testHTTPExecutor
-        
+
         let channel = client.channels.get(test.uniqueChannelName())
-        
+
         waitUntil(timeout: testTimeout) { done in
             channel.publish(nil, data: text, callback: { error in
                 XCTAssertNil(error)
@@ -1449,9 +1449,9 @@ class RestClientChannelTests: XCTestCase {
         let testHTTPExecutor = testEnvironment.testHTTPExecutor
 
         client.internal.httpExecutor = testHTTPExecutor
-        
+
         let channel = client.channels.get(test.uniqueChannelName())
-        
+
         // JSON Array
         waitUntil(timeout: testTimeout) { done in
             channel.publish(nil, data: array, callback: { error in
@@ -1462,7 +1462,7 @@ class RestClientChannelTests: XCTestCase {
                     let dictionaryValue: [String: Any]? = try? JSONUtility.jsonObject(data: AblyTests.msgpackToData(http))
                     let data = (dictionaryValue?["data"] as? String)?.data(using: .utf8)
                     let jsonArray: NSArray? = try? JSONUtility.jsonObject(data: data)
-                    
+
                     XCTAssertEqual(jsonArray, array as NSArray?)
                     XCTAssertEqual(dictionaryValue?["encoding"] as? String, "json")
                 } else {
@@ -1480,9 +1480,9 @@ class RestClientChannelTests: XCTestCase {
         let testHTTPExecutor = testEnvironment.testHTTPExecutor
 
         client.internal.httpExecutor = testHTTPExecutor
-        
+
         let channel = client.channels.get(test.uniqueChannelName())
-        
+
         // JSON Object
         waitUntil(timeout: testTimeout) { done in
             channel.publish(nil, data: dictionary, callback: { error in
@@ -1493,7 +1493,7 @@ class RestClientChannelTests: XCTestCase {
                     let dictionaryValue: [String: Any]? = try? JSONUtility.jsonObject(data: AblyTests.msgpackToData(http))
                     let data = (dictionaryValue?["data"] as? String)?.data(using: .utf8)
                     let jsonDictionary: NSDictionary? = try? JSONUtility.jsonObject(data: data)
-                    
+
                     XCTAssertEqual(jsonDictionary, dictionary as NSDictionary?)
                     XCTAssertEqual(dictionaryValue?["encoding"] as? String, "json")
                 } else {
@@ -1512,7 +1512,7 @@ class RestClientChannelTests: XCTestCase {
         let cases = [text, integer, decimal, dictionary, array, binaryData] as [Any]
 
         let channel = testEnvironment.client.channels.get(test.uniqueChannelName())
-        
+
         cases.forEach { caseTest in
             waitUntil(timeout: testTimeout) { done in
                 channel.publish(nil, data: caseTest, callback: { error in
@@ -1653,7 +1653,7 @@ class RestClientChannelTests: XCTestCase {
             }
         }
     }
-    
+
     // RSL8a, CHD2b, CHS2b, CHO2a
     func test__047__status__with_subscribers__returns_a_channel_details_object_populated_with_channel_metrics() throws {
         let test = Test()
@@ -1682,7 +1682,7 @@ class RestClientChannelTests: XCTestCase {
                 done()
             }
         }
-        
+
         func checkMetrics(completion: @escaping (ARTChannelDetails) -> ()) {
             restChannel.status { details, error in
                 XCTAssertNil(error)
@@ -1701,7 +1701,7 @@ class RestClientChannelTests: XCTestCase {
                 }
             }
         }
-        
+
         waitUntil(timeout: testTimeout) { done in
             checkMetrics { details in
                 XCTAssertEqual(details.status.occupancy.metrics.connections, 1) // CHM2a
@@ -1716,7 +1716,7 @@ class RestClientChannelTests: XCTestCase {
             }
         }
     }
-    
+
     func test__48__channel_name_can_contain_slash_character_which_is_url_encoded_in_the_rest_request_path() throws {
         let test = Test()
         let testEnvironment = try TestEnvironment(test: test)
@@ -1725,9 +1725,9 @@ class RestClientChannelTests: XCTestCase {
 
         client.internal.httpExecutor = testHTTPExecutor
         let channel = client.channels.get(test.uniqueChannelName(prefix: "beforeSlash/afterSlash"))
-        
+
         channel.publish(nil, data: nil)
-        
+
         let url = try XCTUnwrap(testHTTPExecutor.requests.first?.url)
         let urlEncodedChannelName = try XCTUnwrap(channel.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlHostAllowed))
 

--- a/Test/AblyTests/Tests/RestClientPresenceTests.swift
+++ b/Test/AblyTests/Tests/RestClientPresenceTests.swift
@@ -86,7 +86,7 @@ class RestClientPresenceTests: XCTestCase {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let channelName = test.uniqueChannelName()
-        
+
         let client = ARTRest(options: options)
         let channel = client.channels.get(channelName)
 
@@ -122,7 +122,7 @@ class RestClientPresenceTests: XCTestCase {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRest(options: options)
-        
+
         let channelName = test.uniqueChannelName()
         let channel = client.channels.get(channelName)
 
@@ -167,7 +167,7 @@ class RestClientPresenceTests: XCTestCase {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRest(options: options)
-        
+
         let channelName = test.uniqueChannelName()
         let channel = client.channels.get(channelName)
 
@@ -227,7 +227,7 @@ class RestClientPresenceTests: XCTestCase {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRest(options: options)
-        
+
         let channelName = test.uniqueChannelName()
         let channel = client.channels.get(channelName)
 
@@ -282,7 +282,7 @@ class RestClientPresenceTests: XCTestCase {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRest(options: options)
-        
+
         let channelName = test.uniqueChannelName()
         let channel = client.channels.get(channelName)
 
@@ -318,7 +318,7 @@ class RestClientPresenceTests: XCTestCase {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRest(options: options)
-        
+
         let channelName = test.uniqueChannelName()
         let channel = client.channels.get(channelName)
 
@@ -365,7 +365,7 @@ class RestClientPresenceTests: XCTestCase {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRest(options: options)
-        
+
         let channelName = test.uniqueChannelName()
         let channel = client.channels.get(channelName)
 
@@ -443,7 +443,7 @@ class RestClientPresenceTests: XCTestCase {
         let test = Test()
         let options = try AblyTests.commonAppSetup(for: test)
         let client = ARTRest(options: options)
-        
+
         let channelName = test.uniqueChannelName()
         let channel = client.channels.get(channelName)
 

--- a/Test/AblyTests/Tests/RestClientTests.swift
+++ b/Test/AblyTests/Tests/RestClientTests.swift
@@ -280,7 +280,7 @@ class RestClientTests: XCTestCase {
     // RSC4
     func test__024__RestClient__logging__should_accept_a_custom_logger() throws {
         let test = Test()
-        
+
         enum Log {
             static var interceptedLog: (String, ARTLogLevel) = ("", .none)
         }
@@ -483,7 +483,7 @@ class RestClientTests: XCTestCase {
                 done()
             }
         }
-        
+
         let url = try XCTUnwrap(testHTTPExecutor.requests.first?.url, "No request url found")
 
         expect(url.absoluteString).to(contain("//rest.ably.test"))
@@ -515,7 +515,7 @@ class RestClientTests: XCTestCase {
         clientHttps.internal.httpExecutor = testHTTPExecutor
 
         let channelName = test.uniqueChannelName()
-        
+
         waitUntil(timeout: testTimeout) { done in
             publishTestMessage(clientHttps, channelName: channelName) { _ in
                 done()
@@ -1667,7 +1667,7 @@ class RestClientTests: XCTestCase {
                 done()
             }
         }
-        
+
         let request = try XCTUnwrap(testHTTPExecutor.requests.first, "No request found")
 
         switch extractBodyAsMsgPack(request) {
@@ -1705,7 +1705,7 @@ class RestClientTests: XCTestCase {
                 done()
             }
         }
-        
+
         let request = try XCTUnwrap(testHTTPExecutor.requests.first, "No request found")
 
         switch extractBodyAsJSON(request) {
@@ -1854,7 +1854,7 @@ class RestClientTests: XCTestCase {
         let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No request found")
         let url = try XCTUnwrap(request.url, "No request url found")
         let acceptHeaderValue = try XCTUnwrap(request.allHTTPHeaderFields?["Accept"], "Accept HTTP Header is missing")
-        
+
         XCTAssertEqual(request.httpMethod!.uppercased(), "PATCH")
         XCTAssertEqual(url.absoluteString, "https://rest.ably.io:443/feature?foo=1")
         XCTAssertEqual(acceptHeaderValue, "application/x-msgpack,application/json")
@@ -1878,12 +1878,12 @@ class RestClientTests: XCTestCase {
                 done()
             }
         }
-        
+
         let request = try XCTUnwrap(mockHttpExecutor.requests.first, "No requests found")
         let rawBody = try XCTUnwrap(request.httpBody, "should have a body")
         let decodedBody = try XCTUnwrap(try rest.internal.defaultEncoder.decode(rawBody), "Decode request body failed")
         let body = try XCTUnwrap(decodedBody as? NSDictionary, "Request body is invalid")
-        
+
         XCTAssertTrue(try XCTUnwrap(body.value(forKey: "blockchain") as? Bool))
     }
 

--- a/Test/AblyTests/Tests/SummaryTypesTests.swift
+++ b/Test/AblyTests/Tests/SummaryTypesTests.swift
@@ -2,48 +2,48 @@ import XCTest
 @testable import Ably
 
 class SummaryTypesTests: XCTestCase {
-    
+
     // MARK: - Global Summary Functions Tests
-    
+
     func test__ARTSummaryFlagV1__parses_from_dictionary() {
         let dictionary: [String: Any] = [
             "total": 3,
             "clientIds": ["client1", "client2", "client3"]
         ]
-        
+
         let summary = ARTSummaryFlagV1(dictionary)
-        
+
         XCTAssertNotNil(summary)
         XCTAssertEqual(summary?.total, 3)
         XCTAssertEqual(summary?.clientIds, ["client1", "client2", "client3"])
     }
-    
+
     func test__ARTSummaryFlagV1__returns_nil_for_invalid_dictionary() {
         let invalidDictionary: [String: Any] = [
             "total": 3,
             "clientIds": [123, 456] // Invalid - should be strings
         ]
-        
+
         let summary = ARTSummaryFlagV1(invalidDictionary)
-        
+
         XCTAssertNil(summary)
     }
-    
+
     func test__ARTSummaryFlagV1__with_clipped_property() {
         let dictionary: [String: Any] = [
             "total": 5,
             "clientIds": ["client1", "client2"],
             "clipped": true
         ]
-        
+
         let summary = ARTSummaryFlagV1(dictionary)
-        
+
         XCTAssertNotNil(summary)
         XCTAssertEqual(summary?.total, 5)
         XCTAssertEqual(summary?.clientIds, ["client1", "client2"])
         XCTAssertEqual(summary?.clipped, true)
     }
-    
+
     func test__ARTSummaryMultipleV1__parses_dictionary_of_summaries() {
         let dictionary: [String: Any] = [
             "like": [
@@ -62,26 +62,26 @@ class SummaryTypesTests: XCTestCase {
                 ]
             ]
         ]
-        
+
         let summaryDict = ARTSummaryMultipleV1(dictionary)
-        
+
         XCTAssertNotNil(summaryDict)
         XCTAssertEqual(summaryDict?.count, 2)
-        
+
         let likeSummary = summaryDict?["like"]
         XCTAssertNotNil(likeSummary)
         XCTAssertEqual(likeSummary?.total, 10)
         XCTAssertEqual(likeSummary?.clientIds["client1"], NSNumber(value: 5))
         XCTAssertEqual(likeSummary?.clientIds["client2"], NSNumber(value: 3))
         XCTAssertEqual(likeSummary?.clientIds["client3"], NSNumber(value: 2))
-        
+
         let loveSummary = summaryDict?["love"]
         XCTAssertNotNil(loveSummary)
         XCTAssertEqual(loveSummary?.total, 8)
         XCTAssertEqual(loveSummary?.clientIds["client1"], NSNumber(value: 5))
         XCTAssertEqual(loveSummary?.clientIds["client2"], NSNumber(value: 3))
     }
-    
+
     func test__ARTSummaryMultipleV1__returns_nil_for_invalid_values() {
         let invalidDictionary: [String: Any] = [
             "like": [
@@ -92,14 +92,14 @@ class SummaryTypesTests: XCTestCase {
                 ]
             ]
         ]
-        
+
         let summaryDict = ARTSummaryMultipleV1(invalidDictionary)
-        
+
         // Should return dictionary but with nil values for invalid entries
         XCTAssertNotNil(summaryDict)
         XCTAssertNil(summaryDict?["like"]) // This specific entry should be nil due to invalid data
     }
-    
+
     func test__ARTSummaryDistinctV1__parses_dictionary_of_summaries() {
         let dictionary: [String: Any] = [
             "like": [
@@ -112,24 +112,24 @@ class SummaryTypesTests: XCTestCase {
                 "clipped": true
             ]
         ]
-        
+
         let summaryDict = ARTSummaryDistinctV1(dictionary)
-        
+
         XCTAssertNotNil(summaryDict)
         XCTAssertEqual(summaryDict?.count, 2)
-        
+
         let likeSummary = summaryDict?["like"]
         XCTAssertNotNil(likeSummary)
         XCTAssertEqual(likeSummary?.total, 3)
         XCTAssertEqual(likeSummary?.clientIds, ["client1", "client2", "client3"])
-        
+
         let loveSummary = summaryDict?["love"]
         XCTAssertNotNil(loveSummary)
         XCTAssertEqual(loveSummary?.total, 2)
         XCTAssertEqual(loveSummary?.clientIds, ["client1", "client4"])
         XCTAssertEqual(loveSummary?.clipped, true)
     }
-    
+
     func test__ARTSummaryUniqueV1__parses_dictionary_of_summaries() {
         let dictionary: [String: Any] = [
             "reaction": [
@@ -137,12 +137,12 @@ class SummaryTypesTests: XCTestCase {
                 "clientIds": ["user1", "user2", "user3", "user4", "user5"]
             ]
         ]
-        
+
         let summaryDict = ARTSummaryUniqueV1(dictionary)
-        
+
         XCTAssertNotNil(summaryDict)
         XCTAssertEqual(summaryDict?.count, 1)
-        
+
         let reactionSummary = summaryDict?["reaction"]
         XCTAssertNotNil(reactionSummary)
         XCTAssertEqual(reactionSummary?.total, 5)
@@ -150,25 +150,25 @@ class SummaryTypesTests: XCTestCase {
         XCTAssertTrue(reactionSummary?.clientIds.contains("user1") ?? false)
         XCTAssertTrue(reactionSummary?.clientIds.contains("user5") ?? false)
     }
-    
+
     func test__ARTSummaryTotalV1__parses_from_dictionary() {
         let dictionary: [String: Any] = [
             "total": 42
         ]
-        
+
         let summary = ARTSummaryTotalV1(dictionary)
-        
+
         XCTAssertNotNil(summary)
         XCTAssertEqual(summary?.total, 42)
     }
-    
+
     func test__ARTSummaryTotalV1__parses_string_number_from_dictionary() {
         let dictionary: [String: Any] = [
             "total": "123" // String number should be converted to integer
         ]
-        
+
         let summary = ARTSummaryTotalV1(dictionary)
-        
+
         XCTAssertNotNil(summary)
         XCTAssertEqual(summary?.total, 123)
     }

--- a/Test/AblyTests/Tests/UtilitiesTests.swift
+++ b/Test/AblyTests/Tests/UtilitiesTests.swift
@@ -239,7 +239,7 @@ class UtilitiesTests: XCTestCase {
         let rest = ARTRest(options: options)
         let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
-        
+
         testHTTPExecutor.simulateIncomingServerErrorOnNextRequest(
             40400,
             statusCode: 404,
@@ -248,7 +248,7 @@ class UtilitiesTests: XCTestCase {
                 "err": "Error that shouldn't be parsed"
             ]
         )
-        
+
         let request = URLRequest(url: URL(string: "https://www.example.com")!)
         waitUntil(timeout: testTimeout) { done in
             rest.internal.execute(request, wrapperSDKAgents:nil, completion: { response, _, error in
@@ -271,7 +271,7 @@ class UtilitiesTests: XCTestCase {
         let rest = ARTRest(options: options)
         let testHTTPExecutor = TestProxyHTTPExecutor(logger: .init(clientOptions: options))
         rest.internal.httpExecutor = testHTTPExecutor
-        
+
         testHTTPExecutor.simulateIncomingServerErrorOnNextRequest(
             40400,
             statusCode: 404,
@@ -283,7 +283,7 @@ class UtilitiesTests: XCTestCase {
                 ]
             ]
         )
-        
+
         let request = URLRequest(url: URL(string: "https://www.example.com")!)
         waitUntil(timeout: testTimeout) { done in
             rest.internal.execute(request, wrapperSDKAgents:nil, completion: { response, _, error in
@@ -621,7 +621,7 @@ class UtilitiesTests: XCTestCase {
         XCTAssert(messages[0].timestamp == Date(timeIntervalSince1970: 12.345))
         XCTAssert(messages[0].version?.timestamp == Date(timeIntervalSince1970: 12.345))
     }
-    
+
     /// - TM8a
     /// - TM2u
     func test__026_Utilities__message_should_always_populate_annotations_and_summary_when_decoding() throws {

--- a/Test/AblyTestsObjC/ARTArchiveTests.m
+++ b/Test/AblyTestsObjC/ARTArchiveTests.m
@@ -18,21 +18,21 @@
 @implementation ARTArchiveTests
 
 - (void)test_art_unarchivedObjectOfClass_for_state_machine_states {
-    
+
     ARTRest* rest = [[ARTRest alloc] initWithKey:@"xxxx:xxxx"];
     ARTInternalLog *const logger = [[ARTInternalLog alloc] initWithCore:[[ARTMockInternalLogCore alloc] init]];
     ARTPushActivationStateMachine* stateMachine = [[ARTPushActivationStateMachine alloc] initWithRest:rest.internal delegate:[[_StateMachineDelegate alloc] init] logger:logger];
-    
+
     NSArray* initialStates = [NSMutableArray arrayWithArray:@[
         [[ARTPushActivationStateNotActivated alloc] initWithMachine:stateMachine logger:logger],
         [[ARTPushActivationStateWaitingForPushDeviceDetails alloc] initWithMachine:stateMachine logger:logger],
         [[ARTPushActivationStateAfterRegistrationSyncFailed alloc] initWithMachine:stateMachine logger:logger]
     ]];
-    
+
     NSData* data = [initialStates art_archiveWithLogger:nil];
-    
+
     NSArray* unarchivedStates = [ARTPushActivationState art_unarchiveFromData:data withLogger:nil];
-    
+
     XCTAssert([unarchivedStates[0] isKindOfClass:[ARTPushActivationStateNotActivated class]]);
     XCTAssert([unarchivedStates[1] isKindOfClass:[ARTPushActivationStateWaitingForPushDeviceDetails class]]);
     XCTAssert([unarchivedStates[2] isKindOfClass:[ARTPushActivationStateAfterRegistrationSyncFailed class]]);

--- a/Test/AblyTestsObjC/CryptoTest.m
+++ b/Test/AblyTestsObjC/CryptoTest.m
@@ -28,7 +28,7 @@
         [[ARTCipherParams alloc] initWithAlgorithm:@"aes" key:key iv:iv];
     ARTInternalLog *const logger = [[ARTInternalLog alloc] initWithCore:[[ARTMockInternalLogCore alloc] init]];
     id<ARTChannelCipher> cipher = [ARTCrypto cipherWithParams:params logger:logger];
-    
+
     // Prepare message data.
     const NSUInteger maxLength = 70;
     UInt8 messageData[maxLength];
@@ -43,7 +43,7 @@
         NSData *const dIn = [NSData dataWithBytes:&messageData length:i];
         NSData * dOut;
         XCTAssertEqual(ARTStateOk, [cipher encrypt:dIn output:&dOut].state);
-        
+
         // Decrypt the encrypted data and verify the result is the same as what
         // we submitted for encryption.
         NSData * dVerify;


### PR DESCRIPTION
I've noticed that Claude has a tendency to, when editing a section of code, replace whitespace-only lines with empty lines. This leads to quite a lot of diff noise.

Xcode's default is to disallow trailing whitespace (and thus also whitespace-only lines); let's use EditorConfig to enforce that, to hopefully avoid future diff noise.

(Ideally, we'd have proper per-language formatting tools but EditorConfig seemed like the quickest cross-language fix for the current problem.)

This commit was largely generated by Claude. The tooling it chose doesn't do auto-fix (https://github.com/editorconfig-checker/editorconfig-checker/issues/14) so it wrote and ran an ad-hoc script to fix the current linting issues. Let's see if we need a permanent auto-fix script in the future or if we can do without.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added EditorConfig support for consistent coding style enforcement
  * Enhanced push notifications and location-based push functionality
  * Introduced new public configuration accessors for default settings

* **Bug Fixes**
  * Improved error handling for message publishing and encoding failures
  * Enhanced response decoding for publish operations
  * Strengthened connection property synchronization

* **Documentation**
  * Added linting guidelines to contribution documentation

* **Chores**
  * Established automated linting workflow for code consistency
  * Refactored callback dispatch mechanisms for improved queue handling
  * Applied comprehensive code formatting standardization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->