### PR TITLE
[AIT-287] Pass the `RESUMED` flag to LiveObjects `onChannelAttached`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/ably/ably-cocoa-plugin-support",
         "state": {
           "branch": null,
-          "revision": "dd118432a6e023c3d2c8a051299e8081a06db036",
-          "version": "1.0.0"
+          "revision": "2e640ce2ef422cd5ef693a9e1111400e9985e088",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,8 @@ let package = Package(
         .package(name: "msgpack", url: "https://github.com/rvi/msgpack-objective-C", from: "0.4.0"),
         .package(name: "AblyDeltaCodec", url: "https://github.com/ably/delta-codec-cocoa", from: "1.3.5"),
         .package(name: "Nimble", url: "https://github.com/quick/nimble", from: "11.2.2"),
-        .package(name: "ably-cocoa-plugin-support", url: "https://github.com/ably/ably-cocoa-plugin-support", from: "1.0.0")
+        // TODO: Unpin before release
+        .package(name: "ably-cocoa-plugin-support", url: "https://github.com/ably/ably-cocoa-plugin-support", .revision("2e640ce2ef422cd5ef693a9e1111400e9985e088"))
     ],
     targets: [
         .target(

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -810,8 +810,14 @@ art_dispatch_sync(_queue, ^{
     self.modes = message.channelModes;
 
 #ifdef ABLY_SUPPORTS_PLUGINS
-    [self.realtime.options.liveObjectsPlugin nosync_onChannelAttached:self
-                                                           hasObjects:message.hasObjects];
+    if ([self.realtime.options.liveObjectsPlugin respondsToSelector:@selector(nosync_onChannelAttached:hasObjects:resumed:)]) {
+        [self.realtime.options.liveObjectsPlugin nosync_onChannelAttached:self
+                                                               hasObjects:message.hasObjects
+                                                                  resumed:message.resumed];
+    } else {
+        [self.realtime.options.liveObjectsPlugin nosync_onChannelAttached:self
+                                                               hasObjects:message.hasObjects];
+    }
 #endif
 
     if (state == ARTRealtimeChannelAttached) {


### PR DESCRIPTION
Needed for implementing RTO4d from https://github.com/ably/specification/pull/416.

Related PRs:

- https://github.com/ably/ably-cocoa-plugin-support/pull/9
- https://github.com/ably/ably-liveobjects-swift-plugin/pull/112