### PR TITLE
Exclude internal types from Jazzy-generated documentation

### DIFF
--- a/Scripts/jazzy.sh
+++ b/Scripts/jazzy.sh
@@ -2,6 +2,17 @@
 
 # Generates Jazzy documentation: https://github.com/realm/jazzy
 
+# We temporarily hide the SPM module map because Jazzy passes -fmodules to
+# clang, which causes it to discover the Ably.Private module and document all
+# of the SDK's internal headers. With the module map out of the way, clang only
+# sees what the umbrella header (AblyPublic.h) imports.
+
+trap 'mv Source/include/module.modulemap.jazzy-hidden Source/include/module.modulemap 2>/dev/null' EXIT
+mv Source/include/module.modulemap Source/include/module.modulemap.jazzy-hidden || {
+  echo "error: could not hide module map — are you running from the repo root?" >&2
+  exit 1
+}
+
 bundle exec jazzy \
   --objc \
   --clean \


### PR DESCRIPTION
I noticed that there were private types appearing in the Jazzy-generated docs. Told Claude to have a look, and this is what it came up with. It tells me that it thinks that this issue always existed, but I'm not sure; probably the last time I checked the Jazzy output was in c23d0fa but I may well have not noticed this.

Don't really want to spend much time thinking about whether this is the right solution; it seems to give the desired outcome.

Here's Claude's explanation:

> Jazzy passes `-fmodules` to clang, which causes it to discover the `Ably.Private` module defined in the SPM module map (`Source/include/module.modulemap`). This pulls in every private header and results in internal types (e.g. `ARTRealtimeChannelInternal`, `ARTChannel`) appearing in the published documentation.
>
> Fix by temporarily hiding the module map during the Jazzy run so that clang only sees what the umbrella header (`AblyPublic.h`) imports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation generation script to improve build process reliability through enhanced resource management during generation cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->