### PR TITLE
Remove `:nodoc:` annotations from private headers

### DIFF
--- a/Source/PrivateHeaders/Ably/ARTConnectionDetails.h
+++ b/Source/PrivateHeaders/Ably/ARTConnectionDetails.h
@@ -54,7 +54,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// If the `objectsGCGracePeriod` is present in the `ConnectionDetails`, this contains an `NSNumber` wrapping an `NSTimeInterval` containing its value in seconds.
 @property (readonly, nonatomic, nullable) NSNumber *objectsGCGracePeriod;
 
-/// :nodoc:
 - (instancetype)initWithClientId:(NSString *_Nullable)clientId
                    connectionKey:(NSString *_Nullable)connectionKey
                   maxMessageSize:(NSInteger)maxMessageSize

--- a/Source/PrivateHeaders/Ably/ARTDataEncoder.h
+++ b/Source/PrivateHeaders/Ably/ARTDataEncoder.h
@@ -9,7 +9,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// :nodoc:
 @interface ARTDataEncoderOutput : NSObject
 
 @property (readonly, nonatomic, nullable) id data;
@@ -35,7 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-/// :nodoc:
 @interface NSString (ARTDataEncoder)
 
 + (NSString *)artAddEncoding:(NSString *)encoding toString:(NSString *_Nullable)s;

--- a/Source/PrivateHeaders/Ably/ARTDeviceStorage.h
+++ b/Source/PrivateHeaders/Ably/ARTDeviceStorage.h
@@ -5,7 +5,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Instances of ARTDeviceStorage should expect to have their methods called
 // from any thread.
-/// :nodoc:
 @protocol ARTDeviceStorage <NSObject>
 - (nullable id)objectForKey:(NSString *)key;
 - (void)setObject:(nullable id)value forKey:(NSString *)key;

--- a/Source/PrivateHeaders/Ably/ARTEncoder.h
+++ b/Source/PrivateHeaders/Ably/ARTEncoder.h
@@ -17,7 +17,6 @@
 
 @protocol ARTPushRecipient;
 
-/// :nodoc:
 typedef NS_ENUM(NSUInteger, ARTEncoderFormat) {
     ARTEncoderFormatJson,
     ARTEncoderFormatMsgPack
@@ -25,7 +24,6 @@ typedef NS_ENUM(NSUInteger, ARTEncoderFormat) {
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// :nodoc:
 @protocol ARTEncoder
 
 - (NSString *)mimeType;

--- a/Source/PrivateHeaders/Ably/ARTFallback.h
+++ b/Source/PrivateHeaders/Ably/ARTFallback.h
@@ -5,7 +5,6 @@ NS_ASSUME_NONNULL_BEGIN
 @class ARTHttpResponse;
 @class ARTClientOptions;
 
-/// :nodoc:
 @interface ARTFallback : NSObject
 
 /**

--- a/Source/PrivateHeaders/Ably/ARTHttp.h
+++ b/Source/PrivateHeaders/Ably/ARTHttp.h
@@ -10,7 +10,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// :nodoc:
 @protocol ARTHTTPExecutor
 
 - (nullable NSObject<ARTCancellable> *)executeRequest:(NSURLRequest *)request
@@ -18,7 +17,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-/// :nodoc:
 @interface ARTHttp : NSObject<ARTHTTPExecutor>
 
 + (void)setURLSessionClass:(Class)urlSessionClass;

--- a/Source/PrivateHeaders/Ably/ARTLocalDeviceStorage.h
+++ b/Source/PrivateHeaders/Ably/ARTLocalDeviceStorage.h
@@ -5,7 +5,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// :nodoc:
 @interface ARTLocalDeviceStorage : NSObject<ARTDeviceStorage>
 
 - (instancetype)initWithLogger:(ARTInternalLog *)logger;

--- a/Source/PrivateHeaders/Ably/ARTMessageSendStatus.h
+++ b/Source/PrivateHeaders/Ably/ARTMessageSendStatus.h
@@ -40,7 +40,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-/// :nodoc:
 typedef void (^ARTMessageSendCallback)(ARTMessageSendStatus *status);
 
 NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTPendingMessage.h
+++ b/Source/PrivateHeaders/Ably/ARTPendingMessage.h
@@ -4,7 +4,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// :nodoc:
 @interface ARTPendingMessage : ARTQueuedMessage
 
 - (instancetype)initWithProtocolMessage:(ARTProtocolMessage *)msg sentCallback:(nullable ARTCallback)sentCallback ackCallback:(nullable ARTMessageSendCallback)ackCallback UNAVAILABLE_ATTRIBUTE;

--- a/Source/PrivateHeaders/Ably/ARTProtocolMessage.h
+++ b/Source/PrivateHeaders/Ably/ARTProtocolMessage.h
@@ -16,7 +16,6 @@
 @class ARTAnnotation;
 @class ARTPublishResult;
 
-/// :nodoc:
 typedef NS_ENUM(NSUInteger, ARTProtocolMessageAction) {
     ARTProtocolMessageHeartbeat = 0,
     ARTProtocolMessageAck = 1,
@@ -41,13 +40,11 @@ typedef NS_ENUM(NSUInteger, ARTProtocolMessageAction) {
     ARTProtocolMessageAnnotation = 21,
 };
 
-/// :nodoc:
 NSString *_Nonnull ARTProtocolMessageActionToStr(ARTProtocolMessageAction action);
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * :nodoc:
  * A message sent and received over the Realtime protocol.
  * ARTProtocolMessage always relates to a single channel only, but can contain multiple individual messages or presence messages.
  * ARTProtocolMessage are serially numbered on a connection.

--- a/Source/PrivateHeaders/Ably/ARTQueuedMessage.h
+++ b/Source/PrivateHeaders/Ably/ARTQueuedMessage.h
@@ -6,7 +6,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// :nodoc:
 @interface ARTQueuedMessage : NSObject
 
 @property (readonly, nonatomic) ARTProtocolMessage *msg;


### PR DESCRIPTION
They're meaningless — only used by Jazzy which doesn't look at these anyway. (They might be headers which used to be public.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced connection configuration with additional parameters for improved connection management
  * Revised HTTP executor protocol for improved request handling
  * Updated device storage interface for streamlined data management
  * Modified message handling and initialization patterns
  * Removed internal documentation markers to align API visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->