### PR TITLE
[AIT-324] Support for LiveObjects apply-on-ACK

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -79,6 +79,12 @@
 		211A610729DA05D700D169C5 /* ARTAttachRequestParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A610629DA05D700D169C5 /* ARTAttachRequestParams.m */; };
 		211A610829DA05D700D169C5 /* ARTAttachRequestParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A610629DA05D700D169C5 /* ARTAttachRequestParams.m */; };
 		211A610929DA05D700D169C5 /* ARTAttachRequestParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 211A610629DA05D700D169C5 /* ARTAttachRequestParams.m */; };
+		211BEC7C2F521F8300AF5B2D /* ARTPublishResult+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 211BEC7B2F521F8300AF5B2D /* ARTPublishResult+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211BEC7D2F521F8300AF5B2D /* ARTPublishResult+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 211BEC7B2F521F8300AF5B2D /* ARTPublishResult+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211BEC7E2F521F8300AF5B2D /* ARTPublishResult+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 211BEC7B2F521F8300AF5B2D /* ARTPublishResult+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211BEC802F5222EC00AF5B2D /* ARTPublishResultSerial+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 211BEC7F2F5222EC00AF5B2D /* ARTPublishResultSerial+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211BEC812F5222EC00AF5B2D /* ARTPublishResultSerial+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 211BEC7F2F5222EC00AF5B2D /* ARTPublishResultSerial+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211BEC822F5222EC00AF5B2D /* ARTPublishResultSerial+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 211BEC7F2F5222EC00AF5B2D /* ARTPublishResultSerial+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2124B78B29DB12A900AD8361 /* ARTVersion2Log.h in Headers */ = {isa = PBXBuildFile; fileRef = 2124B78A29DB12A900AD8361 /* ARTVersion2Log.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2124B78C29DB12A900AD8361 /* ARTVersion2Log.h in Headers */ = {isa = PBXBuildFile; fileRef = 2124B78A29DB12A900AD8361 /* ARTVersion2Log.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2124B78D29DB12A900AD8361 /* ARTVersion2Log.h in Headers */ = {isa = PBXBuildFile; fileRef = 2124B78A29DB12A900AD8361 /* ARTVersion2Log.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1142,6 +1148,8 @@
 		211A60FE29D8ABF100D169C5 /* ARTChannelStateChangeParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTChannelStateChangeParams.m; sourceTree = "<group>"; };
 		211A610229DA05C700D169C5 /* ARTAttachRequestParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTAttachRequestParams.h; path = PrivateHeaders/Ably/ARTAttachRequestParams.h; sourceTree = "<group>"; };
 		211A610629DA05D700D169C5 /* ARTAttachRequestParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTAttachRequestParams.m; sourceTree = "<group>"; };
+		211BEC7B2F521F8300AF5B2D /* ARTPublishResult+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTPublishResult+Private.h"; path = "PrivateHeaders/Ably/ARTPublishResult+Private.h"; sourceTree = "<group>"; };
+		211BEC7F2F5222EC00AF5B2D /* ARTPublishResultSerial+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "ARTPublishResultSerial+Private.h"; path = "PrivateHeaders/Ably/ARTPublishResultSerial+Private.h"; sourceTree = "<group>"; };
 		2124B78A29DB12A900AD8361 /* ARTVersion2Log.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARTVersion2Log.h; path = PrivateHeaders/Ably/ARTVersion2Log.h; sourceTree = "<group>"; };
 		2124B78E29DB13BD00AD8361 /* ARTInternalLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTInternalLog.m; sourceTree = "<group>"; };
 		2124B79229DB13C400AD8361 /* ARTInternalLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARTInternalLog.h; path = PrivateHeaders/Ably/ARTInternalLog.h; sourceTree = "<group>"; };
@@ -1972,8 +1980,10 @@
 				84B18ACD2EE233C7003768C1 /* ARTDictionarySerializable.h */,
 				21C2BE4C2F0D214C00AE5E41 /* ARTPublishResult.h */,
 				21C2BE542F0D237100AE5E41 /* ARTPublishResult.m */,
+				211BEC7B2F521F8300AF5B2D /* ARTPublishResult+Private.h */,
 				21C2BE4D2F0D214C00AE5E41 /* ARTPublishResultSerial.h */,
 				21C2BE552F0D237100AE5E41 /* ARTPublishResultSerial.m */,
+				211BEC7F2F5222EC00AF5B2D /* ARTPublishResultSerial+Private.h */,
 				21C2BE602F0D5B0E00AE5E41 /* ARTMessageSendStatus.h */,
 				21C2BE5C2F0D5B0100AE5E41 /* ARTMessageSendStatus.m */,
 				21C2BE642F0D776000AE5E41 /* ARTUpdateDeleteResult.h */,
@@ -2346,6 +2356,7 @@
 				D7AE18D21E5B410F00478D82 /* ARTPushChannelSubscriptions.h in Headers */,
 				D7D8F8251BC2C691009718F2 /* ARTTokenDetails.h in Headers */,
 				96A507A51A377DE90077CDF8 /* ARTNSDictionary+ARTDictionaryUtil.h in Headers */,
+				211BEC822F5222EC00AF5B2D /* ARTPublishResultSerial+Private.h in Headers */,
 				D75A3F1B1DDE5B62002A4AAD /* ARTGCD.h in Headers */,
 				D3AD0EBD215E2FB000312105 /* ARTNSString+ARTUtil.h in Headers */,
 				215924B02D636B6B004A235C /* ARTWrapperSDKProxyPushDeviceRegistrations+Private.h in Headers */,
@@ -2362,6 +2373,7 @@
 				D5BB211126AA993E00AA5F3E /* ARTNSURL+ARTUtils.h in Headers */,
 				84039A4C2C811F49001C053E /* ARTChannelOptions+Private.h in Headers */,
 				EB1AE0CC1C5C1EB200D62250 /* ARTEventEmitter+Private.h in Headers */,
+				211BEC7D2F521F8300AF5B2D /* ARTPublishResult+Private.h in Headers */,
 				215F75F82922B1DB009E0E76 /* ARTClientInformation.h in Headers */,
 				D7DF738A1EA645300013CD36 /* ARTLocalDeviceStorage.h in Headers */,
 				960D07931A45F1D800ED8C8C /* ARTCrypto.h in Headers */,
@@ -2414,6 +2426,7 @@
 				EB1B541222FB1AB4006A59AC /* ARTPushChannel+Private.h in Headers */,
 				D710D55521949C8C008F54AD /* ARTPushActivationStateMachine.h in Headers */,
 				D710D58C21949D29008F54AD /* ARTPresenceMessage.h in Headers */,
+				211BEC7C2F521F8300AF5B2D /* ARTPublishResult+Private.h in Headers */,
 				D710D50521949C18008F54AD /* ARTRealtimeChannel+Private.h in Headers */,
 				D710D58E21949D29008F54AD /* ARTDataEncoder.h in Headers */,
 				D710D49221949AB7008F54AD /* ARTRest+Private.h in Headers */,
@@ -2468,6 +2481,7 @@
 				5CC1D9D92E7C302B005DC3ED /* ARTMessageVersion+Private.h in Headers */,
 				21A28E712E54EF3D007D0BFE /* ARTPublicRealtimeChannelUnderlyingObjects.h in Headers */,
 				D710D4A921949ADF008F54AD /* ARTRestChannels.h in Headers */,
+				211BEC812F5222EC00AF5B2D /* ARTPublishResultSerial+Private.h in Headers */,
 				D710D4D821949BF9008F54AD /* ARTRealtimePresence.h in Headers */,
 				D710D48F21949AAE008F54AD /* ARTRest.h in Headers */,
 				D710D5B821949D4F008F54AD /* ARTAuthOptions+Private.h in Headers */,
@@ -2630,6 +2644,7 @@
 				D5BB213026AAA55C00AA5F3E /* ARTNSMutableURLRequest+ARTUtils.h in Headers */,
 				D710D68021949EA3008F54AD /* ARTOSReachability.h in Headers */,
 				D710D55B21949C8D008F54AD /* ARTPushActivationStateMachine.h in Headers */,
+				211BEC7E2F521F8300AF5B2D /* ARTPublishResult+Private.h in Headers */,
 				D710D5B221949D2A008F54AD /* ARTPresenceMessage.h in Headers */,
 				D710D51121949C19008F54AD /* ARTRealtimeChannel+Private.h in Headers */,
 				D710D5B421949D2A008F54AD /* ARTDataEncoder.h in Headers */,
@@ -2684,6 +2699,7 @@
 				5CC1D9D72E7C302B005DC3ED /* ARTMessageVersion+Private.h in Headers */,
 				21A28E722E54EF3D007D0BFE /* ARTPublicRealtimeChannelUnderlyingObjects.h in Headers */,
 				D710D4AF21949AE0008F54AD /* ARTRestChannels.h in Headers */,
+				211BEC802F5222EC00AF5B2D /* ARTPublishResultSerial+Private.h in Headers */,
 				D710D4E821949BFB008F54AD /* ARTRealtimePresence.h in Headers */,
 				D710D49121949AAF008F54AD /* ARTRest.h in Headers */,
 				D710D5C821949D50008F54AD /* ARTAuthOptions+Private.h in Headers */,

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "ably-cocoa-plugin-support",
-        "repositoryURL": "https://github.com/ably/ably-cocoa-plugin-support",
+        "repositoryURL": "https://github.com/ably/ably-cocoa-plugin-support.git",
         "state": {
           "branch": null,
-          "revision": "dd118432a6e023c3d2c8a051299e8081a06db036",
-          "version": "1.0.0"
+          "revision": "8bfbbaad56aa413aa53fc399e6a4ad284177ee84",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,8 @@ let package = Package(
         .package(name: "msgpack", url: "https://github.com/rvi/msgpack-objective-C", from: "0.4.0"),
         .package(name: "AblyDeltaCodec", url: "https://github.com/ably/delta-codec-cocoa", from: "1.3.5"),
         .package(name: "Nimble", url: "https://github.com/quick/nimble", from: "11.2.2"),
-        .package(name: "ably-cocoa-plugin-support", url: "https://github.com/ably/ably-cocoa-plugin-support", from: "1.0.0")
+        // TODO: Unpin before release
+        .package(name: "ably-cocoa-plugin-support", url: "https://github.com/ably/ably-cocoa-plugin-support.git", .revision("8bfbbaad56aa413aa53fc399e6a4ad284177ee84"))
     ],
     targets: [
         .target(

--- a/Source/ARTConnectionDetails.m
+++ b/Source/ARTConnectionDetails.m
@@ -10,7 +10,8 @@
               connectionStateTtl:(NSTimeInterval)connectionStateTtl
                         serverId:(NSString *)serverId
                  maxIdleInterval:(NSTimeInterval)maxIdleInterval
-            objectsGCGracePeriod:(nullable NSNumber *)objectsGCGracePeriod {
+            objectsGCGracePeriod:(nullable NSNumber *)objectsGCGracePeriod
+                        siteCode:(nullable NSString *)siteCode {
     if (self = [super init]) {
         _clientId = clientId;
         _connectionKey = connectionKey;
@@ -21,6 +22,7 @@
         _serverId = serverId;
         _maxIdleInterval = maxIdleInterval;
         _objectsGCGracePeriod = objectsGCGracePeriod;
+        _siteCode = siteCode;
     }
     return self;
 }

--- a/Source/ARTJsonLikeEncoder.m
+++ b/Source/ARTJsonLikeEncoder.m
@@ -1096,7 +1096,8 @@
                                        connectionStateTtl:millisecondsToTimeInterval([input artInteger:@"connectionStateTtl"])
                                                  serverId:[input artString:@"serverId"]
                                           maxIdleInterval:millisecondsToTimeInterval([input artInteger:@"maxIdleInterval"])
-                                     objectsGCGracePeriod:objectsGCGracePeriod];
+                                     objectsGCGracePeriod:objectsGCGracePeriod
+                                                 siteCode:[input artString:@"siteCode"]];
 }
 
 - (ARTChannelMetrics *)channelMetricsFromDictionary:(NSDictionary *)input {

--- a/Source/ARTPluginAPI.m
+++ b/Source/ARTPluginAPI.m
@@ -8,6 +8,8 @@
 #import "ARTClientOptions+Private.h"
 #import "ARTErrorInfo+Private.h"
 #import "ARTConnectionDetails+Private.h"
+#import "ARTPublishResult+Private.h"
+#import "ARTPublishResultSerial+Private.h"
 
 static ARTErrorInfo *_ourPublicErrorInfo(id<APPublicErrorInfo> pluginPublicErrorInfo) {
     if (![pluginPublicErrorInfo isKindOfClass:[ARTErrorInfo class]]) {
@@ -51,7 +53,7 @@ static ARTInternalLog *_internalLogger(id<APLogger> pluginLogger) {
     return (ARTInternalLog *)pluginLogger;
 }
 
-static APRealtimeChannelState _convertOurRealtimeChannelState(ARTRealtimeChannelState ourRealtimeChannelState) {
+APRealtimeChannelState ARTConvertToPluginChannelState(ARTRealtimeChannelState ourRealtimeChannelState) {
     switch (ourRealtimeChannelState) {
     case ARTRealtimeChannelInitialized:
         return APRealtimeChannelStateInitialized;
@@ -69,7 +71,7 @@ static APRealtimeChannelState _convertOurRealtimeChannelState(ARTRealtimeChannel
         return APRealtimeChannelStateFailed;
     }
 
-    [NSException raise:NSInternalInconsistencyException format:@"_convertOurRealtimeChannelState failed to map %lu", ourRealtimeChannelState];
+    [NSException raise:NSInternalInconsistencyException format:@"ARTConvertToPluginChannelState failed to map %lu", ourRealtimeChannelState];
 }
 
 static ARTLogLevel _convertPluginLogLevel(APLogLevel pluginLogLevel) {
@@ -159,11 +161,25 @@ static ARTLogLevel _convertPluginLogLevel(APLogLevel pluginLogLevel) {
                                                          completion:completion];
 }
 
+- (void)nosync_sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
+                                    channel:(id<APRealtimeChannel>)channel
+                       completionWithResult:(void (^)(id<APPublishResultProtocol> _Nullable publishResult, id<APPublicErrorInfo> _Nullable error))completion {
+    ARTRealtimeChannelInternal *internalChannel = _internalRealtimeChannel(channel);
+    dispatch_assert_queue(internalChannel.queue);
+
+    [internalChannel sendObjectWithObjectMessages:objectMessages
+                             completionWithResult:^(ARTPublishResult *publishResult, ARTErrorInfo *error) {
+        if (completion) {
+            completion(publishResult, error);
+        }
+    }];
+}
+
 - (APRealtimeChannelState)nosync_stateForChannel:(id<APRealtimeChannel>)channel {
     ARTRealtimeChannelInternal *internalChannel = _internalRealtimeChannel(channel);
     dispatch_assert_queue(internalChannel.queue);
 
-    return _convertOurRealtimeChannelState(internalChannel.state_nosync);
+    return ARTConvertToPluginChannelState(internalChannel.state_nosync);
 }
 
 - (void)nosync_fetchServerTimeForClient:(id<APRealtimeClient>)client

--- a/Source/ARTPublishResult.m
+++ b/Source/ARTPublishResult.m
@@ -1,4 +1,5 @@
 #import "ARTPublishResult.h"
+#import "ARTPublishResult+Private.h"
 #import "ARTPublishResultSerial.h"
 
 @implementation ARTPublishResult

--- a/Source/ARTPublishResultSerial.m
+++ b/Source/ARTPublishResultSerial.m
@@ -1,4 +1,5 @@
 #import "ARTPublishResultSerial.h"
+#import "ARTPublishResultSerial+Private.h"
 
 @implementation ARTPublishResultSerial
 

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -40,6 +40,8 @@
 #import "ARTPushChannel+Private.h"
 #endif
 
+#import "ARTErrorInfo+Private.h"
+
 #ifdef ABLY_SUPPORTS_PLUGINS
 @import _AblyPluginSupportPrivate;
 #import "ARTPluginAPI.h"
@@ -469,6 +471,16 @@ art_dispatch_sync(_queue, ^{
 #ifdef ABLY_SUPPORTS_PLUGINS
 - (void)sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
                           completion:(ARTCallback)completion {
+    [self sendObjectWithObjectMessages:objectMessages
+                  completionWithResult:^(ARTPublishResult *publishResult, ARTErrorInfo *error) {
+        if (completion) {
+            completion(error);
+        }
+    }];
+}
+
+- (void)sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
+                completionWithResult:(void (^)(ARTPublishResult *_Nullable publishResult, ARTErrorInfo *_Nullable error))completion {
     ARTProtocolMessage *pm = [[ARTProtocolMessage alloc] init];
     pm.action = ARTProtocolMessageObject;
     pm.channel = self.name;
@@ -476,10 +488,10 @@ art_dispatch_sync(_queue, ^{
 
     [self publishProtocolMessage:pm callback:^(ARTMessageSendStatus *status) {
         if (completion) {
-            completion(status.status.errorInfo);
+            completion(status.publishResult, status.status.errorInfo);
         }
     }];
- }
+}
 #endif
 
 - (void)internalSendEditRequestForMessage:(ARTMessage *)message
@@ -726,6 +738,13 @@ art_dispatch_sync(_queue, ^{
     }
 
     [self emit:stateChange.event with:stateChange];
+
+#ifdef ABLY_SUPPORTS_PLUGINS
+    id<APLiveObjectsInternalPluginProtocol> plugin = self.realtime.options.liveObjectsPlugin;
+    if ([plugin respondsToSelector:@selector(nosync_onChannelStateChanged:toState:reason:)]) {
+        [plugin nosync_onChannelStateChanged:self toState:ARTConvertToPluginChannelState(state) reason:params.errorInfo];
+    }
+#endif
 
     if (channelRetryListener) {
         [channelRetryListener startTimer];

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -143,5 +143,7 @@ framework module Ably {
         header "ARTMessageOperation+Private.h"
         header "ARTMessage+Private.h"
         header "ARTMessageSendStatus.h"
+        header "ARTPublishResult+Private.h"
+        header "ARTPublishResultSerial+Private.h"
     }
 }

--- a/Source/PrivateHeaders/Ably/ARTConnectionDetails.h
+++ b/Source/PrivateHeaders/Ably/ARTConnectionDetails.h
@@ -54,6 +54,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// If the `objectsGCGracePeriod` is present in the `ConnectionDetails`, this contains an `NSNumber` wrapping an `NSTimeInterval` containing its value in seconds.
 @property (readonly, nonatomic, nullable) NSNumber *objectsGCGracePeriod;
 
+/// The site code of the server that the client is connected to (CD2j).
+@property (nullable, readonly, nonatomic) NSString *siteCode;
+
 - (instancetype)initWithClientId:(NSString *_Nullable)clientId
                    connectionKey:(NSString *_Nullable)connectionKey
                   maxMessageSize:(NSInteger)maxMessageSize
@@ -62,7 +65,8 @@ NS_ASSUME_NONNULL_BEGIN
               connectionStateTtl:(NSTimeInterval)connectionStateTtl
                         serverId:(NSString *)serverId
                  maxIdleInterval:(NSTimeInterval)maxIdleInterval
-            objectsGCGracePeriod:(nullable NSNumber *)objectsGCGracePeriod;
+            objectsGCGracePeriod:(nullable NSNumber *)objectsGCGracePeriod
+                        siteCode:(nullable NSString *)siteCode;
 
 NS_ASSUME_NONNULL_END
 

--- a/Source/PrivateHeaders/Ably/ARTPluginAPI.h
+++ b/Source/PrivateHeaders/Ably/ARTPluginAPI.h
@@ -2,8 +2,12 @@
 
 @import Foundation;
 @import _AblyPluginSupportPrivate;
+#import "ARTTypes.h"
 
 NS_ASSUME_NONNULL_BEGIN
+
+/// Converts an `ARTRealtimeChannelState` to the equivalent `APRealtimeChannelState`.
+APRealtimeChannelState ARTConvertToPluginChannelState(ARTRealtimeChannelState ourRealtimeChannelState);
 
 /// Our implementation of `APPluginAPIProtocol`, which allows Ably-authored plugins to access the internals of this SDK.
 @interface ARTPluginAPI: NSObject <APPluginAPIProtocol>

--- a/Source/PrivateHeaders/Ably/ARTPublishResult+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPublishResult+Private.h
@@ -1,0 +1,10 @@
+#import <Ably/ARTPublishResult.h>
+
+#ifdef ABLY_SUPPORTS_PLUGINS
+@import _AblyPluginSupportPrivate;
+#endif
+
+#ifdef ABLY_SUPPORTS_PLUGINS
+@interface ARTPublishResult () <APPublishResultProtocol>
+@end
+#endif

--- a/Source/PrivateHeaders/Ably/ARTPublishResultSerial+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPublishResultSerial+Private.h
@@ -1,0 +1,10 @@
+#import <Ably/ARTPublishResultSerial.h>
+
+#ifdef ABLY_SUPPORTS_PLUGINS
+@import _AblyPluginSupportPrivate;
+#endif
+
+#ifdef ABLY_SUPPORTS_PLUGINS
+@interface ARTPublishResultSerial () <APPublishResultSerialProtocol>
+@end
+#endif

--- a/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
@@ -17,6 +17,7 @@
 #endif
 
 @class ARTProtocolMessage;
+@class ARTPublishResult;
 @class ARTRealtimePresenceInternal;
 @class ARTRealtimeAnnotationsInternal;
 @class ARTChannelStateChangeParams;
@@ -158,6 +159,10 @@ ART_EMBED_INTERFACE_EVENT_EMITTER(ARTChannelEvent, ARTChannelStateChange *)
 /// Provides the implementation for `-[ARTPluginAPI sendObjectWithObjectMessages:completion:]`. See documentation for that method in `APPluginAPIProtocol`.
 - (void)sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
                           completion:(ARTCallback)completion;
+
+/// Provides the implementation for `-[ARTPluginAPI sendObjectWithObjectMessages:completionWithResult:]`. See documentation for that method in `APPluginAPIProtocol`.
+- (void)sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
+                completionWithResult:(void (^)(ARTPublishResult *_Nullable publishResult, ARTErrorInfo *_Nullable error))completion;
 #endif
 
 @end

--- a/Source/include/Ably/ARTStatus.h
+++ b/Source/include/Ably/ARTStatus.h
@@ -160,7 +160,8 @@ typedef CF_ENUM(NSUInteger, ARTErrorCode) {
     ARTErrorUnableToEnterPresenceChannelMaxMemberLimitExceeded = 91003,
     ARTErrorUnableToAutomaticallyReEnterPresenceChannel = 91004,
     ARTErrorPresenceStateIsOutOfSync = 91005,
-    ARTErrorMemberImplicitlyLeftPresenceChannel = 91100
+    ARTErrorMemberImplicitlyLeftPresenceChannel = 91100,
+    ARTErrorUnableToApplyObjectsOperationSyncDidNotComplete = 92008
 };
 
 /**

--- a/Source/include/module.modulemap
+++ b/Source/include/module.modulemap
@@ -143,5 +143,7 @@ module Ably {
         header "../PrivateHeaders/Ably/ARTMessageOperation+Private.h"
         header "../PrivateHeaders/Ably/ARTMessage+Private.h"
         header "../PrivateHeaders/Ably/ARTMessageSendStatus.h"
+        header "../PrivateHeaders/Ably/ARTPublishResult+Private.h"
+        header "../PrivateHeaders/Ably/ARTPublishResultSerial+Private.h"
     }
 }

--- a/Test/AblyTests/Test Utilities/TestUtilities.swift
+++ b/Test/AblyTests/Test Utilities/TestUtilities.swift
@@ -1511,7 +1511,7 @@ class TestProxyTransport: ARTWebSocketTransport {
         msg.action = .connected
         msg.connectionId = "x-xxxxxxxx"
         msg.connectionKey = "xxxxxxx-xxxxxxxxxxxxxx-xxxxxxxx"
-        msg.connectionDetails = ARTConnectionDetails(clientId: clientId, connectionKey: "a8c10!t-3D0O4ejwTdvLkl-b33a8c10", maxMessageSize: 16384, maxFrameSize: 262144, maxInboundRate: 250, connectionStateTtl: 60, serverId: "testServerId", maxIdleInterval: 15000, objectsGCGracePeriod: 86_400_000)
+        msg.connectionDetails = ARTConnectionDetails(clientId: clientId, connectionKey: "a8c10!t-3D0O4ejwTdvLkl-b33a8c10", maxMessageSize: 16384, maxFrameSize: 262144, maxInboundRate: 250, connectionStateTtl: 60, serverId: "testServerId", maxIdleInterval: 15000, objectsGCGracePeriod: 86_400_000, siteCode: nil)
         super.receive(msg)
     }
 

--- a/Test/AblyTests/Tests/PluginAPITests.swift
+++ b/Test/AblyTests/Tests/PluginAPITests.swift
@@ -21,11 +21,13 @@ class PluginAPITests: XCTestCase {
 
         internal var receivedConnectionDetails: [(connectionDetails: (any ConnectionDetailsProtocol)?, channel: any RealtimeChannel)] = []
         internal var receivedChannelAttached: [(channel: any RealtimeChannel, hasObjects: Bool)] = []
+        internal var receivedStateChanges: [(channel: any RealtimeChannel, state: RealtimeChannelState, reason: (any PublicErrorInfo)?)] = []
 
         /// Resets all recorded mock state. Called in `setUp()` since this is a shared static instance.
         func clearState() {
             receivedConnectionDetails.removeAll()
             receivedChannelAttached.removeAll()
+            receivedStateChanges.removeAll()
         }
 
         func nosync_prepare(_ channel: any RealtimeChannel, client: any RealtimeClient) {
@@ -56,6 +58,10 @@ class PluginAPITests: XCTestCase {
 
         func nosync_onConnected(withConnectionDetails connectionDetails: (any ConnectionDetailsProtocol)?, channel: any RealtimeChannel) {
             receivedConnectionDetails.append((connectionDetails, channel))
+        }
+
+        func nosync_onChannelStateChanged(_ channel: any RealtimeChannel, toState state: RealtimeChannelState, reason: (any PublicErrorInfo)?) {
+            receivedStateChanges.append((channel, state, reason))
         }
     }
 
@@ -150,7 +156,7 @@ class PluginAPITests: XCTestCase {
 
         let connectedProtocolMessage = ARTProtocolMessage()
         connectedProtocolMessage.action = .connected
-        let connectionDetails = ARTConnectionDetails(clientId: nil, connectionKey: nil, maxMessageSize: 100, maxFrameSize: 100, maxInboundRate: 100, connectionStateTtl: 100, serverId: "", maxIdleInterval: 100, objectsGCGracePeriod: 1500) // all arbitrary except objectsGCGracePeriod
+        let connectionDetails = ARTConnectionDetails(clientId: nil, connectionKey: nil, maxMessageSize: 100, maxFrameSize: 100, maxInboundRate: 100, connectionStateTtl: 100, serverId: "", maxIdleInterval: 100, objectsGCGracePeriod: 1500, siteCode: nil) // all arbitrary except objectsGCGracePeriod
         connectedProtocolMessage.connectionDetails = connectionDetails
         transport.receive(connectedProtocolMessage)
 
@@ -201,7 +207,7 @@ class PluginAPITests: XCTestCase {
 
         let connectedProtocolMessage = ARTProtocolMessage()
         connectedProtocolMessage.action = .connected
-        let connectionDetails = ARTConnectionDetails(clientId: nil, connectionKey: nil, maxMessageSize: 100, maxFrameSize: 100, maxInboundRate: 100, connectionStateTtl: 100, serverId: "", maxIdleInterval: 100, objectsGCGracePeriod: 1500) // all arbitrary except objectsGCGracePeriod
+        let connectionDetails = ARTConnectionDetails(clientId: nil, connectionKey: nil, maxMessageSize: 100, maxFrameSize: 100, maxInboundRate: 100, connectionStateTtl: 100, serverId: "", maxIdleInterval: 100, objectsGCGracePeriod: 1500, siteCode: "us-east-1-A") // all arbitrary except objectsGCGracePeriod and siteCode
         connectedProtocolMessage.connectionDetails = connectionDetails
         transport.receive(connectedProtocolMessage)
 
@@ -209,10 +215,11 @@ class PluginAPITests: XCTestCase {
         try internalQueue.sync {
             let newConnectionDetails = try XCTUnwrap(pluginAPI.nosync_latestConnectionDetails(for: pluginRealtimeClient))
             XCTAssertEqual(newConnectionDetails.objectsGCGracePeriod, 1500)
+            XCTAssertEqual(newConnectionDetails.siteCode?(), "us-east-1-A")
         }
     }
 
-    // MARK: - Channel attached
+    // MARK: - Channel state changes
 
     func test_channelAttachedNotifiesPlugin() throws {
         // Given: A realtime client with a plugin
@@ -248,6 +255,49 @@ class PluginAPITests: XCTestCase {
         XCTAssertTrue(withObjects.hasObjects)
     }
 
+    func test_channelStateChangeNotifiesPlugin() throws {
+        // Given: A realtime client
+        let test = Test()
+        let options = try AblyTests.commonAppSetup(for: test)
+        options.plugins = [.liveObjects: MockLiveObjectsPlugin.self]
+        options.testOptions.transportFactory = TestProxyTransportFactory()
+
+        let client = ARTRealtime(options: options)
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get(test.uniqueChannelName())
+
+        // When: The channel is attached
+        waitUntil(timeout: testTimeout) { done in
+            channel.attach { error in
+                XCTAssertNil(error)
+                done()
+            }
+        }
+
+        // Then: The plugin receives state change notifications including the transition to ATTACHING and ATTACHED
+        var stateChanges = MockLiveObjectsPlugin._internalPlugin.receivedStateChanges
+        var states = stateChanges.map { $0.state }
+        XCTAssertTrue(states.contains(.attaching))
+        XCTAssertTrue(states.contains(.attached))
+
+        // When: The channel transitions to FAILED
+        MockLiveObjectsPlugin._internalPlugin.receivedStateChanges.removeAll()
+
+        let errorMessage = ARTProtocolMessage()
+        errorMessage.action = .error
+        errorMessage.channel = channel.name
+        errorMessage.error = .create(withCode: 50000, status: 500, message: "test error")
+        (client.internal.transport as! TestProxyTransport).receive(errorMessage)
+
+        // Then: The plugin receives a FAILED state change notification with the error as the reason
+        stateChanges = MockLiveObjectsPlugin._internalPlugin.receivedStateChanges
+        states = stateChanges.map { $0.state }
+        XCTAssertTrue(states.contains(.failed))
+        let failed = try XCTUnwrap(stateChanges.first { $0.state == .failed })
+        XCTAssertEqual((failed.reason as? ARTErrorInfo)?.code, 50000)
+    }
+
     // MARK: - Send object
 
     func test_sendObject() throws {
@@ -275,25 +325,41 @@ class PluginAPITests: XCTestCase {
         let pluginChannel = channel.internal as! _AblyPluginSupportPrivate.RealtimeChannel
         let internalQueue = client.internal.queue
 
-        // When: We call nosync_sendObject with a mock object message
+        // When: We call nosync_sendObject (completion variant) with a mock object message
         // (We don't wait for the completion handler; constructing a valid object message that
         // the server would ACK is out of scope for this test; we'll leave that for the LiveObjects
         // plugin tests)
-        let mockObjectMessage = MockInternalLiveObjectsPlugin.MockObjectMessage()
+        let mockObjectMessage1 = MockInternalLiveObjectsPlugin.MockObjectMessage()
         internalQueue.sync {
-            pluginAPI.nosync_sendObject(withObjectMessages: [mockObjectMessage], channel: pluginChannel, completion: nil)
+            pluginAPI.nosync_sendObject(withObjectMessages: [mockObjectMessage1], channel: pluginChannel, completion: nil)
         }
 
         // Then: The SDK asks the mock plugin to encode the object message (which encodes
         // MockObjectMessage.identifier under the key "mockMessageIdentifier"), and sends the
         // result in an OBJECT protocol message
-        let objectMessages = transport.protocolMessagesSent.filter { $0.action == .object }
+        var objectMessages = transport.protocolMessagesSent.filter { $0.action == .object }
         XCTAssertEqual(objectMessages.count, 1)
 
-        let lastRawData = try XCTUnwrap(transport.rawDataSent.last)
-        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: lastRawData) as? [String: Any])
-        let state = try XCTUnwrap(json["state"] as? [[String: Any]])
+        var lastRawData = try XCTUnwrap(transport.rawDataSent.last)
+        var json = try XCTUnwrap(JSONSerialization.jsonObject(with: lastRawData) as? [String: Any])
+        var state = try XCTUnwrap(json["state"] as? [[String: Any]])
         XCTAssertEqual(state.count, 1)
-        XCTAssertEqual(state[0]["mockMessageIdentifier"] as? String, mockObjectMessage.identifier)
+        XCTAssertEqual(state[0]["mockMessageIdentifier"] as? String, mockObjectMessage1.identifier)
+
+        // When: We call nosync_sendObject (completionWithResult variant) with another mock object message
+        let mockObjectMessage2 = MockInternalLiveObjectsPlugin.MockObjectMessage()
+        internalQueue.sync {
+            pluginAPI.nosync_sendObject?(withObjectMessages: [mockObjectMessage2], channel: pluginChannel, completionWithResult: nil)
+        }
+
+        // Then: The result is likewise sent in an OBJECT protocol message
+        objectMessages = transport.protocolMessagesSent.filter { $0.action == .object }
+        XCTAssertEqual(objectMessages.count, 2)
+
+        lastRawData = try XCTUnwrap(transport.rawDataSent.last)
+        json = try XCTUnwrap(JSONSerialization.jsonObject(with: lastRawData) as? [String: Any])
+        state = try XCTUnwrap(json["state"] as? [[String: Any]])
+        XCTAssertEqual(state.count, 1)
+        XCTAssertEqual(state[0]["mockMessageIdentifier"] as? String, mockObjectMessage2.identifier)
     }
 }


### PR DESCRIPTION
Implements the new API from https://github.com/ably/ably-cocoa-plugin-support/pull/11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Object message publish now offers a completion that returns both error info and a publish result.
  * Plugin API adds a channel-state mapping helper and a publish-with-result entry point.
  * Connection details now include an optional siteCode field.

* **Bug Fixes / Signals**
  * Added new error code for failed object-operation sync completion.

* **Tests**
  * Tests and utilities updated with mocks to cover siteCode propagation and publish-result flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->