### PR TITLE
Bump plugin-support to v2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/ably/ably-cocoa-plugin-support.git",
         "state": {
           "branch": null,
-          "revision": "36c529db38154d01537e782f7ed4aa7535fb3237",
-          "version": null
+          "revision": "a290b8942086ffb6e21e4805d9319143669d9414",
+          "version": "2.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,7 @@ let package = Package(
         .package(name: "msgpack", url: "https://github.com/rvi/msgpack-objective-C", from: "0.4.0"),
         .package(name: "AblyDeltaCodec", url: "https://github.com/ably/delta-codec-cocoa", from: "1.3.5"),
         .package(name: "Nimble", url: "https://github.com/quick/nimble", from: "11.2.2"),
-        // TODO: Unpin before release
-        .package(name: "ably-cocoa-plugin-support", url: "https://github.com/ably/ably-cocoa-plugin-support.git", .revision("36c529db38154d01537e782f7ed4aa7535fb3237"))
+        .package(name: "ably-cocoa-plugin-support", url: "https://github.com/ably/ably-cocoa-plugin-support.git", from: "2.0.0")
     ],
     targets: [
         .target(

--- a/Source/ARTPluginAPI.m
+++ b/Source/ARTPluginAPI.m
@@ -157,22 +157,12 @@ static ARTLogLevel _convertPluginLogLevel(APLogLevel pluginLogLevel) {
 
 - (void)nosync_sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
                                     channel:(id<APRealtimeChannel>)channel
-                                 completion:(void (^)(id<APPublicErrorInfo> _Nullable))completion {
-    ARTRealtimeChannelInternal *internalChannel = _internalRealtimeChannel(channel);
-    dispatch_assert_queue(internalChannel.queue);
-
-    [_internalRealtimeChannel(channel) sendObjectWithObjectMessages:objectMessages
-                                                         completion:completion];
-}
-
-- (void)nosync_sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
-                                    channel:(id<APRealtimeChannel>)channel
-                       completionWithResult:(void (^)(id<APPublishResultProtocol> _Nullable publishResult, id<APPublicErrorInfo> _Nullable error))completion {
+                                 completion:(void (^)(id<APPublishResultProtocol> _Nullable publishResult, id<APPublicErrorInfo> _Nullable error))completion {
     ARTRealtimeChannelInternal *internalChannel = _internalRealtimeChannel(channel);
     dispatch_assert_queue(internalChannel.queue);
 
     [internalChannel sendObjectWithObjectMessages:objectMessages
-                             completionWithResult:^(ARTPublishResult *publishResult, ARTErrorInfo *error) {
+                                       completion:^(ARTPublishResult *publishResult, ARTErrorInfo *error) {
         if (completion) {
             completion(publishResult, error);
         }

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -470,17 +470,7 @@ art_dispatch_sync(_queue, ^{
 
 #ifdef ABLY_SUPPORTS_PLUGINS
 - (void)sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
-                          completion:(ARTCallback)completion {
-    [self sendObjectWithObjectMessages:objectMessages
-                  completionWithResult:^(ARTPublishResult *publishResult, ARTErrorInfo *error) {
-        if (completion) {
-            completion(error);
-        }
-    }];
-}
-
-- (void)sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
-                completionWithResult:(void (^)(ARTPublishResult *_Nullable publishResult, ARTErrorInfo *_Nullable error))completion {
+                          completion:(void (^)(ARTPublishResult *_Nullable publishResult, ARTErrorInfo *_Nullable error))completion {
     ARTProtocolMessage *pm = [[ARTProtocolMessage alloc] init];
     pm.action = ARTProtocolMessageObject;
     pm.channel = self.name;
@@ -741,9 +731,7 @@ art_dispatch_sync(_queue, ^{
 
 #ifdef ABLY_SUPPORTS_PLUGINS
     id<APLiveObjectsInternalPluginProtocol> plugin = self.realtime.options.liveObjectsPlugin;
-    if ([plugin respondsToSelector:@selector(nosync_onChannelStateChanged:toState:reason:)]) {
-        [plugin nosync_onChannelStateChanged:self toState:ARTConvertToPluginChannelState(state) reason:params.errorInfo];
-    }
+    [plugin nosync_onChannelStateChanged:self toState:ARTConvertToPluginChannelState(state) reason:params.errorInfo];
 #endif
 
     if (channelRetryListener) {

--- a/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTRealtimeChannel+Private.h
@@ -158,11 +158,7 @@ ART_EMBED_INTERFACE_EVENT_EMITTER(ARTChannelEvent, ARTChannelStateChange *)
 #ifdef ABLY_SUPPORTS_PLUGINS
 /// Provides the implementation for `-[ARTPluginAPI sendObjectWithObjectMessages:completion:]`. See documentation for that method in `APPluginAPIProtocol`.
 - (void)sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
-                          completion:(ARTCallback)completion;
-
-/// Provides the implementation for `-[ARTPluginAPI sendObjectWithObjectMessages:completionWithResult:]`. See documentation for that method in `APPluginAPIProtocol`.
-- (void)sendObjectWithObjectMessages:(NSArray<id<APObjectMessageProtocol>> *)objectMessages
-                completionWithResult:(void (^)(ARTPublishResult *_Nullable publishResult, ARTErrorInfo *_Nullable error))completion;
+                          completion:(void (^)(ARTPublishResult *_Nullable publishResult, ARTErrorInfo *_Nullable error))completion;
 #endif
 
 @end

--- a/Test/AblyTests/Tests/PluginAPITests.swift
+++ b/Test/AblyTests/Tests/PluginAPITests.swift
@@ -217,7 +217,7 @@ class PluginAPITests: XCTestCase {
         try internalQueue.sync {
             let newConnectionDetails = try XCTUnwrap(pluginAPI.nosync_latestConnectionDetails(for: pluginRealtimeClient))
             XCTAssertEqual(newConnectionDetails.objectsGCGracePeriod, 1500)
-            XCTAssertEqual(newConnectionDetails.siteCode?(), "us-east-1-A")
+            XCTAssertEqual(newConnectionDetails.siteCode, "us-east-1-A")
         }
     }
 
@@ -327,7 +327,7 @@ class PluginAPITests: XCTestCase {
         let pluginChannel = channel.internal as! _AblyPluginSupportPrivate.RealtimeChannel
         let internalQueue = client.internal.queue
 
-        // When: We call nosync_sendObject (completion variant) with a mock object message
+        // When: We call nosync_sendObject with a mock object message
         // (We don't wait for the completion handler; constructing a valid object message that
         // the server would ACK is out of scope for this test; we'll leave that for the LiveObjects
         // plugin tests)
@@ -339,29 +339,13 @@ class PluginAPITests: XCTestCase {
         // Then: The SDK asks the mock plugin to encode the object message (which encodes
         // MockObjectMessage.identifier under the key "mockMessageIdentifier"), and sends the
         // result in an OBJECT protocol message
-        var objectMessages = transport.protocolMessagesSent.filter { $0.action == .object }
+        let objectMessages = transport.protocolMessagesSent.filter { $0.action == .object }
         XCTAssertEqual(objectMessages.count, 1)
 
-        var lastRawData = try XCTUnwrap(transport.rawDataSent.last)
-        var json = try XCTUnwrap(JSONSerialization.jsonObject(with: lastRawData) as? [String: Any])
-        var state = try XCTUnwrap(json["state"] as? [[String: Any]])
+        let lastRawData = try XCTUnwrap(transport.rawDataSent.last)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: lastRawData) as? [String: Any])
+        let state = try XCTUnwrap(json["state"] as? [[String: Any]])
         XCTAssertEqual(state.count, 1)
         XCTAssertEqual(state[0]["mockMessageIdentifier"] as? String, mockObjectMessage1.identifier)
-
-        // When: We call nosync_sendObject (completionWithResult variant) with another mock object message
-        let mockObjectMessage2 = MockInternalLiveObjectsPlugin.MockObjectMessage()
-        internalQueue.sync {
-            pluginAPI.nosync_sendObject?(withObjectMessages: [mockObjectMessage2], channel: pluginChannel, completionWithResult: nil)
-        }
-
-        // Then: The result is likewise sent in an OBJECT protocol message
-        objectMessages = transport.protocolMessagesSent.filter { $0.action == .object }
-        XCTAssertEqual(objectMessages.count, 2)
-
-        lastRawData = try XCTUnwrap(transport.rawDataSent.last)
-        json = try XCTUnwrap(JSONSerialization.jsonObject(with: lastRawData) as? [String: Any])
-        state = try XCTUnwrap(json["state"] as? [[String: Any]])
-        XCTAssertEqual(state.count, 1)
-        XCTAssertEqual(state[0]["mockMessageIdentifier"] as? String, mockObjectMessage2.identifier)
     }
 }


### PR DESCRIPTION
Since plugin-support v2 makes all previously `@optional` methods required, the backwards-compatibility scaffolding introduced alongside them is no longer needed.

Relates to https://github.com/ably/ably-liveobjects-swift-plugin/pull/126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated ably-cocoa-plugin-support dependency to version 2.0.0 with flexible version constraints for improved compatibility
  * Consolidated plugin object message handling for streamlined integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->