### PR TITLE
Add `onAttach` callback variants to annotations subscribe

### DIFF
--- a/Source/ARTRealtimeAnnotations.m
+++ b/Source/ARTRealtimeAnnotations.m
@@ -59,8 +59,16 @@
     return [_internal subscribe:callback];
 }
 
+- (ARTEventListener *)subscribeWithAttachCallback:(ARTCallback)onAttach callback:(ARTAnnotationCallback)callback {
+    return [_internal subscribeWithAttachCallback:onAttach callback:callback];
+}
+
 - (ARTEventListener *)subscribe:(NSString *)type callback:(ARTAnnotationCallback)callback {
     return [_internal subscribe:type callback:callback];
+}
+
+- (ARTEventListener *)subscribe:(NSString *)type onAttach:(ARTCallback)onAttach callback:(ARTAnnotationCallback)callback {
+    return [_internal subscribe:type onAttach:onAttach callback:callback];
 }
 
 - (void)unsubscribe {
@@ -185,6 +193,14 @@ art_dispatch_sync(_queue, ^{
             });
         };
     }
+    if (onAttach) {
+        ARTCallback userOnAttach = onAttach;
+        onAttach = ^(ARTErrorInfo *_Nullable e) {
+            art_dispatch_async(self->_userQueue, ^{
+                userOnAttach(e);
+            });
+        };
+    }
 
     __block ARTEventListener *listener = nil;
 
@@ -245,8 +261,16 @@ art_dispatch_sync(_queue, ^{
     return [self _subscribe:nil onAttach:nil callback:cb];
 }
 
+- (ARTEventListener *)subscribeWithAttachCallback:(ARTCallback)onAttach callback:(ARTAnnotationCallback)cb {
+    return [self _subscribe:nil onAttach:onAttach callback:cb];
+}
+
 - (ARTEventListener *)subscribe:(NSString *)type callback:(ARTAnnotationCallback)callback {
     return [self _subscribe:type onAttach:nil callback:callback];
+}
+
+- (ARTEventListener *)subscribe:(NSString *)type onAttach:(ARTCallback)onAttach callback:(ARTAnnotationCallback)callback {
+    return [self _subscribe:type onAttach:onAttach callback:callback];
 }
 
 // RTP7

--- a/Source/ARTWrapperSDKProxyRealtimeAnnotations.m
+++ b/Source/ARTWrapperSDKProxyRealtimeAnnotations.m
@@ -28,8 +28,16 @@ NS_ASSUME_NONNULL_END
     return [self.underlyingRealtimeAnnotations subscribe:callback];
 }
 
+- (ARTEventListener *)subscribeWithAttachCallback:(ARTCallback)onAttach callback:(ARTAnnotationCallback)callback {
+    return [self.underlyingRealtimeAnnotations subscribeWithAttachCallback:onAttach callback:callback];
+}
+
 - (ARTEventListener *)subscribe:(NSString *)type callback:(ARTAnnotationCallback)callback {
     return [self.underlyingRealtimeAnnotations subscribe:type callback:callback];
+}
+
+- (ARTEventListener *)subscribe:(NSString *)type onAttach:(ARTCallback)onAttach callback:(ARTAnnotationCallback)callback {
+    return [self.underlyingRealtimeAnnotations subscribe:type onAttach:onAttach callback:callback];
 }
 
 - (void)getForMessage:(ARTMessage *)message query:(ARTAnnotationsQuery *)query callback:(ARTPaginatedAnnotationsCallback)callback {

--- a/Source/include/Ably/ARTRealtimeAnnotations.h
+++ b/Source/include/Ably/ARTRealtimeAnnotations.h
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * Note that if you want to receive individual realtime annotations (instead of just the rolled-up summaries), you will need to request the `ARTChannelModeAnnotationSubscribe`  in `ARTChannelOptions`, since they are not delivered by default. In general, most clients will not bother with subscribing to individual annotations, and will instead just look at the summary updates.
  *
- * @param callback  A callback containing received annotation.
+ * @param callback A callback containing received annotation.
  *
  * @return An event listener object.
  */
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Note that if you want to receive individual realtime annotations (instead of just the rolled-up summaries), you will need to request the `ARTChannelModeAnnotationSubscribe` in `ARTChannelOptions`, since they are not delivered by default. In general, most clients will not bother with subscribing to individual annotations, and will instead just look at the summary updates.
  *
  * @param type A type of the `ARTAnnotation` to register the listener for.
- * @param callback  A callback containing received annotation.
+ * @param callback A callback containing received annotation.
  *
  * @return An event listener object.
  */

--- a/Source/include/Ably/ARTRealtimeAnnotations.h
+++ b/Source/include/Ably/ARTRealtimeAnnotations.h
@@ -79,6 +79,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (ARTEventListener *_Nullable)subscribe:(ARTAnnotationCallback)callback;
 
 /**
+ * Registers a listener that is called each time an `ARTAnnotation` is received on the channel. An attach callback may optionally be passed in to this call to be notified of success or failure of the channel `-[ARTRealtimeChannelProtocol attach]` operation. It will not be called if the `ARTRealtimeChannelOptions.attachOnSubscribe` channel option is set to `false`.
+ *
+ * Note that if you want to receive individual realtime annotations (instead of just the rolled-up summaries), you will need to request the `ARTChannelModeAnnotationSubscribe` in `ARTChannelOptions`, since they are not delivered by default. In general, most clients will not bother with subscribing to individual annotations, and will instead just look at the summary updates.
+ *
+ * @param onAttach An attach callback function.
+ * @param callback A callback containing received annotation.
+ *
+ * @return An event listener object.
+ */
+- (ARTEventListener *_Nullable)subscribeWithAttachCallback:(nullable ARTCallback)onAttach callback:(ARTAnnotationCallback)callback;
+
+/**
  * Registers a listener that is called each time an `ARTAnnotation` matching a given `type` is received on the channel.
  *
  * Note that if you want to receive individual realtime annotations (instead of just the rolled-up summaries), you will need to request the `ARTChannelModeAnnotationSubscribe` in `ARTChannelOptions`, since they are not delivered by default. In general, most clients will not bother with subscribing to individual annotations, and will instead just look at the summary updates.
@@ -89,6 +101,19 @@ NS_ASSUME_NONNULL_BEGIN
  * @return An event listener object.
  */
 - (ARTEventListener *_Nullable)subscribe:(NSString *)type callback:(ARTAnnotationCallback)callback;
+
+/**
+ * Registers a listener that is called each time an `ARTAnnotation` matching a given `type` is received on the channel. An attach callback may optionally be passed in to this call to be notified of success or failure of the channel `-[ARTRealtimeChannelProtocol attach]` operation. It will not be called if the `ARTRealtimeChannelOptions.attachOnSubscribe` channel option is set to `false`.
+ *
+ * Note that if you want to receive individual realtime annotations (instead of just the rolled-up summaries), you will need to request the `ARTChannelModeAnnotationSubscribe` in `ARTChannelOptions`, since they are not delivered by default. In general, most clients will not bother with subscribing to individual annotations, and will instead just look at the summary updates.
+ *
+ * @param type A type of the `ARTAnnotation` to register the listener for.
+ * @param onAttach An attach callback function.
+ * @param callback A callback containing received annotation.
+ *
+ * @return An event listener object.
+ */
+- (ARTEventListener *_Nullable)subscribe:(NSString *)type onAttach:(nullable ARTCallback)onAttach callback:(ARTAnnotationCallback)callback;
 
 /**
  * Deregisters all listeners currently receiving `ARTAnnotation` for the channel.

--- a/Test/AblyTests/Tests/RealtimeAnnotationsTests.swift
+++ b/Test/AblyTests/Tests/RealtimeAnnotationsTests.swift
@@ -232,6 +232,103 @@ class RealtimeAnnotationsTests: XCTestCase {
         }
     }
 
+    // RTAN4d, RTL7g
+    func test__annotations_subscribe_should_implicitly_attach_the_channel_if_options_attachOnSubscribe_is_true() throws {
+        let test = Test()
+        let client = ARTRealtime(options: try AblyTests.commonAppSetup(for: test))
+        defer { client.dispose(); client.close() }
+        let channel = client.channels.get(test.uniqueChannelName())
+
+        // Initialized
+        XCTAssertEqual(channel.state, ARTRealtimeChannelState.initialized)
+        channel.annotations.subscribe { _ in }
+        XCTAssertEqual(channel.state, ARTRealtimeChannelState.attaching)
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        // Detaching
+        channel.detach()
+        channel.annotations.subscribe { _ in }
+        XCTAssertEqual(channel.state, ARTRealtimeChannelState.detaching)
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+
+        // Detached
+        channel.detach()
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
+        channel.annotations.subscribe { _ in }
+        expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
+    }
+
+    // RTAN4d, RTL7h
+    func test__annotations_subscribe_should_not_implicitly_attach_the_channel_if_options_attachOnSubscribe_is_false() throws {
+        let test = Test()
+        let client = ARTRealtime(options: try AblyTests.commonAppSetup(for: test))
+        defer { client.dispose(); client.close() }
+
+        let channelOptions = ARTRealtimeChannelOptions()
+        channelOptions.attachOnSubscribe = false
+        let channel = client.channels.get(test.uniqueChannelName(), options: channelOptions)
+
+        // Initialized
+        XCTAssertEqual(channel.state, ARTRealtimeChannelState.initialized)
+        channel.annotations.subscribe(attachCallback: { _ in
+            fail("Attach callback should not be called.")
+        }) { _ in }
+        // Make sure that channel stays initialized
+        waitUntil(timeout: testTimeout) { done in
+            delay(1) {
+                XCTAssertEqual(channel.state, ARTRealtimeChannelState.initialized)
+                done()
+            }
+        }
+    }
+
+    // RTAN4d, RTL7g
+    func test__annotations_subscribe_should_result_in_an_error_if_channel_is_in_the_FAILED_state_and_options_attachOnSubscribe_is_true() throws {
+        let test = Test()
+        let client = ARTRealtime(options: try AblyTests.commonAppSetup(for: test))
+        defer { client.dispose(); client.close() }
+
+        let channel = client.channels.get(test.uniqueChannelName())
+        channel.internal.onError(AblyTests.newErrorProtocolMessage())
+        XCTAssertEqual(channel.state, ARTRealtimeChannelState.failed)
+
+        waitUntil(timeout: testTimeout) { done in
+            channel.annotations.subscribe(attachCallback: { errorInfo in
+                XCTAssertNotNil(errorInfo)
+
+                channel.annotations.subscribe("foo", onAttach: { errorInfo in
+                    XCTAssertNotNil(errorInfo)
+                    done()
+                }) { _ in }
+            }) { _ in }
+        }
+    }
+
+    // RTAN4d, RTL7g
+    func test__annotations_subscribe_should_not_result_in_an_error_if_channel_is_in_the_FAILED_state_and_options_attachOnSubscribe_is_false() throws {
+        let test = Test()
+        let client = ARTRealtime(options: try AblyTests.commonAppSetup(for: test))
+        defer { client.dispose(); client.close() }
+
+        let channelOptions = ARTRealtimeChannelOptions()
+        channelOptions.attachOnSubscribe = false
+        let channel = client.channels.get(test.uniqueChannelName(), options: channelOptions)
+
+        channel.internal.onError(AblyTests.newErrorProtocolMessage())
+        XCTAssertEqual(channel.state, ARTRealtimeChannelState.failed)
+
+        channel.annotations.subscribe(attachCallback: { _ in
+            fail("Attach callback should not be called.")
+        }) { _ in }
+        // Make sure that channel stays failed
+        waitUntil(timeout: testTimeout) { done in
+            delay(1) {
+                XCTAssertEqual(channel.state, ARTRealtimeChannelState.failed)
+                done()
+            }
+        }
+    }
+
     // RTAN1a
     func test__publish_annotation_exceeding_max_message_size() throws {
         let test = Test()


### PR DESCRIPTION
Commit d7c8b45 introduced `RealtimeAnnotations#subscribe` but omitted the `onAttach` callback variants that `RealtimeChannel#subscribe` provides. Per RTAN4d, annotations subscribe must have the same return value and callback semantics as channel subscribe (RTL7g), which includes the optional attach callback.

This adds `subscribeWithAttachCallback:callback:` and `subscribe:onAttach:callback:` to `ARTRealtimeAnnotations`, mirroring the existing channel API. The internal `_subscribe:onAttach:callback:` method already accepted an `onAttach` parameter but the public API was not wiring it through.

Also fixes a pre-existing bug in `_subscribe:onAttach:callback:` where the `onAttach` callback was not being wrapped to dispatch to the user queue, unlike the channel's equivalent. The channel wraps `onAttach` to dispatch to the user queue so that it is called on the correct queue per the public API contract.

Tests are copied from the RTL7g/RTL7h channel subscribe tests in `RealtimeClientChannelTests.swift`, adapted to use annotations subscribe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added attach-callback support to annotation subscriptions, including per-type subscription variants.
  * Attach callbacks are now invoked on the user's execution queue for correct asynchronous behavior.

* **Tests**
  * Added comprehensive tests covering annotation subscription behavior, channel attach scenarios, and error/state handling during subscribe operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->