### PR TITLE
[AIT-569] Groundwork for investigation of `LocalDevice`-related issues

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -46,6 +46,12 @@
 		210F67A629E9D93D007B9345 /* ARTRealtimeTransportFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 210F67A529E9D93D007B9345 /* ARTRealtimeTransportFactory.m */; };
 		210F67A729E9D93D007B9345 /* ARTRealtimeTransportFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 210F67A529E9D93D007B9345 /* ARTRealtimeTransportFactory.m */; };
 		210F67A829E9D93D007B9345 /* ARTRealtimeTransportFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 210F67A529E9D93D007B9345 /* ARTRealtimeTransportFactory.m */; };
+		2111231E2F92A9D100A2765A /* ARTThrowingLocalDeviceStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 2111231D2F92A9D100A2765A /* ARTThrowingLocalDeviceStorage.m */; };
+		2111231F2F92A9D100A2765A /* ARTThrowingLocalDeviceStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 2111231D2F92A9D100A2765A /* ARTThrowingLocalDeviceStorage.m */; };
+		211123202F92A9D100A2765A /* ARTThrowingLocalDeviceStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 2111231D2F92A9D100A2765A /* ARTThrowingLocalDeviceStorage.m */; };
+		211123232F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 211123222F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211123242F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 211123222F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211123252F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 211123222F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21113B5129DC6AAF00652C86 /* ARTTestClientOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 21113B5029DC6AAF00652C86 /* ARTTestClientOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21113B5229DC6AAF00652C86 /* ARTTestClientOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 21113B5029DC6AAF00652C86 /* ARTTestClientOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21113B5329DC6AAF00652C86 /* ARTTestClientOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 21113B5029DC6AAF00652C86 /* ARTTestClientOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1137,6 +1143,8 @@
 		21088DC62A5355510033C722 /* ARTConnectRetryState.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTConnectRetryState.m; sourceTree = "<group>"; };
 		210F67A129E9D718007B9345 /* ARTRealtimeTransportFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTRealtimeTransportFactory.h; path = PrivateHeaders/Ably/ARTRealtimeTransportFactory.h; sourceTree = "<group>"; };
 		210F67A529E9D93D007B9345 /* ARTRealtimeTransportFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTRealtimeTransportFactory.m; sourceTree = "<group>"; };
+		2111231D2F92A9D100A2765A /* ARTThrowingLocalDeviceStorage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTThrowingLocalDeviceStorage.m; sourceTree = "<group>"; };
+		211123222F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTThrowingLocalDeviceStorage.h; path = PrivateHeaders/Ably/ARTThrowingLocalDeviceStorage.h; sourceTree = "<group>"; };
 		21113B5029DC6AAF00652C86 /* ARTTestClientOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTTestClientOptions.h; path = PrivateHeaders/Ably/ARTTestClientOptions.h; sourceTree = "<group>"; };
 		21113B5429DC6ACD00652C86 /* ARTTestClientOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTTestClientOptions.m; sourceTree = "<group>"; };
 		2114D4262D4BC5470032839A /* AblyInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AblyInternal.h; path = include/Ably/AblyInternal.h; sourceTree = "<group>"; };
@@ -2120,6 +2128,8 @@
 				D777EEDF206285CF002EBA03 /* ARTDeviceIdentityTokenDetails.m */,
 				D7DEAFCF1E65926D00D23F24 /* ARTLocalDevice.h */,
 				EBFFAC181E97919C003E7326 /* ARTLocalDevice+Private.h */,
+				211123222F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h */,
+				2111231D2F92A9D100A2765A /* ARTThrowingLocalDeviceStorage.m */,
 				D7DEAFD01E65926D00D23F24 /* ARTLocalDevice.m */,
 				D75F49C2205ACFEC003DE04F /* ARTDeviceStorage.h */,
 				D7DF73881EA645300013CD36 /* ARTLocalDeviceStorage.h */,
@@ -2235,6 +2245,7 @@
 				EB89D4091C61C5ED007FA5B7 /* ARTRealtimeChannels.h in Headers */,
 				96E408431A38939E00087F77 /* ARTProtocolMessage.h in Headers */,
 				5CC1D9D42E7C2C77005DC3ED /* ARTMessageVersion.h in Headers */,
+				211123232F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h in Headers */,
 				D78D780921271FB10016808B /* ARTHTTPPaginatedResponse+Private.h in Headers */,
 				21447D3B254A2ECB00B3905A /* ARTSRWebSocket.h in Headers */,
 				EBB721CB2376B454001C3550 /* ARTURLSession.h in Headers */,
@@ -2493,6 +2504,7 @@
 				D710D60D21949DDB008F54AD /* ARTDataQuery.h in Headers */,
 				D710D58221949D28008F54AD /* ARTTokenParams.h in Headers */,
 				D710D51921949C42008F54AD /* ARTDeviceDetails.h in Headers */,
+				211123242F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h in Headers */,
 				84D04C342DE8A4F4000E8AE2 /* ARTRealtimeAnnotations.h in Headers */,
 				D710D50621949C18008F54AD /* ARTConnection+Private.h in Headers */,
 				D710D54E21949C66008F54AD /* ARTNSMutableRequest+ARTPush.h in Headers */,
@@ -2711,6 +2723,7 @@
 				D710D61721949DDC008F54AD /* ARTDataQuery.h in Headers */,
 				D710D5A821949D2A008F54AD /* ARTTokenParams.h in Headers */,
 				D710D52B21949C44008F54AD /* ARTDeviceDetails.h in Headers */,
+				211123252F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h in Headers */,
 				84D04C332DE8A4F4000E8AE2 /* ARTRealtimeAnnotations.h in Headers */,
 				D710D51221949C19008F54AD /* ARTConnection+Private.h in Headers */,
 				D710D55421949C67008F54AD /* ARTNSMutableRequest+ARTPush.h in Headers */,
@@ -3124,6 +3137,7 @@
 				D7F1D3781BF4DE72001A4B5E /* ARTRealtimePresence.m in Sources */,
 				21C2BE5D2F0D5B0100AE5E41 /* ARTMessageSendStatus.m in Sources */,
 				D7DF738B1EA645300013CD36 /* ARTLocalDeviceStorage.m in Sources */,
+				2111231E2F92A9D100A2765A /* ARTThrowingLocalDeviceStorage.m in Sources */,
 				D7B621911E4A6E0200684474 /* ARTPush.m in Sources */,
 				D70C36C6233E6831002FD6E3 /* ARTFormEncode.m in Sources */,
 				D7AE18D31E5B410F00478D82 /* ARTPushChannelSubscriptions.m in Sources */,
@@ -3273,6 +3287,7 @@
 				D710D5D521949D78008F54AD /* ARTClientOptions.m in Sources */,
 				21C2BE5E2F0D5B0100AE5E41 /* ARTMessageSendStatus.m in Sources */,
 				D710D5D621949D78008F54AD /* ARTChannel.m in Sources */,
+				211123202F92A9D100A2765A /* ARTThrowingLocalDeviceStorage.m in Sources */,
 				D70C36C7233E6831002FD6E3 /* ARTFormEncode.m in Sources */,
 				D710D5D121949D78008F54AD /* ARTAuthDetails.m in Sources */,
 				D710D4EC21949C0D008F54AD /* ARTRealtime.m in Sources */,
@@ -3422,6 +3437,7 @@
 				D710D5FC21949D79008F54AD /* ARTChannel.m in Sources */,
 				21C2BE5F2F0D5B0100AE5E41 /* ARTMessageSendStatus.m in Sources */,
 				D70C36C8233E6831002FD6E3 /* ARTFormEncode.m in Sources */,
+				2111231F2F92A9D100A2765A /* ARTThrowingLocalDeviceStorage.m in Sources */,
 				D710D5F721949D79008F54AD /* ARTAuthDetails.m in Sources */,
 				D710D4FC21949C0E008F54AD /* ARTRealtime.m in Sources */,
 				D710D4FD21949C0E008F54AD /* ARTRealtimeChannel.m in Sources */,

--- a/Source/ARTAuth.m
+++ b/Source/ARTAuth.m
@@ -24,6 +24,8 @@
 #import "ARTLocalDeviceStorage.h"
 #import "ARTLocalDevice+Private.h"
 #import "ARTDeviceDetails+Private.h"
+#import "ARTClientOptions+TestConfiguration.h"
+#import "ARTTestClientOptions.h"
 
 @implementation ARTAuth {
     ARTQueuedDealloc *_dealloc;
@@ -849,6 +851,15 @@ art_dispatch_sync(_queue, ^{
 
 #if TARGET_OS_IOS
 - (void)setLocalDeviceClientId_nosync:(NSString *)clientId {
+    // Silent no-op under disableLocalDevice. This setter is invoked as a
+    // side effect of unrelated auth flows (setProtocolClientId:,
+    // setTokenDetails:) that must keep working, so raising isn't an
+    // option. See the docstring on ARTTestClientOptions.disableLocalDevice
+    // for the overall enforcement policy.
+    if (_rest.options.testOptions.disableLocalDevice) {
+        return;
+    }
+
     if (clientId == nil || [clientId isEqualToString:@"*"] || [clientId isEqualToString:_rest.device_nosync.clientId]) {
         return;
     }

--- a/Source/ARTDeviceIdentityTokenDetails.m
+++ b/Source/ARTDeviceIdentityTokenDetails.m
@@ -64,14 +64,4 @@ NSString *const ARTCoderClientIdKey = @"clientId";
     return true;
 }
 
-#pragma mark - Archive/Unarchive
-
-- (NSData *)archiveWithLogger:(nullable ARTInternalLog *)logger {
-    return [self art_archiveWithLogger:logger];
-}
-
-+ (ARTDeviceIdentityTokenDetails *)unarchive:(NSData *)data withLogger:(nullable ARTInternalLog *)logger {
-    return [self art_unarchiveFromData:data withLogger:logger];
-}
-
 @end

--- a/Source/ARTLocalDevice.m
+++ b/Source/ARTLocalDevice.m
@@ -76,6 +76,12 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
     NSString *deviceSecret = deviceId == nil ? nil : [storage secretForDevice:deviceId];
 
     if (deviceId == nil || deviceSecret == nil) {
+        if (deviceId == nil) {
+            ARTLogDebug(logger, @"Generating device ID and secret: no stored device ID");
+        }
+        else {
+            ARTLogError(logger, @"Regenerating device ID and secret: stored device ID %@ has no secret", deviceId);
+        }
         [device generateAndPersistPairOfDeviceIdAndSecret]; // Should be removed later once spec issue #180 resolved.
     }
     else {

--- a/Source/ARTLocalDevice.m
+++ b/Source/ARTLocalDevice.m
@@ -7,6 +7,7 @@
 #import "ARTDeviceIdentityTokenDetails+Private.h"
 #import "ARTCrypto+Private.h"
 #import "ARTInternalLog.h"
+#import "ARTTypes+Private.h"
 
 NSString *const ARTDevicePlatform = @"ios";
 
@@ -83,7 +84,7 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
     }
 
     id identityTokenDetailsInfo = [storage objectForKey:ARTDeviceIdentityTokenKey];
-    ARTDeviceIdentityTokenDetails *identityTokenDetails = [ARTDeviceIdentityTokenDetails unarchive:identityTokenDetailsInfo withLogger:logger];
+    ARTDeviceIdentityTokenDetails *identityTokenDetails = [ARTDeviceIdentityTokenDetails art_unarchiveFromData:identityTokenDetailsInfo withLogger:logger];
     device->_identityTokenDetails = identityTokenDetails;
 
     NSString *clientId = [storage objectForKey:ARTClientIdKey];
@@ -172,7 +173,7 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
 }
 
 - (void)setAndPersistIdentityTokenDetails:(ARTDeviceIdentityTokenDetails *)tokenDetails {
-    [self.storage setObject:[tokenDetails archiveWithLogger:self.logger]
+    [self.storage setObject:[tokenDetails art_archiveWithLogger:self.logger]
                      forKey:ARTDeviceIdentityTokenKey];
     _identityTokenDetails = tokenDetails;
     if (self.clientId == nil) {

--- a/Source/ARTLocalDevice.m
+++ b/Source/ARTLocalDevice.m
@@ -83,8 +83,9 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
         device.secret = deviceSecret;
     }
 
-    id identityTokenDetailsInfo = [storage objectForKey:ARTDeviceIdentityTokenKey];
-    ARTDeviceIdentityTokenDetails *identityTokenDetails = [ARTDeviceIdentityTokenDetails art_unarchiveFromData:identityTokenDetailsInfo withLogger:logger];
+    ARTDeviceIdentityTokenDetails *identityTokenDetails = [ARTDeviceIdentityTokenDetails art_unarchiveFromStorage:storage
+                                                                                                              key:ARTDeviceIdentityTokenKey
+                                                                                                       withLogger:logger];
     device->_identityTokenDetails = identityTokenDetails;
 
     NSString *clientId = [storage objectForKey:ARTClientIdKey];

--- a/Source/ARTLocalDeviceStorage.m
+++ b/Source/ARTLocalDeviceStorage.m
@@ -4,25 +4,53 @@
 
 @implementation ARTLocalDeviceStorage {
     ARTInternalLog *_logger;
+    BOOL _logValues;
 }
 
-- (instancetype)initWithLogger:(ARTInternalLog *)logger {
+- (instancetype)initWithLogger:(ARTInternalLog *)logger logValues:(BOOL)logValues {
     if (self = [super init]) {
         _logger = logger;
+        _logValues = logValues;
     }
     return self;
 }
 
-+ (instancetype)newWithLogger:(ARTInternalLog *)logger {
-    return [[self alloc] initWithLogger:logger];
++ (instancetype)newWithLogger:(ARTInternalLog *)logger logValues:(BOOL)logValues {
+    return [[self alloc] initWithLogger:logger logValues:logValues];
+}
+
+- (id)valueToLogForValue:(id)value {
+    if (!_logValues) {
+        return @"(retracted)";
+    }
+    if ([value isKindOfClass:[NSData class]]) {
+        // `NSData`'s default `description` is a hex-ish dump that's
+        // awkward to read or paste back for inspection. Render as
+        // base64 with a prefix that makes the encoding explicit.
+        return [NSString stringWithFormat:@"<NSData base64:%@>", [(NSData *)value base64EncodedStringWithOptions:0]];
+    }
+    return value;
 }
 
 - (nullable id)objectForKey:(NSString *)key {
-    return [NSUserDefaults.standardUserDefaults objectForKey:key];
+    id value = [NSUserDefaults.standardUserDefaults objectForKey:key];
+    if (value == nil) {
+        ARTLogDebug(_logger, @"UserDefaults read miss for key %@", key);
+    }
+    else {
+        ARTLogDebug(_logger, @"UserDefaults read hit for key %@: %@", key, [self valueToLogForValue:value]);
+    }
+    return value;
 }
 
 - (void)setObject:(nullable id)value forKey:(NSString *)key {
     [NSUserDefaults.standardUserDefaults setObject:value forKey:key];
+    if (value == nil) {
+        ARTLogDebug(_logger, @"UserDefaults deleted for key %@", key);
+    }
+    else {
+        ARTLogDebug(_logger, @"UserDefaults written for key %@: %@", key, [self valueToLogForValue:value]);
+    }
 }
 
 - (NSString *)secretForDevice:(ARTDeviceId *)deviceId {
@@ -30,10 +58,13 @@
     NSString *value = [self keychainGetPasswordForService:ARTDeviceSecretKey account:(NSString *)deviceId error:&error];
 
     if ([error code] == errSecItemNotFound) {
-        ARTLogDebug(_logger, @"Device Secret not found");
+        ARTLogDebug(_logger, @"Device Secret read miss for device %@", deviceId);
     }
     else if (error) {
-        ARTLogError(_logger, @"Device Secret couldn't be read (%@)", [error localizedDescription]);
+        ARTLogError(_logger, @"Device Secret couldn't be read for device %@ (%@)", deviceId, [error localizedDescription]);
+    }
+    else {
+        ARTLogDebug(_logger, @"Device Secret read hit for device %@: %@", deviceId, [self valueToLogForValue:value]);
     }
 
     return value;
@@ -45,17 +76,23 @@
         [self keychainDeletePasswordForService:ARTDeviceSecretKey account:(NSString *)deviceId error:&error];
 
         if ([error code] == errSecItemNotFound) {
-            ARTLogWarn(_logger, @"Device Secret can't be deleted because it doesn't exist");
+            ARTLogWarn(_logger, @"Device Secret can't be deleted for device %@ because it doesn't exist", deviceId);
         }
         else if (error) {
-            ARTLogError(_logger, @"Device Secret couldn't be updated (%@)", [error localizedDescription]);
+            ARTLogError(_logger, @"Device Secret couldn't be deleted for device %@ (%@)", deviceId, [error localizedDescription]);
+        }
+        else {
+            ARTLogDebug(_logger, @"Device Secret deleted for device %@", deviceId);
         }
     }
     else {
         [self keychainSetPassword:value forService:ARTDeviceSecretKey account:(NSString *)deviceId error:&error];
 
         if (error) {
-            ARTLogError(_logger, @"Device Secret couldn't be updated (%@)", [error localizedDescription]);
+            ARTLogError(_logger, @"Device Secret couldn't be written for device %@: %@ (%@)", deviceId, [self valueToLogForValue:value], [error localizedDescription]);
+        }
+        else {
+            ARTLogDebug(_logger, @"Device Secret written for device %@: %@", deviceId, [self valueToLogForValue:value]);
         }
     }
 }

--- a/Source/ARTPushActivationEvent.m
+++ b/Source/ARTPushActivationEvent.m
@@ -30,16 +30,6 @@ NSString *const ARTCoderIdentityTokenDetailsKey = @"identityTokenDetails";
     return true;
 }
 
-#pragma mark - Archive/Unarchive
-
-- (NSData *)archiveWithLogger:(nullable ARTInternalLog *)logger {
-    return [self art_archiveWithLogger:logger];
-}
-
-+ (ARTPushActivationEvent *)unarchive:(NSData *)data withLogger:(ARTInternalLog *)logger {
-    return [self art_unarchiveFromData:data withLogger:logger];
-}
-
 @end
 
 #pragma mark - Event with Error info

--- a/Source/ARTPushActivationState.m
+++ b/Source/ARTPushActivationState.m
@@ -65,16 +65,6 @@ NS_ASSUME_NONNULL_END
     return true;
 }
 
-#pragma mark - Archive/Unarchive
-
-- (NSData *)archive {
-    return [self art_archiveWithLogger:self.logger];
-}
-
-+ (ARTPushActivationState *)unarchive:(NSData *)data withLogger:(nullable ARTInternalLog *)logger {
-    return [self art_unarchiveFromData:data withLogger:logger];
-}
-
 @end
 
 #pragma mark - Persistent State

--- a/Source/ARTPushActivationStateMachine.m
+++ b/Source/ARTPushActivationStateMachine.m
@@ -51,8 +51,9 @@ NS_ASSUME_NONNULL_END
         _userQueue = _rest.userQueue;
         _logger = logger;
         // Unarchiving
-        NSData *stateData = [rest.storage objectForKey:ARTPushActivationCurrentStateKey];
-        _current = [ARTPushActivationState art_unarchiveFromData:stateData withLogger:logger];
+        _current = [ARTPushActivationState art_unarchiveFromStorage:rest.storage
+                                                                key:ARTPushActivationCurrentStateKey
+                                                         withLogger:logger];
         if (!_current) {
             _current = [[ARTPushActivationStateNotActivated alloc] initWithMachine:self logger:logger];
         } else {
@@ -61,8 +62,9 @@ NS_ASSUME_NONNULL_END
             }
             _current.machine = self;
         }
-        NSData *pendingEventsData = [rest.storage objectForKey:ARTPushActivationPendingEventsKey];
-        _pendingEvents = [ARTPushActivationEvent art_unarchiveFromData:pendingEventsData withLogger:logger];
+        _pendingEvents = [ARTPushActivationEvent art_unarchiveFromStorage:rest.storage
+                                                                      key:ARTPushActivationPendingEventsKey
+                                                               withLogger:logger];
         if (!_pendingEvents) {
             _pendingEvents = [NSMutableArray array];
         }

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -31,6 +31,7 @@
 #import "ARTPush+Private.h"
 #import "ARTLocalDevice+Private.h"
 #import "ARTLocalDeviceStorage.h"
+#import "ARTThrowingLocalDeviceStorage.h"
 #import "ARTNSMutableRequest+ARTRest.h"
 #import "ARTHTTPPaginatedResponse+Private.h"
 #import "ARTNSError+ARTUtils.h"
@@ -186,8 +187,13 @@ NS_ASSUME_NONNULL_END
         _queue = options.internalDispatchQueue;
         _userQueue = options.dispatchQueue;
 #if TARGET_OS_IOS
-        _storage = [ARTLocalDeviceStorage newWithLogger:_logger
-                                              logValues:_options.testOptions.logLocalDeviceStorageValues];
+        if (_options.testOptions.disableLocalDevice) {
+            _storage = [[ARTThrowingLocalDeviceStorage alloc] init];
+        }
+        else {
+            _storage = [ARTLocalDeviceStorage newWithLogger:_logger
+                                                  logValues:_options.testOptions.logLocalDeviceStorageValues];
+        }
 #endif
         _http = [[ARTHttp alloc] initWithQueue:_queue logger:_logger];
         ARTLogVerbose(_logger, @"RS:%p %p alloc HTTP", self, _http);
@@ -785,6 +791,10 @@ art_dispatch_async(_queue, ^{
 }
 
 - (ARTLocalDevice *)device_nosync {
+    if (_options.testOptions.disableLocalDevice) {
+        [NSException raise:NSInternalInconsistencyException
+                    format:@"device_nosync invoked on a client configured with disableLocalDevice"];
+    }
     __block ARTLocalDevice *ret;
     art_dispatch_sync([ARTRestInternal deviceAccessQueue], ^{
         ret = [self sharedDevice_onlyCallOnDeviceAccessQueue];

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -186,7 +186,8 @@ NS_ASSUME_NONNULL_END
         _queue = options.internalDispatchQueue;
         _userQueue = options.dispatchQueue;
 #if TARGET_OS_IOS
-        _storage = [ARTLocalDeviceStorage newWithLogger:_logger];
+        _storage = [ARTLocalDeviceStorage newWithLogger:_logger
+                                              logValues:_options.testOptions.logLocalDeviceStorageValues];
 #endif
         _http = [[ARTHttp alloc] initWithQueue:_queue logger:_logger];
         ARTLogVerbose(_logger, @"RS:%p %p alloc HTTP", self, _http);

--- a/Source/ARTTestClientOptions.m
+++ b/Source/ARTTestClientOptions.m
@@ -26,6 +26,7 @@
     copied.reconnectionRealtimeHost = self.reconnectionRealtimeHost;
     copied.jitterCoefficientGenerator = self.jitterCoefficientGenerator;
     copied.logLocalDeviceStorageValues = self.logLocalDeviceStorageValues;
+    copied.disableLocalDevice = self.disableLocalDevice;
 
     return copied;
 }

--- a/Source/ARTTestClientOptions.m
+++ b/Source/ARTTestClientOptions.m
@@ -25,6 +25,7 @@
     copied.transportFactory = self.transportFactory;
     copied.reconnectionRealtimeHost = self.reconnectionRealtimeHost;
     copied.jitterCoefficientGenerator = self.jitterCoefficientGenerator;
+    copied.logLocalDeviceStorageValues = self.logLocalDeviceStorageValues;
 
     return copied;
 }

--- a/Source/ARTThrowingLocalDeviceStorage.m
+++ b/Source/ARTThrowingLocalDeviceStorage.m
@@ -1,0 +1,27 @@
+#import "ARTThrowingLocalDeviceStorage.h"
+
+@implementation ARTThrowingLocalDeviceStorage
+
+- (nullable id)objectForKey:(NSString *)key {
+    [NSException raise:NSInternalInconsistencyException
+                format:@"%@ invoked with key %@ on a client configured with disableLocalDevice", NSStringFromSelector(_cmd), key];
+    return nil;
+}
+
+- (void)setObject:(nullable id)value forKey:(NSString *)key {
+    [NSException raise:NSInternalInconsistencyException
+                format:@"%@ invoked with key %@ on a client configured with disableLocalDevice", NSStringFromSelector(_cmd), key];
+}
+
+- (nullable NSString *)secretForDevice:(ARTDeviceId *)deviceId {
+    [NSException raise:NSInternalInconsistencyException
+                format:@"%@ invoked for device %@ on a client configured with disableLocalDevice", NSStringFromSelector(_cmd), deviceId];
+    return nil;
+}
+
+- (void)setSecret:(nullable NSString *)value forDevice:(ARTDeviceId *)deviceId {
+    [NSException raise:NSInternalInconsistencyException
+                format:@"%@ invoked for device %@ on a client configured with disableLocalDevice", NSStringFromSelector(_cmd), deviceId];
+}
+
+@end

--- a/Source/ARTTypes.m
+++ b/Source/ARTTypes.m
@@ -1,6 +1,7 @@
 #import "ARTTypes.h"
 #import "ARTTypes+Private.h"
 #import "ARTInternalLog.h"
+#import "ARTDeviceStorage.h"
 
 // MARK: Global helper functions
 
@@ -491,6 +492,17 @@ NSString *ARTChannelEventToStr(ARTChannelEvent event) {
         return [NSKeyedUnarchiver unarchiveObjectWithData:data];
     }
 #endif
+}
+
++ (nullable id)art_unarchiveFromStorage:(id<ARTDeviceStorage>)storage
+                                    key:(NSString *)key
+                             withLogger:(nullable ARTInternalLog *)logger {
+    NSData *data = [storage objectForKey:key];
+    if (data == nil) {
+        ARTLogDebug(logger, @"%@ unarchive skipped: no persisted data for key %@", self, key);
+        return nil;
+    }
+    return [self art_unarchiveFromData:data withLogger:logger];
 }
 
 @end

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -109,6 +109,7 @@ framework module Ably {
         header "ARTDeviceIdentityTokenDetails+Private.h"
         header "ARTHttp.h"
         header "ARTLocalDeviceStorage.h"
+        header "ARTThrowingLocalDeviceStorage.h"
         header "ARTInternalLogCore.h"
         header "ARTInternalLogCore+Testing.h"
         header "ARTDataEncoder.h"

--- a/Source/PrivateHeaders/Ably/ARTDeviceIdentityTokenDetails+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTDeviceIdentityTokenDetails+Private.h
@@ -4,10 +4,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ARTDeviceIdentityTokenDetails ()
 
-- (NSData *)archiveWithLogger:(nullable ARTInternalLog *)logger;
-
-+ (nullable ARTDeviceIdentityTokenDetails *)unarchive:(NSData *)data withLogger:(nullable ARTInternalLog *)logger;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTLocalDeviceStorage.h
+++ b/Source/PrivateHeaders/Ably/ARTLocalDeviceStorage.h
@@ -7,9 +7,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ARTLocalDeviceStorage : NSObject<ARTDeviceStorage>
 
-- (instancetype)initWithLogger:(ARTInternalLog *)logger;
+- (instancetype)initWithLogger:(ARTInternalLog *)logger logValues:(BOOL)logValues;
 
-+ (instancetype)newWithLogger:(ARTInternalLog *)logger;
++ (instancetype)newWithLogger:(ARTInternalLog *)logger logValues:(BOOL)logValues;
 
 @end
 

--- a/Source/PrivateHeaders/Ably/ARTPushActivationEvent.h
+++ b/Source/PrivateHeaders/Ably/ARTPushActivationEvent.h
@@ -9,9 +9,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ARTPushActivationEvent : NSObject <NSSecureCoding>
 
-- (NSData *)archiveWithLogger:(nullable ARTInternalLog *)logger;
-+ (nullable ARTPushActivationState *)unarchive:(NSData *)data withLogger:(nullable ARTInternalLog *)logger;
-
 @end
 
 /// Event with Error info

--- a/Source/PrivateHeaders/Ably/ARTPushActivationState.h
+++ b/Source/PrivateHeaders/Ably/ARTPushActivationState.h
@@ -17,9 +17,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable ARTPushActivationState *)transition:(ARTPushActivationEvent *)event;
 
-- (NSData *)archive;
-+ (nullable ARTPushActivationState *)unarchive:(NSData *)data withLogger:(nullable ARTInternalLog *)logger;
-
 @end
 
 /// Persistent State

--- a/Source/PrivateHeaders/Ably/ARTTestClientOptions.h
+++ b/Source/PrivateHeaders/Ably/ARTTestClientOptions.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Provides an interface for injecting additional configuration into `ARTRest` or `ARTRealtime` instances.
 
- This is for anything that test code wishes to be able to configure but which should not be part of the public API of these classes.
+ This is for anything that test code wishes to be able to configure but which should not be part of the public API of these classes. It can also be used for exposing additional debugging options to be used in Ably-authored applications.
  */
 @interface ARTTestClientOptions: NSObject <NSCopying>
 
@@ -49,6 +49,23 @@ NS_ASSUME_NONNULL_BEGIN
  the device secret and the identity token. Initial value is `NO`.
  */
 @property (nonatomic) BOOL logLocalDeviceStorageValues;
+
+/**
+ When `YES`, the client must not access any of the cross-client shared state related to the local device or push activation state machine. The use case is a multi-client demo app (e.g. one with a client under test alongside a diagnostic client) where all side-effects on this shared state should be performed by a single specific client, so that the corresponding log entries appear in that client's logs.
+
+ Enforcement is layered:
+
+ - Persisted state: an `ARTDeviceStorage` is installed that raises on every read and write. This is the backstop for any code path that attempts to touch storage.
+
+ - In-memory shared state: the `ARTLocalDevice` that `ARTRestInternal` exposes via `device_nosync` lives in a process-wide static and may already be cached by another client, so reading it would not necessarily hit storage. `device_nosync` therefore has an explicit guard that raises when this flag is set.
+
+ - Side effects of unrelated flows (e.g. auth propagating a clientId via `ARTAuth.setLocalDeviceClientId_nosync`) silently no-op rather than raise, since raising would break the unrelated flow.
+
+ Other public APIs deliberately about local device or push need not add their own guards — it's acceptable to throw an exception from these APIs.
+
+ Initial value is `NO`.
+ */
+@property (nonatomic) BOOL disableLocalDevice;
 
 @end
 

--- a/Source/PrivateHeaders/Ably/ARTTestClientOptions.h
+++ b/Source/PrivateHeaders/Ably/ARTTestClientOptions.h
@@ -43,6 +43,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) id<ARTJitterCoefficientGenerator> jitterCoefficientGenerator;
 
+/**
+ When `YES`, `ARTLocalDeviceStorage` log lines include the fetched or
+ written value itself. Off by default because persisted values include
+ the device secret and the identity token. Initial value is `NO`.
+ */
+@property (nonatomic) BOOL logLocalDeviceStorageValues;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTThrowingLocalDeviceStorage.h
+++ b/Source/PrivateHeaders/Ably/ARTThrowingLocalDeviceStorage.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+#import "ARTDeviceStorage.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ An `ARTDeviceStorage` whose every method raises
+ `NSInternalInconsistencyException`. Used as the storage of an
+ `ARTRestInternal` when `ARTTestClientOptions.disableLocalDevice` is set.
+ */
+@interface ARTThrowingLocalDeviceStorage : NSObject<ARTDeviceStorage>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTTypes+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTTypes+Private.h
@@ -3,6 +3,7 @@
 
 @class ARTRetryAttempt;
 @class ARTInternalLog;
+@protocol ARTDeviceStorage;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -45,6 +46,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface NSObject (ARTArchive)
 - (nullable NSData *)art_archiveWithLogger:(nullable ARTInternalLog *)logger;
 + (nullable id)art_unarchiveFromData:(NSData *)data withLogger:(nullable ARTInternalLog *)logger;
++ (nullable id)art_unarchiveFromStorage:(id<ARTDeviceStorage>)storage
+                                    key:(NSString *)key
+                             withLogger:(nullable ARTInternalLog *)logger;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/include/module.modulemap
+++ b/Source/include/module.modulemap
@@ -109,6 +109,7 @@ module Ably {
         header "../PrivateHeaders/Ably/ARTDeviceIdentityTokenDetails+Private.h"
         header "../PrivateHeaders/Ably/ARTHttp.h"
         header "../PrivateHeaders/Ably/ARTLocalDeviceStorage.h"
+        header "../PrivateHeaders/Ably/ARTThrowingLocalDeviceStorage.h"
         header "../PrivateHeaders/Ably/ARTInternalLogCore.h"
         header "../PrivateHeaders/Ably/ARTInternalLogCore+Testing.h"
         header "../PrivateHeaders/Ably/ARTDataEncoder.h"

--- a/Test/AblyTests/Test Utilities/MockDeviceStorage.swift
+++ b/Test/AblyTests/Test Utilities/MockDeviceStorage.swift
@@ -14,7 +14,7 @@ class MockDeviceStorage: NSObject, ARTDeviceStorage {
     init(startWith state: ARTPushActivationState? = nil) {
         super.init()
         if let state = state {
-            simulateOnNextRead(data: state.archive(), for: ARTPushActivationCurrentStateKey)
+            simulateOnNextRead(data: state.art_archive(withLogger: nil)!, for: ARTPushActivationCurrentStateKey)
         }
     }
 

--- a/Test/AblyTests/Tests/PushTests.swift
+++ b/Test/AblyTests/Tests/PushTests.swift
@@ -243,7 +243,7 @@ class PushTests: XCTestCase {
         storage.simulateOnNextRead(string: "testId", for: ARTDeviceIdKey)
         storage.simulateOnNextRead(string: "testSecret", for: ARTDeviceSecretKey)
         storage.simulateOnNextRead(string: testToken, for: ARTAPNSDeviceTokenKey)
-        storage.simulateOnNextRead(data: testIdentity.archive(withLogger: nil), for: ARTDeviceIdentityTokenKey)
+        storage.simulateOnNextRead(data: testIdentity.art_archive(withLogger: nil)!, for: ARTDeviceIdentityTokenKey)
 
         let device = rest.device
 
@@ -355,7 +355,7 @@ class PushTests: XCTestCase {
         stateMachine.delegate = delegate
 
         storage.simulateOnNextRead(string: testDeviceToken, for: ARTAPNSDeviceTokenKey)
-        storage.simulateOnNextRead(data: testDeviceIdentity.archive(withLogger: nil), for: ARTDeviceIdentityTokenKey)
+        storage.simulateOnNextRead(data: testDeviceIdentity.art_archive(withLogger: nil)!, for: ARTDeviceIdentityTokenKey)
 
         XCTAssertEqual(realtime.device.clientId, testDeviceIdentity.clientId)
 


### PR DESCRIPTION
A few commits that improve logging around `LocalDevice` storage, and which also provide a new private client option to tell a client not to touch the `LocalDevice`. See commit messages for more details.

I'm using these in my investigation of push registration issues (https://ably.atlassian.net/browse/AIT-569). See #2204 for that WIP investigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added test configuration options to disable local device functionality and control storage value logging for enhanced debugging capabilities.

* **Refactor**
  * Improved local device storage architecture and serialization mechanisms for better code maintainability and testability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->