### PR TITLE
[ECO-5729] Store all persisted data atomically in a single file with None protection

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -52,6 +52,12 @@
 		211123232F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 211123222F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		211123242F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 211123222F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		211123252F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 211123222F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211123312F92A9D100A2765A /* ARTAtomicFileStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 211123302F92A9D100A2765A /* ARTAtomicFileStorage.m */; };
+		211123322F92A9D100A2765A /* ARTAtomicFileStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 211123302F92A9D100A2765A /* ARTAtomicFileStorage.m */; };
+		211123332F92A9D100A2765A /* ARTAtomicFileStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 211123302F92A9D100A2765A /* ARTAtomicFileStorage.m */; };
+		211123352F92A9FB00A2765A /* ARTAtomicFileStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 211123342F92A9FB00A2765A /* ARTAtomicFileStorage.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211123362F92A9FB00A2765A /* ARTAtomicFileStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 211123342F92A9FB00A2765A /* ARTAtomicFileStorage.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		211123372F92A9FB00A2765A /* ARTAtomicFileStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 211123342F92A9FB00A2765A /* ARTAtomicFileStorage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21113B5129DC6AAF00652C86 /* ARTTestClientOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 21113B5029DC6AAF00652C86 /* ARTTestClientOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21113B5229DC6AAF00652C86 /* ARTTestClientOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 21113B5029DC6AAF00652C86 /* ARTTestClientOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		21113B5329DC6AAF00652C86 /* ARTTestClientOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 21113B5029DC6AAF00652C86 /* ARTTestClientOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1145,6 +1151,8 @@
 		210F67A529E9D93D007B9345 /* ARTRealtimeTransportFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTRealtimeTransportFactory.m; sourceTree = "<group>"; };
 		2111231D2F92A9D100A2765A /* ARTThrowingLocalDeviceStorage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTThrowingLocalDeviceStorage.m; sourceTree = "<group>"; };
 		211123222F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTThrowingLocalDeviceStorage.h; path = PrivateHeaders/Ably/ARTThrowingLocalDeviceStorage.h; sourceTree = "<group>"; };
+		211123302F92A9D100A2765A /* ARTAtomicFileStorage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTAtomicFileStorage.m; sourceTree = "<group>"; };
+		211123342F92A9FB00A2765A /* ARTAtomicFileStorage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTAtomicFileStorage.h; path = PrivateHeaders/Ably/ARTAtomicFileStorage.h; sourceTree = "<group>"; };
 		21113B5029DC6AAF00652C86 /* ARTTestClientOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ARTTestClientOptions.h; path = PrivateHeaders/Ably/ARTTestClientOptions.h; sourceTree = "<group>"; };
 		21113B5429DC6ACD00652C86 /* ARTTestClientOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ARTTestClientOptions.m; sourceTree = "<group>"; };
 		2114D4262D4BC5470032839A /* AblyInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AblyInternal.h; path = include/Ably/AblyInternal.h; sourceTree = "<group>"; };
@@ -2130,6 +2138,8 @@
 				EBFFAC181E97919C003E7326 /* ARTLocalDevice+Private.h */,
 				211123222F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h */,
 				2111231D2F92A9D100A2765A /* ARTThrowingLocalDeviceStorage.m */,
+				211123342F92A9FB00A2765A /* ARTAtomicFileStorage.h */,
+				211123302F92A9D100A2765A /* ARTAtomicFileStorage.m */,
 				D7DEAFD01E65926D00D23F24 /* ARTLocalDevice.m */,
 				D75F49C2205ACFEC003DE04F /* ARTDeviceStorage.h */,
 				D7DF73881EA645300013CD36 /* ARTLocalDeviceStorage.h */,
@@ -2246,6 +2256,7 @@
 				96E408431A38939E00087F77 /* ARTProtocolMessage.h in Headers */,
 				5CC1D9D42E7C2C77005DC3ED /* ARTMessageVersion.h in Headers */,
 				211123232F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h in Headers */,
+				211123352F92A9FB00A2765A /* ARTAtomicFileStorage.h in Headers */,
 				D78D780921271FB10016808B /* ARTHTTPPaginatedResponse+Private.h in Headers */,
 				21447D3B254A2ECB00B3905A /* ARTSRWebSocket.h in Headers */,
 				EBB721CB2376B454001C3550 /* ARTURLSession.h in Headers */,
@@ -2505,6 +2516,7 @@
 				D710D58221949D28008F54AD /* ARTTokenParams.h in Headers */,
 				D710D51921949C42008F54AD /* ARTDeviceDetails.h in Headers */,
 				211123242F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h in Headers */,
+				211123362F92A9FB00A2765A /* ARTAtomicFileStorage.h in Headers */,
 				84D04C342DE8A4F4000E8AE2 /* ARTRealtimeAnnotations.h in Headers */,
 				D710D50621949C18008F54AD /* ARTConnection+Private.h in Headers */,
 				D710D54E21949C66008F54AD /* ARTNSMutableRequest+ARTPush.h in Headers */,
@@ -2724,6 +2736,7 @@
 				D710D5A821949D2A008F54AD /* ARTTokenParams.h in Headers */,
 				D710D52B21949C44008F54AD /* ARTDeviceDetails.h in Headers */,
 				211123252F92A9FB00A2765A /* ARTThrowingLocalDeviceStorage.h in Headers */,
+				211123372F92A9FB00A2765A /* ARTAtomicFileStorage.h in Headers */,
 				84D04C332DE8A4F4000E8AE2 /* ARTRealtimeAnnotations.h in Headers */,
 				D710D51221949C19008F54AD /* ARTConnection+Private.h in Headers */,
 				D710D55421949C67008F54AD /* ARTNSMutableRequest+ARTPush.h in Headers */,
@@ -3138,6 +3151,7 @@
 				21C2BE5D2F0D5B0100AE5E41 /* ARTMessageSendStatus.m in Sources */,
 				D7DF738B1EA645300013CD36 /* ARTLocalDeviceStorage.m in Sources */,
 				2111231E2F92A9D100A2765A /* ARTThrowingLocalDeviceStorage.m in Sources */,
+				211123312F92A9D100A2765A /* ARTAtomicFileStorage.m in Sources */,
 				D7B621911E4A6E0200684474 /* ARTPush.m in Sources */,
 				D70C36C6233E6831002FD6E3 /* ARTFormEncode.m in Sources */,
 				D7AE18D31E5B410F00478D82 /* ARTPushChannelSubscriptions.m in Sources */,
@@ -3288,6 +3302,7 @@
 				21C2BE5E2F0D5B0100AE5E41 /* ARTMessageSendStatus.m in Sources */,
 				D710D5D621949D78008F54AD /* ARTChannel.m in Sources */,
 				211123202F92A9D100A2765A /* ARTThrowingLocalDeviceStorage.m in Sources */,
+				211123322F92A9D100A2765A /* ARTAtomicFileStorage.m in Sources */,
 				D70C36C7233E6831002FD6E3 /* ARTFormEncode.m in Sources */,
 				D710D5D121949D78008F54AD /* ARTAuthDetails.m in Sources */,
 				D710D4EC21949C0D008F54AD /* ARTRealtime.m in Sources */,
@@ -3438,6 +3453,7 @@
 				21C2BE5F2F0D5B0100AE5E41 /* ARTMessageSendStatus.m in Sources */,
 				D70C36C8233E6831002FD6E3 /* ARTFormEncode.m in Sources */,
 				2111231F2F92A9D100A2765A /* ARTThrowingLocalDeviceStorage.m in Sources */,
+				211123332F92A9D100A2765A /* ARTAtomicFileStorage.m in Sources */,
 				D710D5F721949D79008F54AD /* ARTAuthDetails.m in Sources */,
 				D710D4FC21949C0E008F54AD /* ARTRealtime.m in Sources */,
 				D710D4FD21949C0E008F54AD /* ARTRealtimeChannel.m in Sources */,

--- a/Examples/AblyPush/AblyPushExample/AblyHelper.swift
+++ b/Examples/AblyPush/AblyPushExample/AblyHelper.swift
@@ -61,10 +61,15 @@ extension AblyHelper {
     }
 
     func printIdentityToken() {
-        if UserDefaults.standard.value(forKey: "ARTDeviceIdentityToken") != nil {
-            print("IDENTITY TOKEN: exists")
+        let device = realtime.device
+        // identityTokenDetails may be nil if the device hasn't been activated for push
+        if let details = device.identityTokenDetails {
+            // The token is a credential; print only a short prefix so debug
+            // output / device logs don't leak it in full.
+            let preview = details.token.prefix(8)
+            print("Identity token exists for device id \(device.id): \(preview)…")
         } else {
-            print("IDENTITY TOKEN: doesn't exist")
+            print("Identity token doesn't exist")
         }
     }
 

--- a/Source/ARTAtomicFileStorage.m
+++ b/Source/ARTAtomicFileStorage.m
@@ -1,0 +1,115 @@
+#import "ARTAtomicFileStorage.h"
+#import "ARTInternalLog.h"
+
+@implementation ARTAtomicFileStorage {
+    ARTInternalLog *_logger;
+    NSLock *_lock;
+}
+
+- (instancetype)initWithFileURL:(NSURL *)fileURL logger:(nullable ARTInternalLog *)logger {
+    if (self = [super init]) {
+        _fileURL = [fileURL copy];
+        _logger = logger;
+        _lock = [[NSLock alloc] init];
+        _lock.name = @"io.ably.ARTAtomicFileStorage";
+    }
+    return self;
+}
+
+- (BOOL)fileExists {
+    [_lock lock];
+    BOOL exists = [[NSFileManager defaultManager] fileExistsAtPath:_fileURL.path];
+    [_lock unlock];
+    return exists;
+}
+
+- (NSDictionary<NSString *, id> *)load {
+    [_lock lock];
+    NSDictionary *result = [self load_nosync];
+    [_lock unlock];
+    return result;
+}
+
+- (NSDictionary<NSString *, id> *)load_nosync {
+    NSError *readError = nil;
+    NSData *data = [NSData dataWithContentsOfURL:_fileURL options:0 error:&readError];
+    if (data == nil) {
+        if (readError.code != NSFileReadNoSuchFileError) {
+            ARTLogWarn(_logger, @"ARTAtomicFileStorage: could not read %@: %@", _fileURL.lastPathComponent, readError.localizedDescription);
+        }
+        return @{};
+    }
+
+    NSError *parseError = nil;
+    id plist = [NSPropertyListSerialization propertyListWithData:data options:NSPropertyListImmutable format:NULL error:&parseError];
+    if (![plist isKindOfClass:[NSDictionary class]]) {
+        ARTLogError(_logger, @"ARTAtomicFileStorage: %@ is not a dictionary plist (%@); treating as empty", _fileURL.lastPathComponent, parseError.localizedDescription);
+        return @{};
+    }
+    return plist;
+}
+
+- (BOOL)save:(NSDictionary<NSString *, id> *)dictionary error:(NSError * _Nullable * _Nullable)outError {
+    [_lock lock];
+    @try {
+        NSError *serializeError = nil;
+        NSData *data = [NSPropertyListSerialization dataWithPropertyList:dictionary
+                                                                  format:NSPropertyListBinaryFormat_v1_0
+                                                                 options:0
+                                                                   error:&serializeError];
+        if (data == nil) {
+            if (outError) *outError = serializeError;
+            ARTLogError(_logger, @"ARTAtomicFileStorage: failed to serialise %@: %@", _fileURL.lastPathComponent, serializeError.localizedDescription);
+            return NO;
+        }
+
+        NSError *dirError = nil;
+        if (![[NSFileManager defaultManager] createDirectoryAtURL:[_fileURL URLByDeletingLastPathComponent]
+                                      withIntermediateDirectories:YES
+                                                       attributes:nil
+                                                            error:&dirError]) {
+            if (outError) *outError = dirError;
+            ARTLogError(_logger, @"ARTAtomicFileStorage: failed to create parent directory for %@: %@", _fileURL.lastPathComponent, dirError.localizedDescription);
+            return NO;
+        }
+
+        NSDataWritingOptions options = NSDataWritingAtomic;
+        // `NSDataWritingFileProtectionNone` is only available on macOS 11+; on
+        // iOS/tvOS it's always available (use of `*` below). Older macOS has no
+        // data-protection concept, so skipping it there is fine.
+        if (@available(macOS 11.0, *)) {
+          // IMPORTANT; DO NOT REMOVE: We use NSDataWritingFileProtectionNone
+          // because the file must be always available to load. This is our
+          // solution to issues that we previously had when storing data as
+          // "protected until first user authentication"; there are scenarios in
+          // which iOS applications get launched before a first unlock and the
+          // LocalDevice data needs to still be loadable in these scenarios.
+          options |= NSDataWritingFileProtectionNone;
+        }
+
+        NSError *writeError = nil;
+        BOOL ok = [data writeToURL:_fileURL options:options error:&writeError];
+        if (!ok) {
+            if (outError) *outError = writeError;
+            ARTLogError(_logger, @"ARTAtomicFileStorage: failed to write %@: %@", _fileURL.lastPathComponent, writeError.localizedDescription);
+            return NO;
+        }
+
+        // Make sure the file is excluded from iCloud backup — the device
+        // secret was previously protected with `ThisDeviceOnly` keychain
+        // semantics, and we want to preserve the "doesn't leave this device"
+        // property even though we've moved away from the keychain.
+        NSURL *mutableURL = [_fileURL copy];
+        NSError *attrError = nil;
+        if (![mutableURL setResourceValue:@YES forKey:NSURLIsExcludedFromBackupKey error:&attrError]) {
+            ARTLogWarn(_logger, @"ARTAtomicFileStorage: could not mark %@ as excluded from backup: %@", _fileURL.lastPathComponent, attrError.localizedDescription);
+        }
+
+        return YES;
+    }
+    @finally {
+        [_lock unlock];
+    }
+}
+
+@end

--- a/Source/ARTLocalDevice.m
+++ b/Source/ARTLocalDevice.m
@@ -8,6 +8,7 @@
 #import "ARTCrypto+Private.h"
 #import "ARTInternalLog.h"
 #import "ARTTypes+Private.h"
+#import "ARTPushActivationStateMachine+Private.h"
 
 NSString *const ARTDevicePlatform = @"ios";
 
@@ -57,12 +58,23 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
     return self;
 }
 
-- (void)generateAndPersistPairOfDeviceIdAndSecret {
-    self.id = [self.class generateId];
-    self.secret = [self.class generateSecret];
-
-    [_storage setObject:self.id forKey:ARTDeviceIdKey];
-    [_storage setSecret:self.secret forDevice:self.id];
+// RSH8b helper. Only generates a new (id, deviceSecret) pair and persists it.
+// Decision about when generation should happen and what else to clear belongs to the caller.
+// If `writer` is omitted, device's storage is used (for standalone calls).
+- (void)generateAndPersistPairOfDeviceIdAndSecretForStorage:(id<ARTDeviceStorage>)writer {
+    NSString *newId = [self.class generateId];
+    NSString *newSecret = [self.class generateSecret];
+    self.id = newId;
+    self.secret = newSecret;
+    // The inner batch makes the helper safe to call standalone: id and
+    // secret reach disk together rather than as two separate flushes. When
+    // a caller is already inside its own batch (e.g. `resetDetails`) the
+    // nested batch is just a counter bump — the outer batch still owns the
+    // single flush.
+    [(writer ?: _storage) performBatchUpdate:^(id<ARTDeviceStorage> writer) {
+        [writer setObject:newId forKey:ARTDeviceIdKey];
+        [writer setObject:newSecret forKey:ARTDeviceSecretKey];
+    }];
 }
 
 + (instancetype)deviceWithStorage:(id<ARTDeviceStorage>)storage logger:(nullable ARTInternalLog *)logger {
@@ -73,72 +85,61 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
     device.push.recipient[@"transportType"] = ARTDevicePushTransportType;
 
     NSString *deviceId = [storage objectForKey:ARTDeviceIdKey];
-    NSString *deviceSecret = deviceId == nil ? nil : [storage secretForDevice:deviceId];
+    NSString *deviceSecret = [storage objectForKey:ARTDeviceSecretKey];
 
-    if (deviceId == nil || deviceSecret == nil) {
-        if (deviceId == nil) {
-            ARTLogDebug(logger, @"Generating device ID and secret: no stored device ID");
-        }
-        else {
-            ARTLogError(logger, @"Regenerating device ID and secret: stored device ID %@ has no secret", deviceId);
-        }
-        [device generateAndPersistPairOfDeviceIdAndSecret]; // Should be removed later once spec issue #180 resolved.
-    }
-    else {
+    // RSH8a
+    if (deviceId && deviceSecret) {
         device.id = deviceId;
         device.secret = deviceSecret;
+
+        ARTDeviceIdentityTokenDetails *identityTokenDetails = [ARTDeviceIdentityTokenDetails art_unarchiveFromStorage:storage
+                                                                                                                  key:ARTDeviceIdentityTokenKey
+                                                                                                           withLogger:logger];
+        device->_identityTokenDetails = identityTokenDetails;
+
+        NSString *clientId = [storage objectForKey:ARTClientIdKey];
+        if (clientId == nil && identityTokenDetails.clientId != nil) {
+            clientId = identityTokenDetails.clientId; // Older versions of the SDK did not persist clientId, so as a fallback when loading data persisted by these versions we use the clientId of the stored identity token
+            [storage setObject:clientId forKey:ARTClientIdKey];
+        }
+        device.clientId = clientId;
+
+        NSArray *supportedTokenTypes = @[
+            ARTAPNSDeviceDefaultTokenType,
+            ARTAPNSDeviceLocationTokenType
+        ];
+
+        for (NSString *tokenType in supportedTokenTypes) {
+            NSString *token = [ARTLocalDevice apnsDeviceTokenOfType:tokenType fromStorage:storage];
+            [device setAPNSDeviceToken:token tokenType:tokenType];
+        }
     }
-
-    ARTDeviceIdentityTokenDetails *identityTokenDetails = [ARTDeviceIdentityTokenDetails art_unarchiveFromStorage:storage
-                                                                                                              key:ARTDeviceIdentityTokenKey
-                                                                                                       withLogger:logger];
-    device->_identityTokenDetails = identityTokenDetails;
-
-    NSString *clientId = [storage objectForKey:ARTClientIdKey];
-    if (clientId == nil && identityTokenDetails.clientId != nil) {
-        clientId = identityTokenDetails.clientId; // Older versions of the SDK did not persist clientId, so as a fallback when loading data persisted by these versions we use the clientId of the stored identity token
-        [storage setObject:clientId forKey:ARTClientIdKey];
-    }
-    device.clientId = clientId;
-
-    NSArray *supportedTokenTypes = @[
-        ARTAPNSDeviceDefaultTokenType,
-        ARTAPNSDeviceLocationTokenType
-    ];
-
-    for (NSString *tokenType in supportedTokenTypes) {
-        NSString *token = [ARTLocalDevice apnsDeviceTokenOfType:tokenType fromStorage:storage];
-        [device setAPNSDeviceToken:token tokenType:tokenType];
+    else {
+        // RSH8b, RSH8k2
+        ARTLogDebug(logger, @"LocalDevice: generating a fresh id+secret pair");
+        [device generateAndPersistPairOfDeviceIdAndSecretForStorage:nil];
     }
     return device;
 }
 
 - (void)setupDetailsWithClientId:(NSString *)clientId {
-    NSString *deviceId = self.id;
-    NSString *deviceSecret = self.secret;
-
-    if (deviceId == nil || deviceSecret == nil) {
-        [self generateAndPersistPairOfDeviceIdAndSecret];
-    }
-
     self.clientId = clientId;
     [_storage setObject:clientId forKey:ARTClientIdKey];
 }
 
 - (void)resetDetails {
-    // Should be replaced later to resetting device's id/secret once spec issue #180 resolved.
-    [self generateAndPersistPairOfDeviceIdAndSecret];
+    [_storage performBatchUpdate:^(id<ARTDeviceStorage> writer) {
+        // Wipe everything persisted, then regenerate — all in the same batch,
+        // so the id+secret regeneration lands together with the wipe.
+        [writer removeAll];
+        [self generateAndPersistPairOfDeviceIdAndSecretForStorage:writer];
 
-    self.clientId = nil;
-    [_storage setObject:nil forKey:ARTClientIdKey];
-    [self setAndPersistIdentityTokenDetails:nil];
-    NSArray *supportedTokenTypes = @[
-        ARTAPNSDeviceDefaultTokenType,
-        ARTAPNSDeviceLocationTokenType
-    ];
-    for (NSString *tokenType in supportedTokenTypes) {
-        [self setAndPersistAPNSDeviceToken:nil tokenType:tokenType];
-    }
+        // Mirror the persistent clear in the in-memory device state.
+        self.clientId = nil;
+        _identityTokenDetails = nil;
+        [self setAPNSDeviceToken:nil tokenType:ARTAPNSDeviceDefaultTokenType];
+        [self setAPNSDeviceToken:nil tokenType:ARTAPNSDeviceLocationTokenType];
+    }];
 }
 
 + (NSString *)generateId {
@@ -180,13 +181,18 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
 }
 
 - (void)setAndPersistIdentityTokenDetails:(ARTDeviceIdentityTokenDetails *)tokenDetails {
-    [self.storage setObject:[tokenDetails art_archiveWithLogger:self.logger]
-                     forKey:ARTDeviceIdentityTokenKey];
+    NSData *tokenData = [tokenDetails art_archiveWithLogger:self.logger];
+    BOOL adoptClientId = (self.clientId == nil && tokenDetails.clientId != nil);
     _identityTokenDetails = tokenDetails;
-    if (self.clientId == nil) {
+    if (adoptClientId) {
         self.clientId = tokenDetails.clientId;
-        [self.storage setObject:tokenDetails.clientId forKey:ARTClientIdKey];
     }
+    [self.storage performBatchUpdate:^(id<ARTDeviceStorage> writer) {
+        [writer setObject:tokenData forKey:ARTDeviceIdentityTokenKey];
+        if (adoptClientId) {
+            [writer setObject:tokenDetails.clientId forKey:ARTClientIdKey];
+        }
+    }];
 }
 
 - (BOOL)isRegistered {

--- a/Source/ARTLocalDeviceStorage.m
+++ b/Source/ARTLocalDeviceStorage.m
@@ -1,23 +1,95 @@
 #import "ARTLocalDeviceStorage.h"
+#import <Security/Security.h>
+#import "ARTAtomicFileStorage.h"
 #import "ARTInternalLog.h"
 #import "ARTLocalDevice+Private.h"
+#import "ARTPushActivationStateMachine+Private.h"
+
+static NSString *const ARTLocalDeviceStorageDirectoryName = @"Ably";
+static NSString *const ARTLocalDeviceStorageFileName = @"LocalDevice.plist";
+
+static NSString *const ARTLegacyAPNSDeviceTokenKey = @"ARTAPNSDeviceToken";
+
+NSString *const ARTMigratedFromLegacyStorageKey = @"ARTMigratedFromLegacyStorage";
 
 @implementation ARTLocalDeviceStorage {
     ARTInternalLog *_logger;
     BOOL _logValues;
+
+    ARTAtomicFileStorage *_store;
+    NSMutableDictionary<NSString *, id> *_cache;
+
+    NSRecursiveLock *_lock;
+    NSInteger _batchDepth;
+    BOOL _isModified;
+
+    ARTLegacyKeychainSecretReader _legacyKeychainReader;
 }
 
-- (instancetype)initWithLogger:(ARTInternalLog *)logger logValues:(BOOL)logValues {
+#pragma mark - Init
+
+- (instancetype)initWithLogger:(nullable ARTInternalLog *)logger logValues:(BOOL)logValues {
+    return [self initWithBaseDirectoryURL:[ARTLocalDeviceStorage defaultBaseDirectoryURL]
+                                   logger:logger
+                                logValues:logValues];
+}
+
++ (instancetype)newWithLogger:(nullable ARTInternalLog *)logger logValues:(BOOL)logValues {
+    return [[self alloc] initWithLogger:logger logValues:logValues];
+}
+
+- (instancetype)initWithBaseDirectoryURL:(NSURL *)baseDirectoryURL
+                                  logger:(nullable ARTInternalLog *)logger
+                               logValues:(BOOL)logValues {
+    return [self initWithBaseDirectoryURL:baseDirectoryURL
+                                   logger:logger
+                                logValues:logValues
+                     legacyKeychainReader:nil];
+}
+
+- (instancetype)initWithBaseDirectoryURL:(NSURL *)baseDirectoryURL
+                                  logger:(nullable ARTInternalLog *)logger
+                               logValues:(BOOL)logValues
+                    legacyKeychainReader:(nullable ARTLegacyKeychainSecretReader)legacyKeychainReader {
     if (self = [super init]) {
         _logger = logger;
         _logValues = logValues;
+        _lock = [[NSRecursiveLock alloc] init];
+        _lock.name = @"io.ably.ARTLocalDeviceStorage";
+        _legacyKeychainReader = [legacyKeychainReader copy];
+
+        NSURL *fileURL = [baseDirectoryURL URLByAppendingPathComponent:ARTLocalDeviceStorageFileName];
+        _store = [[ARTAtomicFileStorage alloc] initWithFileURL:fileURL logger:logger];
+        _cache = [[_store load] mutableCopy];
+
+        // Technically the RSH8a1 check-and-discard should happen lazily when the
+        // LocalDevice is first required; for simplicity we are instead
+        // performing it eagerly at storage init (and thus at client init).
+        // We'll address this later if it turns out to cause problems; tracking
+        // in https://github.com/ably/ably-cocoa/issues/2214.
+        [self migrateLegacyDataIfNeeded];
     }
     return self;
 }
 
-+ (instancetype)newWithLogger:(ARTInternalLog *)logger logValues:(BOOL)logValues {
-    return [[self alloc] initWithLogger:logger logValues:logValues];
++ (NSURL *)defaultBaseDirectoryURL {
+    NSFileManager *fm = [NSFileManager defaultManager];
+    NSError *error = nil;
+    NSURL *appSupport = [fm URLForDirectory:NSApplicationSupportDirectory
+                                   inDomain:NSUserDomainMask
+                          appropriateForURL:nil
+                                     create:YES
+                                      error:&error];
+    if (appSupport == nil) {
+        // Fall back to the temp directory if Application Support is somehow
+        // unavailable — the SDK won't persist anything across launches in that
+        // case, but at least won't crash.
+        appSupport = [NSURL fileURLWithPath:NSTemporaryDirectory()];
+    }
+    return [appSupport URLByAppendingPathComponent:ARTLocalDeviceStorageDirectoryName];
 }
+
+#pragma mark - Logging helpers
 
 - (id)valueToLogForValue:(id)value {
     if (!_logValues) {
@@ -32,193 +104,217 @@
     return value;
 }
 
+#pragma mark - ARTDeviceStorage
+
 - (nullable id)objectForKey:(NSString *)key {
-    id value = [NSUserDefaults.standardUserDefaults objectForKey:key];
+    [_lock lock];
+    id value = _cache[key];
     if (value == nil) {
-        ARTLogDebug(_logger, @"UserDefaults read miss for key %@", key);
+        ARTLogDebug(_logger, @"ARTLocalDeviceStorage: read miss for key %@", key);
     }
     else {
-        ARTLogDebug(_logger, @"UserDefaults read hit for key %@: %@", key, [self valueToLogForValue:value]);
+        ARTLogDebug(_logger, @"ARTLocalDeviceStorage: read hit for key %@: %@", key, [self valueToLogForValue:value]);
     }
+    [_lock unlock];
     return value;
 }
 
 - (void)setObject:(nullable id)value forKey:(NSString *)key {
-    [NSUserDefaults.standardUserDefaults setObject:value forKey:key];
+    [_lock lock];
+    [self mutateCacheForKey:key value:value];
     if (value == nil) {
-        ARTLogDebug(_logger, @"UserDefaults deleted for key %@", key);
+        ARTLogDebug(_logger, @"ARTLocalDeviceStorage: deleted key %@", key);
     }
     else {
-        ARTLogDebug(_logger, @"UserDefaults written for key %@: %@", key, [self valueToLogForValue:value]);
+        ARTLogDebug(_logger, @"ARTLocalDeviceStorage: wrote key %@: %@", key, [self valueToLogForValue:value]);
     }
+    [self flushIfNotBatching];
+    [_lock unlock];
 }
 
-- (NSString *)secretForDevice:(ARTDeviceId *)deviceId {
-    NSError *error = nil;
-    NSString *value = [self keychainGetPasswordForService:ARTDeviceSecretKey account:(NSString *)deviceId error:&error];
-
-    if ([error code] == errSecItemNotFound) {
-        ARTLogDebug(_logger, @"Device Secret read miss for device %@", deviceId);
+- (void)removeAll {
+    [_lock lock];
+    if (_cache.count > 0) {
+        [_cache removeAllObjects];
+        _isModified = YES;
     }
-    else if (error) {
-        ARTLogError(_logger, @"Device Secret couldn't be read for device %@ (%@)", deviceId, [error localizedDescription]);
-    }
-    else {
-        ARTLogDebug(_logger, @"Device Secret read hit for device %@: %@", deviceId, [self valueToLogForValue:value]);
-    }
-
-    return value;
+    [self flushIfNotBatching];
+    [_lock unlock];
 }
 
-- (void)setSecret:(NSString *)value forDevice:(ARTDeviceId *)deviceId {
-    NSError *error = nil;
-    if (value == nil) {
-        [self keychainDeletePasswordForService:ARTDeviceSecretKey account:(NSString *)deviceId error:&error];
-
-        if ([error code] == errSecItemNotFound) {
-            ARTLogWarn(_logger, @"Device Secret can't be deleted for device %@ because it doesn't exist", deviceId);
+- (void)performBatchUpdate:(NS_NOESCAPE void (^)(id<ARTDeviceStorage>))block {
+    [_lock lock];
+    _batchDepth++;
+    @try {
+        block(self);
+    }
+    @finally {
+        _batchDepth--;
+        if (_batchDepth == 0) {
+            [self flushIfModified];
         }
-        else if (error) {
-            ARTLogError(_logger, @"Device Secret couldn't be deleted for device %@ (%@)", deviceId, [error localizedDescription]);
+        [_lock unlock];
+    }
+}
+
+#pragma mark - Internal write helpers
+
+- (void)mutateCacheForKey:(NSString *)key value:(nullable id)value {
+    if (value == nil) {
+        if (_cache[key] == nil) return; // no-op
+        [_cache removeObjectForKey:key];
+    }
+    else {
+        if ([_cache[key] isEqual:value]) return; // no-op
+        _cache[key] = value;
+    }
+    _isModified = YES;
+}
+
+- (void)flushIfNotBatching {
+    if (_batchDepth > 0) return;
+    [self flushIfModified];
+}
+
+- (void)flushIfModified {
+    if (!_isModified) return;
+    NSError *error = nil;
+    if (![_store save:_cache error:&error]) {
+        ARTLogError(_logger, @"ARTLocalDeviceStorage: persist failed for %@: %@", _store.fileURL.lastPathComponent, error.localizedDescription);
+        return;
+    }
+    _isModified = NO;
+    ARTLogDebug(_logger, @"ARTLocalDeviceStorage: flushed %lu keys: (%@) (to %@)", (unsigned long)_cache.count, [_cache.allKeys componentsJoinedByString:@", "], _store.fileURL.lastPathComponent);
+}
+
+#pragma mark - Legacy migration
+
+- (void)migrateLegacyDataIfNeeded {
+    if ([_store fileExists]) {
+        return; // already migrated (or new install with the storage already populated)
+    }
+    [self migrateLegacyData];
+}
+
+/// Reads any legacy data from `NSUserDefaults` + the keychain into the new
+/// file. This is where RSH8a1 is enforced against the legacy data: a
+/// successful load of both `id` and `deviceSecret` is the gate that lets any
+/// of the persisted attributes cross into the new file. If the load fails,
+/// every legacy field is discarded together so the device-fetch path
+/// generates a fresh (id, secret) pair against an empty file.
+///
+/// The realistic reason for `legacySecret` to be absent when an `id` exists
+/// is that the device hasn't been unlocked since reboot, so the keychain is
+/// inaccessible.
+///
+/// Note that this is the _only_ place where we enforce RSH8a1; the load
+/// failures (in particular, a load failure that affects only certain
+/// LocalDevice attributes) which that spec point was written to address could
+/// only, in practice, occur in the legacy storage.
+- (void)migrateLegacyData {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+
+    NSString *legacyDeviceId = [defaults objectForKey:ARTDeviceIdKey];
+    NSString *legacyClientId = [defaults objectForKey:ARTClientIdKey];
+    id legacyIdentityToken = [defaults objectForKey:ARTDeviceIdentityTokenKey];
+    id legacyState = [defaults objectForKey:ARTPushActivationCurrentStateKey];
+    id legacyPendingEvents = [defaults objectForKey:ARTPushActivationPendingEventsKey];
+    id legacyApnsDefault = [defaults objectForKey:ARTAPNSDeviceTokenKeyOfType(ARTAPNSDeviceDefaultTokenType)];
+    id legacyApnsLocation = [defaults objectForKey:ARTAPNSDeviceTokenKeyOfType(ARTAPNSDeviceLocationTokenType)];
+
+    BOOL hasLegacy = (legacyDeviceId || legacyClientId || legacyIdentityToken ||
+                      legacyState || legacyPendingEvents || legacyApnsDefault || legacyApnsLocation);
+    if (!hasLegacy) {
+        return;
+    }
+
+    NSString *legacySecret = nil;
+    if (legacyDeviceId != nil) {
+        OSStatus status = errSecSuccess;
+        if (_legacyKeychainReader) {
+            legacySecret = _legacyKeychainReader(legacyDeviceId, &status);
         }
         else {
-            ARTLogDebug(_logger, @"Device Secret deleted for device %@", deviceId);
+            legacySecret = [self readLegacyKeychainSecretForDevice:legacyDeviceId status:&status];
         }
+        // Any failure is treated as the legacy secret being absent.
+        if (status != errSecSuccess) {
+            ARTLogWarn(_logger, @"ARTLocalDeviceStorage: legacy keychain value is unavailable for device id %@ (status=%d)", legacyDeviceId, (int)status);
+        }
+    }
+
+    NSMutableDictionary *migrated = [NSMutableDictionary dictionary];
+
+    // RSH8a1: the legacy data crosses into the new file only if id and
+    // secret are both loadable. Otherwise we drop everything and let the
+    // device-fetch path start clean.
+    if (legacyDeviceId != nil && legacySecret != nil) {
+        migrated[ARTDeviceIdKey] = legacyDeviceId;
+        migrated[ARTDeviceSecretKey] = legacySecret;
+        migrated[ARTDeviceIdentityTokenKey] = legacyIdentityToken;
+        migrated[ARTClientIdKey] = legacyClientId;
+
+        migrated[ARTAPNSDeviceTokenKeyOfType(ARTAPNSDeviceDefaultTokenType)] = legacyApnsDefault;
+        migrated[ARTAPNSDeviceTokenKeyOfType(ARTAPNSDeviceLocationTokenType)] = legacyApnsLocation;
+
+        migrated[ARTPushActivationCurrentStateKey] = legacyState;
+        migrated[ARTPushActivationPendingEventsKey] = legacyPendingEvents;
+
+        // Mark the data as migrated so future versions can tell it apart from
+        // data generated natively in the new file.
+        migrated[ARTMigratedFromLegacyStorageKey] = @YES;
     }
     else {
-        [self keychainSetPassword:value forService:ARTDeviceSecretKey account:(NSString *)deviceId error:&error];
-
-        if (error) {
-            ARTLogError(_logger, @"Device Secret couldn't be written for device %@: %@ (%@)", deviceId, [self valueToLogForValue:value], [error localizedDescription]);
-        }
-        else {
-            ARTLogDebug(_logger, @"Device Secret written for device %@: %@", deviceId, [self valueToLogForValue:value]);
-        }
+        ARTLogWarn(_logger, @"ARTLocalDeviceStorage: legacy device data is incomplete; discarding legacy device details and state machine data");
     }
+
+    NSError *saveError = nil;
+    if (![_store save:migrated error:&saveError]) {
+        ARTLogError(_logger, @"ARTLocalDeviceStorage: failed to write migrated file: %@", saveError.localizedDescription);
+        return;
+    }
+    _cache = [migrated mutableCopy];
+
+    // Log which fields were migrated. Values go through `valueToLogForValue:`
+    // so secrets/tokens stay retracted unless value logging is explicitly on.
+    NSMutableDictionary *loggableMigrated = [NSMutableDictionary dictionaryWithCapacity:migrated.count];
+    for (NSString *key in migrated) {
+        loggableMigrated[key] = [self valueToLogForValue:migrated[key]];
+    }
+    ARTLogInfo(_logger, @"ARTLocalDeviceStorage: migrated %lu legacy fields: %@", (unsigned long)migrated.count, loggableMigrated);
 }
 
-#pragma mark - Keychain
+#pragma mark - Legacy keychain (read-and-delete only)
 
-- (nonnull NSMutableDictionary *)newKeychainQueryForService:(nonnull NSString *)serviceName account:(nonnull NSString *)account {
-    NSMutableDictionary *dictionary = [NSMutableDictionary dictionaryWithCapacity:3];
-    [dictionary setObject:(__bridge id)kSecClassGenericPassword forKey:(__bridge id)kSecClass];
-    [dictionary setObject:serviceName forKey:(__bridge id)kSecAttrService];
-    [dictionary setObject:account forKey:(__bridge id)kSecAttrAccount];
-#if TARGET_OS_IPHONE
-    [dictionary setObject:(__bridge id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly forKey:(__bridge id)kSecAttrAccessible];
-#endif
-    return dictionary;
-}
-
-- (nonnull NSError *)keychainErrorWithCode:(OSStatus)status {
-    NSString *message = nil;
-    #if TARGET_OS_IPHONE
-    switch (status) {
-        case errSecUnimplemented: {
-            message = @"errSecUnimplemented";
-            break;
-        }
-        case errSecParam: {
-            message = @"errSecParam";
-            break;
-        }
-        case errSecAllocate: {
-            message = @"errSecAllocate";
-            break;
-        }
-        case errSecNotAvailable: {
-            message = @"errSecNotAvailable";
-            break;
-        }
-        case errSecDuplicateItem: {
-            message = @"errSecDuplicateItem";
-            break;
-        }
-        case errSecItemNotFound: {
-            message = @"errSecItemNotFound";
-            break;
-        }
-        case errSecInteractionNotAllowed: {
-            message = @"errSecInteractionNotAllowed";
-            break;
-        }
-        case errSecDecode: {
-            message = @"errSecDecode";
-            break;
-        }
-        case errSecAuthFailed: {
-            message = @"errSecAuthFailed";
-            break;
-        }
-        default: {
-            message = @"errSecDefault";
-        }
-    }
-    #else
-    message = (__bridge_transfer NSString *)SecCopyErrorMessageString(status, NULL);
-    #endif
-    NSDictionary *userInfo = nil;
-    if (message) {
-        userInfo = @{ NSLocalizedDescriptionKey : message };
-    }
-    return [NSError errorWithDomain:[NSString stringWithFormat:@"%@.%@", ARTAblyErrorDomain, @"Keychain"] code:status userInfo:userInfo];
-}
-
-- (nullable NSString *)keychainGetPasswordForService:(nonnull NSString *)serviceName account:(nonnull NSString *)account error:(NSError *__autoreleasing *)error {
-    NSMutableDictionary *query = [self newKeychainQueryForService:serviceName account:account];
-
-    [query setObject:@YES forKey:(__bridge id)kSecReturnData];
-    [query setObject:(__bridge id)kSecMatchLimitOne forKey:(__bridge id)kSecMatchLimit];
+- (nullable NSString *)readLegacyKeychainSecretForDevice:(NSString *)deviceId status:(OSStatus *)outStatus {
+    NSDictionary *query = @{
+        (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrService: ARTDeviceSecretKey,
+        (__bridge id)kSecAttrAccount: deviceId,
+        (__bridge id)kSecReturnData: @YES,
+        (__bridge id)kSecMatchLimit: (__bridge id)kSecMatchLimitOne,
+    };
     CFTypeRef result = NULL;
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
-
+    if (outStatus) *outStatus = status;
     if (status != errSecSuccess) {
-        if (error) {
-            *error = [self keychainErrorWithCode:status];
-        }
+        return nil;
     }
-    else {
-        NSData *passwordData = (__bridge_transfer NSData *)result;
-        if ([passwordData length]) {
-            return [[NSString alloc] initWithData:passwordData encoding:NSUTF8StringEncoding];
-        }
-    }
-
-    return nil;
+    NSData *data = (__bridge_transfer NSData *)result;
+    if (data.length == 0) return nil;
+    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 }
 
-- (BOOL)keychainDeletePasswordForService:(NSString *)serviceName account:(NSString *)account error:(NSError *__autoreleasing *)error {
-    NSMutableDictionary *query = [self newKeychainQueryForService:serviceName account:account];
+- (void)deleteLegacyKeychainSecretForDevice:(NSString *)deviceId {
+    NSDictionary *query = @{
+        (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrService: ARTDeviceSecretKey,
+        (__bridge id)kSecAttrAccount: deviceId,
+    };
     OSStatus status = SecItemDelete((__bridge CFDictionaryRef)query);
-    if (status != errSecSuccess && error != NULL) {
-        *error = [self keychainErrorWithCode:status];
+    if (status != errSecSuccess && status != errSecItemNotFound) {
+        ARTLogWarn(_logger, @"ARTLocalDeviceStorage: failed to delete legacy keychain secret for device %@ (status=%d)", deviceId, (int)status);
     }
-    return (status == errSecSuccess);
-}
-
-- (BOOL)keychainSetPassword:(NSString *)password forService:(NSString *)serviceName account:(NSString *)account error:(NSError *__autoreleasing *)error {
-    NSMutableDictionary *query = nil;
-    NSMutableDictionary *searchQuery = [self newKeychainQueryForService:serviceName account:account];
-    NSData *passwordData = [password dataUsingEncoding:NSUTF8StringEncoding];
-
-    OSStatus status;
-    status = SecItemCopyMatching((__bridge CFDictionaryRef)searchQuery, nil);
-    if (status == errSecSuccess) { //item already exists, update it.
-        query = [[NSMutableDictionary alloc] init];
-        [query setObject:passwordData forKey:(__bridge id)kSecValueData];
-        status = SecItemUpdate((__bridge CFDictionaryRef)(searchQuery), (__bridge CFDictionaryRef)(query));
-    }
-    else if (status == errSecItemNotFound) { //item not found, create it.
-        query = [self newKeychainQueryForService:serviceName account:account];
-        [query setObject:passwordData forKey:(__bridge id)kSecValueData];
-        status = SecItemAdd((__bridge CFDictionaryRef)query, NULL);
-    }
-
-    if (status != errSecSuccess && error != NULL) {
-        *error = [self keychainErrorWithCode:status];
-    }
-
-    return (status == errSecSuccess);
 }
 
 @end

--- a/Source/ARTPushActivationStateMachine.m
+++ b/Source/ARTPushActivationStateMachine.m
@@ -16,12 +16,15 @@
 #import "ARTAuth+Private.h"
 #import "ARTGCD.h"
 
+// These keys are referenced by `ARTLocalDeviceStorage` (built on all
+// platforms) for key routing, so the symbols must be defined regardless of
+// `TARGET_OS_IOS`. The rest of the state machine is iOS-only.
+NSString *const ARTPushActivationCurrentStateKey = @"ARTPushActivationCurrentState";
+NSString *const ARTPushActivationPendingEventsKey = @"ARTPushActivationPendingEvents";
+
 #if TARGET_OS_IOS
 
 #import <UIKit/UIKit.h>
-
-NSString *const ARTPushActivationCurrentStateKey = @"ARTPushActivationCurrentState";
-NSString *const ARTPushActivationPendingEventsKey = @"ARTPushActivationPendingEvents";
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -39,6 +42,7 @@ NS_ASSUME_NONNULL_END
     dispatch_queue_t _queue;
     dispatch_queue_t _userQueue;
     NSMutableArray<ARTPushActivationEvent *> *_pendingEvents;
+    id<ARTDeviceStorage> _storage;
 }
 
 - (instancetype)initWithRest:(ARTRestInternal *const)rest
@@ -50,8 +54,13 @@ NS_ASSUME_NONNULL_END
         _queue = _rest.queue;
         _userQueue = _rest.userQueue;
         _logger = logger;
+
+        // RSH3h: ensure to initialise the device _before_ the state fields are initialised
+        ARTLocalDevice *localDevice = rest.device_nosync;
+        _storage = localDevice.storage;
+
         // Unarchiving
-        _current = [ARTPushActivationState art_unarchiveFromStorage:rest.storage
+        _current = [ARTPushActivationState art_unarchiveFromStorage:_storage
                                                                 key:ARTPushActivationCurrentStateKey
                                                          withLogger:logger];
         if (!_current) {
@@ -62,7 +71,7 @@ NS_ASSUME_NONNULL_END
             }
             _current.machine = self;
         }
-        _pendingEvents = [ARTPushActivationEvent art_unarchiveFromStorage:rest.storage
+        _pendingEvents = [ARTPushActivationEvent art_unarchiveFromStorage:_storage
                                                                       key:ARTPushActivationPendingEventsKey
                                                                withLogger:logger];
         if (!_pendingEvents) {
@@ -72,7 +81,7 @@ NS_ASSUME_NONNULL_END
         // Due to bug #966, old versions of the library might have led us to an illegal
         // persisted state: we have a deviceToken, but the persisted push state is WaitingForPushDeviceDetails.
         // So we need to re-emit the GotPushDeviceDetails event that led us there.
-        if ([_current isKindOfClass:[ARTPushActivationStateWaitingForPushDeviceDetails class]] && rest.device_nosync.apnsDeviceToken != nil) {
+        if ([_current isKindOfClass:[ARTPushActivationStateWaitingForPushDeviceDetails class]] && localDevice.apnsDeviceToken != nil) {
             ARTLogDebug(logger, @"ARTPush: re-emitting stored device details for stuck state machine");
             [self handleEvent:[ARTPushActivationEventGotPushDeviceDetails new]];
         }
@@ -155,13 +164,17 @@ art_dispatch_async(_queue, ^{
 }
 
 - (void)persist {
-    // Archiving
+    NSData *stateData = nil;
     if ([_current isKindOfClass:[ARTPushActivationPersistentState class]]) {
-        [self.rest.storage setObject:[_current art_archiveWithLogger:_logger]
-                              forKey:ARTPushActivationCurrentStateKey];
+        stateData = [_current art_archiveWithLogger:_logger];
     }
-    [self.rest.storage setObject:[_pendingEvents art_archiveWithLogger:_logger]
-                          forKey:ARTPushActivationPendingEventsKey];
+    NSData *eventsData = [_pendingEvents art_archiveWithLogger:_logger];
+    [_storage performBatchUpdate:^(id<ARTDeviceStorage> writer) {
+        if (stateData != nil) {
+            [writer setObject:stateData forKey:ARTPushActivationCurrentStateKey];
+        }
+        [writer setObject:eventsData forKey:ARTPushActivationPendingEventsKey];
+    }];
 }
 
 - (void)deviceRegistration:(ARTErrorInfo *)error {

--- a/Source/ARTThrowingLocalDeviceStorage.m
+++ b/Source/ARTThrowingLocalDeviceStorage.m
@@ -13,15 +13,14 @@
                 format:@"%@ invoked with key %@ on a client configured with disableLocalDevice", NSStringFromSelector(_cmd), key];
 }
 
-- (nullable NSString *)secretForDevice:(ARTDeviceId *)deviceId {
+- (void)removeAll {
     [NSException raise:NSInternalInconsistencyException
-                format:@"%@ invoked for device %@ on a client configured with disableLocalDevice", NSStringFromSelector(_cmd), deviceId];
-    return nil;
+                format:@"%@ invoked on a client configured with disableLocalDevice", NSStringFromSelector(_cmd)];
 }
 
-- (void)setSecret:(nullable NSString *)value forDevice:(ARTDeviceId *)deviceId {
+- (void)performBatchUpdate:(NS_NOESCAPE void (^)(id<ARTDeviceStorage>))block {
     [NSException raise:NSInternalInconsistencyException
-                format:@"%@ invoked for device %@ on a client configured with disableLocalDevice", NSStringFromSelector(_cmd), deviceId];
+                format:@"%@ invoked on a client configured with disableLocalDevice", NSStringFromSelector(_cmd)];
 }
 
 @end

--- a/Source/Ably.modulemap
+++ b/Source/Ably.modulemap
@@ -108,6 +108,7 @@ framework module Ably {
         header "ARTLogAdapter+Testing.h"
         header "ARTDeviceIdentityTokenDetails+Private.h"
         header "ARTHttp.h"
+        header "ARTAtomicFileStorage.h"
         header "ARTLocalDeviceStorage.h"
         header "ARTThrowingLocalDeviceStorage.h"
         header "ARTInternalLogCore.h"

--- a/Source/PrivateHeaders/Ably/ARTAtomicFileStorage.h
+++ b/Source/PrivateHeaders/Ably/ARTAtomicFileStorage.h
@@ -1,0 +1,30 @@
+#import <Foundation/Foundation.h>
+
+@class ARTInternalLog;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Reads and writes a single property-list-backed file atomically.
+/// The file is written with `NSFileProtectionNone` so the data is readable even
+/// before the user has unlocked the device after a reboot.
+///
+/// This class is thread-safe.
+@interface ARTAtomicFileStorage : NSObject
+
+- (instancetype)initWithFileURL:(NSURL *)fileURL logger:(nullable ARTInternalLog *)logger;
+
+@property (nonatomic, readonly) NSURL *fileURL;
+
+/// Returns the persisted dictionary. Returns an empty dictionary if the file
+/// does not exist or cannot be parsed.
+- (NSDictionary<NSString *, id> *)load;
+
+/// Writes `dictionary` to the file. The write is atomic at the file-system
+/// level (write-to-temp-and-rename). Returns `YES` on success.
+- (BOOL)save:(NSDictionary<NSString *, id> *)dictionary error:(NSError * _Nullable * _Nullable)error;
+
+- (BOOL)fileExists;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTDeviceStorage.h
+++ b/Source/PrivateHeaders/Ably/ARTDeviceStorage.h
@@ -8,8 +8,16 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol ARTDeviceStorage <NSObject>
 - (nullable id)objectForKey:(NSString *)key;
 - (void)setObject:(nullable id)value forKey:(NSString *)key;
-- (nullable NSString *)secretForDevice:(ARTDeviceId *)deviceId;
-- (void)setSecret:(nullable NSString *)value forDevice:(ARTDeviceId *)deviceId;
+
+/// Removes all persisted data in a single atomic operation.
+- (void)removeAll;
+
+/// Apply a group of mutations as a single atomic unit. Implementations must
+/// ensure that changes performed inside `block` either all become visible to
+/// subsequent loads, or none of them do — this is what guarantees that, for
+/// example, a `deviceIdentityToken` is never paired with a `deviceId` it does
+/// not belong to. Nested invocations are supported; the outermost call commits.
+- (void)performBatchUpdate:(NS_NOESCAPE void (^)(id<ARTDeviceStorage> writer))block;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/PrivateHeaders/Ably/ARTLocalDeviceStorage.h
+++ b/Source/PrivateHeaders/Ably/ARTLocalDeviceStorage.h
@@ -5,11 +5,53 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Marker written into the persisted file when its contents were migrated from
+/// the legacy `NSUserDefaults`/keychain layout.
+/// It exists so that, if we later need to deal with legacy out-of-sync issues
+/// (e.g. a `deviceIdentityToken` that doesn't match the migrated `deviceId`),
+/// we can identify migrated data and decide whether to validate it.
+extern NSString *const ARTMigratedFromLegacyStorageKey;
+
+/// Block used during legacy migration to look up the device secret in the
+/// keychain. The real implementation calls `SecItemCopyMatching`; tests
+/// substitute a stub that returns the desired `OSStatus` so that the
+/// migration's keychain-locked / unreachable branches can be exercised.
+typedef NSString * _Nullable (^ARTLegacyKeychainSecretReader)(NSString *deviceId, OSStatus * _Nullable outStatus);
+
+/// Persists `LocalDevice` data and push-activation-state-machine data to a
+/// single always-available file in the app's Application Support directory.
+///
+/// Writes are atomic: every persisted value lives in the same file and is
+/// written with a write-to-temp-and-rename, so it is impossible for, e.g., a
+/// `deviceIdentityToken` to be paired with a `deviceId` that it does not
+/// belong to.
+///
+/// On first init, data persisted by older SDK versions (in `NSUserDefaults`
+/// and the keychain) is migrated into the new file (old entries are preserved just in case).
 @interface ARTLocalDeviceStorage : NSObject<ARTDeviceStorage>
 
-- (instancetype)initWithLogger:(ARTInternalLog *)logger logValues:(BOOL)logValues;
+- (instancetype)initWithLogger:(nullable ARTInternalLog *)logger logValues:(BOOL)logValues;
 
-+ (instancetype)newWithLogger:(ARTInternalLog *)logger logValues:(BOOL)logValues;
++ (instancetype)newWithLogger:(nullable ARTInternalLog *)logger logValues:(BOOL)logValues;
+
+/// Initialiser for tests. `baseDirectoryURL` is the directory in which the
+/// storage file lives (and into which legacy data is migrated).
+- (instancetype)initWithBaseDirectoryURL:(NSURL *)baseDirectoryURL
+                                  logger:(nullable ARTInternalLog *)logger
+                               logValues:(BOOL)logValues;
+
+/// Designated initialiser. `legacyKeychainReader` overrides how the migration
+/// reads the legacy device secret from the keychain; pass `nil` to use the
+/// real `SecItemCopyMatching` implementation.
+- (instancetype)initWithBaseDirectoryURL:(NSURL *)baseDirectoryURL
+                                  logger:(nullable ARTInternalLog *)logger
+                               logValues:(BOOL)logValues
+                    legacyKeychainReader:(nullable ARTLegacyKeychainSecretReader)legacyKeychainReader NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Returns the directory used by `+newWithLogger:logValues:`.
++ (NSURL *)defaultBaseDirectoryURL;
 
 @end
 

--- a/Source/include/module.modulemap
+++ b/Source/include/module.modulemap
@@ -108,6 +108,7 @@ module Ably {
         header "../PrivateHeaders/Ably/ARTLogAdapter+Testing.h"
         header "../PrivateHeaders/Ably/ARTDeviceIdentityTokenDetails+Private.h"
         header "../PrivateHeaders/Ably/ARTHttp.h"
+        header "../PrivateHeaders/Ably/ARTAtomicFileStorage.h"
         header "../PrivateHeaders/Ably/ARTLocalDeviceStorage.h"
         header "../PrivateHeaders/Ably/ARTThrowingLocalDeviceStorage.h"
         header "../PrivateHeaders/Ably/ARTInternalLogCore.h"

--- a/Test/AblyTests/Test Utilities/MockDeviceStorage.swift
+++ b/Test/AblyTests/Test Utilities/MockDeviceStorage.swift
@@ -39,21 +39,17 @@ class MockDeviceStorage: NSObject, ARTDeviceStorage {
         }
     }
 
-    func secret(forDevice deviceId: ARTDeviceId) -> String? {
-        return accessQueue.sync {
-            keysRead.append(ARTDeviceSecretKey)
-            if let value = simulateString[ARTDeviceSecretKey] {
-                defer { simulateString.removeValue(forKey: ARTDeviceSecretKey) }
-                return value
-            }
-            return nil
+    func removeAll() {
+        accessQueue.sync {
+            simulateData.removeAll()
+            simulateString.removeAll()
         }
     }
 
-    func setSecret(_ value: String?, forDevice deviceId: ARTDeviceId) {
-        accessQueue.sync {
-            _ = keysWritten.updateValue(value, forKey: ARTDeviceSecretKey)
-        }
+    func performBatchUpdate(_ block: (ARTDeviceStorage) -> Void) {
+        // The mock records every key write individually; there is no on-disk
+        // flush to defer, so atomic batches just run the block synchronously.
+        block(self)
     }
 
     func simulateOnNextRead(data value: Data, `for` key: String) {

--- a/Test/AblyTests/Test Utilities/TestUtilities.swift
+++ b/Test/AblyTests/Test Utilities/TestUtilities.swift
@@ -81,6 +81,16 @@ class AblyTests {
         checkError(errorInfo, withAlternative: "")
     }
 
+    /// Removes the on-disk `LocalDevice` file used by the real device storage,
+    /// so a test (or suite `setUp`) starts from a clean device/state-machine
+    /// slate rather than inheriting state another test persisted.
+    class func clearOnDiskDeviceStorage() {
+        #if os(iOS)
+        let deviceFileURL = ARTLocalDeviceStorage.defaultBaseDirectoryURL().appendingPathComponent("LocalDevice.plist")
+        try? FileManager.default.removeItem(at: deviceFileURL)
+        #endif
+    }
+
     static var testApplication: [String: Any]?
 
     struct QueueIdentity {

--- a/Test/AblyTests/Tests/LocalDeviceStorageTests.swift
+++ b/Test/AblyTests/Tests/LocalDeviceStorageTests.swift
@@ -1,0 +1,412 @@
+#if os(iOS)
+import Ably
+import Ably.Private
+import AblyTesting
+import Security
+import XCTest
+
+final class LocalDeviceStorageTests: XCTestCase {
+
+    private var tempDirectory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("LocalDeviceStorageTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        clearLegacyUserDefaults()
+    }
+
+    override func tearDownWithError() throws {
+        if let dir = tempDirectory, FileManager.default.fileExists(atPath: dir.path) {
+            try? FileManager.default.removeItem(at: dir)
+        }
+        clearLegacyUserDefaults()
+        try super.tearDownWithError()
+    }
+
+    // MARK: Storage creation
+
+    func test_storageFileIsCreated() throws {
+        let storage = makeStorage()
+        storage.setObject("device-1", forKey: ARTDeviceIdKey)
+        storage.setObject("secret-1", forKey: ARTDeviceSecretKey)
+
+        let fileURL = tempDirectory.appendingPathComponent("LocalDevice.plist")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path))
+
+        // Ensure the contents round-trip via NSPropertyListSerialization.
+        let data = try Data(contentsOf: fileURL)
+        let plist = try PropertyListSerialization.propertyList(from: data, options: [], format: nil)
+        XCTAssertNotNil(plist as? [String: Any])
+
+        // Note that we have no assertion that the file is written using NSDataWritingFileProtectionNone; such an assertion would fail on the Simulator, which doesn't implement iOS data protection and reports no protection attribute. You'll need to test the before-first-unlock behaviour manually.
+    }
+
+    // MARK: Storage read/write
+
+    // RSH8a: the persisted LocalDevice attributes must survive a storage
+    // round-trip — i.e. what's written is what a fresh instance loads back.
+    func test_writesAndReadsThroughTheProtocol() {
+        let storage = makeStorage()
+
+        storage.setObject("device-1", forKey: ARTDeviceIdKey)
+        storage.setObject("secret-1", forKey: ARTDeviceSecretKey)
+        let identityTokenData = Data("token-bytes".utf8)
+        storage.setObject(identityTokenData, forKey: ARTDeviceIdentityTokenKey)
+        storage.setObject("client-1", forKey: ARTClientIdKey)
+
+        XCTAssertEqual(storage.object(forKey: ARTDeviceIdKey) as? String, "device-1")
+        XCTAssertEqual(storage.object(forKey: ARTDeviceSecretKey) as? String, "secret-1")
+        XCTAssertEqual(storage.object(forKey: ARTDeviceIdentityTokenKey) as? Data, identityTokenData)
+        XCTAssertEqual(storage.object(forKey: ARTClientIdKey) as? String, "client-1")
+
+        // A fresh instance reading the same files must observe the same values.
+        let reloaded = makeStorage()
+        XCTAssertEqual(reloaded.object(forKey: ARTDeviceIdKey) as? String, "device-1")
+        XCTAssertEqual(reloaded.object(forKey: ARTDeviceSecretKey) as? String, "secret-1")
+        XCTAssertEqual(reloaded.object(forKey: ARTDeviceIdentityTokenKey) as? Data, identityTokenData)
+        XCTAssertEqual(reloaded.object(forKey: ARTClientIdKey) as? String, "client-1")
+    }
+
+    // MARK: atomicity of performBatchUpdate
+
+    // ARTDeviceStorage atomicity contract: a `performBatchUpdate` persists all
+    // of its mutations together in a single flush (so e.g. a
+    // `deviceIdentityToken` is never paired with a `deviceId` it doesn't
+    // belong to).
+    func test_atomicUpdateWritesAllKeysInOneFlush() {
+        let storage = makeStorage()
+
+        storage.performBatchUpdate { writer in
+            writer.setObject("device-1", forKey: ARTDeviceIdKey)
+            writer.setObject("secret-1", forKey: ARTDeviceSecretKey)
+            writer.setObject(Data("token".utf8), forKey: ARTDeviceIdentityTokenKey)
+            writer.setObject("client-1", forKey: ARTClientIdKey)
+        }
+
+        // All four writes must land in the new file content; a follow-up load
+        // sees the full tuple.
+        let reloaded = makeStorage()
+        XCTAssertEqual(reloaded.object(forKey: ARTDeviceIdKey) as? String, "device-1")
+        XCTAssertEqual(reloaded.object(forKey: ARTDeviceSecretKey) as? String, "secret-1")
+        XCTAssertEqual(reloaded.object(forKey: ARTDeviceIdentityTokenKey) as? Data, Data("token".utf8))
+        XCTAssertEqual(reloaded.object(forKey: ARTClientIdKey) as? String, "client-1")
+    }
+
+    // ARTDeviceStorage atomicity contract: mid-batch mutations are not visible
+    // on disk until the outermost `performBatchUpdate` commits.
+    func test_batchUpdateDoesNotReachDiskMidBatch() throws {
+        let storage = makeStorage()
+
+        // Seed an initial on-disk state with one outside-batch write.
+        storage.setObject("v0", forKey: ARTDeviceIdKey)
+
+        let fileURL = tempDirectory.appendingPathComponent("LocalDevice.plist")
+
+        storage.performBatchUpdate { writer in
+            writer.setObject("v1", forKey: ARTDeviceIdKey)
+            writer.setObject(Data("token-v1".utf8), forKey: ARTDeviceIdentityTokenKey)
+
+            // Read the file directly from disk while still inside the batch.
+            // The pre-batch state must still be on disk; mid-batch mutations
+            // live only in the in-memory cache until the block returns.
+            let data = try! Data(contentsOf: fileURL)
+            let plist = try! PropertyListSerialization.propertyList(from: data, options: [], format: nil) as! [String: Any]
+            XCTAssertEqual(plist[ARTDeviceIdKey] as? String, "v0")
+            XCTAssertNil(plist[ARTDeviceIdentityTokenKey])
+        }
+
+        // After the block returns, both writes have landed on disk together.
+        let data = try Data(contentsOf: fileURL)
+        let plist = try XCTUnwrap(PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any])
+        XCTAssertEqual(plist[ARTDeviceIdKey] as? String, "v1")
+        XCTAssertEqual(plist[ARTDeviceIdentityTokenKey] as? Data, Data("token-v1".utf8))
+    }
+
+    // MARK: RSH3h ordering
+
+    // RSH3h (the device is loaded *by* the state machine, not by the caller):
+    // an ARTRealtime *without* a clientId doesn't load the device as a side effect
+    // of construction (a clientId would, via `ARTAuth setLocalDeviceClientId_nosync:`),
+    // so it stays unloaded until the activation state machine is created.
+    func test_RSH3h_stateMachineConstructionLoadsTheDeviceWhenNotPreloaded() {
+        let logger = InternalLog(core: MockInternalLogCore())
+
+        // No clientId, and don't connect — nothing loads the device.
+        let options = ARTClientOptions(key: "fake:key")
+        options.autoConnect = false
+        let realtime = ARTRealtime(options: options)
+        defer { realtime.close() }
+
+        let rest = realtime.internal.rest
+        let storage = MockDeviceStorage()
+        rest.storage = storage
+        // Rebind the shared device singleton to this storage in its unloaded
+        // state, so we observe the load through `storage` rather than one cached
+        // by an earlier test.
+        rest.resetDeviceSingleton()
+        defer { rest.resetDeviceSingleton() }
+
+        // Precondition: the device has not been loaded — storage is untouched.
+        XCTAssertTrue(storage.keysRead.isEmpty)
+        XCTAssertTrue(storage.keysWritten.isEmpty)
+
+        // RSH3h: constructing the state machine loads the device (RSH8a), which
+        // reads the persisted device id and — finding none — generates and
+        // persists a fresh id + secret.
+        _ = ARTPushActivationStateMachine(rest: rest, delegate: StateMachineDelegate(), logger: logger)
+
+        XCTAssertTrue(storage.keysRead.contains(ARTDeviceIdKey))
+        XCTAssertNotNil(storage.keysWritten[ARTDeviceIdKey] ?? nil)
+        XCTAssertNotNil(storage.keysWritten[ARTDeviceSecretKey] ?? nil)
+    }
+
+    // RSH3h + RSH8a1: here the device data is *incomplete* (legacy id present
+    // but the keychain secret can't be read), so step (1) discards the persisted
+    // Activation State Machine data, and the machine constructed in step (2)
+    // must come up in NotActivated — even though a WaitingForDeviceRegistration
+    // state was persisted.
+    //
+    // This test pre-loads the device via `rest.device` before constructing the
+    // machine. That mirrors the common case of a client *with* a clientId, where
+    // the device is already loaded (via `ARTAuth setLocalDeviceClientId_nosync:`)
+    // by the time the machine is created — so the RSH8a1 discard has already run
+    // in step (1), and step (2) merely observes its NotActivated outcome.
+    func test_RSH8a_RSH3h_persistedActivationStateDiscardedWhenDeviceDataIsIncomplete() {
+        let logger = InternalLog(core: MockInternalLogCore())
+        let archivedState = archivedWaitingForDeviceRegistrationState(logger: logger)
+
+        let defaults = UserDefaults.standard
+        defaults.set("legacy-device", forKey: ARTDeviceIdKey)
+        defaults.set(archivedState, forKey: ARTPushActivationCurrentStateKey)
+
+        // Keychain secret is unavailable, so RSH8a1 discards the whole legacy
+        // record — including the activation state — during migration.
+        let reader: ARTLegacyKeychainSecretReader = { _, outStatus in
+            outStatus?.pointee = errSecInteractionNotAllowed
+            return nil
+        }
+        let storage = makeStorage(keychainSecretReader: reader)
+
+        let rest = ARTRest(key: "fake:key")
+        rest.internal.storage = storage
+        rest.internal.resetDeviceSingleton()
+        defer { rest.internal.resetDeviceSingleton() }
+
+        // The incomplete device data triggers RSH8a1, so no activation state is persisted:
+        _ = rest.device
+        let device = rest.device
+        XCTAssertEqual(device.id.count, 36) // a freshly generated UUID
+        XCTAssertNotNil(device.secret)
+        XCTAssertEqual(storage.object(forKey: ARTDeviceIdKey) as? String, device.id)
+        XCTAssertEqual(storage.object(forKey: ARTDeviceSecretKey) as? String, device.secret)
+
+        // RSH3h step (2): with no persisted state, the machine starts NotActivated.
+        let stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate(), logger: logger)
+        XCTAssertTrue(stateMachine.current is ARTPushActivationStateNotActivated)
+    }
+
+    // Primarily RSH8a (the LocalDevice is populated from the persisted state):
+    // the device data is *complete* (legacy id + keychain secret migrate
+    // successfully), so the persisted Activation State Machine state survives
+    // RSH3h step (1), and the machine constructed in step (2) resumes it.
+    //
+    // This test pre-loads the device via `rest.device` before constructing the
+    // machine. That mirrors the common case of a client *with* a clientId, where
+    // the device is already loaded (via `ARTAuth setLocalDeviceClientId_nosync:`)
+    // by the time the machine is created — so step (2) just resumes the state
+    // that the already-completed step (1) retained.
+    func test_RSH8a_RSH3h_persistedActivationStateResumesWhenDeviceDataIsComplete() {
+        let logger = InternalLog(core: MockInternalLogCore())
+        let archivedState = archivedWaitingForDeviceRegistrationState(logger: logger)
+
+        let defaults = UserDefaults.standard
+        defaults.set("legacy-device", forKey: ARTDeviceIdKey)
+        defaults.set(archivedState, forKey: ARTPushActivationCurrentStateKey)
+        // Keychain secret is available, so migration carries the device data —
+        // and the activation state — into the new file.
+        let reader: ARTLegacyKeychainSecretReader = { _, outStatus in
+            outStatus?.pointee = errSecSuccess
+            return "legacy-secret"
+        }
+        let storage = makeStorage(keychainSecretReader: reader)
+
+        let rest = ARTRest(key: "fake:key")
+        rest.internal.storage = storage
+        rest.internal.resetDeviceSingleton()
+        defer { rest.internal.resetDeviceSingleton() }
+
+        // Initialise the LocalDevice (RSH8a) — device data is
+        // valid, so the persisted state is retained.
+        let device = rest.device
+        XCTAssertEqual(device.id, "legacy-device")
+        XCTAssertEqual(device.secret, "legacy-secret")
+        XCTAssertEqual(storage.object(forKey: ARTDeviceIdKey) as? String, device.id)
+        XCTAssertEqual(storage.object(forKey: ARTDeviceSecretKey) as? String, device.secret)
+
+        // RSH3h step (2): the state machine resumes the persisted state.
+        let stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate(), logger: logger)
+        XCTAssertTrue(stateMachine.current is ARTPushActivationStateWaitingForDeviceRegistration)
+    }
+
+    // MARK: legacy migration
+
+    // Not a spec point: backward-compatible migration of the legacy
+    // `NSUserDefaults` + keychain layout into the single persisted file.
+    func test_migratesLegacyUserDefaultsOnFirstInit() {
+        let defaults = UserDefaults.standard
+
+        defaults.set("legacy-device", forKey: ARTDeviceIdKey)
+        defaults.set("legacy-client", forKey: ARTClientIdKey)
+        let identityTokenData = Data("legacy-token-archive".utf8)
+        defaults.set(identityTokenData, forKey: ARTDeviceIdentityTokenKey)
+        let stateData = Data("state-archive".utf8)
+        let eventsData = Data("events-archive".utf8)
+        defaults.set(stateData, forKey: ARTPushActivationCurrentStateKey)
+        defaults.set(eventsData, forKey: ARTPushActivationPendingEventsKey)
+        defaults.set("apns-default-token", forKey: "ARTAPNSDeviceToken-default")
+        defaults.set("apns-location-token", forKey: "ARTAPNSDeviceToken-location")
+
+        // Keychain reader returns the legacy secret — the happy path lets
+        // every field cross into the new file together.
+        let reader: ARTLegacyKeychainSecretReader = { deviceId, outStatus in
+            outStatus?.pointee = errSecSuccess
+            return "legacy-secret"
+        }
+        let storage = makeStorage(keychainSecretReader: reader)
+
+        // Migration writes the legacy data into the new persisted file, so the
+        // file must exist on disk afterwards.
+        let fileURL = tempDirectory.appendingPathComponent("LocalDevice.plist")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path))
+
+        XCTAssertEqual(storage.object(forKey: ARTDeviceIdKey) as? String, "legacy-device")
+        XCTAssertEqual(storage.object(forKey: ARTDeviceSecretKey) as? String, "legacy-secret")
+        XCTAssertEqual(storage.object(forKey: ARTDeviceIdentityTokenKey) as? Data, identityTokenData)
+        XCTAssertEqual(storage.object(forKey: ARTClientIdKey) as? String, "legacy-client")
+        XCTAssertEqual(storage.object(forKey: ARTPushActivationCurrentStateKey) as? Data, stateData)
+        XCTAssertEqual(storage.object(forKey: ARTPushActivationPendingEventsKey) as? Data, eventsData)
+        XCTAssertEqual(storage.object(forKey: "ARTAPNSDeviceToken-default") as? String, "apns-default-token")
+        XCTAssertEqual(storage.object(forKey: "ARTAPNSDeviceToken-location") as? String, "apns-location-token")
+
+        // The migrated data is flagged as such, so future versions
+        // can tell it apart from data generated natively in the new file.
+        XCTAssertEqual(storage.object(forKey: ARTMigratedFromLegacyStorageKey) as? Bool, true)
+
+        // The legacy entries are deliberately left in place after migration, so
+        // they must still be readable from `NSUserDefaults`.
+        for key in [
+            ARTDeviceIdKey,
+            ARTClientIdKey,
+            ARTDeviceIdentityTokenKey,
+            ARTPushActivationCurrentStateKey,
+            ARTPushActivationPendingEventsKey,
+            "ARTAPNSDeviceToken-default",
+            "ARTAPNSDeviceToken-location",
+        ] {
+            XCTAssertNotNil(defaults.object(forKey: key), "legacy key \(key) should be left intact")
+        }
+    }
+
+    // RSH8a1 (applied during migration): if the legacy device secret can't be
+    // read, the whole legacy record is discarded rather than half-migrated, so
+    // the device-fetch path starts clean.
+    func test_discardsLegacyDataWhenKeychainSecretIsUnavailable() {
+        let defaults = UserDefaults.standard
+
+        defaults.set("legacy-device", forKey: ARTDeviceIdKey)
+        defaults.set("legacy-client", forKey: ARTClientIdKey)
+        defaults.set(Data("legacy-token-archive".utf8), forKey: ARTDeviceIdentityTokenKey)
+        defaults.set(Data("state-archive".utf8), forKey: ARTPushActivationCurrentStateKey)
+        defaults.set(Data("events-archive".utf8), forKey: ARTPushActivationPendingEventsKey)
+        defaults.set("apns-default-token", forKey: "ARTAPNSDeviceToken-default")
+        defaults.set("apns-location-token", forKey: "ARTAPNSDeviceToken-location")
+
+        // Keychain reader returns no secret — the realistic cause is the
+        // device being locked before first unlock. RSH8a1 discards every
+        // legacy field together; the device-fetch path will start clean.
+        let reader: ARTLegacyKeychainSecretReader = { _, outStatus in
+            outStatus?.pointee = errSecInteractionNotAllowed
+            return nil
+        }
+        let storage = makeStorage(keychainSecretReader: reader)
+
+        // Migration still creates the new file (so it won't try to migrate
+        // again), but since everything was discarded it holds an empty plist.
+        let fileURL = tempDirectory.appendingPathComponent("LocalDevice.plist")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path))
+        let data = try! Data(contentsOf: fileURL)
+        let plist = try! PropertyListSerialization.propertyList(from: data, options: [], format: nil) as! [String: Any]
+        XCTAssertTrue(plist.isEmpty)
+
+        // Nothing crosses into the new file: the incomplete legacy record is
+        // discarded wholesale.
+        for key in [
+            ARTDeviceIdKey,
+            ARTDeviceSecretKey,
+            ARTDeviceIdentityTokenKey,
+            ARTClientIdKey,
+            ARTPushActivationCurrentStateKey,
+            ARTPushActivationPendingEventsKey,
+            "ARTAPNSDeviceToken-default",
+            "ARTAPNSDeviceToken-location",
+        ] {
+            XCTAssertNil(storage.object(forKey: key), "key \(key) survived migration")
+        }
+
+        // Nothing was migrated, so the migration marker is not set either.
+        XCTAssertNil(storage.object(forKey: ARTMigratedFromLegacyStorageKey))
+
+        // The legacy entries are deliberately left in place after migration, so
+        // they must still be readable from `NSUserDefaults`.
+        for key in [
+            ARTDeviceIdKey,
+            ARTClientIdKey,
+            ARTDeviceIdentityTokenKey,
+            ARTPushActivationCurrentStateKey,
+            ARTPushActivationPendingEventsKey,
+            "ARTAPNSDeviceToken-default",
+            "ARTAPNSDeviceToken-location",
+        ] {
+            XCTAssertNotNil(defaults.object(forKey: key), "legacy key \(key) should be left intact")
+        }
+    }
+}
+
+// MARK: helpers
+
+extension LocalDeviceStorageTests {
+
+    private func makeStorage(keychainSecretReader: ARTLegacyKeychainSecretReader? = nil) -> ARTLocalDeviceStorage {
+        return ARTLocalDeviceStorage(baseDirectoryURL: tempDirectory, logger: nil, logValues: false, legacyKeychainReader: keychainSecretReader)
+    }
+
+    // An archived activation state, used by the RSH3h test so that its survival/absence
+    // is what distinguishes "state retained" from "state discarded".
+    private func archivedWaitingForDeviceRegistrationState(logger: InternalLog) -> Data {
+        let rest = ARTRest(key: "fake:key")
+        rest.internal.storage = MockDeviceStorage()
+        let stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate(), logger: logger)
+        let state = ARTPushActivationStateWaitingForDeviceRegistration(machine: stateMachine, logger: logger)
+        return state.art_archive(withLogger: nil)!
+    }
+
+    private func clearLegacyUserDefaults() {
+        let defaults = UserDefaults.standard
+        for key in [
+            ARTDeviceIdKey,
+            ARTDeviceIdentityTokenKey,
+            ARTClientIdKey,
+            ARTPushActivationCurrentStateKey,
+            ARTPushActivationPendingEventsKey,
+            "ARTAPNSDeviceToken",
+            "ARTAPNSDeviceToken-default",
+            "ARTAPNSDeviceToken-location",
+        ] {
+            defaults.removeObject(forKey: key)
+        }
+    }
+}
+
+#endif

--- a/Test/AblyTests/Tests/PushActivationStateMachineTests.swift
+++ b/Test/AblyTests/Tests/PushActivationStateMachineTests.swift
@@ -33,18 +33,16 @@ class PushActivationStateMachineTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
+        // Start from a clean on-disk device storage
+        AblyTests.clearOnDiskDeviceStorage()
+
         rest = ARTRest(key: "xxxx:xxxx")
         httpExecutor = MockHTTPExecutor()
         rest.internal.httpExecutor = httpExecutor
         storage = MockDeviceStorage()
         rest.internal.storage = storage
         initialStateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate(), logger: .init(core: MockInternalLogCore()))
-    }
-
-    override func tearDown() {
         rest.internal.resetDeviceSingleton()
-
-        super.tearDown()
     }
 
     func test__002__Activation_state_machine__should_set_NotActivated_state_as_current_state_when_disk_is_empty() {
@@ -56,9 +54,9 @@ class PushActivationStateMachineTests: XCTestCase {
         rest.internal.storage = storage
         let stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate(), logger: .init(core: MockInternalLogCore()))
         expect(stateMachine.current).to(beAKindOf(ARTPushActivationStateWaitingForDeviceRegistration.self))
-        XCTAssertEqual(storage.keysRead.count, 2)
+        XCTAssertEqual(storage.keysRead.count, 4) // 2 for state + 2 device key/secret
         XCTAssertEqual(storage.keysRead.filter { $0.hasSuffix("CurrentState") }.count, 1)
-        expect(storage.keysWritten).to(beEmpty())
+        XCTAssertEqual(storage.keysWritten.count, 2) // generated key/secret
     }
 
     func test__004__Activation_state_machine__AfterRegistrationUpdateFailed_state_from_persistence_gets_migrated_to_AfterRegistrationSyncFailed() {
@@ -216,6 +214,7 @@ class PushActivationStateMachineTests: XCTestCase {
         storage = MockDeviceStorage(startWith: ARTPushActivationStateWaitingForPushDeviceDetails(machine: initialStateMachine, logger: .init(core: MockInternalLogCore())))
         rest.internal.storage = storage
         stateMachine = ARTPushActivationStateMachine(rest: rest.internal, delegate: StateMachineDelegate(), logger: .init(core: MockInternalLogCore()))
+        rest.internal.resetDeviceSingleton()
     }
 
     // RSH3b1

--- a/Test/AblyTests/Tests/PushTests.swift
+++ b/Test/AblyTests/Tests/PushTests.swift
@@ -36,14 +36,17 @@ class PushTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
+        // Start from a clean on-disk device storage
+        AblyTests.clearOnDiskDeviceStorage()
+
         rest = ARTRest(key: "xxxx:xxxx")
-        rest.internal.resetDeviceSingleton()
         mockHttpExecutor = MockHTTPExecutor()
         rest.internal.httpExecutor = mockHttpExecutor
         storage = MockDeviceStorage()
         rest.internal.storage = storage
         stateMachineDelegate = StateMachineDelegate()
         rest.push.internal.createActivationStateMachine(withDelegate: stateMachineDelegate!)
+        rest.internal.resetDeviceSingleton()
     }
 
     // RSH2
@@ -344,6 +347,19 @@ class PushTests: XCTestCase {
         )
         realtime.internal.rest.storage = storage
 
+        // Per RSH8a1 the load path discards everything when `id` or
+        // `deviceSecret` can't be loaded, so to exercise the identity-token
+        // path we must simulate a consistent (id, secret, token) triple. This
+        // must be seeded BEFORE the device is loaded — creating the state
+        // machine below initialises the LocalDevice (RSH3h) — and we reset the
+        // shared device singleton so it reloads from this storage rather than
+        // one cached by `setUp`.
+        storage.simulateOnNextRead(string: "testId", for: ARTDeviceIdKey)
+        storage.simulateOnNextRead(string: "testSecret", for: ARTDeviceSecretKey)
+        storage.simulateOnNextRead(string: testDeviceToken, for: ARTAPNSDeviceTokenKey)
+        storage.simulateOnNextRead(data: testDeviceIdentity.art_archive(withLogger: nil)!, for: ARTDeviceIdentityTokenKey)
+        realtime.internal.rest.resetDeviceSingleton()
+
         var stateMachine: ARTPushActivationStateMachine!
         waitUntil(timeout: testTimeout) { done in
             realtime.internal.rest.push.getActivationMachine { machine in
@@ -353,9 +369,6 @@ class PushTests: XCTestCase {
         }
         let delegate = StateMachineDelegate()
         stateMachine.delegate = delegate
-
-        storage.simulateOnNextRead(string: testDeviceToken, for: ARTAPNSDeviceTokenKey)
-        storage.simulateOnNextRead(data: testDeviceIdentity.art_archive(withLogger: nil)!, for: ARTDeviceIdentityTokenKey)
 
         XCTAssertEqual(realtime.device.clientId, testDeviceIdentity.clientId)
 


### PR DESCRIPTION
Closes #2206.

## Summary

- Replaces `NSUserDefaults` + keychain with a single property-list file (`Application Support/Ably/LocalDevice.plist`) written atomically and, on iOS, with `NSFileProtectionNone`, so the data is readable regardless of device lock state.
- Adds `performBatchUpdate:` to `<ARTDeviceStorage>`: a block-scoped API that batches related writes into a single flush, so the `(id, secret)` tuple can be updated atomically.
- Implements **RSH8a1** from spec PR ably/specification#474 in `+[ARTLocalDevice deviceWithStorage:logger:]`: on load failure (`id` or `deviceSecret` missing) all persisted LocalDevice attributes and all persisted Activation State Machine data are discarded, then a fresh `(id, secret)` pair is regenerated as part of LocalDevice initialisation (the eager-generation behaviour noted by RSH8k2).
- One-time migration of legacy `UserDefaults` + keychain data on first init; legacy entries are deleted after migration. If the keychain secret can't be loaded for any reason (realistically: the device hasn't been unlocked since reboot), the legacy data is discarded entirely and the device-fetch path starts clean — `push.activate()` will re-register the device on next call.

## Manual test (cross-branch migration)

1. Check out `main`, build and run the `AblyPushExample` app on a device.
2. Register the device for push, then subscribe to a channel. Find the device by id in the Ably dashboard (Devices) or the Ably CLI (`ably devices list`).
3. Without uninstalling or resetting app state, switch to this PR's branch (`fix/2206-atomic-file-storage`) and rebuild.
4. Launch the app with the SDK log level set to info or higher and watch for:
   ```
   ARTLocalDeviceStorage: migrated N legacy fields
   ```
5. Verify the same device id is still registered. Unsubscribing the previously-subscribed channel from this branch should succeed — the dashboard should show the subscription gone — confirming the migrated `deviceIdentityToken` is still bound to the migrated device id.

If migration runs while the keychain is inaccessible (e.g. the app launches in the background before first unlock), the legacy data is discarded and a fresh device id is generated. The dashboard then shows a new device id and the old registration becomes orphaned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Atomic file-backed device storage with thread-safe reads/writes and optional legacy migration
  * Atomic batching API for grouped device identity and push-state updates
  * Example helper now reports identity-token availability from persisted device details

* **Bug Fixes**
  * Improved reliability when loading, persisting, and migrating device identity and push tokens
  * Safer handling of missing or inconsistent persisted device data

* **Refactor**
  * Replaced direct legacy defaults/keychain access with coordinated atomic storage

* **Tests**
  * Added tests for migration, atomicity, and persistence scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->