### PR TITLE
  ci: GHA workflow security cleanup

### DIFF
--- a/.github/workflows/check-pod.yaml
+++ b/.github/workflows/check-pod.yaml
@@ -13,7 +13,7 @@ jobs:
   check:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
           persist-credentials: false
 
@@ -57,7 +57,7 @@ jobs:
           mkdir -p carthage-built-framework-artifact-contents/carthage-built-framework
           mv Ably.framework.zip carthage-built-framework-artifact-contents/carthage-built-framework
       - name: Archive built framework
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: carthage-built-framework
           path: carthage-built-framework-artifact-contents

--- a/.github/workflows/check-pod.yaml
+++ b/.github/workflows/check-pod.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Select Specific Xcode Version (16.4)
         run: |

--- a/.github/workflows/check-pod.yaml
+++ b/.github/workflows/check-pod.yaml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: macos-15

--- a/.github/workflows/check-spm.yaml
+++ b/.github/workflows/check-spm.yaml
@@ -17,11 +17,11 @@ jobs:
     runs-on: macos-15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
           persist-credentials: false
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: 16.4
 

--- a/.github/workflows/check-spm.yaml
+++ b/.github/workflows/check-spm.yaml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          persist-credentials: false
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: 16.4

--- a/.github/workflows/check-spm.yaml
+++ b/.github/workflows/check-spm.yaml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-15

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: macos-15
     
     permissions:
+      contents: read
       deployments: write
       id-token: write
       

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,8 @@ jobs:
       
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Select Specific Xcode Version (16.4)
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
           persist-credentials: false
 
@@ -44,21 +44,21 @@ jobs:
           python3 ./Scripts/generate-markdown-api-reference.py
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-cocoa
           role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
 
       - name: Upload Jazzy Documentation
-        uses: ably/sdk-upload-action@v1
+        uses: ably/sdk-upload-action@8c6179796fc7ee8fc9bb28d5223ffef005b985cc # v1.3.0
         with:
           sourcePath: Docs/jazzy
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           artifactName: jazzydoc
 
       - name: Upload Markdown API Reference
-        uses: ably/sdk-upload-action@v2
+        uses: ably/sdk-upload-action@4e694297f208b72b5a9f6b1248a1556f19f821d6 # v2.2.0
         with:
           sourcePath: Docs/markdown-api-reference
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -22,7 +22,9 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-        
+        with:
+          persist-credentials: false
+
       - name: Select Xcode (16.4)
         run: |
           sudo xcode-select -s /Applications/Xcode_16.4.app

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: macos-15

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -18,4 +18,5 @@ jobs:
     uses: ably/features/.github/workflows/sdk-features.yml@main
     with:
       repository-name: ably-cocoa
-    secrets: inherit
+    secrets:
+      ABLY_AWS_ACCOUNT_ID_SDK: ${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -6,8 +6,15 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: read
+      deployments: write
+      id-token: write
     uses: ably/features/.github/workflows/sdk-features.yml@main
     with:
       repository-name: ably-cocoa

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       deployments: write
       id-token: write
-    uses: ably/features/.github/workflows/sdk-features.yml@main
+    uses: ably/features/.github/workflows/sdk-features.yml@6b3fc7a8ede2ebdd7a6325314f3a96c6466f1453 # main as of 2026-05-26
     with:
       repository-name: ably-cocoa
     secrets:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
           persist-credentials: false
 
@@ -53,7 +53,7 @@ jobs:
         run: ./Scripts/log-environment-information.sh
 
       - name: Check out xcparse repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           repository: ably-forks/xcparse
           ref: emit-test-case-info
@@ -66,8 +66,8 @@ jobs:
           cd xcparse
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: "actions/cache@v3 (xcparse binary)"
-        uses: actions/cache@v3
+      - name: "actions/cache (xcparse binary)"
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: xcparse/.build/debug/xcparse
           key: ${{ runner.os }}-xcparse-${{ steps.get-xcparse-commit-sha.outputs.sha }}
@@ -96,21 +96,21 @@ jobs:
       
       - name: Upload Static Analyzer Reports
         if: ${{ failure() && steps.analyzer-output.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: static-analyzer-reports-${{ matrix.lane }}
           path: ./derived_data/**/report-*.html
       
       - name: Upload Xcodebuild Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: xcodebuild-logs-${{ matrix.lane }}
           path: ~/Library/Developer/Xcode/DerivedData/*/Logs
 
       - name: Upload Test Output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: test-output-${{ matrix.lane }}
           path: fastlane/test_output

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -40,7 +40,9 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v2
-        
+        with:
+          persist-credentials: false
+
       - name: Select Xcode (16.4)
         run: |
           sudo xcode-select -s /Applications/Xcode_16.4.app
@@ -56,6 +58,7 @@ jobs:
           repository: ably-forks/xcparse
           ref: emit-test-case-info
           path: xcparse
+          persist-credentials: false
 
       - id: get-xcparse-commit-sha
         name: Get xcparse commit SHA

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -11,6 +11,9 @@ on:
 # - Changes made to this file needs to replicated across other integration-test-*.yaml files.
 # - The Fastlane lane name is duplicated in more than one place within this workflow.
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: macos-15
@@ -58,7 +61,7 @@ jobs:
         name: Get xcparse commit SHA
         run: |
           cd xcparse
-          echo "::set-output name=sha::$(git rev-parse HEAD)"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: "actions/cache@v3 (xcparse binary)"
         uses: actions/cache@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up editorconfig-checker
-        uses: editorconfig-checker/action-editorconfig-checker@main
+        uses: editorconfig-checker/action-editorconfig-checker@840e866d93b8e032123c23bac69dece044d4d84c # v2.2.0
 
       - name: Run editorconfig-checker
         run: editorconfig-checker

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up editorconfig-checker
         uses: editorconfig-checker/action-editorconfig-checker@main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   editorconfig:
     name: EditorConfig


### PR DESCRIPTION
Routine hygiene pass over the seven GitHub Actions workflows in this repo, prompted by a workflow security audit. No behavioural changes are intended.

  The changes are split into four commits, one per finding type:

  1. **Declare minimal permissions on workflows** — every workflow now sets an explicit `permissions:` block (most are `contents: read`). Without one, the job's `GITHUB_TOKEN` falls back
  to the repository-default scope, which is broader than these workflows need.

  2. **Disable credential persistence on checkout steps** — `actions/checkout` writes a token to `.git/config` and leaves it there for the rest of the job by default. Setting
  `persist-credentials: false` means the token is only used to fetch and is then removed.

  3. **Pass only the required secret to the features workflow** — `features.yml` previously used `secrets: inherit`, forwarding every secret to the reusable workflow. It now passes only
  `ABLY_AWS_ACCOUNT_ID_SDK`, which is the single named secret the called workflow declares.

  4. **Pin third-party actions to commit SHAs** — tag references like `@v4` are mutable; pinning to a full commit SHA freezes the exact code that runs in CI. The tagged release is
  recorded in a trailing comment so updates are still easy to review. `ably/features` and `editorconfig-checker/action-editorconfig-checker` were previously tracking `@main` and are now
  pinned to a specific commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflow security by pinning action versions to specific commit SHAs instead of floating version tags.
  * Added explicit job-level permissions blocks across all workflows, restricting access to minimal required scopes.
  * Configured checkout steps to disable credential persistence for improved security posture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ably/ably-cocoa/pull/2208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->