### PR TITLE
[AIT-846] Universal Test Suite (UTS) groundwork

### DIFF
--- a/.claude/skills/uts-to-swift/SKILL.md
+++ b/.claude/skills/uts-to-swift/SKILL.md
@@ -1,0 +1,558 @@
+---
+name: uts-to-swift
+description: Translate a UTS (Universal Test Suite) pseudocode test spec into Swift tests in the UTS target. Run as /uts-to-swift <path-to-spec-file>
+license: proprietary
+allowed-tools: Bash, Read, Edit, Write
+metadata:
+  team: engineering
+  version: "1.0.0"
+  tags: testing, uts, swift, cocoa, ably-cocoa, test-translation
+  marketplace: false
+---
+
+# UTS to Swift
+
+Translate the UTS pseudocode test spec at `$ARGUMENTS` into a runnable Swift test in the `UTS` test target (`Test/UTS`).
+
+Reference: [Writing Derived Tests](https://raw.githubusercontent.com/ably/specification/refs/heads/main/uts/docs/writing-derived-tests.md)
+
+---
+
+## Step 0 — Validate arguments
+
+**If `$ARGUMENTS` is empty or blank**, stop immediately and tell the user:
+
+```
+Please re-run the command with the path to a UTS pseudocode spec file.
+
+Usage: /uts-to-swift <path-to-spec-file> or /uts-to-swift <spec-file-url>  https://github.com/ably/specification/blob/main/uts/realtime/unit/connection/connection_recovery_test.md
+
+Example:
+   /uts-to-swift /path/to/spec/file.md
+   /uts-to-swift https://github.com/ably/specification/blob/main/uts/realtime/unit/connection/connection_recovery_test.md
+
+```
+
+Do not proceed to Step 1.
+
+**If `$ARGUMENTS` is provided but does not end in `.md`**, stop and tell the user:
+
+```
+Error: "<value>" does not look like a spec file path (expected a .md file).
+
+```
+
+Do not proceed to Step 1.
+
+**If `$ARGUMENTS` ends in `.md` but the file does not exist** (check with `test -f "$ARGUMENTS"`), stop and tell the user:
+
+```
+Error: file not found: "<value>"
+
+```
+
+Do not proceed to Step 1.
+
+Only continue to Step 1 once the file is confirmed to exist.
+
+---
+
+## Step 1 — Read the spec
+
+Read the file at `$ARGUMENTS`. Identify all the test cases — each has a title, a structured `Test ID` like `realtime/unit/RTN16g/recovery-key-structure-0` and a requirement.
+
+---
+
+## Step 2 — Determine output path and class name
+
+Map the spec path to a test path:
+
+Mirror the spec's `uts/` directory layout under `Test/UTS/Tests/`: keep the same `rest`/`realtime` top-level folder and the `unit`/`integration` tier below it. This stops files that share a name in different parts of the spec from colliding (e.g. `uts/realtime/integration/auth.md` and `uts/rest/integration/auth.md`).
+
+| Spec file | Test file |
+|---|---|
+| `.../uts/rest/unit/<name>.md` | `Test/UTS/Tests/rest/unit/<Name>Tests.swift` |
+| `.../uts/realtime/unit/<sub>/<name>.md` | `Test/UTS/Tests/realtime/unit/<sub>/<Name>Tests.swift` |
+
+Class name: take the file name, strip a trailing `_test`, convert `snake_case` → `PascalCase`, append `Tests`. Example: `connection_recovery_test.md` → `ConnectionRecoveryTests`. Each test is a **Swift Testing** suite — `@Suite(.serialized) final class <Name>Tests: UTSTestCase`.
+
+If a suitable suite already exists, add the new test methods to it rather than creating a duplicate.
+
+---
+
+## Step 3 — Read the harness
+
+Read ALL files in `Test/UTS/Harness/` before generating any code (you need the exact method names/signatures).
+
+---
+
+## Step 4 — Generate the Swift test file
+
+Apply the translation rules below, then write the file.
+
+### Client construction
+
+Set `ClientOptions` fields (`key`, `autoConnect`, `recover`, `disconnectedRetryTimeout`, etc.) in the `makeRealtime`/`makeRest` configuration block. Set `options.key` to "app.key:secret".
+
+| Pseudocode | Swift |
+|---|---|
+| `install_mock(mock_http)` / `install_mock(mock_ws)` | `installMock(mockHTTPClient)` / `installMock(wsProvider)` — **before** `makeRealtime`/`makeRest` (the mock is injected at construction) |
+| `Rest(options: ClientOptions(key: "..."))` | `let rest = makeRest { $0.key = "..." }` |
+| `Realtime(options: ClientOptions(key: "...", autoConnect: false))` | `let client = makeRealtime { $0.key = "..."; $0.autoConnect = false }` |
+| `enable_fake_timers()` | `enableFakeTimers()` — **before** `makeRealtime`/`makeRest` (the clock is injected at construction) |
+
+### Mock setup — WebSocket
+
+Use the **handler pattern**: configure the simulated server in `onConnectionAttempt`. As in the spec, opening the socket and delivering the `CONNECTED` message are two separate calls — `respond_with_success()` then `send_to_client(...)`.
+
+Spec pseudocode:
+
+```pseudo
+mock_ws = MockWebSocket(
+  onConnectionAttempt: (conn) => {
+    conn.respond_with_success()
+    conn.send_to_client(ProtocolMessage(
+      action: CONNECTED,
+      connectionId: "connection-1",
+      connectionKey: "key-abc-123",
+      connectionDetails: ConnectionDetails(connectionKey: "key-abc-123")
+    ))
+  }
+)
+install_mock(mock_ws)
+client = Realtime(options: ClientOptions(key: "appId.keyId:keySecret", autoConnect: false))
+client.connect()
+AWAIT_STATE client.connection.state == ConnectionState.connected
+ws_connection = mock_ws.events.find(e => e.type == CONNECTION_SUCCESS).connection
+```
+
+Swift (the harness exposes `activeConnection` as the cocoa equivalent of the spec's `events.find(CONNECTION_SUCCESS).connection`):
+
+```swift
+let wsProvider = MockWebSocketProvider(onConnectionAttempt: { connection in
+    connection.respondWithSuccess()
+    connection.sendToClient(.connected(connectionId: "connection-1", connectionKey: "key-abc-123"))
+})
+installMock(wsProvider)
+let client = makeRealtime { options in
+    options.key = "appId.keyId:keySecret"
+    options.autoConnect = false
+}
+client.connect()
+awaitConnectionState(client, .connected)
+let ws = try #require(wsProvider.activeConnection)
+```
+
+When attempts need different behaviour (e.g. first succeeds, reconnects refused), branch on a counter inside the handler:
+
+Spec pseudocode:
+
+```pseudo
+connection_attempt_count = 0
+mock_ws = MockWebSocket(
+  onConnectionAttempt: (conn) => {
+    connection_attempt_count++
+    IF connection_attempt_count == 1:
+      conn.respond_with_success()
+      conn.send_to_client(ProtocolMessage(
+        action: CONNECTED,
+        connectionId: "conn-s",
+        connectionKey: "key-s",
+        connectionDetails: ConnectionDetails(connectionKey: "key-s", connectionStateTtl: 2000)
+      ))
+    ELSE:
+      conn.respond_with_refused()
+  }
+)
+```
+
+Swift:
+
+```swift
+var attemptCount = 0
+let wsProvider = MockWebSocketProvider(onConnectionAttempt: { connection in
+    attemptCount += 1
+    if attemptCount == 1 {
+        connection.respondWithSuccess()
+        connection.sendToClient(.connected(connectionId: "conn-s", connectionKey: "key-s", connectionStateTtl: 2))
+    } else {
+        connection.respondWithRefused()
+    }
+})
+```
+
+### Mock setup — HTTP
+
+Spec pseudocode:
+
+```pseudo
+captured_requests = []
+mock_http = MockHttpClient(
+  onConnectionAttempt: (conn) => conn.respond_with_success(),
+  onRequest: (req) => {
+    captured_requests.push(req)
+    req.respond_with(200, [1704067200000])
+  }
+)
+install_mock(mock_http)
+client = Rest(options: ClientOptions(key: "app.key:secret"))
+```
+
+Swift:
+
+```swift
+let capturedRequests = Captured<PendingHTTPRequest>()
+let mockHTTPClient = MockHTTPClient(
+    onConnectionAttempt: { connection in connection.respondWithSuccess() },
+    onRequest: { request in
+        capturedRequests.append(request)
+        request.respondWith(status: 200, body: [1704067200000])
+    }
+)
+installMock(mockHTTPClient)
+let rest = makeRest { $0.key = "app.key:secret" }
+```
+
+### Variable declarations
+
+Take spec variable names (adopted to camel case), for new ones, if needed don't use "noname" names (like "fields"), make the name concrete.
+
+### Capturing connection attempts / requests
+
+The target is built in the Swift 6 language mode. Since mock handler closures are`@Sendable` and run on the SDK's queues, a plain `var array` captured into them is a compile error (a data race). Use the harness's thread-safe (lock-guarded) `Captured<T>` instead:
+
+Spec pseudocode:
+
+```pseudo
+captured_connection_attempts = []
+mock_ws = MockWebSocket(
+  onConnectionAttempt: (conn) => {
+    captured_connection_attempts.append(conn)
+    conn.respond_with_success()
+    conn.send_to_client(ProtocolMessage(
+      action: CONNECTED,
+      connectionId: "c",
+      connectionKey: "k",
+      connectionDetails: ConnectionDetails(connectionKey: "k")
+    ))
+  }
+)
+# ... after AWAIT_STATE client.connection.state == ConnectionState.connected:
+ASSERT captured_connection_attempts[0].url.query_params["recover"] == "..."
+```
+
+Swift:
+
+```swift
+let capturedConnectionAttempts = Captured<MockWebSocket>()
+let wsProvider = MockWebSocketProvider(onConnectionAttempt: { connection in
+    capturedConnectionAttempts.append(connection)
+    connection.respondWithSuccess()
+    connection.sendToClient(.connected(connectionId: "c", connectionKey: "k"))
+})
+// ... after awaitConnectionState(client, .connected):
+#expect(capturedConnectionAttempts[0].queryParams["recover"] == "...")
+```
+
+`Captured<T>` exposes `append`, `all`, `count`, `first`, and `subscript(Int)`. Use `capturedConnectionAttempts.count` to change outcome for different connection attemts.
+
+### Inspecting outgoing frames
+
+The spec inspects client-sent frames through the mock's event timeline (`mock_ws.events.filter(e => e.type == "ws_frame" AND e.direction == "client_to_server")`); the cocoa harness exposes the decoded equivalent as `ws.sentMessages`. Capture after the channel/connection state confirms the send happened:
+
+Spec pseudocode:
+
+```pseudo
+ws_connection = mock_ws.events.find(e => e.type == CONNECTION_SUCCESS).connection
+channel.attach()
+ws_connection.send_to_client(ProtocolMessage(action: ATTACHED, channel: "channel-one", channelSerial: "serial-1"))
+AWAIT_STATE channel.state == ChannelState.attached
+sent_frames = mock_ws.events.filter(e => e.type == "ws_frame" AND e.direction == "client_to_server")
+attach_frame = sent_frames.find(f => f.message.action == ATTACH AND f.message.channel == "channel-one")
+ASSERT attach_frame.message.channelSerial == "serial-1"
+```
+
+Swift:
+
+```swift
+let ws = try #require(wsProvider.activeConnection)
+channelOne.attach()
+ws.sendToClient(.attached(channel: "channel-one", channelSerial: "serial-1"))
+awaitChannelState(channelOne, .attached)
+// cocoa's decoded equivalent of the spec's events.filter(ws_frame, client_to_server)
+let attachFrames = ws.sentMessages.filter { $0.action == .attach && $0.channel == "channel-one" }
+#expect(attachFrames.count == 1)
+#expect(attachFrames.first?.channelSerial == "serial-1")
+```
+
+### Mock method reference
+
+`connection` is the object the relevant handler hands you — for WebSocket it's the `MockWebSocket` passed to `onConnectionAttempt` (the spec's `mock_ws`/`conn`); for HTTP it's the `PendingHTTPConnection` passed to the `MockHTTPClient` `onConnectionAttempt`. `request` is the `PendingHTTPRequest` passed to `onRequest`.
+
+| Pseudocode | Swift |
+|---|---|
+| `conn.respond_with_success()` | `connection.respondWithSuccess()` |
+| `conn.respond_with_refused()` | `connection.respondWithRefused()` |
+| `mock_ws.send_to_client(msg)` | `connection.sendToClient(msg)` |
+| `mock_ws.send_to_client_and_close(msg)` | `connection.sendToClientAndClose(msg)` |
+| `mock_ws.simulate_disconnect()` | `connection.simulateDisconnect()` |
+| `req.respond_with(200, {...})` | `request.respondWith(status: 200, body: [...])` |
+| `req.respond_with_timeout()` | `request.respondWithTimeout()` |
+| `conn.respond_with_refused/timeout/dns_error()` (HTTP) | `connection.respondWithRefused()` / `respondWithTimeout()` / `respondWithDNSError()` |
+
+### Protocol messages and types
+
+Server-to-client messages are described with the `Sendable` `ProtocolMessage` factories — `sendToClient`/`sendToClientAndClose` take a `ProtocolMessage` and build the real `ARTProtocolMessage` at delivery, so no non-Sendable value crosses the queue hop. Use these factories; add a new one (and the matching `makeProtocolMessage()` case) if you need another action:
+
+| Pseudocode | Swift |
+|---|---|
+| `ProtocolMessage(action: CONNECTED, connectionId, connectionKey, connectionDetails(...))` | `.connected(connectionId:, connectionKey:, maxIdleInterval:, connectionStateTtl:)` |
+| `ProtocolMessage(action: ATTACHED, channel, channelSerial)` | `.attached(channel:, channelSerial:)` |
+| `ProtocolMessage(action: ERROR, error: ErrorInfo(code, statusCode, message))` | `.error(code:, statusCode:, message:)` |
+| `ProtocolMessage(action: ACK, msgSerial, count)` | `.ack(msgSerial:, count:)` |
+| `ProtocolMessage(action: CLOSED)` | `.closed()` |
+| `connectionStateTtl: 2000` (wire ms) | seconds here: `connectionStateTtl: 2` |
+| `ConnectionState.connected` / `ChannelState.attached` | `.connected` / `.attached` (`ARTRealtimeConnectionState` / `ARTRealtimeChannelState`) |
+
+### Awaiting state
+
+`AWAIT_STATE x.state == ConnectionState.X` → `awaitConnectionState(client, .x)` (default 2s timeout, or `timeout:`). Channels: `awaitChannelState(channel, .attached)`. For other conditions (e.g. "a frame was sent") use `poll("description") { <bool> }`. Don't use poll unless you can't find alternative or spec says to do so.
+
+### Timer control
+
+Spec pseudocode:
+
+```pseudo
+client = Realtime(...)
+# ...
+enable_fake_timers()
+# ...
+ADVANCE_TIME(1500)                     # fires due timers
+```
+
+Swift:
+
+```swift
+enableFakeTimers()                     // BEFORE makeRealtime/makeRest
+let client = makeRealtime { ... }
+// ...
+advanceTime(byMilliseconds: 1500)      // fires due timers and settles the cascade
+```
+
+For multi-retry scenarios use the spec's loop (don't compute exact jumps):
+
+Spec pseudocode:
+
+```pseudo
+LOOP up to 10 times:
+  ADVANCE_TIME(1500)
+  IF client.connection.state == ConnectionState.suspended:
+    BREAK
+AWAIT_STATE client.connection.state == ConnectionState.suspended
+```
+
+Swift:
+
+```swift
+for _ in 0..<10 {
+    advanceTime(byMilliseconds: 1500)
+    if client.connection.state == .suspended { break }
+}
+awaitConnectionState(client, .suspended)
+```
+
+### Asserting on logs
+
+To assert "an error is logged", inject a `CapturingLog` and check it:
+
+```swift
+let log = CapturingLog()
+let client = makeRealtime { $0.key = "..."; $0.logHandler = log }
+// ...
+#expect(log.contains(level: .error, message: "recovery key"))
+```
+
+### Comments and assertion fidelity
+
+Carry over **every** comment from the spec pseudocode verbatim, as a `//` comment at the matching step — these explain *why* each step exists and must not be dropped or paraphrased.
+
+Translate every spec `ASSERT`/`AWAIT` into a Swift assertion at the same place. If an assertion genuinely has no Swift equivalent (e.g. it checks a language-specific construct, or the SDK exposes no observable hook for it), **do not silently omit it** — keep the spec's comment/line and add a `//` note explaining why no assertion is emitted. Never delete the spec line.
+
+```swift
+// The recovery key should round-trip the connection id        ← spec comment, copied verbatim
+#expect(recovered.connectionId == "connection-1")
+
+// ASSERT connection.errorReason IS null
+// (no assertion: ARTConnection exposes no errorReason getter in this state — see deviations.md)
+```
+
+A dropped or weakened assertion that is *not* annotated this way is a bug — Step 7 re-checks for it.
+
+### Assertions (Swift Testing)
+
+Use Swift Testing macros (`import Testing`, **not** `XCTest`):
+
+| Pseudocode | Swift |
+|---|---|
+| `ASSERT x == y` | `#expect(x == y)` |
+| `ASSERT x IS NOT null` | `let x = try #require(optional)` (or `#expect(x != nil)`) |
+| `ASSERT x IS null` | `#expect(x == nil)` |
+| `ASSERT "k" IN map` / `NOT IN` | `#expect(map["k"] != nil)` / `#expect(map["k"] == nil)` |
+| `ASSERT list.length == N` | `#expect(list.count == N)` |
+| `ASSERT x == y (with message)` | `#expect(x == y, "message")` |
+| `AWAIT op FAILS WITH error` | capture the error (see async below) and `#expect(error.code == ...)` / `#expect(error.statusCode == ...)` |
+
+`#expect(...)` records a failure and continues; `try #require(...)` unwraps/asserts and stops the test on failure (use it when later lines depend on the value, like `XCTUnwrap`).
+
+REST calls will callback (e.g. `rest.time { ... }`) — make the test `async throws` and create a helper method that bridges the completion handler with a continuation:
+
+```swift
+private func awaitTime(_ rest: ARTRest, sourceLocation: SourceLocation = #_sourceLocation) async -> Date {
+    await withCheckedContinuation { (continuation: CheckedContinuation<Date, Never>) in
+        rest.time { date, error in
+            if let error { Issue.record("time() failed: \(error)", sourceLocation: sourceLocation) }
+            guard let date else { Issue.record("time() failed: date should not be nil", sourceLocation: sourceLocation) }
+            continuation.resume(returning: date)   // resume exactly once
+        }
+    }
+}
+```
+
+Put these `async` helpers in the test class extention at the bottom of the test file. Inside the harness, report non-assertion failures (timeouts, unexpected errors) with `Issue.record("...", sourceLocation:)`.
+
+### Test naming and annotation
+
+- `// UTS: <spec-id>` comment immediately above each test, then the `@Test` attribute.
+- Method name: `test_<SPEC>_<description_with_underscores>` — keep the spec point intact, join words with underscores. Take the description from the spec test title. Keep camelCase for symbol names. Mark the function `throws` (and `async` if it awaits).
+
+```swift
+// UTS: realtime/unit/RTN16g/recovery-key-structure-0
+@Test
+func test_RTN16g_createRecoveryKey_returns_a_recovery_key() throws {
+    ...
+}
+```
+
+### File template
+
+```swift
+import Testing
+import Foundation
+import Ably
+import Ably.Private
+
+/// <Feature> (<spec points>)
+/// Derived from <spec URL>
+@Suite(.serialized)
+final class <Name>Tests: UTSTestCase {
+
+    // UTS: <spec-id>
+    @Test
+    func test_<SPEC>_<description>() throws {
+        let wsProvider = MockWebSocketProvider(onConnectionAttempt: { connection in
+            connection.respondWithSuccess()
+            connection.sendToClient(.connected(connectionId: "connection-1", connectionKey: "key-1"))
+        })
+        installMock(wsProvider)
+        let client = makeRealtime { options in
+            options.key = "appId.keyId:keySecret"
+        }
+
+        client.connect()
+        awaitConnectionState(client, .connected)
+
+        #expect(client.connection.state == .connected)
+        closeClient(client)
+    }
+}
+```
+
+Helper methods return types should be ready for use in the test code without additional casting (if you need "value as? String" in the test, move this convertion to the helper instead). Don't return optionals from these methods - assert not `nil` within the method itself, unless test expects optional. Don't create additional helper types for parsing dictionaries - just use a dictionary with the most suited type for the test, accessing its fields by subscript. For dictionaries containing values of different types use `[String: Any]`. Don't wrap dictionary constant initialization into helper method. Put helper methods for the suite into an extension at the bottom of the file. Keep the spec's original tests order in the generated test file. Keep test segmentation by adding comments like "// Setup", "// Test Steps", "// Assertions".
+
+---
+
+## Step 5 — Compile
+
+```bash
+swift build --build-tests
+```
+
+Fix any compilation errors and recompile until clean.
+
+---
+
+## Step 6 — Run tests
+
+```bash
+swift test --filter <ClassName>
+# or a single test (Swift Testing matches the function name):
+swift test --filter <ClassName>/<test_method_name>
+```
+
+(`--filter` takes a regex over test names; `swift test --filter UTS` runs the whole suite.)
+
+Handle failures using this decision tree (see [reference doc](https://github.com/ably/specification/blob/main/uts/docs/writing-derived-tests.md)):
+
+```
+Test fails
+  |
+  +-- Does the UTS spec match the features spec?
+  |     NO  → fix the test, record the UTS spec error in deviations.md
+  |     YES
+  |       +-- Does the test accurately translate the UTS spec?
+  |             NO  → fix the test (no deviation entry)
+  |             YES → SDK deviation — adapt the test, record in deviations.md
+```
+
+### Deviation patterns
+
+**Env-gated skip (preferred)** — test contains spec-correct assertions but is disabled by default via the Swift Testing `.enabled(if:)` trait, so it only runs when `RUN_DEVIATIONS` is set:
+
+```swift
+// DEVIATION: see deviations.md
+@Test(.enabled(if: ProcessInfo.processInfo.environment["RUN_DEVIATIONS"] != nil))
+func test_<SPEC>_...() throws {
+    // ... spec-correct setup and assertions ...
+}
+```
+
+Reproduce with `RUN_DEVIATIONS=1 swift test --filter <ClassName>/<method>`.
+
+**Adapted assertion** — assert the SDK's actual behaviour to prevent regressions:
+
+```swift
+// DEVIATION: spec requires code 40106, SDK returns 40160 — see deviations.md
+#expect(error.code == 40160)
+```
+
+**Never use the accommodate-both pattern** Every test must assert either spec behaviour or the SDK's actual behaviour — never both at once.
+
+Note: a *harness-driving* difference (e.g. using fake timers where the spec uses real ones, or a queue-ordering workaround) is **not** an SDK deviation — explain it in a code comment, not `deviations.md`. `deviations.md` is only for SDK non-compliance and mock-capability gaps.
+
+### Deviations file
+
+Append to `Test/UTS/deviations.md` under the matching section (Failing Tests / Adapted Tests / Mock Infrastructure Limitations). Each entry needs:
+
+1. The spec point (e.g. `RSA4c2`)
+2. What the spec says
+3. What the SDK does
+4. Which test is affected and how it was adapted
+
+---
+
+## Step 7 — Review generated output against the spec
+
+Re-read the original spec and the generated Swift test side-by-side. Fix anything that fails a check before declaring the task done.
+
+- **Coverage** — every spec test-case ID has a `func` with a matching `// UTS:` comment and a descriptive name.
+- **Assertion completeness** — every `ASSERT`/`AWAIT`/observable outcome has a direct `#expect` / `#require` / `awaitConnectionState` / `awaitChannelState` / `poll`; none silently dropped or weakened to a comment.
+- **Setup fidelity** — client options, mock responses, timer setup, and the order of channel operations match the spec.
+- **Spec comments copied** — the pseudocode's inline `#` comments are carried over as `//` comments at the matching steps verbatim.
+
+### Deviation honesty
+
+For any place where the generated test diverges from the spec pseudocode (adapted assertion, env-gated skip, or omitted step):
+- A `// DEVIATION:` comment explains why
+- The deviation is recorded in `deviations.md`
+
+If you find gaps, fix them and re-run Steps 5–6 before finishing.

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ably-cocoa.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ably-cocoa.xcscheme
@@ -45,6 +45,16 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "UTS"
+               BuildableName = "UTS"
+               BlueprintName = "UTS"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Package.swift
+++ b/Package.swift
@@ -66,6 +66,28 @@ let package = Package(
                 .copy("ably-common")
             ]
         ),
+        // Universal Test Suite (UTS)
+        // A standalone Swift Testing suite (import Testing / @Suite) derived from the language-neutral
+        // specs in the `ably/specification` repo (uts/). Deliberately does not depend on Nimble or XCTest.
+        .testTarget(
+            name: "UTS",
+            dependencies: [
+                .byName(name: "Ably"),
+                .product(name: "_AblyPluginSupportPrivate", package: "ably-cocoa-plugin-support")
+            ],
+            path: "Test/UTS",
+            exclude: [
+                "README.md",
+                "deviations.md"
+            ],
+            swiftSettings: [
+                // Build the UTS suite in the Swift 6 language mode (strict concurrency checking) so the
+                // compiler catches data races in the harness/tests. The package manifest is still
+                // swift-tools-version 5.3, which predates `.swiftLanguageMode`, so this is applied via
+                // the compiler flag. Only affects this test target (not the shipped product).
+                .unsafeFlags(["-swift-version", "6"])
+            ]
+        ),
         // A handful of tests written in Objective-C (they can't be part of AblyTests because SPM doesn't allow mixed-language targets).
         .testTarget(
             name: "AblyTestsObjC",

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -259,7 +259,7 @@ typedef NS_ENUM(NSUInteger, ARTNetworkState) {
         _channels = [[ARTRealtimeChannelsInternal alloc] initWithRealtime:self logger:self.logger];
         _transport = nil;
         _networkState = ARTNetworkStateIsUnknown;
-        _reachabilityClass = [ARTOSReachability class];
+        _reachabilityClass = options.testOptions.reachabilityClass;
         _msgSerial = 0;
         _queuedMessages = [NSMutableArray array];
         _pendingMessages = [NSMutableArray array];

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -196,7 +196,7 @@ NS_ASSUME_NONNULL_END
 #endif
         _http = [[ARTHttp alloc] initWithQueue:_queue logger:_logger];
         ARTLogVerbose(_logger, @"RS:%p %p alloc HTTP", self, _http);
-        _httpExecutor = _http;
+        _httpExecutor = options.testOptions.httpExecutor ?: _http;
 
         id<ARTEncoder> jsonEncoder = [[ARTJsonLikeEncoder alloc] initWithRest:self delegate:[[ARTJsonEncoder alloc] init] logger:_logger];
         id<ARTEncoder> msgPackEncoder = [[ARTJsonLikeEncoder alloc] initWithRest:self delegate:[[ARTMsgPackEncoder alloc] init] logger:_logger];

--- a/Source/ARTTestClientOptions.m
+++ b/Source/ARTTestClientOptions.m
@@ -33,6 +33,7 @@
     copied.disableLocalDevice = self.disableLocalDevice;
     copied.timeProvider = self.timeProvider;
     copied.reachabilityClass = self.reachabilityClass;
+    copied.httpExecutor = self.httpExecutor;
 
     return copied;
 }

--- a/Source/ARTTestClientOptions.m
+++ b/Source/ARTTestClientOptions.m
@@ -4,6 +4,7 @@
 #import "ARTRealtimeTransportFactory.h"
 #import "ARTJitterCoefficientGenerator.h"
 #import "ARTSystemTimeProvider.h"
+#import "ARTOSReachability.h"
 
 @implementation ARTTestClientOptions
 
@@ -14,6 +15,7 @@
         _transportFactory = [[ARTDefaultRealtimeTransportFactory alloc] init];
         _jitterCoefficientGenerator = [[ARTDefaultJitterCoefficientGenerator alloc] init];
         _timeProvider = [[ARTSystemTimeProvider alloc] init];
+        _reachabilityClass = [ARTOSReachability class];
     }
 
     return self;
@@ -30,6 +32,7 @@
     copied.logLocalDeviceStorageValues = self.logLocalDeviceStorageValues;
     copied.disableLocalDevice = self.disableLocalDevice;
     copied.timeProvider = self.timeProvider;
+    copied.reachabilityClass = self.reachabilityClass;
 
     return copied;
 }

--- a/Source/PrivateHeaders/Ably/ARTTestClientOptions.h
+++ b/Source/PrivateHeaders/Ably/ARTTestClientOptions.h
@@ -3,6 +3,7 @@
 @protocol ARTRealtimeTransportFactory;
 @protocol ARTJitterCoefficientGenerator;
 @protocol ARTTimeProvider;
+@protocol ARTHTTPExecutor;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -53,6 +54,11 @@ NS_ASSUME_NONNULL_BEGIN
  The class used to instantiate the `ARTReachability` implementation that `ARTRealtime` uses to monitor network state. Tests install a no-op or controllable implementation here. Initial value is `ARTOSReachability`.
  */
 @property (nonatomic) Class reachabilityClass;
+
+/**
+ An `ARTHTTPExecutor` that `ARTRestInternal` uses for all of its HTTP requests instead of creating its own. Tests install a mock here so that requests are intercepted rather than sent over the network. When `nil` (the initial value), the rest client creates its own `ARTHttp`.
+ */
+@property (nullable, nonatomic) id<ARTHTTPExecutor> httpExecutor;
 
 /**
  When `YES`, `ARTLocalDeviceStorage` log lines include the fetched or

--- a/Source/PrivateHeaders/Ably/ARTTestClientOptions.h
+++ b/Source/PrivateHeaders/Ably/ARTTestClientOptions.h
@@ -50,6 +50,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) id<ARTTimeProvider> timeProvider;
 
 /**
+ The class used to instantiate the `ARTReachability` implementation that `ARTRealtime` uses to monitor network state. Tests install a no-op or controllable implementation here. Initial value is `ARTOSReachability`.
+ */
+@property (nonatomic) Class reachabilityClass;
+
+/**
  When `YES`, `ARTLocalDeviceStorage` log lines include the fetched or
  written value itself. Off by default because persisted values include
  the device secret and the identity token. Initial value is `NO`.

--- a/Test/Ably.xctestplan
+++ b/Test/Ably.xctestplan
@@ -27,6 +27,13 @@
         "identifier" : "AblyTestsObjC",
         "name" : "AblyTestsObjC"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "UTS",
+        "name" : "UTS"
+      }
     }
   ],
   "version" : 1

--- a/Test/UTS/Harness/Captured.swift
+++ b/Test/UTS/Harness/Captured.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// A thread-safe collector for the spec's "local `captured_*` array" pattern
+/// (`uts/.../helpers/mock_http.md` & `mock_websocket.md`, "Common Mistakes").
+///
+/// The mock handler closures (`onConnectionAttempt`, `onRequest`) are invoked by the SDK on its own
+/// queues, while the test reads what was captured on the test thread. A plain local `var array`
+/// captured into those `@Sendable` closures is a data race the Swift 6 compiler rejects; this small
+/// lock-guarded, `Sendable` reference type lets a test keep a *local* collector (not a property on
+/// the mock) while staying race-free.
+final class Captured<Element>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var items: [Element] = []
+
+    init() {}
+
+    /// Records an element (called from a mock handler, on an SDK queue).
+    func append(_ element: Element) {
+        lock.lock()
+        items.append(element)
+        lock.unlock()
+    }
+
+    /// A snapshot of everything captured so far (read from the test thread, after the operation has settled).
+    var all: [Element] {
+        lock.lock(); defer { lock.unlock() }
+        return items
+    }
+
+    var count: Int { all.count }
+    var first: Element? { all.first }
+    subscript(_ index: Int) -> Element { all[index] }
+}

--- a/Test/UTS/Harness/CapturingLog.swift
+++ b/Test/UTS/Harness/CapturingLog.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Ably
+
+/// An `ARTLog` that records every message the SDK logs, for tests that assert on log output (e.g.
+/// "an error is logged"). Install via `ARTClientOptions.logHandler`.
+///
+/// The SDK's internal logger forwards every message to the injected `logHandler` (only the level
+/// filter lives in `ARTLog.log:withLevel:`), so overriding `log(_:with:)` *without* calling `super`
+/// captures everything regardless of `logLevel` — and keeps the console quiet.
+final class CapturingLog: ARTLog {
+    struct Entry {
+        let level: ARTLogLevel
+        let message: String
+    }
+
+    private let lock = NSLock()
+    private var storedEntries: [Entry] = []
+
+    var entries: [Entry] {
+        lock.lock(); defer { lock.unlock() }
+        return storedEntries
+    }
+
+    override func log(_ message: String, with level: ARTLogLevel) {
+        lock.lock()
+        storedEntries.append(Entry(level: level, message: message))
+        lock.unlock()
+    }
+
+    /// Whether any captured message at `level` contains `substring` (case-insensitive).
+    func contains(level: ARTLogLevel, message substring: String) -> Bool {
+        entries.contains { $0.level == level && $0.message.localizedCaseInsensitiveContains(substring) }
+    }
+}

--- a/Test/UTS/Harness/MockHTTPClient.swift
+++ b/Test/UTS/Harness/MockHTTPClient.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Ably
+import Ably.Private
+
+/// The UTS `MockHttpClient` — a fake `ARTHTTPExecutor` that intercepts the SDK's outgoing HTTP
+/// requests so tests can observe them and inject responses, with no real network. Installed via
+/// `rest.internal.httpExecutor` (the cocoa mapping of the spec's `install_mock`).
+///
+/// Mirrors `uts/rest/unit/helpers/mock_http.md`. The cocoa HTTP seam is **request-level**
+/// (`executeRequest:completion:`), so each `execute(_:)` is a standalone attempt: `onConnectionAttempt`
+/// is consulted first (its `respond_with_refused`/`timeout`/`dns_error` fail the request with the
+/// corresponding `NSError`), and unless the connection failed, the request is delivered to `onRequest`.
+final class MockHTTPClient: NSObject, ARTHTTPExecutor, Sendable {
+    /// Returns the error the connection should fail with, or `nil` if it succeeds.
+    typealias ConnectionHandler = @Sendable (PendingHTTPConnection) -> NSError?
+    typealias RequestHandler = @Sendable (PendingHTTPRequest) -> Void
+
+    private let onConnectionAttempt: ConnectionHandler?
+    private let onRequest: RequestHandler?
+
+    init(onConnectionAttempt: ConnectionHandler? = nil, onRequest: RequestHandler? = nil) {
+        self.onConnectionAttempt = onConnectionAttempt
+        self.onRequest = onRequest
+        super.init()
+    }
+
+    // MARK: ARTHTTPExecutor
+
+    func execute(_ request: URLRequest, completion callback: ((HTTPURLResponse?, Data?, Error?) -> Void)? = nil) -> (ARTCancellable & NSObjectProtocol)? {
+        // Connection phase — fail the request if the connection handler rejects it.
+        if let connectionError = onConnectionAttempt?(PendingHTTPConnection(request: request)) {
+            callback?(nil, nil, connectionError)
+            return NoopCancellable()
+        }
+
+        // Request phase — deliver to onRequest.
+        guard let onRequest else {
+            // A request reached the mock with no handler installed: a test set-up error.
+            fatalError("MockHTTPClient received a request but no onRequest handler is installed")
+        }
+        onRequest(PendingHTTPRequest(request: request, completion: callback))
+        return NoopCancellable()
+    }
+}
+
+/// A connection attempt (UTS `PendingConnection`). The cocoa HTTP seam doesn't expose real TCP, so
+/// this is derived from the request's URL; the `onConnectionAttempt` handler inspects it and returns
+/// the resulting error (or `nil`). Immutable — the result is the handler's return value.
+struct PendingHTTPConnection {
+    let host: String
+    let port: Int
+    let tls: Bool
+
+    init(request: URLRequest) {
+        guard let url = request.url, let host = url.host else {
+            // The SDK should never make a request without a URL host; if it does, the test set-up
+            // (or the SDK) is broken, so fail fast rather than fabricate a connection.
+            fatalError("MockHTTPClient received a connection attempt for a request without a URL host")
+        }
+        self.tls = (url.scheme?.lowercased() == "https")
+        self.host = host
+        self.port = url.port ?? (tls ? 443 : 80)
+    }
+
+    /// Connection succeeds; requests proceed (UTS `respond_with_success`).
+    func respondWithSuccess() -> NSError? { nil }
+    /// TCP connection refused (UTS `respond_with_refused`).
+    func respondWithRefused() -> NSError? { Self.urlError(.cannotConnectToHost) }
+    /// Connection times out (UTS `respond_with_timeout`).
+    func respondWithTimeout() -> NSError? { Self.urlError(.timedOut) }
+    /// DNS resolution fails (UTS `respond_with_dns_error`).
+    func respondWithDNSError() -> NSError? { Self.urlError(.cannotFindHost) }
+
+    private static func urlError(_ code: URLError.Code) -> NSError {
+        NSError(domain: NSURLErrorDomain, code: code.rawValue, userInfo: nil)
+    }
+}
+
+/// A request the SDK made (UTS `PendingRequest`): inspectable, and respondable by the test. Holds the
+/// completion callback rather than any mutable state.
+struct PendingHTTPRequest {
+    let request: URLRequest
+    private let completion: ((HTTPURLResponse?, Data?, Error?) -> Void)?
+
+    init(request: URLRequest, completion: ((HTTPURLResponse?, Data?, Error?) -> Void)?) {
+        self.request = request
+        self.completion = completion
+    }
+
+    var url: URL {
+        guard let url = request.url else {
+            fatalError("MockHTTPClient received a request without a URL")
+        }
+        return url
+    }
+    var method: String { request.httpMethod ?? "GET" }
+    var headers: [String: String] { request.allHTTPHeaderFields ?? [:] }
+    var body: Data? { request.httpBody }
+
+    /// Query parameters parsed from the request URL (UTS `url.query_params`).
+    var queryParams: [String: String] {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+              let items = components.queryItems else { return [:] }
+        var result: [String: String] = [:]
+        for item in items where item.value != nil { result[item.name] = item.value }
+        return result
+    }
+
+    /// Sends an HTTP response (UTS `respond_with`). `body` may be `Data`, `String`, or a
+    /// JSON-serialisable value (dictionary/array); defaults to a JSON content type.
+    func respondWith(status: Int, body: Any, headers: [String: String] = [:]) {
+        var headerFields = headers
+        if headerFields["Content-Type"] == nil {
+            headerFields["Content-Type"] = "application/json"
+        }
+        let response = HTTPURLResponse(url: url, statusCode: status, httpVersion: "HTTP/1.1", headerFields: headerFields)
+        completion?(response, Self.data(from: body), nil)
+    }
+
+    /// Simulates a request timeout after the connection was established (UTS `respond_with_timeout`).
+    func respondWithTimeout() {
+        completion?(nil, nil, NSError(domain: NSURLErrorDomain, code: URLError.timedOut.rawValue, userInfo: nil))
+    }
+
+    private static func data(from body: Any) -> Data {
+        switch body {
+        case let data as Data: return data
+        case let string as String: return Data(string.utf8)
+        default: return (try? JSONSerialization.data(withJSONObject: body)) ?? Data()
+        }
+    }
+}
+
+/// No-op cancellable returned by `MockHTTPClient.execute` (the response is delivered synchronously, so
+/// there's nothing to cancel).
+private final class NoopCancellable: NSObject, ARTCancellable {
+    func cancel() {}
+}

--- a/Test/UTS/Harness/MockTimeProvider.swift
+++ b/Test/UTS/Harness/MockTimeProvider.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Ably
+import Ably.Private
+
+/// A deterministic `ARTTimeProvider` for UTS unit tests.
+///
+/// Both the wall clock and the continuous clock start at a fixed origin and only ever move when the test calls
+/// `advanceTime(byMilliseconds:)` — nothing fires on its own, so tests are fully in control
+/// (the UTS `enable_fake_timers()` / `ADVANCE_TIME(ms)` primitives).
+///
+/// Every block scheduled through the SDK's `scheduleAfter:queue:block:` is recorded here, which
+/// means this provider doubles as the timer-leak safety net the UTS derived-tests guide asks for:
+/// `cancelAllScheduled()` in teardown cancels every surviving timer, including ones the SDK may
+/// have orphaned and which are no longer reachable through its public API.
+final class MockTimeProvider: NSObject, TimeProvider, @unchecked Sendable {
+    /// A point on / duration of the continuous clock, in the same units as `clock_gettime_nsec_np`.
+    private typealias Nanoseconds = UInt64
+
+    private let lock = NSLock()
+
+    /// Wall-clock origin: a fixed, arbitrary point in time (ms since the Unix epoch).
+    private var wallClockMilliseconds: Double = 1_600_000_000_000
+
+    /// Continuous-clock origin.
+    private var continuousNanoseconds: Nanoseconds = 1_000_000_000
+
+    private final class ScheduledBlock: @unchecked Sendable {
+        let fireAtNanoseconds: Nanoseconds
+        let queue: DispatchQueue
+        let block: @Sendable () -> Void
+        var isCancelled = false
+
+        init(fireAtNanoseconds: Nanoseconds, queue: DispatchQueue, block: @escaping @Sendable () -> Void) {
+            self.fireAtNanoseconds = fireAtNanoseconds
+            self.queue = queue
+            self.block = block
+        }
+    }
+
+    /// A cancellable handle returned to the SDK for a scheduled block.
+    private final class Handle: NSObject, SchedulerHandle {
+        private let owner: MockTimeProvider
+        fileprivate let scheduled: ScheduledBlock
+
+        init(owner: MockTimeProvider, scheduled: ScheduledBlock) {
+            self.owner = owner
+            self.scheduled = scheduled
+        }
+
+        func cancel() {
+            owner.cancel(scheduled)
+        }
+    }
+
+    /// The fake clock's own continuous-clock instant. The system instant
+    /// (`ARTSystemContinuousClockInstant`) is private to `ARTSystemTimeProvider`, so the fake
+    /// provider supplies its own value type conforming to the boundary protocol.
+    private final class Instant: NSObject, ContinuousClockInstant, @unchecked Sendable {
+        let nanoseconds: UInt64
+        init(nanoseconds: UInt64) { self.nanoseconds = nanoseconds }
+
+        func isAfter(_ other: ContinuousClockInstant) -> Bool {
+            guard let other = other as? Instant else { return false }
+            return nanoseconds > other.nanoseconds
+        }
+
+        func addingDuration(_ duration: TimeInterval) -> ContinuousClockInstant {
+            Instant(nanoseconds: nanoseconds + UInt64(max(0, duration) * 1_000_000_000))
+        }
+    }
+
+    private var scheduledBlocks: [ScheduledBlock] = []
+
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
+    }
+
+    /// Count of pending (not-yet-fired, not-cancelled) blocks. Caller must hold the lock.
+    private var pendingCount: Int {
+        scheduledBlocks.filter { !$0.isCancelled }.count
+    }
+
+    // MARK: ARTTimeProvider
+
+    func wallClockNow() -> Date {
+        withLock { Date(timeIntervalSince1970: wallClockMilliseconds / 1000.0) }
+    }
+
+    func continuousClockNow() -> ContinuousClockInstant {
+        withLock { Instant(nanoseconds: continuousNanoseconds) }
+    }
+
+    func schedule(after delay: TimeInterval, queue: DispatchQueue, block: @escaping @Sendable () -> Void) -> SchedulerHandle {
+        withLock {
+            rememberQueue(queue)
+            let fireAt = continuousNanoseconds + Nanoseconds(max(0, delay) * 1_000_000_000)
+            let scheduled = ScheduledBlock(fireAtNanoseconds: fireAt, queue: queue, block: block)
+            scheduledBlocks.append(scheduled)
+            return Handle(owner: self, scheduled: scheduled)
+        }
+    }
+
+    // MARK: Test control
+
+    /// Every distinct queue the SDK has scheduled a timer on. `advanceTime` barriers these to let
+    /// SDK work settle around firing timers. We remember them (rather than reading the queues of the
+    /// currently-pending blocks) because there are moments when no block is pending — at the leading
+    /// drain before a queued handler has scheduled its timer, and between firing a timer and its
+    /// cascade scheduling the next one — yet we still need to barrier the SDK's queue. The SDK only
+    /// schedules timers on its internal queue, so that queue is remembered the first time any timer
+    /// is scheduled (during connect for example); the callback queue isn't drained here, which is fine
+    /// since the tests observe state through the internal queue, not via listener callbacks.
+    private var knownQueues: [ObjectIdentifier: DispatchQueue] = [:]
+
+    /// Caller must hold `lock`. Keyed by identity, so re-registering a queue is a no-op.
+    private func rememberQueue(_ queue: DispatchQueue) {
+        knownQueues[ObjectIdentifier(queue)] = queue
+    }
+
+    /// Advances both clocks by `milliseconds` and runs the SDK to quiescence:
+    ///
+    /// 1. Drains first, so any already-queued work (e.g. an unexpected disconnect transitioning to
+    ///    DISCONNECTED) finishes *registering its timer* before the clock moves past it.
+    /// 2. Advances both clocks.
+    /// 3. Fires every now-due block and drains the cascade it triggers, repeating while the cascade
+    ///    schedules further blocks that are themselves already due (e.g. a zero-delay reschedule).
+    ///
+    /// After it returns, the SDK has fully reacted to the elapsed time: state has settled and the
+    /// next timer (if any) is registered. Chained retries that are scheduled *relative to the new
+    /// time* remain in the future and need a subsequent `advanceTime` — matching real elapsed time.
+    func advanceTime(byMilliseconds milliseconds: Double) {
+        drainAllQueues()
+
+        let target = withLock { () -> Nanoseconds in
+            continuousNanoseconds = continuousNanoseconds + Nanoseconds(max(0, milliseconds) * 1_000_000)
+            wallClockMilliseconds += milliseconds
+            return continuousNanoseconds
+        }
+
+        while fireBlocksDue(upTo: target) {
+            drainAllQueues()
+        }
+    }
+
+    /// Dispatches every not-yet-fired, not-cancelled block whose fire time is `<= target` onto its
+    /// target queue (in fire-time order). Returns `true` if it dispatched anything.
+    private func fireBlocksDue(upTo target: Nanoseconds) -> Bool {
+        let due = withLock { () -> [ScheduledBlock] in
+            let due = scheduledBlocks
+                .filter { !$0.isCancelled && $0.fireAtNanoseconds <= target }
+                .sorted { $0.fireAtNanoseconds < $1.fireAtNanoseconds }
+            scheduledBlocks.removeAll { scheduled in due.contains { $0 === scheduled } }
+            return due
+        }
+        for scheduled in due {
+            scheduled.queue.async(execute: scheduled.block)
+        }
+        return !due.isEmpty
+    }
+
+    /// Settles the SDK's queues until a pass no longer changes the number of scheduled timers —
+    /// i.e. the work has stopped scheduling (or cancelling) timers and has quiesced. Each pass takes
+    /// the lock once (snapshotting both the queues to barrier and the pending count together).
+    private func drainAllQueues(maxPasses: Int = 100) {
+        var previousCount = -1
+        for _ in 0..<maxPasses {
+            let (queues, count) = withLock { (Array(knownQueues.values), pendingCount) }
+            if count == previousCount {
+                return
+            }
+            previousCount = count
+            for queue in queues {
+                queue.sync {}
+            }
+        }
+    }
+
+    /// Cancels every scheduled block. Used in teardown as the timer-leak safety net.
+    func cancelAllScheduled() {
+        withLock { scheduledBlocks.removeAll() }
+    }
+
+    private func cancel(_ scheduled: ScheduledBlock) {
+        withLock {
+            scheduled.isCancelled = true
+            scheduledBlocks.removeAll { $0 === scheduled }
+        }
+    }
+}

--- a/Test/UTS/Harness/MockWebSocket.swift
+++ b/Test/UTS/Harness/MockWebSocket.swift
@@ -1,0 +1,231 @@
+import Foundation
+import Ably
+import Ably.Private
+
+/// The UTS `mock_ws` — the object test code interacts with. It outlives any single socket
+/// (the SDK creates a new `MockWebSocket` for every connection attempt), holding the
+/// `onConnectionAttempt` handler and the history of all connection attempts.
+///
+/// It is installed via `ARTClientOptions.testOptions.transportFactory` (the cocoa mapping of the
+/// spec's `install_mock`). The SDK still builds a *real* `ARTWebSocketTransport`, so URL and
+/// query-param construction (`recover`, `resume`, `format`, …) is exercised by production code;
+/// only the underlying socket is faked, via the `ARTWebSocketFactory` seam.
+///
+/// `onConnectionAttempt` is the handler-based pattern from the spec: it receives the `MockWebSocket`
+/// for each connection the SDK opens, and configures the simulated server's response
+/// (`respondWithSuccess()` + `sendToClient(...)`).
+final class MockWebSocketProvider: @unchecked Sendable {
+    typealias ConnectionAttemptHandler = @Sendable (MockWebSocket) -> Void
+
+    private let onConnectionAttempt: ConnectionAttemptHandler?
+    private let lock = NSLock()
+    private var latestConnection: MockWebSocket?
+
+    /// The most recent connection (UTS `active_connection`). Set on the internal queue, read from
+    /// the test thread, so guarded by a lock. Tests that need the full history of connection
+    /// attempts capture them into a local array inside `onConnectionAttempt` (the spec's pattern).
+    var activeConnection: MockWebSocket? {
+        lock.lock(); defer { lock.unlock() }
+        return latestConnection
+    }
+
+    init(onConnectionAttempt: ConnectionAttemptHandler? = nil) {
+        self.onConnectionAttempt = onConnectionAttempt
+    }
+
+    fileprivate func register(_ socket: MockWebSocket) {
+        lock.lock()
+        latestConnection = socket
+        lock.unlock()
+    }
+
+    fileprivate func fireConnectionAttempt(_ socket: MockWebSocket) {
+        onConnectionAttempt?(socket)
+    }
+}
+
+/// A single simulated WebSocket connection. Conforms to `ARTWebSocket` so the real
+/// `ARTWebSocketTransport` can drive it, and exposes the UTS server-side API
+/// (`respondWithSuccess`, `sendToClient`, `simulateDisconnect`, …) for tests.
+final class MockWebSocket: NSObject, ARTWebSocket, @unchecked Sendable {
+
+    // MARK: ARTWebSocket
+
+    weak var delegate: ARTWebSocketDelegate?
+    var delegateDispatchQueue: DispatchQueue?
+    private(set) var readyState: ARTWebSocketReadyState = .connecting
+
+    // MARK: Inspection
+
+    /// The full request the SDK built for this connection (real production URL building).
+    let request: URLRequest
+    /// Convenience accessor for the connection URL.
+    var url: URL { request.url ?? URL(string: "wss://invalid")! }
+    /// Query parameters parsed from the connection URL (UTS `url.query_params`).
+    var queryParams: [String: String] {
+        guard let url = request.url,
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+              let items = components.queryItems else { return [:] }
+        var result: [String: String] = [:]
+        for item in items where item.value != nil {
+            result[item.name] = item.value
+        }
+        return result
+    }
+
+    /// Protocol messages the SDK has sent towards the server, decoded, in order
+    /// (UTS client-to-server `ws_frame` events). Appended on the internal queue, read from the
+    /// test thread, so guarded by a lock.
+    var sentMessages: [ARTProtocolMessage] {
+        lock.lock(); defer { lock.unlock() }
+        return sent
+    }
+    private var sent: [ARTProtocolMessage] = []
+    private let lock = NSLock()
+
+    private let decoder: ARTEncoder
+
+    init(request: URLRequest, decoder: ARTEncoder) {
+        self.request = request
+        self.decoder = decoder
+        super.init()
+    }
+
+    func setDelegateDispatchQueue(_ queue: DispatchQueue) {
+        delegateDispatchQueue = queue
+    }
+
+    func open() {
+        // No-op: opening is driven by the test via `onConnectionAttempt` → `respondWithSuccess()`,
+        // not by the real network. (The transport calls this on a private queue we don't control;
+        // keeping it a no-op means all simulated server activity is delivered via the delegate queue.)
+    }
+
+    func close(withCode code: Int, reason: String?) {
+        readyState = .closed
+    }
+
+    func send(_ message: Any?) {
+        guard let data = message as? Data else { return }
+        guard let decoded = try? decoder.decodeProtocolMessage(data) else { return }
+        lock.lock()
+        sent.append(decoded)
+        lock.unlock()
+    }
+
+    // MARK: UTS server-side API
+
+    /// Accepts the connection at the transport level (UTS `respond_with_success()`).
+    func respondWithSuccess() {
+        readyState = .open
+        deliverToDelegate { [weak self] in
+            guard let self else { return }
+            self.delegate?.webSocketDidOpen?(self)
+        }
+    }
+
+    /// Delivers a protocol message to the client, leaving the connection open
+    /// (UTS `send_to_client`).
+    func sendToClient(_ message: ProtocolMessage) {
+        deliverToDelegate { [weak self] in
+            guard let self else { return }
+            guard self.readyState == .open else { return }
+            self.delegate?.webSocket?(self, didReceiveMessage: message.makeProtocolMessage())
+        }
+    }
+
+    /// Delivers a protocol message and then closes the connection (UTS `send_to_client_and_close`).
+    /// Used for connection-level `ERROR` (no channel) and `DISCONNECTED`.
+    func sendToClientAndClose(_ message: ProtocolMessage) {
+        deliverToDelegate { [weak self] in
+            guard let self else { return }
+            if self.readyState == .open {
+                self.delegate?.webSocket?(self, didReceiveMessage: message.makeProtocolMessage())
+            }
+            self.readyState = .closed
+            self.delegate?.webSocket?(self, didCloseWithCode: WSCloseCode.normal, reason: "Normal Closure", wasClean: true)
+        }
+    }
+
+    /// Refuses the connection at the network level (UTS `respond_with_refused()`); the SDK treats
+    /// this as a retryable connection failure (`realtimeTransportRefused:`).
+    func respondWithRefused() {
+        deliverToDelegate { [weak self] in
+            guard let self else { return }
+            self.readyState = .closed
+            self.delegate?.webSocket?(self, didCloseWithCode: WSCloseCode.refuse, reason: "Connection refused", wasClean: false)
+        }
+    }
+
+    /// Drops the connection without any server message (UTS `simulate_disconnect`).
+    func simulateDisconnect() {
+        deliverToDelegate { [weak self] in
+            guard let self else { return }
+            self.readyState = .closed
+            // GoingAway maps to `realtimeTransportDisconnected:` (an unexpected connectivity drop).
+            self.delegate?.webSocket?(self, didCloseWithCode: WSCloseCode.goingAway, reason: "Going Away", wasClean: false)
+        }
+    }
+
+    /// Delivers a delegate callback on the `delegateDispatchQueue` the transport set, per the
+    /// `ARTWebSocket` contract (the real `ARTSRWebSocket` calls its delegate on this queue). It is
+    /// always set before any server-side method runs: the transport sets it synchronously in
+    /// `setupWebSocket`, before `onConnectionAttempt` (and any later test call) fires.
+    private func deliverToDelegate(_ block: @escaping @Sendable () -> Void) {
+        guard let queue = delegateDispatchQueue else {
+            assertionFailure("MockWebSocket delegate callback before delegateDispatchQueue was set")
+            return
+        }
+        queue.async(execute: block)
+    }
+}
+
+/// WebSocket close codes interpreted by `ARTWebSocketTransport.webSocket:didCloseWithCode:…`.
+private enum WSCloseCode {
+    static let normal = 1000    // ARTWsCloseNormal  -> realtimeTransportClosed:
+    static let goingAway = 1001 // ARTWsGoingAway    -> realtimeTransportDisconnected:
+    static let refuse = 1003    // ARTWsRefuse       -> realtimeTransportRefused:
+}
+
+/// Creates `MockWebSocket`s and notifies the `MockWebSocketProvider` of each connection attempt.
+final class MockWebSocketFactory: NSObject, WebSocketFactory {
+    private let workQueue: DispatchQueue
+    private let decoder: ARTEncoder
+    private let wsProvider: MockWebSocketProvider
+
+    init(workQueue: DispatchQueue, decoder: ARTEncoder, wsProvider: MockWebSocketProvider) {
+        self.workQueue = workQueue
+        self.decoder = decoder
+        self.wsProvider = wsProvider
+        super.init()
+    }
+
+    func createWebSocket(with request: URLRequest, logger: InternalLog?) -> ARTWebSocket {
+        let webSocket = MockWebSocket(request: request, decoder: decoder)
+        wsProvider.register(webSocket)
+        // Fire `onConnectionAttempt` on the work queue. This block is enqueued during the transport's
+        // `setupWebSocket` turn, so it runs *after* the transport has wired up `delegate` and
+        // `delegateDispatchQueue` (both set synchronously right after this method returns).
+        let wsProvider = self.wsProvider
+        workQueue.async {
+            wsProvider.fireConnectionAttempt(webSocket)
+        }
+        return webSocket
+    }
+}
+
+/// A `RealtimeTransportFactory` that builds a real `ARTWebSocketTransport` backed by a
+/// `MockWebSocketFactory`. Installed via `ARTClientOptions.testOptions.transportFactory`.
+final class MockWebSocketTransportFactory: NSObject, RealtimeTransportFactory {
+    private let wsProvider: MockWebSocketProvider
+
+    init(wsProvider: MockWebSocketProvider) {
+        self.wsProvider = wsProvider
+        super.init()
+    }
+
+    func transport(withRest rest: ARTRestInternal, options: ARTClientOptions, resumeKey: String?, logger: InternalLog) -> ARTRealtimeTransport {
+        let webSocketFactory = MockWebSocketFactory(workQueue: rest.queue, decoder: rest.defaultEncoder, wsProvider: wsProvider)
+        return ARTWebSocketTransport(rest: rest, options: options, resumeKey: resumeKey, logger: logger, webSocketFactory: webSocketFactory)
+    }
+}

--- a/Test/UTS/Harness/NoOpReachability.swift
+++ b/Test/UTS/Harness/NoOpReachability.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Ably
+import Ably.Private
+
+/// A reachability implementation that never reports any network changes.
+///
+/// Unit tests use the `MockWebSocket` transport and must not touch the real network; installing
+/// this via `options.testOptions.reachabilityClass` stops the SDK from starting OS-level
+/// network monitoring during a test.
+final class NoOpReachability: NSObject, ARTReachability {
+    init(logger: InternalLog, queue: DispatchQueue) {
+        super.init()
+    }
+
+    func listen(forHost host: String, callback: @escaping (Bool) -> Void) {
+        // Intentionally empty: never deliver a reachability change.
+    }
+
+    func off() {
+        // Nothing to tear down.
+    }
+}

--- a/Test/UTS/Harness/ProtocolMessage.swift
+++ b/Test/UTS/Harness/ProtocolMessage.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Ably
+import Ably.Private
+
+/// A `Sendable` description of a server-to-client protocol message that a test injects via
+/// `MockWebSocket.sendToClient(_:)` / `sendToClientAndClose(_:)`.
+struct ProtocolMessage: Sendable {
+
+    private enum Kind: Sendable {
+        case connected(connectionId: String, connectionKey: String, maxIdleInterval: TimeInterval, connectionStateTtl: TimeInterval)
+        case attached(channel: String, channelSerial: String)
+        case error(code: Int, statusCode: Int, message: String)
+        case ack(msgSerial: Int, count: Int)
+        case closed
+    }
+
+    private let kind: Kind
+
+    /// A `CONNECTED` message carrying connection details (UTS `ProtocolMessage(action: CONNECTED, ...)`).
+    static func connected(connectionId: String,
+                          connectionKey: String,
+                          maxIdleInterval: TimeInterval = 15,
+                          connectionStateTtl: TimeInterval = 120) -> ProtocolMessage {
+        .init(kind: .connected(connectionId: connectionId, connectionKey: connectionKey, maxIdleInterval: maxIdleInterval, connectionStateTtl: connectionStateTtl))
+    }
+
+    /// An `ATTACHED` message for a channel (UTS `ProtocolMessage(action: ATTACHED, ...)`).
+    static func attached(channel: String, channelSerial: String) -> ProtocolMessage {
+        .init(kind: .attached(channel: channel, channelSerial: channelSerial))
+    }
+
+    /// An `ERROR` message (UTS `ProtocolMessage(action: ERROR, error: ErrorInfo(...))`).
+    static func error(code: Int, statusCode: Int, message: String) -> ProtocolMessage {
+        .init(kind: .error(code: code, statusCode: statusCode, message: message))
+    }
+
+    /// An `ACK` message (UTS `ProtocolMessage(action: ACK, msgSerial: ..., count: ...)`).
+    static func ack(msgSerial: Int, count: Int) -> ProtocolMessage {
+        .init(kind: .ack(msgSerial: msgSerial, count: count))
+    }
+
+    /// A `CLOSED` message (UTS `ProtocolMessage(action: CLOSED)`).
+    static func closed() -> ProtocolMessage {
+        .init(kind: .closed)
+    }
+
+    /// Builds the concrete `ARTProtocolMessage`. Call on the delegate queue, at delivery time.
+    func makeProtocolMessage() -> ARTProtocolMessage {
+        let message = ARTProtocolMessage()
+        switch kind {
+        case let .connected(connectionId, connectionKey, maxIdleInterval, connectionStateTtl):
+            message.action = .connected
+            message.connectionId = connectionId
+            message.connectionKey = connectionKey
+            message.connectionDetails = ARTConnectionDetails(
+                clientId: nil,
+                connectionKey: connectionKey,
+                maxMessageSize: 0,
+                maxFrameSize: 0,
+                maxInboundRate: 0,
+                connectionStateTtl: connectionStateTtl,
+                serverId: "",
+                maxIdleInterval: maxIdleInterval,
+                objectsGCGracePeriod: nil,
+                siteCode: nil
+            )
+        case let .attached(channel, channelSerial):
+            message.action = .attached
+            message.channel = channel
+            message.channelSerial = channelSerial
+        case let .error(code, statusCode, text):
+            message.action = .error
+            message.error = ARTErrorInfo.create(withCode: code, status: statusCode, message: text)
+        case let .ack(msgSerial, count):
+            message.action = .ack
+            message.msgSerial = NSNumber(value: msgSerial)
+            message.count = Int32(count)
+        case .closed:
+            message.action = .closed
+        }
+        return message
+    }
+}

--- a/Test/UTS/Harness/UTSTestCase.swift
+++ b/Test/UTS/Harness/UTSTestCase.swift
@@ -1,0 +1,188 @@
+import Foundation
+import Testing
+import Ably
+import Ably.Private
+
+/// Base class for UTS-derived unit tests.
+///
+/// UTS suites are Swift Testing suites that subclass this (`@Suite(.serialized) final class FooTests: UTSTestCase`).
+/// Swift Testing creates a fresh instance per `@Test`, so each test gets its own clients/mocks and
+/// `deinit` tears them down.
+///
+/// Provides the cocoa mappings of the UTS harness primitives:
+/// - `installMock(_:)` — the spec's `install_mock`: registers the `MockWebSocketProvider` / `MockHTTPClient`
+///   so the next client built by `makeRealtime()` / `makeRest()` picks it up. The mock is never
+///   passed to the client constructor (a mistake per `uts/docs/writing-test-specs.md`).
+/// - `awaitConnectionState` / `awaitChannelState` — the spec's `AWAIT_STATE`: proceed immediately
+///   if the condition already holds, otherwise poll until it does or the timeout expires.
+/// - `advanceTime(byMilliseconds:)` — fake-timer advancement (`ADVANCE_TIME`).
+/// - protocol-message builders, and cleanup of clients and scheduled timers.
+class UTSTestCase {
+
+    /// Default `AWAIT_STATE` timeout. Generous: with a frozen `MockTimeProvider` the SDK settles in
+    /// microseconds, so this only bites when a state genuinely never arrives (a real failure).
+    static let defaultAwaitTimeout: TimeInterval = 2
+
+    /// The deterministic clock, installed into clients only after `enableFakeTimers()` is called.
+    var timeProvider: MockTimeProvider?
+
+    private var installedWebSocketProvider: MockWebSocketProvider?
+    private var installedMockHTTPClient: MockHTTPClient?
+    private var clients: [ARTRealtime] = []
+
+    // MARK: Enable fake timers
+
+    /// UTS `enable_fake_timers()`. Clients built *after* this call use the deterministic
+    /// `MockTimeProvider` (advanced via `advanceTime(byMilliseconds:)`); by default — and for clients
+    /// built before this call — they use the real `ARTSystemTimeProvider`. Mirrors the spec, where
+    /// most tests run on real timers and only those exercising timeouts/retries opt into fake ones.
+    func enableFakeTimers() {
+        timeProvider = MockTimeProvider()
+    }
+
+    // MARK: Install mock
+
+    /// Registers `wsProvider` to be used by the next `makeRealtime()` call (UTS `install_mock`).
+    func installMock(_ wsProvider: MockWebSocketProvider) {
+        installedWebSocketProvider = wsProvider
+    }
+
+    /// Registers `mockHTTP` to be used by the next `makeRest()` call (UTS `install_mock`).
+    func installMock(_ mockHTTP: MockHTTPClient) {
+        installedMockHTTPClient = mockHTTP
+    }
+
+    // MARK: Client construction
+
+    /// Builds an `ARTRealtime` wired to the currently installed `MockWebSocketProvider` and the
+    /// shared `MockTimeProvider`. A provider must be installed first via `installMock(_:)`. Like the
+    /// UTS specs, this leaves the SDK's `autoConnect` default (`true`) in place; tests that need to
+    /// control connection timing set `options.autoConnect = false` in the `configure` closure.
+    func makeRealtime(configure: (ARTClientOptions) -> Void = { _ in }, sourceLocation: SourceLocation = #_sourceLocation) -> ARTRealtime {
+        guard let wsProvider = installedWebSocketProvider else {
+            Issue.record("No MockWebSocketProvider installed — call installMock(_:) before makeRealtime()", sourceLocation: sourceLocation)
+            fatalError("No MockWebSocketProvider installed")
+        }
+
+        let options = ARTClientOptions()
+        options.useBinaryProtocol = false
+
+        let suffix = UUID().uuidString
+        options.internalDispatchQueue = DispatchQueue(label: "io.ably.uts.internal.\(suffix)")
+        options.dispatchQueue = DispatchQueue(label: "io.ably.uts.callback.\(suffix)")
+
+        if let timeProvider {
+            options.testOptions.timeProvider = timeProvider
+        }
+        options.testOptions.transportFactory = MockWebSocketTransportFactory(wsProvider: wsProvider)
+        options.testOptions.reachabilityClass = NoOpReachability.self
+        // Realtime specs also use `install_mock(mock_http)` (auth callbacks, connection failures,
+        // fallback hosts, …), so wire an installed MockHTTPClient into the client's REST layer too.
+        if let installedMockHTTPClient {
+            options.testOptions.httpExecutor = installedMockHTTPClient
+        }
+
+        configure(options)
+
+        let client = ARTRealtime(options: options)
+        clients.append(client)
+        return client
+    }
+
+    /// Builds an `ARTRest` whose HTTP layer is the currently installed `MockHTTPClient` (so requests are
+    /// intercepted, not sent over the network). A mock must be installed first via `installMock(_:)`.
+    func makeRest(configure: (ARTClientOptions) -> Void = { _ in }, sourceLocation: SourceLocation = #_sourceLocation) -> ARTRest {
+        guard let mockHTTP = installedMockHTTPClient else {
+            Issue.record("No MockHTTPClient installed — call installMock(_:) before makeRest()", sourceLocation: sourceLocation)
+            fatalError("No MockHTTPClient installed")
+        }
+
+        let options = ARTClientOptions()
+        options.useBinaryProtocol = false
+
+        let suffix = UUID().uuidString
+        options.internalDispatchQueue = DispatchQueue(label: "io.ably.uts.internal.\(suffix)")
+        options.dispatchQueue = DispatchQueue(label: "io.ably.uts.callback.\(suffix)")
+
+        if let timeProvider {
+            options.testOptions.timeProvider = timeProvider
+        }
+        options.testOptions.httpExecutor = mockHTTP
+
+        configure(options)
+
+        let rest = ARTRest(options: options)
+        return rest
+    }
+
+    // MARK: AWAIT_STATE
+
+    /// Waits until `client.connection.state == expected` (UTS `AWAIT_STATE`).
+    func awaitConnectionState(_ client: ARTRealtime,
+                              _ expected: ARTRealtimeConnectionState,
+                              timeout: TimeInterval = defaultAwaitTimeout,
+                              sourceLocation: SourceLocation = #_sourceLocation) {
+        poll("connection.state == \(ARTRealtimeConnectionStateToStr(expected))",
+             timeout: timeout, sourceLocation: sourceLocation) {
+            client.connection.state == expected
+        }
+    }
+
+    /// Waits until `channel.state == expected` (UTS `AWAIT_STATE`).
+    func awaitChannelState(_ channel: ARTRealtimeChannel,
+                           _ expected: ARTRealtimeChannelState,
+                           timeout: TimeInterval = defaultAwaitTimeout,
+                           sourceLocation: SourceLocation = #_sourceLocation) {
+        poll("channel '\(channel.name)'.state == \(ARTRealtimeChannelStateToStr(expected))",
+             timeout: timeout, sourceLocation: sourceLocation) {
+            channel.state == expected
+        }
+    }
+
+    /// Generic `AWAIT_STATE`: proceed immediately if `condition` already holds, otherwise poll until
+    /// it does or `timeout` elapses (then fail). Used for non-state conditions such as "a frame has
+    /// been sent". The small sleep just avoids a hot busy-loop.
+    @discardableResult
+    func poll(_ description: String,
+              timeout: TimeInterval = defaultAwaitTimeout,
+              sourceLocation: SourceLocation = #_sourceLocation,
+              until condition: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() {
+            if Date() >= deadline {
+                Issue.record("Timed out after \(timeout)s awaiting: \(description)", sourceLocation: sourceLocation)
+                return false
+            }
+            Thread.sleep(forTimeInterval: 0.0005)
+        }
+        return true
+    }
+
+    // MARK: Fake timers
+
+    /// Advances the fake clock (UTS `ADVANCE_TIME`). Requires `enableFakeTimers()` to have been
+    /// called — otherwise clients are on the real clock and there is nothing to advance.
+    func advanceTime(byMilliseconds milliseconds: Double, sourceLocation: SourceLocation = #_sourceLocation) {
+        guard let timeProvider else {
+            Issue.record("advanceTime requires enableFakeTimers() before makeRealtime()", sourceLocation: sourceLocation)
+            return
+        }
+        timeProvider.advanceTime(byMilliseconds: milliseconds)
+    }
+
+    /// Closes a client (UTS `CLOSE_CLIENT`).
+    func closeClient(_ client: ARTRealtime) {
+        client.close()
+    }
+
+    // MARK: Cleanup
+
+    /// Per-test teardown. Swift Testing releases the suite instance after each `@Test`, so this runs
+    /// once per test: it closes any clients and cancels surviving fake timers (the leak safety net).
+    deinit {
+        for client in clients {
+            client.close()
+        }
+        timeProvider?.cancelAllScheduled()
+    }
+}

--- a/Test/UTS/README.md
+++ b/Test/UTS/README.md
@@ -1,0 +1,45 @@
+# UTS — Universal Test Suite (ably-cocoa)
+
+Tests derived from the language-neutral specs in [`ably/specification`](https://github.com/ably/specification) under [`uts/`](https://github.com/ably/specification/blob/main/uts).
+This is a **standalone Swift Testing target** (`UTS`), separate from `AblyTests`, and deliberately does **not** depend on Nimble or XCTest. It is built in the **Swift 6 language mode** (strict concurrency checking) so the compiler catches data races in the harness and tests.
+
+## Layout
+
+```
+Test/UTS/
+  Harness/
+    UTSTestCase.swift             # base case: installMock, makeRealtime/makeRest, awaitConnectionState/awaitChannelState, advanceTime
+    MockWebSocket.swift           # MockWebSocketProvider (the spec's mock_ws) + MockWebSocket (fake socket) + factories
+    MockHTTPClient.swift                # MockHTTPClient (fake ARTHTTPExecutor) + PendingHTTPConnection / PendingHTTPRequest
+    MockTimeProvider.swift        # deterministic ARTTimeProvider (enable_fake_timers / ADVANCE_TIME)
+    Captured.swift                # thread-safe collector for the spec's local captured_* arrays (Swift 6 safe)
+    CapturingLog.swift            # ARTLog that records log lines for assertions
+    NoOpReachability.swift        # disables OS network monitoring in unit tests
+    ProtocolMessage.swift         # Sendable server-message factories (.connected/.attached/.error/.ack/.closed)
+  Tests/
+    ConnectionRecoveryTests.swift # RTN16
+    TimeTests.swift               # RSC16
+  deviations.md                   # SDK deviations found during evaluation
+```
+
+## How the harness maps the UTS primitives
+
+| UTS pseudocode | cocoa mapping |
+|---|---|
+| `install_mock(mock_ws)` | `installMock(_:)` — registers the `MockWebSocketProvider`; the next `makeRealtime()` wires it into `ARTClientOptions.testOptions.transportFactory` (per-client DI). The mock is never passed to the constructor. |
+| `mock_ws = MockWebSocket(onConnectionAttempt:)` | `MockWebSocketProvider(onConnectionAttempt:)` — builds a real `ARTWebSocketTransport` over a fake `MockWebSocket` per connection |
+| `mock_ws.active_connection.respond_with_success()` / `send_to_client(...)` | `MockWebSocket.respondWithSuccess()` / `sendToClient(_:)` |
+| `AWAIT_STATE conn.state == s` | `awaitConnectionState(client, s)` — poll until it holds or timeout (state getters sync onto the internal queue) |
+| `AWAIT_STATE channel.state == s` | `awaitChannelState(channel, s)` |
+| `enable_fake_timers()` / `ADVANCE_TIME(ms)` | shared `MockTimeProvider` / `advanceTime(byMilliseconds:)` |
+| `// UTS: <id>` | comment immediately above each test method |
+
+URL/query-param construction (`recover`, `resume`, `format`, …) is exercised by **real** SDK code;
+only the socket is faked, through the `ARTWebSocketFactory` seam.
+
+## Running
+
+```bash
+swift test --filter UTS
+swift test --filter UTS.ConnectionRecoveryTests/<test_name>
+```

--- a/Test/UTS/Tests/realtime/unit/connection/ConnectionRecoveryTests.swift
+++ b/Test/UTS/Tests/realtime/unit/connection/ConnectionRecoveryTests.swift
@@ -1,0 +1,493 @@
+import Testing
+import Foundation
+import Ably
+import Ably.Private
+
+/// Connection Recovery Tests (RTN16d, RTN16f, RTN16f1, RTN16g, RTN16g1, RTN16g2, RTN16i, RTN16j, RTN16k, RTN16l)
+/// Derived from https://github.com/ably/specification/blob/main/uts/realtime/unit/connection/connection_recovery_test.md
+@Suite(.serialized)
+final class ConnectionRecoveryTests: UTSTestCase {
+
+    // UTS: realtime/unit/RTN16g/recovery-key-structure-0
+    @Test
+    func test_RTN16g_createRecoveryKey_returns_connectionKey_msgSerial_and_channelSerials() throws {
+        // Setup
+        let wsProvider = MockWebSocketProvider(onConnectionAttempt: { connection in
+            connection.respondWithSuccess()
+            connection.sendToClient(.connected(
+                connectionId: "connection-1",
+                connectionKey: "key-abc-123",
+                maxIdleInterval: 15,
+                connectionStateTtl: 120
+            ))
+        })
+        installMock(wsProvider)
+
+        let client = makeRealtime { options in
+            options.key = "appId.keyId:keySecret"
+            options.autoConnect = false
+        }
+
+        // Test Steps
+        // Connect
+        client.connect()
+        awaitConnectionState(client, .connected)
+
+        // Get the WebSocket connection for sending mock responses
+        let wsConnection = try #require(wsProvider.activeConnection)
+
+        // Get two channels and simulate attaching them (including one with unicode name)
+        let channelA = client.channels.get("channel-alpha")
+        let channelB = client.channels.get("channel-éàü-世界")
+
+        // Attach channel_a
+        channelA.attach()
+        wsConnection.sendToClient(.attached(channel: "channel-alpha", channelSerial: "serial-a-001"))
+        awaitChannelState(channelA, .attached)
+
+        // Attach channel_b (unicode name)
+        channelB.attach()
+        wsConnection.sendToClient(.attached(channel: "channel-éàü-世界", channelSerial: "serial-b-002"))
+        awaitChannelState(channelB, .attached)
+
+        // Create recovery key
+        let recoveryKeyString = client.connection.createRecoveryKey()
+
+        // Assertions
+        // Recovery key is not null
+        let unwrappedRecoveryKeyString = try #require(recoveryKeyString)
+
+        // Deserialize the recovery key (JSON format per ably-js reference)
+        let recoveryKey = try parseJSONObject(unwrappedRecoveryKeyString)
+
+        // Contains connectionKey
+        #expect(recoveryKey["connectionKey"] as? String == "key-abc-123")
+
+        // Contains msgSerial (starts at 0 since no messages were sent)
+        #expect(recoveryKey["msgSerial"] as? Int == 0)
+
+        // Contains channelSerials map with both channels
+        let channelSerials = try #require(recoveryKey["channelSerials"] as? [String: String])
+        #expect(channelSerials["channel-alpha"] == "serial-a-001")
+
+        // RTN16g1: Unicode channel name is correctly encoded in the serialized key
+        #expect(channelSerials["channel-éàü-世界"] == "serial-b-002")
+
+        // Verify round-trip: re-serializing and deserializing preserves the unicode name
+        let reSerialized = try toJSONString(recoveryKey)
+        let reParsed = try parseJSONObject(reSerialized)
+        let reParsedSerials = try #require(reParsed["channelSerials"] as? [String: String])
+        #expect(reParsedSerials["channel-éàü-世界"] == "serial-b-002")
+
+        closeClient(client)
+    }
+
+    // UTS: realtime/unit/RTN16g2/recovery-key-null-inactive-0
+    @Test
+    func test_RTN16g2_createRecoveryKey_returns_null_in_inactive_states() throws {
+        // Setup
+        let wsProvider = MockWebSocketProvider(onConnectionAttempt: { connection in
+            connection.respondWithSuccess()
+            connection.sendToClient(.connected(
+                connectionId: "connection-1",
+                connectionKey: "key-1",
+                maxIdleInterval: 15,
+                connectionStateTtl: 120
+            ))
+        })
+        installMock(wsProvider)
+
+        let client = makeRealtime { options in
+            options.key = "appId.keyId:keySecret"
+            options.autoConnect = false
+        }
+
+        // Test Steps
+        // Before connecting (INITIALIZED state, no connectionKey)
+        #expect(client.connection.createRecoveryKey() == nil)
+
+        // Connect and verify recovery key is available when CONNECTED
+        client.connect()
+        awaitConnectionState(client, .connected)
+        #expect(client.connection.createRecoveryKey() != nil)
+
+        // Transition to CLOSING then CLOSED
+        let wsConnection = try #require(wsProvider.activeConnection)
+        client.connection.close()
+        awaitConnectionState(client, .closing)
+        #expect(client.connection.createRecoveryKey() == nil)
+
+        // The mock server doesn't auto-respond to the client's CLOSE frame, so deliver the server's
+        // CLOSED to drive the connection from CLOSING to CLOSED (harness-driving detail:
+        wsConnection.sendToClient(.closed())
+
+        awaitConnectionState(client, .closed)
+        #expect(client.connection.createRecoveryKey() == nil)
+
+        // Assertions
+        // All null cases verified inline above.
+        // For FAILED and SUSPENDED states, create separate clients to test:
+
+        // --- Test FAILED state ---
+        let wsProviderFailed = MockWebSocketProvider(onConnectionAttempt: { connection in
+            connection.respondWithSuccess()
+            connection.sendToClient(.connected(
+                connectionId: "conn-f",
+                connectionKey: "key-f",
+                maxIdleInterval: 15,
+                connectionStateTtl: 120
+            ))
+        })
+        installMock(wsProviderFailed)
+
+        let clientFailed = makeRealtime { options in
+            options.key = "appId.keyId:keySecret"
+            options.autoConnect = false
+        }
+        clientFailed.connect()
+        awaitConnectionState(clientFailed, .connected)
+
+        // Trigger FAILED via fatal ERROR
+        let wsConn = try #require(wsProviderFailed.activeConnection)
+        wsConn.sendToClientAndClose(.error(code: 50000, statusCode: 500, message: "Fatal error"))
+        awaitConnectionState(clientFailed, .failed)
+        #expect(clientFailed.connection.createRecoveryKey() == nil)
+
+        // --- Test SUSPENDED state ---
+        let suspendedAttempts = Captured<MockWebSocket>()
+        let wsProviderSuspended = MockWebSocketProvider(onConnectionAttempt: { connection in
+            suspendedAttempts.append(connection)
+            // All connections fail after initial, to force SUSPENDED
+            if suspendedAttempts.count == 1 {
+                connection.respondWithSuccess()
+                connection.sendToClient(.connected(
+                    connectionId: "conn-s",
+                    connectionKey: "key-s",
+                    maxIdleInterval: 15,
+                    connectionStateTtl: 2
+                ))
+            } else {
+                connection.respondWithRefused()
+            }
+        })
+        installMock(wsProviderSuspended)
+
+        enableFakeTimers()
+
+        let clientSuspended = makeRealtime { options in
+            options.key = "appId.keyId:keySecret"
+            options.disconnectedRetryTimeout = 0.5
+            options.autoConnect = false
+            options.fallbackHosts = []
+        }
+
+        clientSuspended.connect()
+        awaitConnectionState(clientSuspended, .connected)
+
+        let wsConnS = try #require(wsProviderSuspended.activeConnection)
+        wsConnS.simulateDisconnect()
+
+        // Advance time until SUSPENDED (connectionStateTtl expires)
+        for _ in 0..<10 {
+            advanceTime(byMilliseconds: 1500)
+            if clientSuspended.connection.state == .suspended {
+                break
+            }
+        }
+
+        awaitConnectionState(clientSuspended, .suspended)
+        #expect(clientSuspended.connection.createRecoveryKey() == nil)
+
+        closeClient(clientSuspended)
+    }
+
+    // UTS: realtime/unit/RTN16k/recover-query-param-0
+    @Test
+    func test_RTN16k_recover_option_adds_recover_query_param_to_WebSocket_URL() throws {
+        // Setup
+        let capturedConnectionAttempts = Captured<MockWebSocket>()
+
+        // Construct a valid recoveryKey
+        let recoveryKey = try toJSONString([
+            "connectionKey": "recovered-key-xyz",
+            "msgSerial": 5,
+            "channelSerials": [String: String]()
+        ])
+
+        let wsProvider = MockWebSocketProvider(onConnectionAttempt: { connection in
+            capturedConnectionAttempts.append(connection)
+            connection.respondWithSuccess()
+
+            if capturedConnectionAttempts.count == 1 {
+                // First connection: successful recovery (same connectionId as implied by recoveryKey)
+                connection.sendToClient(.connected(
+                    connectionId: "recovered-conn-id",
+                    connectionKey: "new-key-after-recovery",
+                    maxIdleInterval: 15,
+                    connectionStateTtl: 120
+                ))
+            } else {
+                // Subsequent connection: resume after disconnect
+                connection.sendToClient(.connected(
+                    connectionId: "recovered-conn-id",
+                    connectionKey: "resumed-key",
+                    maxIdleInterval: 15,
+                    connectionStateTtl: 120
+                ))
+            }
+        })
+        installMock(wsProvider)
+
+        let client = makeRealtime { options in
+            options.key = "appId.keyId:keySecret"
+            options.recover = recoveryKey
+            options.autoConnect = false
+        }
+
+        // Test Steps
+        // Connect - should use recover param
+        client.connect()
+        awaitConnectionState(client, .connected)
+
+        // Simulate disconnect and reconnection
+        let wsConnection = try #require(wsProvider.activeConnection)
+        wsConnection.simulateDisconnect()
+
+        // Wait for resume reconnection
+        // (poll for the second connection attempt first: right after simulate_disconnect the
+        // connection is still transiently CONNECTED, so awaiting CONNECTED alone could match the
+        // pre-disconnect state rather than the resume.)
+        poll("second connection attempt") { capturedConnectionAttempts.count == 2 }
+        awaitConnectionState(client, .connected, timeout: 5)
+
+        // Assertions
+        // First connection attempt includes recover param with connectionKey from recoveryKey
+        #expect(capturedConnectionAttempts[0].queryParams["recover"] == "recovered-key-xyz")
+
+        // First connection attempt does NOT include resume param
+        #expect(capturedConnectionAttempts[0].queryParams["resume"] == nil)
+
+        // Second connection attempt uses resume (not recover) since client is now connected
+        #expect(capturedConnectionAttempts[1].queryParams["resume"] == "new-key-after-recovery")
+        #expect(capturedConnectionAttempts[1].queryParams["recover"] == nil)
+
+        closeClient(client)
+    }
+
+    // UTS: realtime/unit/RTN16f/recover-initializes-msgserial-0
+    @Test
+    func test_RTN16f_recover_option_initializes_msgSerial_from_recoveryKey() throws {
+        // Setup
+        // Construct a recoveryKey with msgSerial of 42
+        let recoveryKey = try toJSONString([
+            "connectionKey": "old-key",
+            "msgSerial": 42,
+            "channelSerials": ["test-channel": "ch-serial-1"]
+        ])
+
+        let connectionAttempts = Captured<MockWebSocket>()
+        let wsProvider = MockWebSocketProvider(onConnectionAttempt: { connection in
+            connectionAttempts.append(connection)
+            connection.respondWithSuccess()
+
+            if connectionAttempts.count == 1 {
+                // Successful recovery
+                connection.sendToClient(.connected(
+                    connectionId: "recovered-conn",
+                    connectionKey: "new-key",
+                    maxIdleInterval: 15,
+                    connectionStateTtl: 120
+                ))
+            }
+        })
+        installMock(wsProvider)
+
+        let client = makeRealtime { options in
+            options.key = "appId.keyId:keySecret"
+            options.recover = recoveryKey
+            options.autoConnect = false
+        }
+
+        // Test Steps
+        // Connect with recovery
+        client.connect()
+        awaitConnectionState(client, .connected)
+
+        // Get WebSocket connection reference
+        let wsConnection = try #require(wsProvider.activeConnection)
+
+        // Attach the recovered channel
+        let channel = client.channels.get("test-channel")
+        channel.attach()
+        wsConnection.sendToClient(.attached(channel: "test-channel", channelSerial: "ch-serial-updated"))
+        awaitChannelState(channel, .attached)
+
+        // Publish a message - the msgSerial should start from the recovered value (42)
+        channel.publish("event", data: "data")
+
+        // Capture the MESSAGE frame sent by the client
+        poll("MESSAGE frame sent to server") {
+            wsConnection.sentMessages.contains { $0.action == .message }
+        }
+        let messageFrame = wsConnection.sentMessages.first { $0.action == .message }
+
+        // ACK the message
+        wsConnection.sendToClient(.ack(msgSerial: 42, count: 1))
+
+        // Assertions
+        // The first message published uses msgSerial from the recoveryKey
+        let unwrappedMessageFrame = try #require(messageFrame)
+        #expect(unwrappedMessageFrame.msgSerial?.intValue == 42)
+
+        closeClient(client)
+    }
+
+    // UTS: realtime/unit/RTN16f1/malformed-recovery-key-0
+    @Test
+    func test_RTN16f1_malformed_recoveryKey_logs_error_and_connects_normally() {
+        // Setup
+        let capturedConnectionAttempts = Captured<MockWebSocket>()
+        let log = CapturingLog()
+        let wsProvider = MockWebSocketProvider(onConnectionAttempt: { connection in
+            capturedConnectionAttempts.append(connection)
+            connection.respondWithSuccess()
+            connection.sendToClient(.connected(
+                connectionId: "fresh-conn",
+                connectionKey: "fresh-key",
+                maxIdleInterval: 15,
+                connectionStateTtl: 120
+            ))
+        })
+        installMock(wsProvider)
+
+        // Use a malformed (non-JSON) recover string
+        let client = makeRealtime { options in
+            options.key = "appId.keyId:keySecret"
+            options.recover = "this-is-not-valid-json!!!"
+            options.autoConnect = false
+            options.logHandler = log
+        }
+
+        // Test Steps
+        // Connect - should proceed as a normal connection (no recover param)
+        client.connect()
+        awaitConnectionState(client, .connected)
+
+        // Assertions
+        // Connection succeeded normally
+        #expect(client.connection.state == .connected)
+        #expect(client.connection.id == "fresh-conn")
+        #expect(client.connection.key == "fresh-key")
+
+        // No recover param was sent (malformed key was rejected)
+        #expect(capturedConnectionAttempts[0].queryParams["recover"] == nil)
+
+        // Also no resume param (this is a fresh connection)
+        #expect(capturedConnectionAttempts[0].queryParams["resume"] == nil)
+
+        // Only one connection attempt (normal connection, no retries)
+        #expect(capturedConnectionAttempts.count == 1)
+
+        // Implementation note: The spec requires that an error be logged when the recovery key is
+        // malformed. Verified here by capturing log output and asserting an error-level message
+        // mentioning the malformed recovery key was emitted.
+        #expect(log.contains(level: .error, message: "recovery key"))
+
+        closeClient(client)
+    }
+
+    // UTS: realtime/unit/RTN16j/recover-channel-serials-0
+    @Test
+    func test_RTN16j_recover_option_instantiates_channels_from_recoveryKey() throws {
+        // Setup
+        // Construct a recoveryKey with multiple channels
+        let recoveryKey = try toJSONString([
+            "connectionKey": "old-key-abc",
+            "msgSerial": 10,
+            "channelSerials": [
+                "channel-one": "serial-1-abc",
+                "channel-two": "serial-2-def",
+                "channel-üñîçöðé": "serial-3-unicode"
+            ]
+        ])
+
+        let wsProvider = MockWebSocketProvider(onConnectionAttempt: { connection in
+            connection.respondWithSuccess()
+            connection.sendToClient(.connected(
+                connectionId: "recovered-conn",
+                connectionKey: "new-key",
+                maxIdleInterval: 15,
+                connectionStateTtl: 120
+            ))
+        })
+        installMock(wsProvider)
+
+        let client = makeRealtime { options in
+            options.key = "appId.keyId:keySecret"
+            options.recover = recoveryKey
+            options.autoConnect = false
+        }
+
+        // Test Steps
+        // Connect with recovery
+        client.connect()
+        awaitConnectionState(client, .connected)
+
+        // Assertions
+        // RTN16j: Channels from the recoveryKey are instantiated
+        let channelOne = client.channels.get("channel-one")
+        let channelTwo = client.channels.get("channel-two")
+        let channelUnicode = client.channels.get("channel-üñîçöðé")
+
+        // Each channel has its channelSerial set from the recoveryKey
+        #expect(channelOne.properties.channelSerial == "serial-1-abc")
+        #expect(channelTwo.properties.channelSerial == "serial-2-def")
+        #expect(channelUnicode.properties.channelSerial == "serial-3-unicode")
+
+        // RTN16i: Channels are NOT automatically attached — the user must explicitly attach them.
+        // They should be in INITIALIZED state (the library instantiated them but didn't attach).
+        #expect(channelOne.state == .initialized)
+        #expect(channelTwo.state == .initialized)
+        #expect(channelUnicode.state == .initialized)
+
+        // When the user attaches, the ATTACH message should include the channelSerial
+        // (this enables the server to resume the channel from the correct point)
+        let wsConnection = try #require(wsProvider.activeConnection)
+
+        channelOne.attach()
+
+        // Capture the ATTACH frame sent by the client
+        poll("ATTACH frame for channel-one sent to server") {
+            wsConnection.sentMessages.contains { $0.action == .attach && $0.channel == "channel-one" }
+        }
+        let sentFrames = wsConnection.sentMessages.filter { $0.action == .attach && $0.channel == "channel-one" }
+        #expect(sentFrames.count == 1)
+        #expect(sentFrames.first?.channelSerial == "serial-1-abc")
+
+        // Complete the attachment
+        wsConnection.sendToClient(.attached(channel: "channel-one", channelSerial: "serial-1-abc-updated"))
+        awaitChannelState(channelOne, .attached)
+
+        closeClient(client)
+    }
+}
+
+// MARK: - Helpers
+
+private extension ConnectionRecoveryTests {
+    /// Deserializes a JSON object string into a dictionary (UTS `fromJson`).
+    func parseJSONObject(_ string: String, sourceLocation: SourceLocation = #_sourceLocation) throws -> [String: Any] {
+        let object = try JSONSerialization.jsonObject(with: Data(string.utf8))
+        guard let dictionary = object as? [String: Any] else {
+            Issue.record("Expected a JSON object, got: \(string)", sourceLocation: sourceLocation)
+            return [:]
+        }
+        return dictionary
+    }
+
+    /// Serializes a dictionary to a JSON object string (UTS `toJson`).
+    func toJSONString(_ object: [String: Any]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: object)
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/Test/UTS/Tests/rest/unit/TimeTests.swift
+++ b/Test/UTS/Tests/rest/unit/TimeTests.swift
@@ -1,0 +1,209 @@
+import Testing
+import Foundation
+import Ably
+import Ably.Private
+
+/// Time API (RSC16)
+/// Derived from https://github.com/ably/specification/blob/main/uts/rest/unit/time.md
+@Suite(.serialized)
+final class TimeTests: UTSTestCase {
+
+    // UTS: rest/unit/RSC16/returns-server-time-0
+    @Test
+    func test_RSC16_returns_server_time() async throws {
+        // Setup
+        let capturedRequests = Captured<PendingHTTPRequest>()
+        let serverTimeMs = 1_704_067_200_000 // 2024-01-01 00:00:00 UTC
+
+        let mockHTTP = MockHTTPClient(
+            onConnectionAttempt: { connection in connection.respondWithSuccess() },
+            onRequest: { request in
+                capturedRequests.append(request)
+                request.respondWith(status: 200, body: [serverTimeMs])
+            }
+        )
+        installMock(mockHTTP)
+
+        let rest = makeRest { options in options.key = "app.key:secret" }
+
+        // Test Steps
+        let result = try await awaitTime(rest)
+
+        // Assertions
+        // Result should be a DateTime matching the server timestamp
+        // ASSERT result IS DateTime
+        #expect(Int(result.timeIntervalSince1970 * 1000) == serverTimeMs)
+
+        // Verify correct endpoint was called
+        #expect(capturedRequests.count == 1)
+        let request = capturedRequests[0]
+        #expect(request.method == "GET")
+        #expect(request.url.path == "/time")
+    }
+
+    // UTS: rest/unit/RSC16/request-format-get-time-1
+    @Test
+    func test_RSC16_request_format_get_time() async throws {
+        // Setup
+        let capturedRequests = Captured<PendingHTTPRequest>()
+
+        let mockHTTP = MockHTTPClient(
+            onConnectionAttempt: { connection in connection.respondWithSuccess() },
+            onRequest: { request in
+                capturedRequests.append(request)
+                request.respondWith(status: 200, body: [1_704_067_200_000])
+            }
+        )
+        installMock(mockHTTP)
+
+        let rest = makeRest { options in options.key = "app.key:secret" }
+
+        // Test Steps
+        _ = try await awaitTime(rest)
+
+        // Assertions
+        #expect(capturedRequests.count == 1)
+        let request = capturedRequests[0]
+
+        // Should be GET request to /time
+        #expect(request.method == "GET")
+        #expect(request.url.path == "/time")
+
+        // Should have standard Ably headers
+        #expect(request.headers["X-Ably-Version"] != nil)
+        #expect(request.headers["Ably-Agent"] != nil)
+    }
+
+    // UTS: rest/unit/RSC16/no-auth-required-2
+    @Test
+    func test_RSC16_no_auth_required() async throws {
+        // Setup
+        let capturedRequests = Captured<PendingHTTPRequest>()
+
+        let mockHTTP = MockHTTPClient(
+            onConnectionAttempt: { connection in connection.respondWithSuccess() },
+            onRequest: { request in
+                capturedRequests.append(request)
+                request.respondWith(status: 200, body: [1_704_067_200_000])
+            }
+        )
+        installMock(mockHTTP)
+
+        // Client has credentials, but time() should not use them
+        let rest = makeRest { options in options.key = "app.key:secret" }
+
+        // Test Steps
+        let result = try await awaitTime(rest)
+
+        // Assertions
+        // Should succeed
+        // ASSERT result IS DateTime
+        #expect(result.timeIntervalSince1970 > 0)
+
+        // Request should not have Authorization header even though client has credentials
+        #expect(capturedRequests.count == 1)
+        let request = capturedRequests[0]
+        #expect(request.headers["Authorization"] == nil)
+    }
+
+    // UTS: rest/unit/RSC16/works-without-tls-3
+    @Test
+    func test_RSC16_works_without_tls() async throws {
+        // Setup
+        let capturedRequests = Captured<PendingHTTPRequest>()
+
+        let mockHTTP = MockHTTPClient(
+            onConnectionAttempt: { connection in connection.respondWithSuccess() },
+            onRequest: { request in
+                capturedRequests.append(request)
+                request.respondWith(status: 200, body: [1_704_067_200_000])
+            }
+        )
+        installMock(mockHTTP)
+
+        // Client with API key but using token auth to avoid RSC18 restriction
+        // on authenticated operations. time() should still work over HTTP.
+        let rest = makeRest { options in
+            options.key = "app.key:secret"
+            options.tls = false
+            options.useTokenAuth = true
+        }
+
+        // Test Steps
+        let result = try await awaitTime(rest)
+
+        // Assertions
+        // Should succeed without sending authentication over HTTP
+        // ASSERT result IS DateTime
+        #expect(result.timeIntervalSince1970 > 0)
+
+        // Request should use HTTP (not HTTPS)
+        #expect(capturedRequests.count == 1)
+        let request = capturedRequests[0]
+        #expect(request.url.scheme == "http")
+
+        // Request should not have Authorization header
+        #expect(request.headers["Authorization"] == nil)
+    }
+
+    // UTS: rest/unit/RSC16/error-propagated-4
+    @Test
+    func test_RSC16_error_propagated() async throws {
+        // Setup
+        let mockHTTP = MockHTTPClient(
+            onConnectionAttempt: { connection in connection.respondWithSuccess() },
+            onRequest: { request in
+                request.respondWith(status: 500, body: [
+                    "error": [
+                        "message": "Internal server error",
+                        "code": 50000,
+                        "statusCode": 500,
+                    ],
+                ])
+            }
+        )
+        installMock(mockHTTP)
+
+        let rest = makeRest { options in options.key = "app.key:secret" }
+
+        // Test Steps
+        // AWAIT client.time() FAILS WITH error
+        let error = try await awaitTimeError(rest)
+        #expect(error.statusCode == 500)
+        #expect(error.code == 50000)
+    }
+}
+
+// MARK: - time() continuation helpers
+
+extension TimeTests {
+    /// Bridges the completion-handler `time:` API (UTS `AWAIT client.time()`, success path).
+    func awaitTime(_ rest: ARTRest, sourceLocation: SourceLocation = #_sourceLocation) async throws -> Date {
+        let date: Date? = await withCheckedContinuation { continuation in
+            rest.time { date, error in
+                if let error {
+                    Issue.record("time() failed unexpectedly: \(error)", sourceLocation: sourceLocation)
+                    continuation.resume(returning: nil)
+                    return
+                }
+                continuation.resume(returning: date)
+            }
+        }
+        return try #require(date, "time() returned no date", sourceLocation: sourceLocation)
+    }
+
+    /// Bridges the completion-handler `time:` API (UTS `AWAIT client.time() FAILS WITH error`).
+    func awaitTimeError(_ rest: ARTRest, sourceLocation: SourceLocation = #_sourceLocation) async throws -> ARTErrorInfo {
+        let error: ARTErrorInfo? = await withCheckedContinuation { continuation in
+            rest.time { date, error in
+                if let error {
+                    continuation.resume(returning: error as? ARTErrorInfo ?? ARTErrorInfo.create(from: error))
+                    return
+                }
+                Issue.record("time() succeeded unexpectedly with date \(String(describing: date))", sourceLocation: sourceLocation)
+                continuation.resume(returning: nil)
+            }
+        }
+        return try #require(error, "time() returned no error", sourceLocation: sourceLocation)
+    }
+}

--- a/Test/UTS/deviations.md
+++ b/Test/UTS/deviations.md
@@ -1,0 +1,27 @@
+# UTS Deviations (ably-cocoa)
+
+This file records gaps found while running UTS-derived tests against ably-cocoa, per
+`uts/docs/writing-derived-tests.md`. Deviation tests assert the **spec-correct** behaviour and are
+gated behind the `RUN_DEVIATIONS` environment variable so normal runs stay green:
+
+```swift
+@Test(.enabled(if: ProcessInfo.processInfo.environment["RUN_DEVIATIONS"] != nil))
+```
+
+Reproduce a single deviation with:
+
+```bash
+RUN_DEVIATIONS=1 swift test --filter UTS.<TestClass>/<testMethod>
+```
+
+## Failing Tests (SDK non-compliance, spec-correct test skipped)
+
+_None recorded yet._
+
+## Adapted Tests (assert actual SDK behaviour, deviation documented)
+
+_None recorded yet._
+
+## Mock Infrastructure Limitations
+
+_None recorded yet._


### PR DESCRIPTION
## Summary

Second of two PRs split out from the original combined PR #2210. **Stacked on top of #2210** (base branch `AIT-846-mock-for-time`) — review/merge that one first.

This PR adds the **Universal Test Suite (UTS) groundwork**: the `Test/UTS` target (harness + mocks + the first translated example tests) and the `/uts-to-swift` translation skill. It builds on the `ARTTimeProvider` abstraction from #2210 to drive deterministic time in tests.

### Contents
- **Harness** (`Test/UTS/Harness/`): `UTSTestCase` base, `MockWebSocket`/`MockWebSocketProvider`, `MockHTTPClient`, `MockTimeProvider`, `NoOpReachability`, `CapturingLog`, `Captured<T>`, Sendable `ProtocolMessage` builders.
- **Tests** (`Test/UTS/Tests/`): mirror the spec's `uts/` layout — `realtime/unit/ConnectionRecoveryTests.swift`, `rest/unit/TimeTests.swift`.
- **Skill** (`.claude/skills/uts-to-swift/`): translates a UTS pseudocode spec into Swift tests.
- A few small SDK test-injection seams on `ARTTestClientOptions` (`reachabilityClass`, `httpExecutor`).

Builds: SDK + tests ✓ · `swift test --filter UTS` 11/11 ✓.

### Review
Addresses the comments from review [4485155284](https://github.com/ably/ably-cocoa/pull/2210#pullrequestreview-4485155284); per-comment commit links are posted as replies on #2210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Universal Test Suite (UTS) framework with deterministic testing capabilities via mock network and controllable timers.

* **Tests**
  * Added UTS test suites for REST and Realtime functionality.

* **Documentation**
  * Added UTS setup guides and testing infrastructure documentation.

* **Chores**
  * Configured build system and Swift package for UTS test target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->