### PR TITLE
Remove `logExceptionReportingUrl` client option

### DIFF
--- a/Source/ARTClientOptions.m
+++ b/Source/ARTClientOptions.m
@@ -56,7 +56,6 @@ NSString *ARTDefaultEnvironment = nil;
     _httpMaxRetryCount = 3;
     _fallbackHosts = nil;
     _fallbackHostsUseDefault = false;
-    _logExceptionReportingUrl = @"https://765e1fcaba404d7598d2fd5a2a43c4f0:8d469b2b0fb34c01a12ae217931c4aed@errors.ably.io/3";
     _dispatchQueue = dispatch_get_main_queue();
     _internalDispatchQueue = dispatch_queue_create("io.ably.main", DISPATCH_QUEUE_SERIAL);
     _pushFullWait = false;
@@ -145,7 +144,6 @@ NSString *ARTDefaultEnvironment = nil;
 #pragma clang diagnostic pop
 
     options.httpRequestTimeout = self.httpRequestTimeout;
-    options.logExceptionReportingUrl = self.logExceptionReportingUrl;
     options.dispatchQueue = self.dispatchQueue;
     options.internalDispatchQueue = self.internalDispatchQueue;
     options.pushFullWait = self.pushFullWait;

--- a/Source/include/Ably/ARTClientOptions.h
+++ b/Source/include/Ably/ARTClientOptions.h
@@ -148,11 +148,6 @@ extern const ARTPluginName ARTPluginNameLiveObjects;
 @property (nonatomic) BOOL fallbackHostsUseDefault DEPRECATED_MSG_ATTRIBUTE("Future library releases will ignore any supplied value.");
 
 /**
- * DEPRECATED: this property is deprecated and will be removed in a future version. Defaults to a string value for an Ably error reporting DSN (Data Source Name), which is typically a URL in the format `https://[KEY]:[SECRET]@errors.ably.io/[ID]`. When set to `nil` exception reporting is disabled.
- */
-@property (readwrite, nonatomic, nullable) NSString *logExceptionReportingUrl;
-
-/**
  The queue to which all calls to user-provided callbacks will be dispatched
  asynchronously. It will be used as target queue for an internal, serial queue.
 


### PR DESCRIPTION
Setting this option has been a no-op since 4ccc7b5. Technically we should wait until a major release to remove this option, but we've had a customer report ([Slack thread](https://ably-real-time.slack.com/archives/CURL4U2FP/p1781515415287729)) that the default value has triggered an automated security check due to using the `scheme://user:password@host` URL format. I think we can just remove the option; it seems unlikely anybody was _ever_ setting it to a non-default value, and even if they were and still are, a compilation failure will make it clear to them that doing so is achieving nothing.

Resolves #2025.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the deprecated exception reporting URL configuration option from client options
  * Applications currently using this configuration setting will require updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->