### PR TITLE
Add API for registering Live Activity push-to-start token

### DIFF
--- a/Source/ARTLocalDevice.m
+++ b/Source/ARTLocalDevice.m
@@ -37,6 +37,7 @@ NSString *const ARTClientIdKey = @"ARTClientId";
 
 NSString *const ARTAPNSDeviceDefaultTokenType = @"default";
 NSString *const ARTAPNSDeviceLocationTokenType = @"location";
+NSString *const ARTAPNSDevicePushToStartTokenType = @"pushToStart";
 
 NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
     return [ARTAPNSDeviceTokenKey stringByAppendingFormat:@"-%@", tokenType ?: ARTAPNSDeviceDefaultTokenType];
@@ -106,7 +107,8 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
 
         NSArray *supportedTokenTypes = @[
             ARTAPNSDeviceDefaultTokenType,
-            ARTAPNSDeviceLocationTokenType
+            ARTAPNSDeviceLocationTokenType,
+            ARTAPNSDevicePushToStartTokenType
         ];
 
         for (NSString *tokenType in supportedTokenTypes) {
@@ -139,6 +141,7 @@ NSString* ARTAPNSDeviceTokenKeyOfType(NSString *tokenType) {
         _identityTokenDetails = nil;
         [self setAPNSDeviceToken:nil tokenType:ARTAPNSDeviceDefaultTokenType];
         [self setAPNSDeviceToken:nil tokenType:ARTAPNSDeviceLocationTokenType];
+        [self setAPNSDeviceToken:nil tokenType:ARTAPNSDevicePushToStartTokenType];
     }];
 }
 

--- a/Source/ARTPush.m
+++ b/Source/ARTPush.m
@@ -70,6 +70,10 @@
     return [ARTPushInternal didFailToRegisterForLocationNotificationsWithError:error realtime:realtime];
 }
 
+- (void)registerPushToStartToken:(NSData *)token {
+    [_internal registerPushToStartToken:token];
+}
+
 - (void)activate {
     [_internal activate];
 }
@@ -251,6 +255,10 @@
     [rest internalAsync:^(ARTRestInternal *rest) {
         [ARTPushInternal didFailToRegisterForLocationNotificationsWithError:error restInternal:rest];
     }];
+}
+
+- (void)registerPushToStartToken:(NSData *)token {
+    [_rest setAndPersistAPNSDeviceTokenData:token tokenType:ARTAPNSDevicePushToStartTokenType];
 }
 
 - (void)activate {

--- a/Source/ARTWrapperSDKProxyPush.m
+++ b/Source/ARTWrapperSDKProxyPush.m
@@ -27,6 +27,10 @@ NS_ASSUME_NONNULL_END
 
 #if TARGET_OS_IOS
 
+- (void)registerPushToStartToken:(nonnull NSData *)token {
+    [self.underlyingPush registerPushToStartToken:token];
+}
+
 - (void)activate {
     [self.underlyingPush activate];
 }

--- a/Source/PrivateHeaders/Ably/ARTLocalDevice+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTLocalDevice+Private.h
@@ -13,6 +13,7 @@ extern NSString *const ARTClientIdKey;
 
 extern NSString *const ARTAPNSDeviceDefaultTokenType;
 extern NSString *const ARTAPNSDeviceLocationTokenType;
+extern NSString *const ARTAPNSDevicePushToStartTokenType;
 
 NSString* ARTAPNSDeviceTokenKeyOfType(NSString * _Nullable tokenType);
 

--- a/Source/PrivateHeaders/Ably/ARTPush+Private.h
+++ b/Source/PrivateHeaders/Ably/ARTPush+Private.h
@@ -44,6 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)didFailToRegisterForLocationNotificationsWithError:(NSError *)error realtime:(ARTRealtime *)realtime;
 
+- (void)registerPushToStartToken:(NSData *)token;
+
 - (void)activate;
 
 - (void)deactivate;

--- a/Source/include/Ably/ARTPush.h
+++ b/Source/include/Ably/ARTPush.h
@@ -92,6 +92,16 @@ NS_ASSUME_NONNULL_BEGIN
 /// Call this method if you got an error calling `CLLocationManager.startMonitoringLocationPushes(completion:)`.
 + (void)didFailToRegisterForLocationNotificationsWithError:(NSError *)error realtime:(ARTRealtime *)realtime;
 
+// Live Activity push-to-start token
+
+/**
+ * Registers a Live Activity push-to-start token (obtained from `Activity.pushToStartTokenUpdates`) with Ably, adding it to the existing device registration. Use this when the device has already been activated (i.e. `-activate` has completed). The token is stored in `ARTLocalDevice`'s push recipient and synced to Ably.
+ * You should implement `-[ARTPushRegistererDelegate didUpdateAblyPush:]` to handle success or failure of this operation.
+ *
+ * @param token The push-to-start token data, as delivered by `Activity.pushToStartTokenUpdates`.
+ */
+- (void)registerPushToStartToken:(NSData *)token NS_SWIFT_NAME(registerPushToStartToken(_:));
+
 /**
  * Activates the device for push notifications with APNS, obtaining a unique identifier from it. Subsequently registers the device with Ably and stores the `ARTLocalDevice.identityTokenDetails` in local storage.
  * You should implement `-[ARTPushRegistererDelegate didActivateAblyPush:]` to handle success or failure of this operation.

--- a/Test/AblyTests/Tests/PushActivationStateMachineTests.swift
+++ b/Test/AblyTests/Tests/PushActivationStateMachineTests.swift
@@ -600,6 +600,38 @@ class PushActivationStateMachineTests: XCTestCase {
         try reusableTestsWrapper__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_CalledDeactivate__reusableTestsRsh3d2(testCase: .should_fire_DeregistrationFailed_event)
     }
 
+    // A push-to-start token added to an already-activated device (as done by
+    // -[ARTPush registerPushToStartToken:]) is synced to Ably via a PATCH whose
+    // recipient carries the token under the "pushToStart" apnsDeviceTokens key.
+    func test__100__Activation_state_machine__State_WaitingForNewPushDeviceDetails__on_Event_GotPushDeviceDetails__with_push_to_start_token__PATCHes_recipient() throws {
+        beforeEach__Activation_state_machine__State_WaitingForNewPushDeviceDetails()
+
+        let expectedToken = "70757368-746f-2d73-7461-7274"
+        stateMachine.rest.device.setAndPersistAPNSDeviceToken(expectedToken, tokenType: ARTAPNSDevicePushToStartTokenType)
+        defer { stateMachine.rest.device.setAndPersistAPNSDeviceToken(nil, tokenType: ARTAPNSDevicePushToStartTokenType) }
+
+        waitUntil(timeout: testTimeout) { done in
+            stateMachine.transitions = { event, _, _ in
+                if event is ARTPushActivationEventRegistrationSynced {
+                    stateMachine.transitions = nil
+                    done()
+                }
+            }
+            stateMachine.send(ARTPushActivationEventGotPushDeviceDetails())
+        }
+
+        let request = try XCTUnwrap(httpExecutor.requests.first { req in
+            req.httpMethod == "PATCH" && req.url?.path.hasPrefix("/push/deviceRegistrations/") == true
+        }, "Should have a PATCH \"/push/deviceRegistrations/{id}\" request")
+        let rawBody = try XCTUnwrap(request.httpBody, "Request should have a body")
+        let decodedBody = try XCTUnwrap(try stateMachine.rest.defaultEncoder.decode(rawBody), "Decode request body failed")
+        let body = try XCTUnwrap(decodedBody as? NSDictionary, "Request body is invalid")
+        let push = try XCTUnwrap(body.value(forKey: "push") as? [String: Any], "Body should have a push")
+        let recipient = try XCTUnwrap(push["recipient"] as? [String: Any], "push should have a recipient")
+        let apnsDeviceTokens = try XCTUnwrap(recipient["apnsDeviceTokens"] as? [String: String], "recipient should have apnsDeviceTokens")
+        XCTAssertEqual(apnsDeviceTokens["pushToStart"], expectedToken)
+    }
+
     enum TestCase_ReusableTestsTestStateWaitingForRegistrationSyncThrough {
         case on_Event_CalledActivate
         case on_Event_RegistrationSynced

--- a/Test/AblyTests/Tests/PushTests.swift
+++ b/Test/AblyTests/Tests/PushTests.swift
@@ -23,6 +23,12 @@ class PushTests: XCTestCase {
         static let tokenString = tokenData.map { String(format: "%02x", $0) }.joined()
     }
 
+    enum TestPushToStartToken {
+        static let tokenBase64 = "cHVzaC10by1zdGFydCB0b2tlbg=="
+        static let tokenData = Data(base64Encoded: tokenBase64, options: [])!
+        static let tokenString = tokenData.map { String(format: "%02x", $0) }.joined()
+    }
+
     // XCTest invokes this method before executing the first test in the test suite. We use it to ensure that the global variables are initialized at the same moment, and in the same order, as they would have been when we used the Quick testing framework.
     override class var defaultTestSuite: XCTestSuite {
         _ = rest
@@ -221,6 +227,26 @@ class PushTests: XCTestCase {
         XCTAssertNil(tryInObjC {
             ARTPush.didRegisterForRemoteNotifications(withDeviceToken: TestDeviceToken.tokenData, rest: rest)
         })
+    }
+
+    // Live Activity push-to-start token
+
+    // registerPushToStartToken stores the token under the push-to-start token type and
+    // sends a GotPushDeviceDetails event to the state machine (which, on an already-activated
+    // device, syncs the recipient to Ably via a PATCH).
+    func test__100__push_to_start__registerPushToStartToken_stores_token_and_sends_GotPushDeviceDetails() {
+        defer { rest.push.internal.activationMachine.onEvent = nil }
+        waitUntil(timeout: testTimeout) { done in
+            rest.push.internal.activationMachine.onEvent = { event, _ in
+                if event is ARTPushActivationEventGotPushDeviceDetails {
+                    done()
+                }
+            }
+            rest.push.registerPushToStartToken(TestPushToStartToken.tokenData)
+        }
+        let expectedTokenKey = "ARTAPNSDeviceToken-pushToStart" // ARTAPNSDeviceTokenKeyOfType("pushToStart")
+        expect(storage.keysWritten.keys).to(contain([expectedTokenKey]))
+        XCTAssertEqual(storage.keysWritten.at(expectedTokenKey)?.value as? String, TestPushToStartToken.tokenString)
     }
 
     // RSH8


### PR DESCRIPTION
### Changes Introduced


`registerPushToStartToken`: Allows the addition of a token to an already-activated device and syncs the updated recipient to Ably using the existing PATCH path.

### Example App

https://github.com/ttypic/liveactivity-example

### Docs

https://github.com/ably/docs/pull/3464


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for registering and syncing push-to-start tokens for Live Activities on iOS.
  * Existing device storage now recognizes this token type and restores it when available.
* **Bug Fixes**
  * Resetting push device details now clears push-to-start token state along with other APNS token types.
* **Tests**
  * Added coverage for saving, loading, and sending push-to-start tokens during device registration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->