### PR TITLE
docs: document LiveObjects versioning, distribution and test targets; fix UTS integration build on iOS/tvOS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,9 +63,86 @@ To run tests, do any of the following:
 
 The `make test_*` commands are used by CI and expect you to have a simulator device of a specific model and OS version. See [`Fastfile`](./fastlane/Fastfile) for these values. If you don't have a matching simulator, you can create one using `simctl`. For example, `xcrun simctl create "iPhone 12 (14.4)" "iPhone 12" "com.apple.CoreSimulator.SimRuntime.iOS-14-4"`.
 
+### Test targets
+
+`swift test` builds and runs every test target in the package:
+
+| Target | Path | Contents |
+| --- | --- | --- |
+| `AblyTests` | `Test/AblyTests` | Swift tests for the core SDK |
+| `AblyTestsObjC` | `Test/AblyTestsObjC` | Objective-C tests for the core SDK |
+| `UTS` | `Test/UTS` | Universal Test Suite, derived from the language-neutral specs in the [`specification`](https://github.com/ably/specification) repository. Its `objects` module links `AblyLiveObjects`, which is why the Fastlane lanes raise their deployment target — see [Supported OS versions](#supported-os-versions) |
+| `AblyLiveObjectsTests` | `LiveObjects/Tests/AblyLiveObjectsTests` | LiveObjects tests, including the ported UTS `objects` unit specs under `UTS/` |
+
+To run just one of them, filter by module name — for example `swift test --filter 'AblyLiveObjectsTests\.'`.
+
+Every one of these targets selects its files by directory: SwiftPM globs the target's `path`, and the test plans name whole targets rather than individual tests. A new test file is therefore picked up automatically, with no change to `Package.swift`, to any test plan, or to any CI workflow. Note in particular that the LiveObjects UTS ports live inside `AblyLiveObjectsTests`, so they are run by that target's CI jobs and not by the `UTS` target's.
+
+In CI:
+
+- [`integration-test.yaml`](.github/workflows/integration-test.yaml) runs the Fastlane lanes, which build the `ably-cocoa` scheme against [`Test/Ably.xctestplan`](Test/Ably.xctestplan) — `AblyTests`, `AblyTestsObjC` and `UTS`.
+- [`liveobjects.yaml`](.github/workflows/liveobjects.yaml) runs `AblyLiveObjectsTests` three ways: `swift test --filter 'AblyLiveObjectsTests\.'`, the `AblyLiveObjects` scheme via `LiveObjects/BuildTool`, and the code-coverage job. These are not equivalent — `BuildTool test-library` uses the scheme's default `AllTests` plan, whereas the coverage job passes `-testPlan UnitTests`, which skips anything tagged `.integration`.
+- [`check-spm.yaml`](.github/workflows/check-spm.yaml) only builds; it runs no tests.
+
 ## Plugins
 
 ably-cocoa allows users to pass in Ably-authored plugins via the `ARTClientOptions.plugins` property. These plugins extend the functionality of the SDK. For more information on the implementation of the plugins mechanism, see [`Docs/plugins.md`](Docs/plugins.md).
+
+## LiveObjects
+
+The LiveObjects plugin lives in [`LiveObjects/`](LiveObjects) and is vended as this package's `AblyLiveObjects` product. It has its own [`CONTRIBUTING.md`](LiveObjects/CONTRIBUTING.md) covering setup, tests, linting and coding guidelines; read that before working on plugin code.
+
+Two things about the plugin affect the repository as a whole, and so are documented here rather than there.
+
+### Supported OS versions
+
+The package's declared platform floor in [`Package.swift`](Package.swift) is that of the core SDK: macOS 10.11, iOS 9, tvOS 10. LiveObjects requires **macOS 11, iOS 14, tvOS 14** — the versions mandated by [ADR-114](https://ably.atlassian.net/wiki/spaces/ENG/pages/3199500291/ADR-114+Increase+Cocoa+SDK+minimum+supported+version+to+iOS+14) and the [RFC](https://ably.atlassian.net/wiki/spaces/SDKs/pages/2986147844/RFC+Deprecate+iOS+13+support+for+ably-cocoa) behind it, which the core SDK has not yet adopted.
+
+SwiftPM platform requirements are package-wide, so a single package hosts both floors by annotating every top-level declaration in `LiveObjects/Sources/AblyLiveObjects` with:
+
+```swift
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
+```
+
+Don't write these annotations by hand. After adding a declaration, run [`Scripts/annotate-liveobjects-availability.py`](Scripts/annotate-liveobjects-availability.py) from the repo root:
+
+```sh
+python3 Scripts/annotate-liveobjects-availability.py
+```
+
+It annotates every unannotated top-level declaration under `LiveObjects/Sources/AblyLiveObjects` (pass another directory as its sole argument to override that), and is idempotent — running it on an already-annotated tree changes nothing.
+
+CI enforces this two ways: it runs the script and fails on a non-empty diff, which covers all top-level declarations; and it separately builds the target with `-require-explicit-availability=error`, which covers the public ones.
+
+Test code cannot use the same mechanism, because swift-testing's `@Suite` macro rejects types marked `@available`. Instead, any test build that links `AblyLiveObjects` raises its own deployment target to the plugin's floor. Two places do this today, both by passing `IPHONEOS_DEPLOYMENT_TARGET=14.0` and `TVOS_DEPLOYMENT_TARGET=14.0` to `xcodebuild`:
+
+- `LiveObjects/BuildTool` (`testDeploymentTargetOverrides`), for the invocations that build and run `AblyLiveObjectsTests`.
+- [`fastlane/Fastfile`](fastlane/Fastfile), in the `xcargs` shared by the integration-test lanes, because the `UTS` target links `AblyLiveObjects` too. Without it the harness fails on the iOS and tvOS simulators with errors of the form `'…' is only available in iOS 14.0 or newer`.
+
+Neither overrides macOS: xcodebuild raises the macOS test bundle's floor well above the package's of its own accord, and the test code relies on that. Both affect the test build only — the package's declared platform floor and the shipped artifacts are unchanged.
+
+If you add another `xcodebuild`-based path that compiles a test target linking `AblyLiveObjects`, it will need the same override. Test code that needs a newer OS than the plugin's floor must still carry its own `@available` — for example `Subscriber.swift`, whose parameter packs require iOS/tvOS 17, along with every test that uses it.
+
+### Distribution
+
+`AblyLiveObjects` is available **via Swift Package Manager only**. CocoaPods and Carthage consumers receive the core SDK alone, so a release tag does not deliver the same set of products to every channel:
+
+| Channel | `Ably` | `AblyLiveObjects` |
+| --- | --- | --- |
+| Swift Package Manager | yes | yes |
+| CocoaPods | yes | no |
+| Carthage | yes | no |
+
+This is a deliberate decision rather than an omission. Four separate things would each have to change to lift it:
+
+- [`Ably.podspec`](Ably.podspec)'s `source_files` covers `Source/` only, so neither `LiveObjects/` nor `_AblyPluginSupportPrivate/` ships in the pod; and `Ably.xcodeproj`, which Carthage builds, contains no LiveObjects or plugin-support targets.
+- `ABLY_SUPPORTS_PLUGINS` is defined only in `Package.swift`. Without it the plugin hook points — `ARTClientOptions.plugins` and the plumbing in `ARTRealtimeChannel.m`, `ARTRealtime.m` and `ARTJsonLikeEncoder.m` — are compiled out. It is a compile-time define on the core target, so enabling it would enable it for every CocoaPods and Carthage consumer, in a configuration that has never been built or tested.
+- `_AblyPluginSupportPrivate` is a target but not a product, so SPM structurally prevents an external consumer from depending on it. Neither CocoaPods nor Carthage has an equivalent to that distinction: any module the plugin can import is a module the consumer can import. Private spec repositories don't help — they restrict who may fetch an artifact, not what is importable once fetched, and a public `Ably` pod cannot depend on a privately hosted one without breaking `pod install` for everyone.
+- The podspec declares iOS/tvOS 10, macOS 10.12 and Swift 5.0, whereas LiveObjects needs the floors above and the Swift 6 language mode.
+
+Note that OS version requirements are *not* among these reasons: per-declaration `@available` lets one package host components with different floors, which is why the plugin no longer needs a repository of its own (see [`Docs/plugins.md`](Docs/plugins.md) on how this supersedes ADR-128).
+
+Revisit this if a customer on CocoaPods asks for LiveObjects. CocoaPods would be the only candidate — its file lists are globs, whereas `Ably.xcodeproj` enumerates every file individually and is maintained by hand, which would make Carthage support a permanent per-file cost.
 
 ## Coding standards
 
@@ -97,10 +174,22 @@ make lint
 
 ## Release Process
 
+### Versioning
+
+The repository has a single version number, applied to everything it publishes. Since the LiveObjects plugin moved into this repository it no longer has a version of its own: the standalone [ably-liveobjects-swift-plugin](https://github.com/ably/ably-liveobjects-swift-plugin) package stopped at 0.4.0, and the first release of `AblyLiveObjects` from here carries this repository's next version number. There is no 0.x line to continue, and the plugin's [historical changelog](LiveObjects/CHANGELOG.md) is kept only for reference.
+
+Because a shared version number implies more than it delivers, two things are worth stating explicitly in release notes:
+
+* **A tag does not mean the same thing on every channel.** CocoaPods and Carthage consumers receive only the `Ably` product; see [Distribution](#distribution). A release whose only change is to LiveObjects is a no-op for them, and the changelog entry should say so.
+* **`AblyLiveObjects` is exempt from semantic versioning.** It is experimental: breaking changes to its API may be made in minor or patch releases without a major version bump, and the repository's semver guarantees apply to the `Ably` product only. Repeat this in the changelog entry of any release that changes the LiveObjects API.
+
+Minor versions are not bumped ahead of 2.0.0; use `make bump_patch` unless the `Ably` product's public API has changed. Standard semantic versioning begins at 2.0.0.
+
+### Steps
+
 For each release, the following needs to be done:
 
-* Confirm that none of our `Package.swift` dependencies are specified using a fixed `.revision`.
-    * The dependency that is most likely to be using a fixed revision is [ably-cocoa-plugin-support](https://github.com/ably/ably-cocoa-plugin-support); make a new release of that library if needed.
+* Confirm that none of our `Package.swift` dependencies are specified using a fixed `.revision`. (The plugin-support library used to be the likeliest offender here; it is now the in-repo `_AblyPluginSupportPrivate` target rather than an external dependency, so it no longer needs its own release.)
 * Create a new branch `release/x.x.x` (where `x.x.x` is the new version number) from the `main` branch
 * Run `make bump_[major|minor|patch]` to bump the new version number. This will create a Git commit, push it to origin: `git push -u origin release/x.x.x`
 * Go to [Github releases](https://github.com/ably/ably-cocoa/releases) and press the `Draft a new release` button. Choose your new branch as a target
@@ -110,10 +199,11 @@ For each release, the following needs to be done:
 * Commit these changes and push to the origin `git add CHANGELOG.md && git commit -m "Update change log." && git push -u origin release/x.x.x`
 * Make a pull request against `main` and await approval of reviewer(s)
 * Once approved and/or any additional commits have been added, merge the PR (f you do this from Github's web interface then use the "Rebase and merge" option)
-* After merging the PR, wait for all CI jobs for `main` to pass.
+* After merging the PR, wait for all CI jobs for `main` to pass
 * Publish your drafted release:
     * refer to previous releases for release notes format
     * attach to the release the prebuilt framework file (`Ably.framework.zip`) generated by Carthage – you can find this file in the `carthage-built-framework` artifact uploaded by the `check-pod` CI workflow
 * Checkout `main` locally, pulling in changes using `git checkout main && git pull`. Make sure the new tag you need was created on publish
-* Release an update for CocoaPods using `pod trunk push Ably.podspec --allow-warnings`. Details on this command, as well as instructions for adding other contributors as maintainers, are at [Getting setup with Trunk](https://guides.cocoapods.org/making/getting-setup-with-trunk.html) in the [CocoaPods Guides](https://guides.cocoapods.org/)
+* Release an update for CocoaPods using `pod trunk push Ably.podspec --allow-warnings`. Details on this command, as well as instructions for adding other contributors as maintainers, are at [Getting setup with Trunk](https://guides.cocoapods.org/making/getting-setup-with-trunk.html) in the [CocoaPods Guides](https://guides.cocoapods.org/). This publishes the `Ably` product only — there is no LiveObjects pod
 * Test the integration of the library in a Xcode project using Carthage and CocoaPods using the [installation guide](https://github.com/ably/ably-cocoa#installation-guide)
+* Test that Swift Package Manager resolves the new tag, selecting both the `Ably` and `AblyLiveObjects` products

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,17 +71,19 @@ The `make test_*` commands are used by CI and expect you to have a simulator dev
 | --- | --- | --- |
 | `AblyTests` | `Test/AblyTests` | Swift tests for the core SDK |
 | `AblyTestsObjC` | `Test/AblyTestsObjC` | Objective-C tests for the core SDK |
-| `UTS` | `Test/UTS` | Universal Test Suite, derived from the language-neutral specs in the [`specification`](https://github.com/ably/specification) repository. Its `objects` module links `AblyLiveObjects`, which is why the Fastlane lanes raise their deployment target — see [Supported OS versions](#supported-os-versions) |
-| `AblyLiveObjectsTests` | `LiveObjects/Tests/AblyLiveObjectsTests` | LiveObjects tests, including the ported UTS `objects` unit specs under `UTS/` |
+| `UTS` | `Test/UTS` | Universal Test Suite, derived from the language-neutral specs in the [`specification`](https://github.com/ably/specification) repository — including the ported LiveObjects `objects` unit specs under `unit/objects/`. Its `objects` suites link `AblyLiveObjects`, which is why the Fastlane lanes raise their deployment target — see [Supported OS versions](#supported-os-versions) |
+| `AblyLiveObjectsTests` | `LiveObjects/Tests/AblyLiveObjectsTests` | LiveObjects native unit and integration tests |
 
 To run just one of them, filter by module name — for example `swift test --filter 'AblyLiveObjectsTests\.'`.
 
-Every one of these targets selects its files by directory: SwiftPM globs the target's `path`, and the test plans name whole targets rather than individual tests. A new test file is therefore picked up automatically, with no change to `Package.swift`, to any test plan, or to any CI workflow. Note in particular that the LiveObjects UTS ports live inside `AblyLiveObjectsTests`, so they are run by that target's CI jobs and not by the `UTS` target's.
+Every one of these targets selects its files by directory: SwiftPM globs the target's `path`, and the test plans name whole targets rather than individual tests. A new test file is therefore picked up automatically, with no change to `Package.swift`, to any test plan, or to any CI workflow. Note in particular that the ported LiveObjects `objects` UTS unit specs live inside the `UTS` target (under `Test/UTS/unit/objects/`), alongside the rest of the Universal Test Suite, so they run as part of that target rather than `AblyLiveObjectsTests`.
+
+Both `AblyLiveObjectsTests` and the `objects` UTS suites also depend on a shared test-support target, `AblyLiveObjectsTesting` (`Test/AblyLiveObjectsTesting`), imported with `@testable` for internal-access test helpers and mocks. It is a regular (non-test) target, so it is compiled but never run on its own — which is why it is not listed above.
 
 In CI:
 
 - [`integration-test.yaml`](.github/workflows/integration-test.yaml) runs the Fastlane lanes, which build the `ably-cocoa` scheme against [`Test/Ably.xctestplan`](Test/Ably.xctestplan) — `AblyTests`, `AblyTestsObjC` and `UTS`.
-- [`liveobjects.yaml`](.github/workflows/liveobjects.yaml) runs `AblyLiveObjectsTests` three ways: `swift test --filter 'AblyLiveObjectsTests\.'`, the `AblyLiveObjects` scheme via `LiveObjects/BuildTool`, and the code-coverage job. These are not equivalent — `BuildTool test-library` uses the scheme's default `AllTests` plan, whereas the coverage job passes `-testPlan UnitTests`, which skips anything tagged `.integration`.
+- [`liveobjects.yaml`](.github/workflows/liveobjects.yaml) runs `AblyLiveObjectsTests` three ways: `swift test --filter 'AblyLiveObjectsTests\.'`, the `AblyLiveObjects` scheme via `LiveObjects/BuildTool`, and the code-coverage job. These are not equivalent — `BuildTool test-library` uses the scheme's default `AllTests` plan, whereas the coverage job passes `-testPlan UnitTests`, which skips anything tagged `.integration`. It also runs the `UTS` target on macOS (`swift test --filter UTS`), which is where the ported LiveObjects `objects` unit specs now live.
 - [`check-spm.yaml`](.github/workflows/check-spm.yaml) only builds; it runs no tests.
 
 ## Plugins

--- a/LiveObjects/CONTRIBUTING.md
+++ b/LiveObjects/CONTRIBUTING.md
@@ -151,4 +151,4 @@ Some of our integration tests require access to ably-cocoa internals that are no
 
 The plugin is released as part of ably-cocoa; see ably-cocoa's [CONTRIBUTING.md](../CONTRIBUTING.md) for the release process, and its [Versioning](../CONTRIBUTING.md#versioning) and [Distribution](../CONTRIBUTING.md#distribution) sections for what a release tag means for this plugin in particular. In short: the plugin shares ably-cocoa's version number, is published via Swift Package Manager only, and is exempt from the repository's semantic versioning guarantees while it remains experimental.
 
-(This plugin previously had its own, independent releases in the [ably-liveobjects-swift-plugin](https://github.com/ably/ably-liveobjects-swift-plugin) repository; those releases remain on that repository's releases page.)
+(This plugin previously had its own, independent releases in the [ably-liveobjects-swift-plugin](https://github.com/ably/ably-liveobjects-swift-plugin/releases) repository; those releases remain on that repository's releases page.)

--- a/LiveObjects/CONTRIBUTING.md
+++ b/LiveObjects/CONTRIBUTING.md
@@ -149,4 +149,6 @@ Some of our integration tests require access to ably-cocoa internals that are no
 
 ## Release process
 
-The plugin is released as part of ably-cocoa; see ably-cocoa's [CONTRIBUTING.md](../CONTRIBUTING.md) for the release process. (This plugin was previously released independently from the ably-liveobjects-swift-plugin repository; its historical releases remain on that repository's releases page.)
+The plugin is released as part of ably-cocoa; see ably-cocoa's [CONTRIBUTING.md](../CONTRIBUTING.md) for the release process, and its [Versioning](../CONTRIBUTING.md#versioning) and [Distribution](../CONTRIBUTING.md#distribution) sections for what a release tag means for this plugin in particular. In short: the plugin shares ably-cocoa's version number, is published via Swift Package Manager only, and is exempt from the repository's semantic versioning guarantees while it remains experimental.
+
+(This plugin previously had its own, independent releases in the [ably-liveobjects-swift-plugin](https://github.com/ably/ably-liveobjects-swift-plugin) repository; those releases remain on that repository's releases page.)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,7 +13,12 @@ class LaneConfig < Struct.new(:name, :devices)
       scheme: "ably-cocoa",
       derived_data_path: "derived_data",
       test_without_building: false,
-      xcargs: { ABLY_ENV: ably_env, CLANG_ANALYZER_OUTPUT: 'plist-html' },
+      # Raise the test build's deployment target so the UTS test target — which links
+      # AblyLiveObjects (requires iOS 14 / tvOS 14) — compiles. This affects the test build only,
+      # not the shipped artifacts; the package's declared platform floor stays low. Mirrors
+      # LiveObjects/BuildTool's `testDeploymentTargetOverrides`. macOS needs no override (its
+      # default test-build floor already satisfies AblyLiveObjects).
+      xcargs: { ABLY_ENV: ably_env, CLANG_ANALYZER_OUTPUT: 'plist-html', IPHONEOS_DEPLOYMENT_TARGET: '14.0', TVOS_DEPLOYMENT_TARGET: '14.0' },
       output_directory: "fastlane/test_output/sdk/#{name}"
     }
 


### PR DESCRIPTION
Supersedes #2236, which targeted `integration/liveobjects`. Rebased onto #2235.

## Summary

Documents what the LiveObjects monorepo merge changed for contributors and releasers, and lands the one CI fix needed to make that documentation true.

Three questions prompted this: how LiveObjects tests run in CI, how the plugin is versioned and released now that it shares a repository with the core SDK, and what the recommended minimum OS versions are.

Two commits:

- `docs: document LiveObjects versioning, distribution and test targets` — `CONTRIBUTING.md` and `LiveObjects/CONTRIBUTING.md` only.
- `ci: raise integration-test deployment target so UTS builds on iOS/tvOS` — `fastlane/Fastfile`, cherry-picked from `integration/liveobjects-uts-unit-helpers`.

## The CI fix

#2235 makes the `UTS` target link `AblyLiveObjects`, but the Fastlane integration build compiles the `ably-cocoa` scheme's test targets at the package's platform floor, which is far below the plugin's iOS 14 / tvOS 14. The harness's references to plugin types therefore fail with `'…' is only available in iOS 14.0 or newer`. On #2235 this shows up as:

```
check (iOS,   test_iOS26_2)   fail
check (tvOS,  test_tvOS26_2)  fail
check (macOS, test_macOS)     pass
```

macOS passing is the tell: xcodebuild raises macOS test-bundle floors of its own accord, so only iOS and tvOS need help. The fix adds `IPHONEOS_DEPLOYMENT_TARGET` and `TVOS_DEPLOYMENT_TARGET` of 14.0 to the lanes' `xcargs`, mirroring `LiveObjects/BuildTool`'s `testDeploymentTargetOverrides`. It affects the test build only — the package's declared platform floor and the shipped artifacts are unchanged.

## What's documented

**Test targets and CI.** A table of the package's four test targets and which workflow runs each. The key fact is that every target selects its files by directory — SwiftPM globs the target's `path`, and the test plans name whole targets, never individual tests — so new tests are picked up with no manifest, test-plan or workflow change. Also records that the LiveObjects UTS ports live inside `AblyLiveObjectsTests`, not the `UTS` target, and that `BuildTool test-library` uses the `AllTests` plan while the coverage job uses `UnitTests` (which skips `.integration`). That asymmetry is currently harmless but would silently diverge the moment a UTS port carries that tag.

**Supported OS versions.** macOS 11 / iOS 14 / tvOS 14 for LiveObjects against the core SDK's macOS 10.11 / iOS 9 / tvOS 10; how per-declaration `@available` lets one package host both, with the command that applies the annotations and the two independent CI checks that enforce them; and why test code can't use the same mechanism (swift-testing's `@Suite` macro rejects `@available`, so the test builds raise their own deployment target instead — both places that do so are now listed, and both now exist on this branch).

**Distribution.** `AblyLiveObjects` is SPM-only. This was already asserted in `README.md`, but nowhere recorded as a decision, so the section gives the channel/product matrix and the four independent reasons — podspec/pbxproj don't ship the sources, `ABLY_SUPPORTS_PLUGINS` is defined only in `Package.swift`, `_AblyPluginSupportPrivate` is a target-not-product with no CocoaPods/Carthage equivalent, and the podspec's Swift/OS floors are too low. It also states that OS version requirements are *not* among the reasons, since ADR-128's superseded premise makes that the natural wrong guess.

**Versioning.** One version number for everything the repository publishes; the standalone plugin's 0.4.0 line does not continue; a tag doesn't mean the same thing on every channel; `AblyLiveObjects` is exempt from semver while experimental.

**Drive-by fix.** The release checklist told releasers to check whether ably-cocoa-plugin-support needed its own release. It's been the in-repo `_AblyPluginSupportPrivate` target since `cbe4a692` and is no longer an external dependency.

## Two things needing a decision before merge

**1. The minor-version policy sentence isn't sourced.** The draft says minor versions aren't bumped ahead of 2.0.0. That comes from a Slack conversation, not from any commit, ADR or doc in the repo. Confirm or correct it.

**2. ADR-114 has a gap that this PR documents around rather than fixes.**

[ADR-114](https://ably.atlassian.net/wiki/spaces/ENG/pages/3199500291/ADR-114+Increase+Cocoa+SDK+minimum+supported+version+to+iOS+14) is the source of the iOS 14 floor, and the LiveObjects sources sit at it today via `@available`. Two problems with treating it as the authority:

- **It is iOS-only.** The ADR and its [RFC](https://ably.atlassian.net/wiki/spaces/SDKs/pages/2986147844/RFC+Deprecate+iOS+13+support+for+ably-cocoa) contain no adoption data, competitor comparison or API justification for macOS or tvOS. `.macOS(.v11)` and `.tvOS(.v14)` are same-year equivalents (all autumn 2020) paired by convention, never argued for. So there is no defensible answer to "what should the minimum macOS/tvOS version be?" — only an inherited one.

- **It was never applied to the core SDK.** All four ADR action items are still `incomplete`, and `Package.swift` remains `.macOS(.v10_11), .iOS(.v9), .tvOS(.v10)`. The one commit that raised the whole package (`176dd4a7`, "Raise minimum OS requirements — Matches Chat and LiveObjects") lives on an unmerged Swift-migration branch.

The provenance is also thinner than the ADR reference suggests. The floor reached LiveObjects by copying: the plugin's initial commit (`b38ce55f`) took it from ably-chat-swift, whose own initial commit (`646c220c`) cites Umair's guidance and ADR-114. No one has re-evaluated it for LiveObjects specifically, and the RFC itself concedes that iOS 13 is where nearly all the technical value is — Swift Concurrency, native WebSockets and `ObservableObject` all arrive in 13. The step to 14 rests mainly on `Logger`, plus the argument that breaking compatibility twice costs more than breaking it once.

This has a concrete cost today: the split floor is why `Scripts/annotate-liveobjects-availability.py` and the two test-build deployment-target overrides exist. Closing it — either by raising the package floor or by writing a successor ADR that covers all three platforms — would let all three disappear.

I've deliberately kept this out of `CONTRIBUTING.md`, since it's an org-level decision rather than contributor guidance. Raising it here so it isn't lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on test targets, CI coverage, platform availability, distribution, and release versioning.
  * Clarified LiveObjects release procedures, Swift Package Manager distribution, and experimental versioning expectations.
  * Updated historical release references and separated core SDK and LiveObjects publishing steps.

* **Tests**
  * Added Swift Package Manager product-resolution testing guidance.
  * Updated iOS and tvOS test builds to use deployment target 14.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->