### PR TITLE
Retry test provisioning requests to fix flaky CI (sandbox timeouts)

### DIFF
--- a/Examples/Tests/TestsTests/TestsTests.swift
+++ b/Examples/Tests/TestsTests/TestsTests.swift
@@ -15,9 +15,6 @@ class TestsTests: XCTestCase {
     let options: ARTClientOptions! = nil
 
     func testAblyWorks() {
-        var responseData: Data?
-
-        let postAppExpectation = self.expectation(description: "POST app to sandbox")
         let request = NSMutableURLRequest(url: URL(string: "https://sandbox-rest.ably.io:443/apps")!)
         request.httpMethod = "POST"
         request.httpBody = "{\"keys\":[{}]}".data(using: String.Encoding.utf8)
@@ -25,18 +22,46 @@ class TestsTests: XCTestCase {
             "Accept" : "application/json",
             "Content-Type" : "application/json"
         ]
-        URLSession.shared.dataTask(with: request as URLRequest) { data, _, error in
-            defer { postAppExpectation.fulfill() }
-            if let e = error {
-                XCTFail("Error setting up sandbox app: \(e)")
-                return
-            }
-            responseData = data
-        }.resume()
-        self.waitForExpectations(timeout: 10, handler: nil)
 
-        guard let key = responseData
-            .flatMap({ try? JSONSerialization.jsonObject(with: $0, options: JSONSerialization.ReadingOptions(rawValue: 0)) })
+        func postSandboxApp() throws -> Data {
+            var result: Result<Data, Error> = .failure(URLError(.timedOut))
+            let requestCompleted = DispatchSemaphore(value: 0)
+            URLSession.shared.dataTask(with: request as URLRequest) { data, _, error in
+                if let data {
+                    result = .success(data)
+                } else {
+                    result = .failure(error ?? URLError(.unknown))
+                }
+                requestCompleted.signal()
+            }.resume()
+            _ = requestCompleted.wait(timeout: .now() + 15)
+            return try result.get()
+        }
+
+        // Retries against transient network stalls on CI; safe for the non-idempotent POST because
+        // an orphaned app from a timed-out create is auto-deleted by the sandbox after a few
+        // minutes of no use. (Local copy of the package's `withProvisioningRetriesSync` — this
+        // example project cannot import the package's test targets.)
+        func withRetries<T>(_ body: () throws -> T) throws -> T {
+            for attempt in 0 ..< 4 {
+                do {
+                    return try body()
+                } catch {
+                    Thread.sleep(forTimeInterval: 0.5 * Double(1 << attempt))
+                }
+            }
+            return try body()
+        }
+
+        let responseData: Data
+        do {
+            responseData = try withRetries(postSandboxApp)
+        } catch {
+            XCTFail("Error setting up sandbox app: \(error)")
+            return
+        }
+
+        guard let key = (try? JSONSerialization.jsonObject(with: responseData, options: JSONSerialization.ReadingOptions(rawValue: 0)))
             .flatMap({ $0 as? NSDictionary })
             .flatMap({ $0["keys"] as? NSArray })
             .flatMap({ $0[0] as? NSDictionary })

--- a/Examples/Tests/TestsTests/TestsTests.swift
+++ b/Examples/Tests/TestsTests/TestsTests.swift
@@ -24,18 +24,45 @@ class TestsTests: XCTestCase {
         ]
 
         func postSandboxApp() throws -> Data {
-            var result: Result<Data, Error> = .failure(URLError(.timedOut))
+            var result: Result<Data, Error> = .failure(URLError(.unknown))
             let requestCompleted = DispatchSemaphore(value: 0)
-            URLSession.shared.dataTask(with: request as URLRequest) { data, _, error in
-                if let data {
+            URLSession.shared.dataTask(with: request as URLRequest) { data, response, error in
+                if let error {
+                    result = .failure(error)
+                } else if let data, let httpResponse = response as? HTTPURLResponse, (200 ..< 300).contains(httpResponse.statusCode) {
                     result = .success(data)
                 } else {
-                    result = .failure(error ?? URLError(.unknown))
+                    let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+                    result = .failure(NSError(domain: "TestsTests", code: status, userInfo: [
+                        NSLocalizedDescriptionKey: "POST /apps returned HTTP \(status)",
+                    ]))
                 }
                 requestCompleted.signal()
             }.resume()
-            _ = requestCompleted.wait(timeout: .now() + 15)
+            // Only read `result` when the completion has signalled — on a timeout the handler may
+            // still fire later, and reading concurrently with that write would be a data race.
+            guard requestCompleted.wait(timeout: .now() + 15) == .success else {
+                throw URLError(.timedOut)
+            }
             return try result.get()
+        }
+
+        // Parses inside the retried path so a transient malformed body engages a retry too. The
+        // body is deliberately kept out of the error: a 2xx body can contain valid API keys, and
+        // test failures land in public CI logs.
+        func provisionSandboxKey() throws -> String {
+            let responseData = try postSandboxApp()
+            guard let key = (try? JSONSerialization.jsonObject(with: responseData, options: JSONSerialization.ReadingOptions(rawValue: 0)))
+                .flatMap({ $0 as? NSDictionary })
+                .flatMap({ $0["keys"] as? NSArray })
+                .flatMap({ $0.firstObject as? NSDictionary })
+                .flatMap({ $0["keyStr"] as? NSString })
+            else {
+                throw NSError(domain: "TestsTests", code: 0, userInfo: [
+                    NSLocalizedDescriptionKey: "POST /apps returned a 2xx body with no usable keys (\(responseData.count) bytes)",
+                ])
+            }
+            return key as String
         }
 
         // Retries against transient network stalls on CI; safe for the non-idempotent POST because
@@ -53,25 +80,15 @@ class TestsTests: XCTestCase {
             return try body()
         }
 
-        let responseData: Data
+        let key: String
         do {
-            responseData = try withRetries(postSandboxApp)
+            key = try withRetries(provisionSandboxKey)
         } catch {
             XCTFail("Error setting up sandbox app: \(error)")
             return
         }
 
-        guard let key = (try? JSONSerialization.jsonObject(with: responseData, options: JSONSerialization.ReadingOptions(rawValue: 0)))
-            .flatMap({ $0 as? NSDictionary })
-            .flatMap({ $0["keys"] as? NSArray })
-            .flatMap({ $0[0] as? NSDictionary })
-            .flatMap({ $0["keyStr"] as? NSString })
-        else {
-            XCTFail("Expected key in response data, got: \(String(describing: responseData))")
-            return
-        }
-
-        let options = ARTClientOptions(key: key as String)
+        let options = ARTClientOptions(key: key)
         options.environment = "sandbox"
         let client = ARTRealtime(options: options)
 
@@ -90,7 +107,7 @@ class TestsTests: XCTestCase {
         let backgroundRealtimeExpectation = self.expectation(description: "Realtime in a Background Queue")
         var realtime: ARTRealtime! //strong reference
         URLSession.shared.dataTask(with: URL(string: "https://ably.io")!) { _,_,_  in
-            realtime = ARTRealtime(key: key as String)
+            realtime = ARTRealtime(key: key)
             realtime.channels.get("foo").attach { _ in
                 do { backgroundRealtimeExpectation.fulfill() }
             }
@@ -100,7 +117,7 @@ class TestsTests: XCTestCase {
         let backgroundRestExpectation = self.expectation(description: "Rest in a Background Queue")
         var rest: ARTRest! //strong reference
         URLSession.shared.dataTask(with: URL(string: "https://ably.io")!) { _,_,_  in
-            rest = ARTRest(key: key as String)
+            rest = ARTRest(key: key)
             rest.channels.get("foo").history { result, error in
                 do { backgroundRestExpectation.fulfill() }
             }

--- a/LiveObjects/Tests/AblyLiveObjectsTests/Helpers/Sandbox.swift
+++ b/LiveObjects/Tests/AblyLiveObjectsTests/Helpers/Sandbox.swift
@@ -1,4 +1,5 @@
 import Ably
+import AblyTesting
 import Foundation
 
 /// Provides the ``createAPIKey()`` function to create an API key for the Ably sandbox environment.
@@ -6,7 +7,7 @@ enum Sandbox {
     /// The Ably **nonprod sandbox** host (the same endpoint the UTS integration tier and ably-java
     /// use). Keys created by ``createAPIKey()`` are only valid against this environment, so clients
     /// must point `restHost`/`realtimeHost` here.
-    static let sandboxHost = "sandbox.realtime.ably-nonprod.net"
+    static let sandboxHost = SandboxEnvironment.nonprodHost
 
     private struct TestApp: Codable {
         var keys: [Key]
@@ -37,11 +38,17 @@ enum Sandbox {
         return try JSONSerialization.data(withJSONObject: dictionary["post_apps"]!)
     }
 
+    /// Retried against transient network stalls on CI (a single stalled request otherwise fails
+    /// every test awaiting the shared key). Retrying the non-idempotent POST is safe: an orphaned
+    /// app from a timed-out create is auto-deleted by the sandbox after a few minutes of no use.
     static func createAPIKey() async throws -> String {
+        try await withProvisioningRetries { try await provisionApp() }
+    }
+
+    private static func provisionApp() async throws -> String {
         var request = URLRequest(url: .init(string: "https://\(sandboxHost)/apps")!)
         request.httpMethod = "POST"
-        // Not retried (a timed-out POST may still have provisioned an app); fail fast instead of
-        // the 60s URLSession default.
+        // Fail fast instead of the 60s URLSession default.
         request.timeoutInterval = 30
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try await loadAppCreationRequestBody()

--- a/LiveObjects/Tests/AblyLiveObjectsTests/Helpers/Sandbox.swift
+++ b/LiveObjects/Tests/AblyLiveObjectsTests/Helpers/Sandbox.swift
@@ -48,8 +48,7 @@ enum Sandbox {
     private static func provisionApp() async throws -> String {
         var request = URLRequest(url: .init(string: "https://\(sandboxHost)/apps")!)
         request.httpMethod = "POST"
-        // Fail fast instead of the 60s URLSession default.
-        request.timeoutInterval = 30
+        request.timeoutInterval = SandboxEnvironment.provisioningTimeout
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try await loadAppCreationRequestBody()
 

--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,8 @@ let package = Package(
                 .target(name: "AblyLiveObjectsTesting"),
                 .target(name: "Ably"),
                 .target(name: "_AblyPluginSupportPrivate"),
+                // Shared provisioning-retry helper + nonprod sandbox host constant.
+                .byName(name: "AblyTesting"),
             ],
             path: "LiveObjects/Tests/AblyLiveObjectsTests",
             exclude: [
@@ -139,6 +141,8 @@ let package = Package(
                 // Shared LiveObjects test helpers/mocks + internal-access seams,
                 // used by the objects UTS ports.
                 .target(name: "AblyLiveObjectsTesting"),
+                // Shared provisioning-retry helper (Helpers/ProvisioningRetry.swift).
+                .byName(name: "AblyTesting"),
             ],
             path: "Test/UTS",
             exclude: [

--- a/Test/AblyTesting/Helpers/ProvisioningRetry.swift
+++ b/Test/AblyTesting/Helpers/ProvisioningRetry.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Retries `body` up to `attempts` times against transient network stalls, with exponential
+/// backoff between attempts (0.5s, 1s, 2s, …); the final attempt's error propagates. A cancelled
+/// task propagates out of the throwing sleep instead of burning the remaining retries.
+///
+/// Intended for test-setup provisioning calls (sandbox app creation, fixture ingestion, tooling
+/// downloads) where a single stalled request would otherwise fail every test sharing the result.
+/// Callers are responsible for retry safety — e.g. the non-idempotent sandbox `POST /apps` is safe
+/// because an orphaned app from a timed-out create is auto-deleted after a few minutes of no use.
+@available(macOS 10.15, iOS 13, tvOS 13, *)
+public func withProvisioningRetries<T>(attempts: Int = 5, _ body: () async throws -> T) async throws -> T {
+    precondition(attempts >= 1, "attempts must be at least 1")
+    for attempt in 0 ..< attempts - 1 {
+        do {
+            return try await body()
+        } catch {
+            try await Task.sleep(nanoseconds: UInt64(500_000_000 * (1 << attempt)))
+        }
+    }
+    return try await body()
+}
+
+/// Synchronous variant of ``withProvisioningRetries(attempts:_:)`` for the XCTest-era helpers that
+/// provision on the calling thread (sleeps the thread between attempts).
+public func withProvisioningRetriesSync<T>(attempts: Int = 5, _ body: () throws -> T) throws -> T {
+    precondition(attempts >= 1, "attempts must be at least 1")
+    for attempt in 0 ..< attempts - 1 {
+        do {
+            return try body()
+        } catch {
+            Thread.sleep(forTimeInterval: 0.5 * Double(1 << attempt))
+        }
+    }
+    return try body()
+}

--- a/Test/AblyTesting/Helpers/SandboxEnvironment.swift
+++ b/Test/AblyTesting/Helpers/SandboxEnvironment.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Shared constants for the Ably sandbox environments used by test provisioning.
 public enum SandboxEnvironment {
     /// The Ably **nonprod sandbox** host — the `nonprod:sandbox` endpoint, resolved to a hostname.
@@ -5,4 +7,9 @@ public enum SandboxEnvironment {
     /// `restHost`/`realtimeHost` here. Single source of truth for every test tree that provisions
     /// against nonprod (the UTS integration tier and the LiveObjects tests).
     public static let nonprodHost = "sandbox.realtime.ably-nonprod.net"
+
+    /// Per-request timeout for provisioning calls — fail fast instead of the 60s URLSession
+    /// default, so a single stalled attempt doesn't dominate the retry budget of
+    /// `withProvisioningRetries`.
+    public static let provisioningTimeout: TimeInterval = 30
 }

--- a/Test/AblyTesting/Helpers/SandboxEnvironment.swift
+++ b/Test/AblyTesting/Helpers/SandboxEnvironment.swift
@@ -1,0 +1,8 @@
+/// Shared constants for the Ably sandbox environments used by test provisioning.
+public enum SandboxEnvironment {
+    /// The Ably **nonprod sandbox** host — the `nonprod:sandbox` endpoint, resolved to a hostname.
+    /// Keys provisioned against it are environment-scoped, so clients must point
+    /// `restHost`/`realtimeHost` here. Single source of truth for every test tree that provisions
+    /// against nonprod (the UTS integration tier and the LiveObjects tests).
+    public static let nonprodHost = "sandbox.realtime.ably-nonprod.net"
+}

--- a/Test/AblyTests/Test Utilities/TestUtilities.swift
+++ b/Test/AblyTests/Test Utilities/TestUtilities.swift
@@ -136,9 +136,7 @@ class AblyTests {
                 "Accept" : "application/json",
                 "Content-Type" : "application/json"
             ]
-            // Fail fast instead of the 60s URLSession default, so a stalled attempt doesn't
-            // dominate the retry budget.
-            request.timeoutInterval = 30
+            request.timeoutInterval = SandboxEnvironment.provisioningTimeout
 
             func provisionApp() throws -> [String: Any] {
                 let (responseData, response) = try SynchronousHTTPClient().perform(request)

--- a/Test/AblyTests/Test Utilities/TestUtilities.swift
+++ b/Test/AblyTests/Test Utilities/TestUtilities.swift
@@ -3,6 +3,7 @@ import CommonCrypto
 import Foundation
 import XCTest
 import Nimble
+import AblyTesting
 import AblyTestingObjC
 
 import Ably.Private
@@ -136,9 +137,24 @@ class AblyTests {
                 "Content-Type" : "application/json"
             ]
 
-            let (responseData, _) = try SynchronousHTTPClient().perform(request)
+            func provisionApp() throws -> [String: Any] {
+                let (responseData, _) = try SynchronousHTTPClient().perform(request)
+                let body: [String: Any] = try JSONUtility.jsonObject(data: responseData)
+                // Validate here so an unexpected body (e.g. a sandbox error response with a
+                // 2xx status) engages the retry instead of crashing the `keys` unwrap below.
+                guard let keys = body["keys"] as? [[String: Any]], keys.first?["keyStr"] is String else {
+                    throw NSError(domain: "AblyTests", code: 0, userInfo: [
+                        NSLocalizedDescriptionKey: "POST /apps returned a body with no usable keys: \(body)",
+                    ])
+                }
+                return body
+            }
 
-            app = try JSONUtility.jsonObject(data: responseData)
+            // Retried against transient network stalls on CI (a single stalled request otherwise
+            // fails every test sharing the app). Retrying the non-idempotent POST is safe — an
+            // orphaned app from a timed-out create is auto-deleted by the sandbox after a few
+            // minutes of no use.
+            app = try withProvisioningRetriesSync { try provisionApp() }
             testApplication = app
 
             if debug {
@@ -642,7 +658,8 @@ private func getEmbeddedJWTTokenViaEchoServer(keyName: String, keySecret: String
     ]
 
     let request = NSMutableURLRequest(url: urlComponents!.url!)
-    let (responseData, _) = try SynchronousHTTPClient().perform(request)
+    // Retried against transient network stalls on CI (idempotent GET to the echo server).
+    let (responseData, _) = try withProvisioningRetriesSync { try SynchronousHTTPClient().perform(request) }
     return String(data: responseData, encoding: String.Encoding.utf8)
 }
 

--- a/Test/AblyTests/Test Utilities/TestUtilities.swift
+++ b/Test/AblyTests/Test Utilities/TestUtilities.swift
@@ -140,6 +140,11 @@ class AblyTests {
 
             func provisionApp() throws -> [String: Any] {
                 let (responseData, response) = try SynchronousHTTPClient().perform(request)
+                guard (200 ..< 300).contains(response.statusCode) else {
+                    throw NSError(domain: "AblyTests", code: response.statusCode, userInfo: [
+                        NSLocalizedDescriptionKey: "POST /apps returned HTTP \(response.statusCode)",
+                    ])
+                }
                 let body: [String: Any] = try JSONUtility.jsonObject(data: responseData)
                 // Validate here so an unexpected body (e.g. a sandbox error response with a
                 // 2xx status) engages the retry instead of crashing the `keys` unwrap below.
@@ -661,8 +666,18 @@ private func getEmbeddedJWTTokenViaEchoServer(keyName: String, keySecret: String
     ]
 
     let request = NSMutableURLRequest(url: urlComponents!.url!)
-    // Retried against transient network stalls on CI (idempotent GET to the echo server).
-    let (responseData, _) = try withProvisioningRetriesSync { try SynchronousHTTPClient().perform(request) }
+    // Retried against transient network stalls on CI (idempotent GET to the echo server). A
+    // non-2xx body must not be returned as a "JWT", so the status check lives inside the retried
+    // closure; the error deliberately omits the URL, whose query string carries the key secret.
+    let responseData = try withProvisioningRetriesSync { () throws -> Data in
+        let (data, response) = try SynchronousHTTPClient().perform(request)
+        guard (200 ..< 300).contains(response.statusCode) else {
+            throw NSError(domain: "AblyTests", code: response.statusCode, userInfo: [
+                NSLocalizedDescriptionKey: "GET /createJWT (echo server) returned HTTP \(response.statusCode)",
+            ])
+        }
+        return data
+    }
     return String(data: responseData, encoding: String.Encoding.utf8)
 }
 

--- a/Test/AblyTests/Test Utilities/TestUtilities.swift
+++ b/Test/AblyTests/Test Utilities/TestUtilities.swift
@@ -136,15 +136,20 @@ class AblyTests {
                 "Accept" : "application/json",
                 "Content-Type" : "application/json"
             ]
+            // Fail fast instead of the 60s URLSession default, so a stalled attempt doesn't
+            // dominate the retry budget.
+            request.timeoutInterval = 30
 
             func provisionApp() throws -> [String: Any] {
-                let (responseData, _) = try SynchronousHTTPClient().perform(request)
+                let (responseData, response) = try SynchronousHTTPClient().perform(request)
                 let body: [String: Any] = try JSONUtility.jsonObject(data: responseData)
                 // Validate here so an unexpected body (e.g. a sandbox error response with a
                 // 2xx status) engages the retry instead of crashing the `keys` unwrap below.
+                // The body itself stays out of the error: it can contain valid API keys, and
+                // test failures land in public CI logs.
                 guard let keys = body["keys"] as? [[String: Any]], keys.first?["keyStr"] is String else {
                     throw NSError(domain: "AblyTests", code: 0, userInfo: [
-                        NSLocalizedDescriptionKey: "POST /apps returned a body with no usable keys: \(body)",
+                        NSLocalizedDescriptionKey: "POST /apps returned HTTP \(response.statusCode) with no usable keys; body fields: \(body.keys.sorted())",
                     ])
                 }
                 return body

--- a/Test/AblyTests/Tests/RestClientStatsTests.swift
+++ b/Test/AblyTests/Tests/RestClientStatsTests.swift
@@ -16,9 +16,7 @@ private func postTestStats(_ stats: [[String: Any]], for test: Test) throws -> A
         request.httpBody = try JSONUtility.serialize(stats)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Basic \(keyBase64)", forHTTPHeaderField: "Authorization")
-        // Fail fast instead of the 60s URLSession default, so a stalled attempt doesn't dominate
-        // the retry budget.
-        request.timeoutInterval = 30
+        request.timeoutInterval = SandboxEnvironment.provisioningTimeout
 
         // `perform` only throws on transport errors; a non-2xx ingestion response would otherwise
         // count as success and skip the fresh-app retry below.

--- a/Test/AblyTests/Tests/RestClientStatsTests.swift
+++ b/Test/AblyTests/Tests/RestClientStatsTests.swift
@@ -1,23 +1,31 @@
 import Ably
+import AblyTesting
 import Foundation
 import Nimble
 import XCTest
 
 private func postTestStats(_ stats: [[String: Any]], for test: Test) throws -> ARTClientOptions {
-    let options = try AblyTests.commonAppSetup(for: test, forceNewApp: true)
+    func provisionAppAndIngestStats() throws -> ARTClientOptions {
+        let options = try AblyTests.commonAppSetup(for: test, forceNewApp: true)
 
-    let keyBase64 = encodeBase64(options.key ?? "")
+        let keyBase64 = encodeBase64(options.key ?? "")
 
-    let request = NSMutableURLRequest(url: URL(string: "\(try AblyTests.clientOptions(for: test).restUrl().absoluteString)/stats")!)
+        let request = NSMutableURLRequest(url: URL(string: "\(try AblyTests.clientOptions(for: test).restUrl().absoluteString)/stats")!)
 
-    request.httpMethod = "POST"
-    request.httpBody = try JSONUtility.serialize(stats)
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.setValue("Basic \(keyBase64)", forHTTPHeaderField: "Authorization")
+        request.httpMethod = "POST"
+        request.httpBody = try JSONUtility.serialize(stats)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Basic \(keyBase64)", forHTTPHeaderField: "Authorization")
 
-    try SynchronousHTTPClient().perform(request)
+        try SynchronousHTTPClient().perform(request)
 
-    return options
+        return options
+    }
+
+    // Retried with a fresh app per attempt: stats ingestion is not idempotent, so retrying the
+    // POST onto the same app could double-count a timed-out-but-ingested attempt and break the
+    // exact-count assertions; a fresh app starts at zero.
+    return try withProvisioningRetriesSync { try provisionAppAndIngestStats() }
 }
 
 private func queryStats(_ client: ARTRest, _ query: ARTStatsQuery, file: FileString = #file, line: UInt = #line) throws -> ARTPaginatedResult<ARTStats> {

--- a/Test/AblyTests/Tests/RestClientStatsTests.swift
+++ b/Test/AblyTests/Tests/RestClientStatsTests.swift
@@ -16,8 +16,18 @@ private func postTestStats(_ stats: [[String: Any]], for test: Test) throws -> A
         request.httpBody = try JSONUtility.serialize(stats)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Basic \(keyBase64)", forHTTPHeaderField: "Authorization")
+        // Fail fast instead of the 60s URLSession default, so a stalled attempt doesn't dominate
+        // the retry budget.
+        request.timeoutInterval = 30
 
-        try SynchronousHTTPClient().perform(request)
+        // `perform` only throws on transport errors; a non-2xx ingestion response would otherwise
+        // count as success and skip the fresh-app retry below.
+        let (_, response) = try SynchronousHTTPClient().perform(request)
+        guard (200 ..< 300).contains(response.statusCode) else {
+            throw NSError(domain: "AblyTests", code: response.statusCode, userInfo: [
+                NSLocalizedDescriptionKey: "POST /stats returned HTTP \(response.statusCode)",
+            ])
+        }
 
         return options
     }

--- a/Test/UTS/README.md
+++ b/Test/UTS/README.md
@@ -629,8 +629,9 @@ Components:
 
 Provisions a real backend app **directly** (not through the proxy, so provisioning is independent
 of any fault rules under test): fetches the canonical `test-app-setup.json` from ably-common,
-`POST`s its `post_apps` body to `https://sandbox.realtime.ably-nonprod.net/apps` (GETs are retried
-with backoff; the POST is never retried, to avoid duplicate apps), and exposes `appId`,
+`POST`s its `post_apps` body to `https://sandbox.realtime.ably-nonprod.net/apps` (both are
+retried with backoff via `AblyTesting`'s `withProvisioningRetries` — retrying the POST is safe
+because an orphaned app from a timed-out create is auto-deleted by the sandbox), and exposes `appId`,
 `defaultKey` (full-capability `appId.keyId:keySecret`), and the full `keys` list. `delete()`
 removes the app in teardown (best-effort — cleanup must never mask a test failure). Owns the single
 upstream host constant `SandboxApp.sandboxHost` — the `nonprod:sandbox` endpoint used uniformly

--- a/Test/UTS/infra/integration/SandboxApp.swift
+++ b/Test/UTS/infra/integration/SandboxApp.swift
@@ -1,3 +1,4 @@
+import AblyTesting
 import Foundation
 
 /// A test app provisioned in the Ably sandbox (`sandbox.realtime.ably-nonprod.net`).
@@ -20,7 +21,7 @@ final class SandboxApp: Sendable {
     /// realtime/objects/rest integration specs), resolved to a hostname. Realtime and REST share
     /// this single host, so point both transports at it: set `realtimeHost` and/or `restHost` from
     /// here.
-    static let sandboxHost = "sandbox.realtime.ably-nonprod.net"
+    static let sandboxHost = SandboxEnvironment.nonprodHost
 
     private static let sandboxBaseURL = URL(string: "https://\(sandboxHost)")!
 
@@ -43,24 +44,28 @@ final class SandboxApp: Sendable {
         self.keys = keys
     }
 
-    /// Provisions a fresh sandbox app and returns its id and keys.
+    /// Provisions a fresh sandbox app and returns its id and keys. Retried, including the
+    /// non-idempotent POST — an orphaned app from a timed-out create is auto-deleted by the
+    /// sandbox after a few minutes of no use.
     static func create() async throws -> SandboxApp {
         let appSpec = try await loadAppCreationJSON()
-        let request = try jsonRequest("POST", sandboxBaseURL.appendingPathComponent("apps"), body: appSpec)
-        let (data, status) = try await httpRequest(request, session: session)
-        guard (200..<300).contains(status) else {
-            throw HTTPError("Sandbox POST /apps returned \(status): \(String(decoding: data, as: UTF8.self))")
+        return try await withProvisioningRetries {
+            let request = try jsonRequest("POST", sandboxBaseURL.appendingPathComponent("apps"), body: appSpec)
+            let (data, status) = try await httpRequest(request, session: session)
+            guard (200..<300).contains(status) else {
+                throw HTTPError("Sandbox POST /apps returned \(status): \(String(decoding: data, as: UTF8.self))")
+            }
+            guard let body = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let appId = body["appId"] as? String,
+                  let keyObjects = body["keys"] as? [[String: Any]] else {
+                throw HTTPError("Sandbox POST /apps returned an unexpected body")
+            }
+            let keys = keyObjects.compactMap { $0["keyStr"] as? String }
+            guard let defaultKey = keys.first else {
+                throw HTTPError("Sandbox POST /apps returned no keys")
+            }
+            return SandboxApp(appId: appId, defaultKey: defaultKey, keys: keys)
         }
-        guard let body = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let appId = body["appId"] as? String,
-              let keyObjects = body["keys"] as? [[String: Any]] else {
-            throw HTTPError("Sandbox POST /apps returned an unexpected body")
-        }
-        let keys = keyObjects.compactMap { $0["keyStr"] as? String }
-        guard let defaultKey = keys.first else {
-            throw HTTPError("Sandbox POST /apps returned no keys")
-        }
-        return SandboxApp(appId: appId, defaultKey: defaultKey, keys: keys)
     }
 
     /// Deletes the provisioned app. Errors are ignored — best-effort cleanup must never mask a
@@ -73,30 +78,18 @@ final class SandboxApp: Sendable {
         _ = try? await httpRequest(request, session: Self.session)
     }
 
-    /// Fetches the `post_apps` body from the shared `test-app-setup.json` in ably-common.
-    /// Retried (idempotent GET only — retrying POST /apps could provision duplicate apps).
+    /// Fetches the `post_apps` body from the shared `test-app-setup.json` in ably-common. Retried.
     private static func loadAppCreationJSON() async throws -> Any {
-        var lastError: Error = HTTPError("unreachable")
-        for attempt in 0..<5 {
-            do {
-                let (data, status) = try await httpRequest(URLRequest(url: appSetupURL), session: session)
-                guard status == 200 else {
-                    throw HTTPError("GET test-app-setup.json returned \(status)")
-                }
-                guard let setup = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-                      let postApps = setup["post_apps"] else {
-                    throw HTTPError("test-app-setup.json has no post_apps key")
-                }
-                return postApps
-            } catch {
-                lastError = error
-                if attempt < 4 {
-                    // Exponential backoff between attempts: 0.5s, 1s, 2s, 4s. A cancelled task
-                    // propagates out of the throwing sleep instead of burning the remaining retries.
-                    try await Task.sleep(nanoseconds: UInt64(500_000_000 * (1 << attempt)))
-                }
+        try await withProvisioningRetries {
+            let (data, status) = try await httpRequest(URLRequest(url: appSetupURL), session: session)
+            guard status == 200 else {
+                throw HTTPError("GET test-app-setup.json returned \(status)")
             }
+            guard let setup = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let postApps = setup["post_apps"] else {
+                throw HTTPError("test-app-setup.json has no post_apps key")
+            }
+            return postApps
         }
-        throw lastError
     }
 }

--- a/Test/UTS/infra/integration/proxy/ProxyManager.swift
+++ b/Test/UTS/infra/integration/proxy/ProxyManager.swift
@@ -3,6 +3,7 @@
 // platforms this file compiles to nothing and the proxy suites are excluded by the same condition).
 #if os(macOS)
 
+import AblyTesting
 import Foundation
 import CryptoKit
 
@@ -202,12 +203,15 @@ actor ProxyManager {
     private static func downloadArchive() async throws -> Data {
         FileHandle.standardError.write(Data("Downloading uts-proxy \(proxyVersion) (\(archiveName))…\n".utf8))
         // GitHub release downloads 302-redirect to the asset CDN; URLSession follows by default.
+        // Retried (idempotent GET).
         let url = URL(string: "\(githubBase)/\(archiveName)")!
-        let (data, status) = try await httpRequest(URLRequest(url: url), session: downloadSession)
-        guard status == 200 else {
-            throw HTTPError("Failed to download uts-proxy from \(url): HTTP \(status)")
+        return try await withProvisioningRetries {
+            let (data, status) = try await httpRequest(URLRequest(url: url), session: downloadSession)
+            guard status == 200 else {
+                throw HTTPError("Failed to download uts-proxy from \(url): HTTP \(status)")
+            }
+            return data
         }
-        return data
     }
 
     private static func verifyChecksum(_ bytes: Data) throws {

--- a/Test/UTS/integration/standard/objects/helpers/ObjectsRestProvisioning.swift
+++ b/Test/UTS/integration/standard/objects/helpers/ObjectsRestProvisioning.swift
@@ -1,3 +1,4 @@
+import AblyTesting
 import Foundation
 
 /// REST fixture provisioning for the `objects` integration specs — the Swift implementation of the
@@ -30,15 +31,28 @@ func provisionObjectsViaRest(apiKey: String,
     ) ?? channelName
     let url = URL(string: "https://\(SandboxApp.sandboxHost)/channels/\(encodedChannelName)/object")!
 
+    // Ensure every operation carries an idempotency `id` so the whole batch can be retried
+    // against transient network stalls without double-applying (the server dedupes by `id`).
+    let idempotentOperations = operations.map { operation -> [String: Any] in
+        var operation = operation
+        if operation["id"] == nil {
+            operation["id"] = UUID().uuidString
+        }
+        return operation
+    }
+
     // operations: a single operation object, or an array of operation objects (batch)
-    let body: Any = operations.count == 1 ? operations[0] : operations
+    let body: Any = idempotentOperations.count == 1 ? idempotentOperations[0] : idempotentOperations
     var request = try jsonRequest("POST", url, body: body)
     let basic = Data(apiKey.utf8).base64EncodedString()
     request.setValue("Basic \(basic)", forHTTPHeaderField: "Authorization")
 
-    let (data, status) = try await httpRequest(request, session: objectsProvisioningSession)
-    guard (200..<300).contains(status) else {
-        throw HTTPError("POST /channels/\(channelName)/object returned \(status): \(String(decoding: data, as: UTF8.self))")
+    let data = try await withProvisioningRetries {
+        let (responseData, status) = try await httpRequest(request, session: objectsProvisioningSession)
+        guard (200..<300).contains(status) else {
+            throw HTTPError("POST /channels/\(channelName)/object returned \(status): \(String(decoding: responseData, as: UTF8.self))")
+        }
+        return responseData
     }
 
     // The response is a single result object or an array of them, each carrying `objectIds`.


### PR DESCRIPTION
## Motivation

The Integration Test workflow on `main` fails intermittently when a single provisioning request to the sandbox stalls (`NSURLErrorDomain -1001`), which fails **every** test sharing the provisioned app/fixture rather than one test:

- [Run 31860107399](https://github.com/ably/ably-cocoa/actions/runs/31860107399) — iOS-simulator lane, `POST /apps` timeout during shared-app setup.
- [Run 29035538851](https://github.com/ably/ably-cocoa/actions/runs/29035538851) — macOS lane, a bad `POST /apps` response crashed the whole lane at a force-unwrap in `TestUtilities` (`Fatal error: Unexpectedly found nil while unwrapping an Optional value`).

## What this does

Every provisioning-path network call in the repo now retries with exponential backoff (5 attempts: 0.5s / 1s / 2s / 4s between them; the final attempt's error propagates), via a shared helper in `AblyTesting` — `withProvisioningRetries` (async) and `withProvisioningRetriesSync` (for the XCTest-era sync helpers).

Retry safety was assessed per site:

| Site | Call | Why retrying is safe |
|---|---|---|
| Legacy `AblyTests.commonAppSetup` | `POST /apps` | An orphaned app from a timed-out create is auto-deleted by the sandbox after a few minutes of no use |
| UTS `SandboxApp.create` | `POST /apps` + `GET test-app-setup.json` | Same orphan auto-deletion; the GET is idempotent |
| LiveObjects `Sandbox.createAPIKey` | `POST /apps` (nonprod) | Same |
| Examples `TestsTests` | `POST /apps` | Same (local copy of the helper — the example project cannot import package test targets) |
| UTS `provisionObjectsViaRest` | `POST /channels/{ch}/object` | Every operation is stamped with an idempotency `id`, so the server dedupes a retried batch — no double-apply |
| `RestClientStatsTests.postTestStats` | `POST /stats` fixtures | Retried with a **fresh app per attempt**: ingestion is not idempotent and could double-count on the same app; a fresh app starts at zero |
| `TestUtilities.getEmbeddedJWTTokenViaEchoServer` | `GET` echo server | Idempotent |
| UTS `ProxyManager.downloadArchive` | `GET` uts-proxy binary | Idempotent |

Deliberately **not** retried: `ProxySession` control calls (localhost — a retry would mask genuine proxy breakage) and anything through `ARTRest`/`ARTRealtime` (the SDK's own HTTP stack is the thing under test).

Also included:

- **Crash fix**: `commonAppSetup` now validates the `POST /apps` response body, so an unexpected 2xx body throws (engaging the retry) instead of crashing the process at the `app["keys"] as!` force-unwrap — the direct cause of the macOS failure above.
- **Single source of truth for the nonprod host**: `SandboxEnvironment.nonprodHost` replaces the string duplicated between UTS `SandboxApp` and LiveObjects `Sandbox` (the legacy→nonprod migration had to touch every copy of it).
- `Examples`' `testAblyWorks` provisioning restructured into named `postSandboxApp()` / `withRetries` functions in the process.

## Testing

- `swift build --build-tests`, `make lint`, and LiveObjects `BuildTool lint` all clean.
- Against the real sandbox: `RestClientStatsTests` 13/13 (exercises the fresh-app stats retry), JWT `test__140`, `UTS.ObjectsGcTests` 2/2 (exercises `SandboxApp.create` + the id-stamped objects provisioning), LiveObjects `ObjectLifetimesTests` (exercises the converted `createAPIKey`), and the LiveObjects unit loop.
- The Examples file was validated by `swiftc -typecheck` (no iOS simulator runtime available locally); the Examples Test workflow on this PR is its full gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved sandbox and integration test reliability with automatic retries and exponential backoff for provisioning, setup, downloads, and authentication requests.
  - Added request timeouts and clearer failure reporting for unsuccessful or malformed responses.
  - Added idempotency protection for REST provisioning operations to prevent duplicate resources during retries.
  - Standardized use of the non-production sandbox environment across test suites.
  - Improved handling of transient network and service failures during test setup and data ingestion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->