### PR TITLE
Update/fix local cocoa package reference

### DIFF
--- a/LiveObjects/Example/AblyLiveObjectsExample.xcodeproj/project.pbxproj
+++ b/LiveObjects/Example/AblyLiveObjectsExample.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 			);
 			mainGroup = 21F09A932C60CAF00025AF73;
 			packageReferences = (
+				84BEEEB83035F8380074797C /* XCLocalSwiftPackageReference "../../../ably-cocoa" */,
 			);
 			productRefGroup = 21F09A9D2C60CAF00025AF73 /* Products */;
 			projectDirPath = "";
@@ -362,6 +363,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		84BEEEB83035F8380074797C /* XCLocalSwiftPackageReference "../../../ably-cocoa" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../../../ably-cocoa";
+		};
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		21971DFE2C60D89C0074B8AE /* AblyLiveObjects */ = {

--- a/LiveObjects/Example/AblyLiveObjectsExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LiveObjects/Example/AblyLiveObjectsExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "25a2803bcea663a414b9fa25e89bd6e612066e1f6babbba264f64fa2fdc9a98f",
+  "pins" : [
+    {
+      "identity" : "delta-codec-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ably/delta-codec-cocoa",
+      "state" : {
+        "revision" : "d53eec08f9443c6160d941327a6f9d8bbb93cea2",
+        "version" : "1.3.5"
+      }
+    },
+    {
+      "identity" : "msgpack-objective-c",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/rvi/msgpack-objective-C",
+      "state" : {
+        "revision" : "3e36b48e04ecd756cb927bd5f5b9bf6d45e475f9",
+        "version" : "0.4.0"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
Update/fix local cocoa package reference. Otherwise Xcode project doesn't compile after repo is cloned fresh ("AblyLiveObjects couldn't be found" build error).
Add Xcode generated Package.resolved to the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Updated the example project to use the local Ably Swift package for development and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->