### PR TITLE
[AIT-1307] Fix remaining flaky CI: runner-level retries, test race fixes, UTS harness + spec alignment

### DIFF
--- a/.claude/skills/uts-to-swift/SKILL.md
+++ b/.claude/skills/uts-to-swift/SKILL.md
@@ -870,6 +870,9 @@ This is the guarantee that no setup step, operation, or assertion was dropped �
       `setup_synced_channel(...)`) is performed via `awaitConnectionState` / `awaitChannelState` /
       `poll` (unit tier) or `awaitState` / `awaitChannelState` / `pollUntil` (integration tiers) or
       the corresponding SDK call
+- [ ] A value-assigned `poll_until` (`x = poll_until(…)`) maps to the generic value-returning
+      `pollUntil` with later assertions on the returned value — **no re-read after the poll** (the
+      rule lives in `writing-derived-tests.md`; the overloads in `infra/Utils.swift`)
 - [ ] Every `step` line — client/mock construction, `ClientOptions`, installed mocks, channel ops — is
       reflected in the test setup or body. Multi-line spec constructs split across several `step` lines;
       reconcile them as a group.
@@ -919,8 +922,13 @@ Some specs are **integration tests** — they run against the **real Ably sandbo
 
 **Shared foundation (both tiers, covered once):** `SandboxApp` provisioning and teardown via the tier's
 base test case, real (unmocked) clients, and the async `awaitState` / `awaitChannelState` / `pollUntil`
-waits — never a fixed sleep, since real network is involved (use generous 10–30s timeouts; the helpers
-default to 15s). Swift Testing has no `setUp()`/`tearDown()` and `deinit` can't `await`, so the base cases
+waits — never a fixed sleep, since real network is involved. The helpers' defaults (15s) already
+satisfy the spec's generous-timeout guidance: pass an explicit `timeout:` only when the spec itself
+states one; for steps the spec doesn't time (including plumbing the port adds, per
+`writing-derived-tests.md`), omit it. The `poll_until` form mapping (value-assigned → the generic
+value-returning `pollUntil`, bare condition → the Bool overload) is documented on the helpers
+themselves (`infra/Utils.swift` doc comments, `Test/UTS/README.md` §11.3) and its semantics in
+`writing-derived-tests.md`. Swift Testing has no `setUp()`/`tearDown()` and `deinit` can't `await`, so the base cases
 provide **scoped-resource methods** instead — each `with…` method provisions its resource, runs your body,
 and *always* tears it down, rethrowing the body's error afterwards. **Never hand-roll teardown**; wrap the
 scenario in the scopes. Only the *wiring* differs per tier; that's what the two tier subsections below

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,5 @@ gem 'jazzy'
 
 gem 'fastlane'
 
-plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
-eval_gemfile(plugins_path) if File.exist?(plugins_path)
+# A literal path (not a variable) — Dependabot rejects interpolated eval_gemfile arguments.
+eval_gemfile("fastlane/Pluginfile")

--- a/Test/AblyTests/Tests/RealtimeClientPresenceTests.swift
+++ b/Test/AblyTests/Tests/RealtimeClientPresenceTests.swift
@@ -545,8 +545,8 @@ class RealtimeClientPresenceTests: XCTestCase {
             }
         }
 
-        XCTAssertEqual(channel.internal.presence.members.count, 1)
-        XCTAssertEqual(channel.internal.presence.internalMembers.count, 1)
+        expect(channel.internal.presence.members).toEventually(haveCount(1), timeout: testTimeout)
+        expect(channel.internal.presence.internalMembers).toEventually(haveCount(1), timeout: testTimeout)
 
         channel.subscribe { _ in
             fail("Shouldn't receive any presence event")
@@ -555,14 +555,18 @@ class RealtimeClientPresenceTests: XCTestCase {
 
         waitUntil(timeout: testTimeout) { done in
             channel.once(.failed) { _ in
-                expect(channel.internal.presence.members).to(beEmpty())
-                expect(channel.internal.presence.internalMembers).to(beEmpty())
                 done()
             }
             AblyTests.queue.async {
                 channel.internal.onError(AblyTests.newErrorProtocolMessage())
             }
         }
+
+        // The map is cleared on the internal queue; the FAILED event can be delivered to the
+        // user queue before the clear lands, so assert the settled state rather than inside
+        // the state-change callback.
+        expect(channel.internal.presence.members).toEventually(beEmpty(), timeout: testTimeout)
+        expect(channel.internal.presence.internalMembers).toEventually(beEmpty(), timeout: testTimeout)
     }
 
     // RTP5a
@@ -1343,7 +1347,7 @@ class RealtimeClientPresenceTests: XCTestCase {
             }
         }
 
-        XCTAssertEqual(channel.internal.presence.members.count, 0)
+        expect(channel.internal.presence.members).toEventually(haveCount(0), timeout: testTimeout)
         waitUntil(timeout: testTimeout) { done in
             channel.presence.subscribe(.enter) { member in
                 XCTAssertEqual(member.clientId, "john")

--- a/Test/UTS/README.md
+++ b/Test/UTS/README.md
@@ -705,13 +705,14 @@ callbacks — ably-java's `AuthReauthTest` does the same).
 **The shared async helpers** both integration walkthroughs below lean on (from
 `infra/Utils.swift` — java's `infra/Utils.kt`, see §6.9). All are wall-clock and poll-based
 (never a fixed sleep); on timeout they record a Swift Testing `Issue` (and return `false`)
-rather than throwing:
+rather than throwing — though `pollUntil` re-throws an error thrown by its condition, aborting
+the poll (a thrown error is a genuine failure; "not ready yet" is signalled by returning nil):
 
 | Helper | Shape | Purpose |
 |--------|-------|---------|
 | `awaitState` | `await awaitState(client, .connected, timeout: 15)` | suspend until `connection.state == target` (or already there) |
 | `awaitChannelState` | `await awaitChannelState(channel, .attached, timeout: 15)` | same, for a channel's state |
-| `pollUntil` | `let page = await pollUntil("…") { cond ? value : nil }` or `await pollUntil("…") { condition }` | the spec's `poll_until`: the generic form returns the settled value (assert on it — a refetch can under-return); the Bool form is for latch/monotonic conditions with no page to keep |
+| `pollUntil` | `let page = await pollUntil("…") { cond ? value : nil }` or `await pollUntil("…") { condition }` | the spec's `poll_until`: the generic form returns the settled value (assert on it — a refetch can return fewer items); the Bool form is for latch/monotonic conditions with no page to keep |
 
 ### 11.4 Walkthrough: the direct-sandbox test (`ChannelHistoryTests`)
 

--- a/Test/UTS/README.md
+++ b/Test/UTS/README.md
@@ -711,7 +711,7 @@ rather than throwing:
 |--------|-------|---------|
 | `awaitState` | `await awaitState(client, .connected, timeout: 15)` | suspend until `connection.state == target` (or already there) |
 | `awaitChannelState` | `await awaitChannelState(channel, .attached, timeout: 15)` | same, for a channel's state |
-| `pollUntil` | `await pollUntil("what you wait for", timeout: 15, interval: 0.1) { condition }` | suspend until an arbitrary predicate holds — e.g. `pollUntil("re-auth") { count.count > original }` |
+| `pollUntil` | `let page = await pollUntil("…") { cond ? value : nil }` or `await pollUntil("…") { condition }` | the spec's `poll_until`: the generic form returns the settled value (assert on it — a refetch can under-return); the Bool form is for latch/monotonic conditions with no page to keep |
 
 ### 11.4 Walkthrough: the direct-sandbox test (`ChannelHistoryTests`)
 

--- a/Test/UTS/infra/Utils.swift
+++ b/Test/UTS/infra/Utils.swift
@@ -16,17 +16,22 @@ import Ably.Private
 /// same loop shape as ably-java's `Utils.pollUntil`): polls `condition` every `interval` seconds
 /// until it yields a value and returns that settled value, or records a test failure once
 /// `timeout` (wall-clock seconds) elapses. Callers assert on the returned page rather than
-/// refetching — a refetch can hit a less-replicated frontend and under-return, reintroducing the
-/// eventual-consistency race the poll just absorbed.
+/// refetching — a refetch can hit a less-replicated frontend and return fewer items than the poll
+/// just observed, reintroducing the eventual-consistency race the poll just absorbed.
+///
+/// `condition` is `rethrows`: if it throws, the poll aborts immediately and the error propagates
+/// to the caller (failing the test) — no timeout `Issue` is recorded. This matches the spec's
+/// plain `poll_until`: a thrown error is a genuine failure, whereas a not-ready state is
+/// signalled by returning nil (e.g. an under-replicated item count), not by throwing.
 @discardableResult
 func pollUntil<T>(_ description: String,
                   timeout: TimeInterval = 15,
                   interval: TimeInterval = 0.1,
                   sourceLocation: SourceLocation = #_sourceLocation,
-                  _ condition: () async -> T?) async -> T? {
+                  _ condition: () async throws -> T?) async rethrows -> T? {
     let deadline = Date().addingTimeInterval(timeout)
     while Date() < deadline, !Task.isCancelled {
-        if let value = await condition() {
+        if let value = try await condition() {
             return value
         }
         try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
@@ -44,9 +49,9 @@ func pollUntil(_ description: String,
                timeout: TimeInterval = 15,
                interval: TimeInterval = 0.1,
                sourceLocation: SourceLocation = #_sourceLocation,
-               _ condition: () async -> Bool) async -> Bool {
-    await pollUntil(description, timeout: timeout, interval: interval, sourceLocation: sourceLocation) {
-        await condition() ? true : nil
+               _ condition: () async throws -> Bool) async rethrows -> Bool {
+    try await pollUntil(description, timeout: timeout, interval: interval, sourceLocation: sourceLocation) {
+        try await condition() ? true : nil
     } != nil
 }
 

--- a/Test/UTS/infra/Utils.swift
+++ b/Test/UTS/infra/Utils.swift
@@ -12,32 +12,42 @@ import Ably.Private
 /// anti-flake rule: no fixed blind waits — poll on observable state, with a short interval
 /// between checks).
 
-/// Suspends until `condition` returns `true`, polling every `interval` seconds, or records a test
-/// failure once `timeout` (wall-clock seconds) elapses. Returns whether the condition was met.
-///
-/// The integration analogue of `UTSTestCase.poll` — e.g.
-/// `await pollUntil("auth callback re-invoked") { authCallbackCount.count > original }`.
+/// The integration tier's `poll_until` (the spec's `RETURN result IF … ELSE null` contract, the
+/// same loop shape as ably-java's `Utils.pollUntil`): polls `condition` every `interval` seconds
+/// until it yields a value and returns that settled value, or records a test failure once
+/// `timeout` (wall-clock seconds) elapses. Callers assert on the returned page rather than
+/// refetching — a refetch can hit a less-replicated frontend and under-return, reintroducing the
+/// eventual-consistency race the poll just absorbed.
+@discardableResult
+func pollUntil<T>(_ description: String,
+                  timeout: TimeInterval = 15,
+                  interval: TimeInterval = 0.1,
+                  sourceLocation: SourceLocation = #_sourceLocation,
+                  _ condition: () async -> T?) async -> T? {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline, !Task.isCancelled {
+        if let value = await condition() {
+            return value
+        }
+        try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+    }
+    Issue.record(Task.isCancelled ? "Cancelled while polling for: \(description)"
+                                  : "Timed out after \(timeout)s polling for: \(description)",
+                 sourceLocation: sourceLocation)
+    return nil
+}
+
+/// Bare-condition form of `pollUntil` (the spec's `poll_until(condition: …)` used as a statement,
+/// for latch/monotonic conditions with no page to keep).
 @discardableResult
 func pollUntil(_ description: String,
                timeout: TimeInterval = 15,
                interval: TimeInterval = 0.1,
                sourceLocation: SourceLocation = #_sourceLocation,
                _ condition: () async -> Bool) async -> Bool {
-    let deadline = Date().addingTimeInterval(timeout)
-    while !(await condition()) {
-        if Date() >= deadline {
-            Issue.record("Timed out after \(timeout)s polling for: \(description)", sourceLocation: sourceLocation)
-            return false
-        }
-        do {
-            try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
-        } catch {
-            // Task cancelled — bail out instead of spinning a hot loop until the deadline.
-            Issue.record("Cancelled while polling for: \(description)", sourceLocation: sourceLocation)
-            return false
-        }
-    }
-    return true
+    await pollUntil(description, timeout: timeout, interval: interval, sourceLocation: sourceLocation) {
+        await condition() ? true : nil
+    } != nil
 }
 
 /// Suspends until `client.connection.state == expected` (the integration tier's `AWAIT_STATE`,
@@ -45,48 +55,77 @@ func pollUntil(_ description: String,
 ///
 /// A state-change listener latches the transition (registered before the current-state check), so a
 /// transient state — e.g. `.disconnected` under the RTN15a immediate reconnect — cannot be missed.
+/// Entering FAILED while awaiting another state short-circuits with the failure reason (FAILED is
+/// terminal, so the expected state can no longer arrive; waiting out the timeout just hides the
+/// cause).
 @discardableResult
 func awaitState(_ client: ARTRealtime,
                 _ expected: ARTRealtimeConnectionState,
                 timeout: TimeInterval = 15,
                 sourceLocation: SourceLocation = #_sourceLocation) async -> Bool {
     let reached = Captured<Bool>()
+    let failedReason = Captured<String>()
     let listener = client.connection.on { change in
         if change.current == expected {
             reached.append(true)
+        } else if change.current == .failed {
+            failedReason.append(change.reason?.message ?? "no reason")
         }
     }
     defer { client.connection.off(listener) }
     if client.connection.state == expected {
         reached.append(true)
+    } else if client.connection.state == .failed {
+        failedReason.append(client.connection.errorReason?.message ?? "no reason")
     }
-    return await pollUntil("connection.state == \(ARTRealtimeConnectionStateToStr(expected))",
-                           timeout: timeout, sourceLocation: sourceLocation) {
-        reached.count > 0
+    await pollUntil("connection.state == \(ARTRealtimeConnectionStateToStr(expected))",
+                    timeout: timeout, sourceLocation: sourceLocation) {
+        reached.count > 0 || failedReason.count > 0
     }
+    if reached.count > 0 {
+        return true
+    }
+    if let reason = failedReason.first {
+        Issue.record("connection entered FAILED while awaiting \(ARTRealtimeConnectionStateToStr(expected)): \(reason)",
+                     sourceLocation: sourceLocation)
+    }
+    return false
 }
 
 /// Suspends until `channel.state == expected` (the integration tier's `AWAIT_STATE` for channels),
-/// latching the transition like `awaitState` above.
+/// latching the transition and short-circuiting on FAILED like `awaitState` above.
 @discardableResult
 func awaitChannelState(_ channel: ARTRealtimeChannel,
                        _ expected: ARTRealtimeChannelState,
                        timeout: TimeInterval = 15,
                        sourceLocation: SourceLocation = #_sourceLocation) async -> Bool {
     let reached = Captured<Bool>()
+    let failedReason = Captured<String>()
     let listener = channel.on { change in
         if change.current == expected {
             reached.append(true)
+        } else if change.current == .failed {
+            failedReason.append(change.reason?.message ?? "no reason")
         }
     }
     defer { channel.off(listener) }
     if channel.state == expected {
         reached.append(true)
+    } else if channel.state == .failed {
+        failedReason.append(channel.errorReason?.message ?? "no reason")
     }
-    return await pollUntil("channel '\(channel.name)'.state == \(ARTRealtimeChannelStateToStr(expected))",
-                           timeout: timeout, sourceLocation: sourceLocation) {
-        reached.count > 0
+    await pollUntil("channel '\(channel.name)'.state == \(ARTRealtimeChannelStateToStr(expected))",
+                    timeout: timeout, sourceLocation: sourceLocation) {
+        reached.count > 0 || failedReason.count > 0
     }
+    if reached.count > 0 {
+        return true
+    }
+    if let reason = failedReason.first {
+        Issue.record("channel '\(channel.name)' entered FAILED while awaiting \(ARTRealtimeChannelStateToStr(expected)): \(reason)",
+                     sourceLocation: sourceLocation)
+    }
+    return false
 }
 
 /// Query parameters parsed from a URL (UTS `url.query_params`) — the counterpart of ably-java's

--- a/Test/UTS/infra/integration/IntegrationTestCase.swift
+++ b/Test/UTS/infra/integration/IntegrationTestCase.swift
@@ -35,8 +35,13 @@ class IntegrationTestCase {
     func withRealtimeClient(_ options: ARTClientOptions, _ body: (ARTRealtime) async throws -> Void) async throws {
         let client = ARTRealtime(options: options)
         try await runThenCleanUp(client, body: body) { client in
-            client.close()
-            await awaitState(client, .closed, timeout: 10)
+            // Per the specs' common cleanup: only close from a closable state. close() from
+            // FAILED is a no-op (the connection is already terminal), so awaiting CLOSED there
+            // would burn the timeout and record a spurious failure after the body passed.
+            if client.connection.state != .failed {
+                client.close()
+                await awaitState(client, .closed)
+            }
         }
     }
 

--- a/Test/UTS/infra/integration/IntegrationTestCase.swift
+++ b/Test/UTS/infra/integration/IntegrationTestCase.swift
@@ -35,10 +35,12 @@ class IntegrationTestCase {
     func withRealtimeClient(_ options: ARTClientOptions, _ body: (ARTRealtime) async throws -> Void) async throws {
         let client = ARTRealtime(options: options)
         try await runThenCleanUp(client, body: body) { client in
-            // Per the specs' common cleanup: only close from a closable state. close() from
-            // FAILED is a no-op (the connection is already terminal), so awaiting CLOSED there
-            // would burn the timeout and record a spurious failure after the body passed.
-            if client.connection.state != .failed {
+            // Per the specs' common cleanup: only close from a state that can reach CLOSED.
+            // close() never transitions out of FAILED (terminal) or INITIALIZED (never
+            // connected) — see ARTRealtime `_close` — so awaiting CLOSED there would burn the
+            // timeout and record a spurious failure after the body passed.
+            let state = client.connection.state
+            if state != .failed, state != .initialized {
                 client.close()
                 await awaitState(client, .closed)
             }

--- a/Test/UTS/integration/proxy/realtime/AuthReauthTests.swift
+++ b/Test/UTS/integration/proxy/realtime/AuthReauthTests.swift
@@ -84,9 +84,10 @@ final class AuthReauthTests: ProxyTestCase {
                 // TokenRequest that the SDK still exchanges for a token (a REST round-trip through
                 // the proxy) before sending AUTH — so also wait for the AUTH frame to reach the
                 // proxy log before asserting on it.
-                guard await pollUntil("client-to-server AUTH frame recorded in the proxy log", timeout: 15, {
+                guard let clientAuthFrames = await pollUntil("client-to-server AUTH frame recorded in the proxy log", timeout: 15, interval: 0.5, {
                     let log = (try? await session.getLog()) ?? []
-                    return !self.clientToServerAuthFrames(in: log).isEmpty
+                    let frames = self.clientToServerAuthFrames(in: log)
+                    return frames.isEmpty ? nil : frames
                 }) else { return }
 
                 // Assertions
@@ -106,8 +107,7 @@ final class AuthReauthTests: ProxyTestCase {
                 #expect(nonConnectedChanges.count == 0)
 
                 // Proxy log shows the SDK sent an AUTH frame (action 17) from client to server
-                let log = try await session.getLog()
-                let clientAuthFrames = clientToServerAuthFrames(in: log)
+                // (the frames the poll above settled on — the log is append-only, so they stand)
                 #expect(clientAuthFrames.count >= 1)
 
                 // Spec note: after the SDK sends the AUTH response, the server may respond with a
@@ -116,7 +116,7 @@ final class AuthReauthTests: ProxyTestCase {
                 // key assertions are that the SDK's auth machinery was triggered (authCallback
                 // invoked, AUTH frame sent) and that the connection was not disrupted.
             }
-            // Cleanup (per spec): client.connection.close() + AWAIT_STATE closed (10s) is handled
+            // Cleanup (per spec): client.connection.close() + AWAIT_STATE closed (15s) is handled
             // by the withRealtimeClient scope; session.close() by the withProxySession scope.
         }
     }

--- a/Test/UTS/integration/standard/realtime/ChannelHistoryTests.swift
+++ b/Test/UTS/integration/standard/realtime/ChannelHistoryTests.swift
@@ -59,11 +59,12 @@ final class ChannelHistoryTests: IntegrationTestCase {
                     await awaitPublish(pubChannel, name: "event3", data: "data3")
 
                     // Retrieve history from subscriber client
-                    // Poll until all messages appear
-                    guard await pollUntil("subscriber history contains all 3 messages", timeout: 10, interval: 0.5, {
-                        await self.historyItemsQuietly(of: subChannel).count == 3
+                    // Poll until all messages appear, keeping the page the poll settled on —
+                    // a refetch could hit a less-replicated frontend and under-return.
+                    guard let historyItems = await pollUntil("subscriber history contains all 3 messages", timeout: 10, interval: 0.5, {
+                        let items = await self.historyItemsQuietly(of: subChannel)
+                        return items.count == 3 ? items : nil
                     }) else { return }
-                    let historyItems = await historyItems(of: subChannel)
 
                     // Assertions
                     try #require(historyItems.count == 3)
@@ -104,22 +105,9 @@ extension ChannelHistoryTests {
     }
 
     /// Fetches the channel's history (default query — backwards order) and returns its items,
-    /// recording an issue on error.
-    private func historyItems(of channel: ARTRealtimeChannel,
-                              sourceLocation: SourceLocation = #_sourceLocation) async -> [ARTMessage] {
-        await withCheckedContinuation { (continuation: CheckedContinuation<[ARTMessage], Never>) in
-            channel.history { result, error in
-                if let error {
-                    Issue.record("history() failed: \(error)", sourceLocation: sourceLocation)
-                }
-                continuation.resume(returning: result?.items ?? [])
-            }
-        }
-    }
-
-    /// Non-reporting variant of `historyItems` for use inside `pollUntil` predicates: a transient
-    /// `history()` error must surface as a retry — and, at worst, as the poll's own timeout issue —
-    /// not fail the test. Returns an empty list on error.
+    /// swallowing errors, for use inside `pollUntil` predicates: a transient `history()` error
+    /// must surface as a retry — and, at worst, as the poll's own timeout issue — not fail the
+    /// test. Returns an empty list on error.
     private func historyItemsQuietly(of channel: ARTRealtimeChannel) async -> [ARTMessage] {
         await withCheckedContinuation { (continuation: CheckedContinuation<[ARTMessage], Never>) in
             channel.history { result, _ in

--- a/Test/UTS/integration/standard/realtime/ChannelHistoryTests.swift
+++ b/Test/UTS/integration/standard/realtime/ChannelHistoryTests.swift
@@ -60,9 +60,9 @@ final class ChannelHistoryTests: IntegrationTestCase {
 
                     // Retrieve history from subscriber client
                     // Poll until all messages appear, keeping the page the poll settled on —
-                    // a refetch could hit a less-replicated frontend and under-return.
-                    guard let historyItems = await pollUntil("subscriber history contains all 3 messages", timeout: 10, interval: 0.5, {
-                        let items = await self.historyItemsQuietly(of: subChannel)
+                    // a refetch could hit a less-replicated frontend and return fewer items than the poll just observed.
+                    guard let historyItems = try await pollUntil("subscriber history contains all 3 messages", timeout: 10, interval: 0.5, {
+                        let items = try await self.historyItems(of: subChannel)
                         return items.count == 3 ? items : nil
                     }) else { return }
 
@@ -105,13 +105,18 @@ extension ChannelHistoryTests {
     }
 
     /// Fetches the channel's history (default query — backwards order) and returns its items,
-    /// swallowing errors, for use inside `pollUntil` predicates: a transient `history()` error
-    /// must surface as a retry — and, at worst, as the poll's own timeout issue — not fail the
-    /// test. Returns an empty list on error.
-    private func historyItemsQuietly(of channel: ARTRealtimeChannel) async -> [ARTMessage] {
-        await withCheckedContinuation { (continuation: CheckedContinuation<[ARTMessage], Never>) in
-            channel.history { result, _ in
-                continuation.resume(returning: result?.items ?? [])
+    /// propagating any `history()` error so it aborts the enclosing `pollUntil` and surfaces the
+    /// real failure — matching the plain `poll_until` reference semantics (js/java do the same).
+    /// The eventual-consistency race is an under-count, absorbed by the poll's count check, not an
+    /// error.
+    private func historyItems(of channel: ARTRealtimeChannel) async throws -> [ARTMessage] {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[ARTMessage], Error>) in
+            channel.history { result, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: result?.items ?? [])
+                }
             }
         }
     }

--- a/Test/UTS/integration/standard/realtime/ChannelHistoryTests.swift
+++ b/Test/UTS/integration/standard/realtime/ChannelHistoryTests.swift
@@ -40,6 +40,7 @@ final class ChannelHistoryTests: IntegrationTestCase {
                     publisher.connect()
                     subscriber.connect()
 
+                    // The spec times these in-body connect-awaits explicitly (WITH timeout: 10 seconds).
                     guard await awaitState(publisher, .connected, timeout: 10) else { return }
                     guard await awaitState(subscriber, .connected, timeout: 10) else { return }
 

--- a/Test/UTS/integration/standard/rest/HistoryTests.swift
+++ b/Test/UTS/integration/standard/rest/HistoryTests.swift
@@ -155,11 +155,12 @@ final class HistoryTests: IntegrationTestCase {
             await self.awaitPublish(channel, name: "late1", data: "l1")
             await self.awaitPublish(channel, name: "late2", data: "l2")
 
-            // Poll until all messages appear and retrieve with server timestamps
-            guard await pollUntil("channel history contains all 4 messages", timeout: 10, interval: 0.5, {
-                await self.historyItemsQuietly(of: channel).count == 4
+            // Poll until all messages appear, keeping the page the poll settled on — its
+            // server-assigned timestamps drive the boundary below, and a refetch could under-return.
+            guard let allMessages = await pollUntil("channel history contains all 4 messages", timeout: 10, interval: 0.5, {
+                let items = await self.historyItemsQuietly(of: channel)
+                return items.count == 4 ? items : nil
             }) else { return }
-            let allMessages = await historyItems(of: channel)
 
             // Use server-assigned timestamps to define the time boundary.
             // Client-side now() must not be used here — client and server clocks may

--- a/Test/UTS/integration/standard/rest/HistoryTests.swift
+++ b/Test/UTS/integration/standard/rest/HistoryTests.swift
@@ -35,9 +35,9 @@ final class HistoryTests: IntegrationTestCase {
             await self.awaitPublish(channel, name: "event3", data: ["key": "value"])
 
             // Poll until messages appear in history, keeping the page the poll settled on —
-            // a refetch could hit a less-replicated frontend and under-return.
-            guard let history = await pollUntil("channel history contains all 3 messages", timeout: 10, interval: 0.5, {
-                let items = await self.historyItemsQuietly(of: channel)
+            // a refetch could hit a less-replicated frontend and return fewer items than the poll just observed.
+            guard let history = try await pollUntil("channel history contains all 3 messages", timeout: 10, interval: 0.5, {
+                let items = try await self.historyItems(of: channel)
                 return items.count == 3 ? items : nil
             }) else { return }
 
@@ -78,8 +78,8 @@ final class HistoryTests: IntegrationTestCase {
             await self.awaitPublish(channel, name: "third", data: "3")
 
             // Poll until all messages appear
-            guard await pollUntil("channel history contains all 3 messages", timeout: 10, interval: 0.5, {
-                await self.historyItemsQuietly(of: channel).count == 3
+            guard try await pollUntil("channel history contains all 3 messages", timeout: 10, interval: 0.5, {
+                try await self.historyItems(of: channel).count == 3
             }) else { return }
 
             let forwardsQuery = ARTDataQuery()
@@ -113,8 +113,8 @@ final class HistoryTests: IntegrationTestCase {
             }
 
             // Poll until all messages are persisted
-            guard await pollUntil("channel history contains all 10 messages", timeout: 10, interval: 0.5, {
-                await self.historyItemsQuietly(of: channel).count == 10
+            guard try await pollUntil("channel history contains all 10 messages", timeout: 10, interval: 0.5, {
+                try await self.historyItems(of: channel).count == 10
             }) else { return }
 
             let limitQuery = ARTDataQuery()
@@ -156,9 +156,9 @@ final class HistoryTests: IntegrationTestCase {
             await self.awaitPublish(channel, name: "late2", data: "l2")
 
             // Poll until all messages appear, keeping the page the poll settled on — its
-            // server-assigned timestamps drive the boundary below, and a refetch could under-return.
-            guard let allMessages = await pollUntil("channel history contains all 4 messages", timeout: 10, interval: 0.5, {
-                let items = await self.historyItemsQuietly(of: channel)
+            // server-assigned timestamps drive the boundary below, and a refetch could return fewer items.
+            guard let allMessages = try await pollUntil("channel history contains all 4 messages", timeout: 10, interval: 0.5, {
+                let items = try await self.historyItems(of: channel)
                 return items.count == 4 ? items : nil
             }) else { return }
 
@@ -267,13 +267,17 @@ extension HistoryTests {
         }
     }
 
-    /// Non-reporting variant of `historyItems` (default query) for use inside `pollUntil`
-    /// predicates: a transient `history()` error must surface as a retry — and, at worst, as the
-    /// poll's own timeout issue — not fail the test. Returns an empty list on error.
-    private func historyItemsQuietly(of channel: ARTRestChannel) async -> [ARTMessage] {
-        await withCheckedContinuation { (continuation: CheckedContinuation<[ARTMessage], Never>) in
-            channel.history { result, _ in
-                continuation.resume(returning: result?.items ?? [])
+    /// Fetches the channel's history (default query) and returns its items, propagating any
+    /// `history()` error so it aborts the enclosing `pollUntil` and surfaces the real failure
+    /// (matching the plain `poll_until` reference semantics; js/java do the same).
+    private func historyItems(of channel: ARTRestChannel) async throws -> [ARTMessage] {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[ARTMessage], Error>) in
+            channel.history { result, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: result?.items ?? [])
+                }
             }
         }
     }

--- a/Test/UTS/integration/standard/rest/HistoryTests.swift
+++ b/Test/UTS/integration/standard/rest/HistoryTests.swift
@@ -34,11 +34,12 @@ final class HistoryTests: IntegrationTestCase {
             await self.awaitPublish(channel, name: "event2", data: "data2")
             await self.awaitPublish(channel, name: "event3", data: ["key": "value"])
 
-            // Poll until messages appear in history
-            guard await pollUntil("channel history contains all 3 messages", timeout: 10, interval: 0.5, {
-                await self.historyItemsQuietly(of: channel).count == 3
+            // Poll until messages appear in history, keeping the page the poll settled on —
+            // a refetch could hit a less-replicated frontend and under-return.
+            guard let history = await pollUntil("channel history contains all 3 messages", timeout: 10, interval: 0.5, {
+                let items = await self.historyItemsQuietly(of: channel)
+                return items.count == 3 ? items : nil
             }) else { return }
-            let history = await historyItems(of: channel)
 
             // Assertions
             try #require(history.count == 3)

--- a/Test/UTS/integration/standard/rest/PresenceTests.swift
+++ b/Test/UTS/integration/standard/rest/PresenceTests.swift
@@ -181,7 +181,7 @@ final class PresenceTests: IntegrationTestCase {
 
             try await withRealtimeClient(realtimeOptions) { realtime in
                 realtime.connect()
-                guard await awaitState(realtime, .connected, timeout: 10) else { return }
+                guard await awaitState(realtime, .connected) else { return }
                 let realtimeChannel = realtime.channels.get(channelName)
                 await self.awaitPresenceOp("presence.enter") { realtimeChannel.presence.enter("entered", callback: $0) }
                 await self.awaitPresenceOp("presence.update") { realtimeChannel.presence.update("updated", callback: $0) }
@@ -191,10 +191,11 @@ final class PresenceTests: IntegrationTestCase {
             // Poll REST history until events appear
             let restChannel = client.channels.get(channelName)
 
-            guard await pollUntil("presence history has at least 3 events", timeout: 10, interval: 0.5, {
-                await (self.presenceHistoryQuietly(restChannel.presence)?.items.count ?? 0) >= 3
+            // Keep the page the poll settled on — a refetch could under-return.
+            guard let history = await pollUntil("presence history has at least 3 events", timeout: 10, interval: 0.5, {
+                let result = await self.presenceHistoryQuietly(restChannel.presence)
+                return (result?.items.count ?? 0) >= 3 ? result : nil
             }) else { return }
-            let history = try #require(await self.presenceHistory(restChannel.presence))
 
             #expect(history.items.count >= 3)
 
@@ -219,9 +220,6 @@ final class PresenceTests: IntegrationTestCase {
 
             let channelName = "presence-history-time-\(UUID().uuidString)"
 
-            // Record time before any presence events
-            let timeBefore = Date()
-
             // Generate presence events via realtime
             let realtimeOptions = ARTClientOptions(key: app.defaultKey)
             realtimeOptions.realtimeHost = SandboxApp.sandboxHost
@@ -232,19 +230,26 @@ final class PresenceTests: IntegrationTestCase {
 
             try await withRealtimeClient(realtimeOptions) { realtime in
                 realtime.connect()
-                guard await awaitState(realtime, .connected, timeout: 10) else { return }
+                guard await awaitState(realtime, .connected) else { return }
                 let realtimeChannel = realtime.channels.get(channelName)
                 await self.awaitPresenceOp("presence.enter") { realtimeChannel.presence.enter("test", callback: $0) }
                 await self.awaitPresenceOp("presence.leave") { realtimeChannel.presence.leave(nil, callback: $0) }
             } // AWAIT realtime.close() — performed by the withRealtimeClient scope (close + await CLOSED)
 
-            let timeAfter = Date()
-
-            // Poll until events appear
+            // Poll until events appear, keeping the page the poll settled on (its server-assigned
+            // timestamps drive the query below) — a refetch could under-return.
             let restChannel = client.channels.get(channelName)
-            guard await pollUntil("presence history has at least 2 events", timeout: 10, interval: 0.5, {
-                await (self.presenceHistoryQuietly(restChannel.presence)?.items.count ?? 0) >= 2
+            guard let events = await pollUntil("presence history has at least 2 events", timeout: 10, interval: 0.5, {
+                let result = await self.presenceHistoryQuietly(restChannel.presence)
+                return (result?.items.count ?? 0) >= 2 ? result?.items : nil
             }) else { return }
+
+            // Use server-assigned timestamps to define the queried range. Client-side now() must
+            // not be used here — client and server clocks may differ, and a skewed client clock
+            // would silently exclude the events.
+            let eventTimestamps = events.compactMap(\.timestamp)
+            let timeBefore = try #require(eventTimestamps.min()).addingTimeInterval(-1)
+            let timeAfter = try #require(eventTimestamps.max()).addingTimeInterval(1)
 
             // Query with time range
             let query = ARTDataQuery()
@@ -278,7 +283,7 @@ final class PresenceTests: IntegrationTestCase {
 
             try await withRealtimeClient(realtimeOptions) { realtime in
                 realtime.connect()
-                guard await awaitState(realtime, .connected, timeout: 10) else { return }
+                guard await awaitState(realtime, .connected) else { return }
                 let realtimeChannel = realtime.channels.get(channelName)
                 await self.awaitPresenceOp("presence.enter") { realtimeChannel.presence.enter("first", callback: $0) }
                 await self.awaitPresenceOp("presence.update") { realtimeChannel.presence.update("second", callback: $0) }
@@ -330,7 +335,7 @@ final class PresenceTests: IntegrationTestCase {
 
             try await withRealtimeClient(realtimeOptions) { realtime in
                 realtime.connect()
-                guard await awaitState(realtime, .connected, timeout: 10) else { return }
+                guard await awaitState(realtime, .connected) else { return }
                 let realtimeChannel = realtime.channels.get(channelName)
                 for i in 1...5 {
                     await self.awaitPresenceOp("presence.update") { realtimeChannel.presence.update("update-\(i)", callback: $0) }
@@ -455,17 +460,17 @@ final class PresenceTests: IntegrationTestCase {
             let jsonData: [String: Any] = ["key": "value", "number": 123]
             try await withRealtimeClient(realtimeOptions) { realtime in
                 realtime.connect()
-                guard await awaitState(realtime, .connected, timeout: 10) else { return }
+                guard await awaitState(realtime, .connected) else { return }
                 let realtimeChannel = realtime.channels.get(channelName)
                 await self.awaitPresenceOp("presence.enter") { realtimeChannel.presence.enter(jsonData, callback: $0) }
             } // AWAIT realtime.close() — performed by the withRealtimeClient scope (close + await CLOSED)
 
-            // Poll and retrieve history
+            // Poll and retrieve history, keeping the page the poll settled on.
             let restChannel = client.channels.get(channelName)
-            guard await pollUntil("presence history has at least 1 event", timeout: 10, interval: 0.5, {
-                await (self.presenceHistoryQuietly(restChannel.presence)?.items.count ?? 0) >= 1
+            guard let history = await pollUntil("presence history has at least 1 event", timeout: 10, interval: 0.5, {
+                let result = await self.presenceHistoryQuietly(restChannel.presence)
+                return (result?.items.count ?? 0) >= 1 ? result : nil
             }) else { return }
-            let history = try #require(await self.presenceHistory(restChannel.presence))
 
             // ASSERT history.items[0].data IS Object/Map (the #require's cast covers it)
             let data = try #require(history.items.first?.data as? [String: Any])

--- a/Test/UTS/integration/standard/rest/PresenceTests.swift
+++ b/Test/UTS/integration/standard/rest/PresenceTests.swift
@@ -191,10 +191,10 @@ final class PresenceTests: IntegrationTestCase {
             // Poll REST history until events appear
             let restChannel = client.channels.get(channelName)
 
-            // Keep the page the poll settled on — a refetch could under-return.
-            guard let history = await pollUntil("presence history has at least 3 events", timeout: 10, interval: 0.5, {
-                let result = await self.presenceHistoryQuietly(restChannel.presence)
-                return (result?.items.count ?? 0) >= 3 ? result : nil
+            // Keep the page the poll settled on — a refetch could return fewer items.
+            guard let history = try await pollUntil("presence history has at least 3 events", timeout: 10, interval: 0.5, {
+                let result = try await self.presenceHistoryPage(restChannel.presence)
+                return result.items.count >= 3 ? result : nil
             }) else { return }
 
             #expect(history.items.count >= 3)
@@ -237,11 +237,11 @@ final class PresenceTests: IntegrationTestCase {
             } // AWAIT realtime.close() — performed by the withRealtimeClient scope (close + await CLOSED)
 
             // Poll until events appear, keeping the page the poll settled on (its server-assigned
-            // timestamps drive the query below) — a refetch could under-return.
+            // timestamps drive the query below) — a refetch could return fewer items.
             let restChannel = client.channels.get(channelName)
-            guard let events = await pollUntil("presence history has at least 2 events", timeout: 10, interval: 0.5, {
-                let result = await self.presenceHistoryQuietly(restChannel.presence)
-                return (result?.items.count ?? 0) >= 2 ? result?.items : nil
+            guard let events = try await pollUntil("presence history has at least 2 events", timeout: 10, interval: 0.5, {
+                let result = try await self.presenceHistoryPage(restChannel.presence)
+                return result.items.count >= 2 ? result.items : nil
             }) else { return }
 
             // Use server-assigned timestamps to define the queried range. Client-side now() must
@@ -292,8 +292,8 @@ final class PresenceTests: IntegrationTestCase {
 
             // Poll until events appear
             let restChannel = client.channels.get(channelName)
-            guard await pollUntil("presence history has at least 3 events", timeout: 10, interval: 0.5, {
-                await (self.presenceHistoryQuietly(restChannel.presence)?.items.count ?? 0) >= 3
+            guard try await pollUntil("presence history has at least 3 events", timeout: 10, interval: 0.5, {
+                try await self.presenceHistoryPage(restChannel.presence).items.count >= 3
             }) else { return }
 
             // Get history forwards (oldest first)
@@ -344,8 +344,8 @@ final class PresenceTests: IntegrationTestCase {
 
             // Poll until all events appear
             let restChannel = client.channels.get(channelName)
-            guard await pollUntil("presence history has at least 5 events", timeout: 10, interval: 0.5, {
-                await (self.presenceHistoryQuietly(restChannel.presence)?.items.count ?? 0) >= 5
+            guard try await pollUntil("presence history has at least 5 events", timeout: 10, interval: 0.5, {
+                try await self.presenceHistoryPage(restChannel.presence).items.count >= 5
             }) else { return }
 
             // Request with small limit
@@ -467,9 +467,9 @@ final class PresenceTests: IntegrationTestCase {
 
             // Poll and retrieve history, keeping the page the poll settled on.
             let restChannel = client.channels.get(channelName)
-            guard let history = await pollUntil("presence history has at least 1 event", timeout: 10, interval: 0.5, {
-                let result = await self.presenceHistoryQuietly(restChannel.presence)
-                return (result?.items.count ?? 0) >= 1 ? result : nil
+            guard let history = try await pollUntil("presence history has at least 1 event", timeout: 10, interval: 0.5, {
+                let result = try await self.presenceHistoryPage(restChannel.presence)
+                return result.items.count >= 1 ? result : nil
             }) else { return }
 
             // ASSERT history.items[0].data IS Object/Map (the #require's cast covers it)
@@ -619,13 +619,19 @@ extension PresenceTests {
         }
     }
 
-    /// Non-reporting variant of `presenceHistory` (default query) for use inside `pollUntil`
-    /// predicates: a transient `presence.history()` error must surface as a retry — and, at worst,
-    /// as the poll's own timeout issue — not fail the test. Returns nil on error.
-    private func presenceHistoryQuietly(_ presence: ARTRestPresence) async -> ARTPaginatedResult<ARTPresenceMessage>? {
-        await withCheckedContinuation { (continuation: CheckedContinuation<ARTPaginatedResult<ARTPresenceMessage>?, Never>) in
-            presence.history { result, _ in
-                continuation.resume(returning: result)
+    /// Fetches presence history (default query), propagating any `presence.history()` error so it
+    /// aborts the enclosing `pollUntil` and surfaces the real failure (plain `poll_until`
+    /// semantics; js/java do the same).
+    private func presenceHistoryPage(_ presence: ARTRestPresence) async throws -> ARTPaginatedResult<ARTPresenceMessage> {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<ARTPaginatedResult<ARTPresenceMessage>, Error>) in
+            presence.history { result, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let result {
+                    continuation.resume(returning: result)
+                } else {
+                    continuation.resume(throwing: HTTPError("presence.history returned no result and no error"))
+                }
             }
         }
     }

--- a/Test/UTS/integration/standard/rest/PublishTests.swift
+++ b/Test/UTS/integration/standard/rest/PublishTests.swift
@@ -108,9 +108,9 @@ final class PublishTests: IntegrationTestCase {
             }
 
             // Poll history until the message appears, keeping the page the poll settled on —
-            // a refetch could hit a less-replicated frontend and under-return.
-            guard let history = await pollUntil("channel history has at least one message", timeout: 10, interval: 0.5, {
-                let items = await self.historyItemsQuietly(of: channel)
+            // a refetch could hit a less-replicated frontend and return fewer items than the poll just observed.
+            guard let history = try await pollUntil("channel history has at least one message", timeout: 10, interval: 0.5, {
+                let items = try await self.historyItems(of: channel)
                 return items.isEmpty ? nil : items
             }) else { return }
 
@@ -274,13 +274,17 @@ extension PublishTests {
         }
     }
 
-    /// Non-reporting variant of `historyItems` for use inside `pollUntil` predicates: a transient
-    /// `history()` error must surface as a retry — and, at worst, as the poll's own timeout issue —
-    /// not fail the test. Returns an empty list on error.
-    private func historyItemsQuietly(of channel: ARTRestChannel) async -> [ARTMessage] {
-        await withCheckedContinuation { (continuation: CheckedContinuation<[ARTMessage], Never>) in
-            channel.history { result, _ in
-                continuation.resume(returning: result?.items ?? [])
+    /// Fetches the channel's history (default query) and returns its items, propagating any
+    /// `history()` error so it aborts the enclosing `pollUntil` and surfaces the real failure
+    /// (matching the plain `poll_until` reference semantics; js/java do the same).
+    private func historyItems(of channel: ARTRestChannel) async throws -> [ARTMessage] {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[ARTMessage], Error>) in
+            channel.history { result, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: result?.items ?? [])
+                }
             }
         }
     }

--- a/Test/UTS/integration/standard/rest/PublishTests.swift
+++ b/Test/UTS/integration/standard/rest/PublishTests.swift
@@ -107,11 +107,12 @@ final class PublishTests: IntegrationTestCase {
                 await self.awaitPublish(channel, message: message)
             }
 
-            // Poll history until message appears (avoid fixed wait)
-            guard await pollUntil("channel history has at least one message", timeout: 10, interval: 0.5, {
-                await self.historyItemsQuietly(of: channel).count > 0
+            // Poll history until the message appears, keeping the page the poll settled on —
+            // a refetch could hit a less-replicated frontend and under-return.
+            guard let history = await pollUntil("channel history has at least one message", timeout: 10, interval: 0.5, {
+                let items = await self.historyItemsQuietly(of: channel)
+                return items.isEmpty ? nil : items
             }) else { return }
-            let history = await historyItems(of: channel)
 
             // Verify only one message in history
             #expect(history.count == 1)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,6 +13,10 @@ class LaneConfig < Struct.new(:name, :devices)
       scheme: "ably-cocoa",
       derived_data_path: "derived_data",
       test_without_building: false,
+      # Retry only the tests that failed, in place (xcodebuild -retry-tests-on-failure).
+      # Absorbs single-occurrence environmental timeouts on the CI runners; a genuine
+      # regression still fails CI because it fails every attempt.
+      number_of_retries: 2,
       # Raise the test build's deployment target so the UTS test target — which links
       # AblyLiveObjects (requires iOS 14 / tvOS 14) — compiles. This affects the test build only,
       # not the shipped artifacts; the package's declared platform floor stays low. Mirrors


### PR DESCRIPTION
- Fixes https://ably.atlassian.net/browse/AIT-1307

## Related PR

- Companion spec PR (the UTS spec/docs changes these ports align to): ably/specification#517

## Motivation

Follow-up to #2241 (sandbox provisioning retries). With provisioning failures gone, the latest `main` Integration Test run ([32277853593](https://github.com/ably/ably-cocoa/actions/runs/32277853593)) still failed on all three lanes — each on a **different, intermittent** test:

| Lane | Failure | Class |
|---|---|---|
| macOS | UTS `test_RSP4b1` (both protocol variants) | Clock-skew flake — **second live firing** (tvOS on 08-15, macOS on 08-19): the test bracketed a server-timestamped history window with the runner's local clock |
| tvOS | `RealtimeClientPresenceTests.test__019` | Test-code race: presence-map emptiness asserted inside the `.failed` callback, racing the internal-queue map clear (the CI log shows the still-present member) |
| iOS | `AuthTests.test__002` — publish `waitUntil` > 20s | Environmental round-trip stall, same family as the earlier `test__038/039/043/044` presence timeouts |

Each class gets a fix at its own level: the environmental family gets a runner-level retry; the races get code fixes; the clock-skew flake gets a spec fix (companion PR) with the port aligned here.

## Changes

### 1. CI level
- **`fastlane/Fastfile`** — `number_of_retries: 2` on all SDK test lanes: maps to `xcodebuild -retry-tests-on-failure`, re-running **only failed tests** in place. Absorbs single-occurrence environmental stalls; a genuine regression still fails every attempt. (Parity with ably-java's Gradle test-retry plugin.)
- **`Gemfile`** — literal `eval_gemfile("fastlane/Pluginfile")`: Dependabot rejects interpolated arguments, which had every Dependabot run red.

### 2. Legacy test race fixes
- **`test__019`** — emptiness assertions moved out of the `.failed` state-change callback to `toEventually(beEmpty())` after it: the map is cleared on the internal queue and the event can be delivered to the user queue first; eventual emptiness is RTP5a's observable contract.
- **`test__039`** — one-shot off-queue precondition read (`members.count == 0`) converted to the same `toEventually` pattern the file already uses.

### 3. UTS harness (`Test/UTS/infra`)
- **`pollUntil` is now the spec's value-returning `poll_until`** (generic overload; a Bool overload remains for latch/monotonic conditions). Tests assert on the page the poll settled on — a refetch after a Bool poll can hit a less-replicated frontend and under-return, failing exact-count assertions against a healthy backend. All three sibling corpora already implement this contract (spec pseudocode, ably-js's generic `pollUntil<T>`, ably-java via capture-inside-the-condition); the old cocoa Bool-then-refetch shape was the outlier.
- **`awaitState`/`awaitChannelState` short-circuit on FAILED** (when it isn't the awaited state), reporting the actual `errorReason` instead of burning the 15s timeout plus a cascading second timeout.
- **Cleanup** (`withRealtimeClient`): close-await on the 15s harness default (matching the specs' normalized cleanup template), skipped entirely when the connection is FAILED — `close()` from FAILED is a no-op (RTN12), so awaiting CLOSED there recorded a spurious teardown failure after a passing body.

### 4. UTS ports aligned to ably/specification#517
- **`PresenceTests` RSP4b1** — time-range boundaries derived from the events' server-assigned timestamps (±1s), per the corrected spec.
- **Five poll-then-refetch sites** (`HistoryTests` RSL2a, `PublishTests` RSL1k5, `PresenceTests` RSP4/RSP4b1/RSP5) converted to settled-value polls, matching the spec's value-assigned `poll_until`.
- **`AuthReauthTests`** — AUTH-frame poll in the spec's value form (asserting on the frames the poll observed), with the spec's 500ms interval.
- **Connect-waits**: port-invented ones (spec relies on auto-connect) use the harness default 15s; `ChannelHistoryTests`' two awaits keep `timeout: 10` because that spec times them explicitly (ably-java honours the same 10s).

### 5. Docs
- **`Test/UTS/README.md`** — `pollUntil` row documents both forms.
- **`.claude/skills/uts-to-swift/SKILL.md`** — *slimmed*: translation semantics (poll forms, deliberate `WAIT`s, untimed-step timeouts, `random_id`) now live in the spec repo's translator-facing `writing-derived-tests.md` (companion PR), so every SDK inherits them; the skill keeps only harness mechanics and fixes a misleading pre-existing timeout hint.

## Validation

- Every touched suite passes against the live sandbox/proxy: `HistoryTests`, `PublishTests`, `PresenceTests` (33 tests incl. RSP4b1 both variants), `ObjectsFaultsTests`, `AuthReauthTests`, `ChannelHistoryTests`, plus `test__019`/`test__039`/`AuthTests.test__002` individually.
- `swift build --build-tests`, `make lint`, LiveObjects BuildTool lint all clean.
- Spec↔port alignment machine-verified: a three-corpus audit (spec ↔ ably-js ↔ cocoa) plus an independent adversarial verification pass over every staged hunk; the one genuine mismatch it caught (ChannelHistory's spec-timed 10s awaits) is fixed as described above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asynchronous connection, presence, history, and publishing test reliability.
  * Failures and errors are now reported immediately instead of being hidden or delayed by timeouts.
  * Preserved results obtained during polling to avoid inconsistent follow-up checks.
  * Added retries for failed test runs, up to two attempts.

* **Documentation**
  * Clarified polling behavior, timeout handling, default waits, and supported result types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->