### PR TITLE
[AIT-1329] Render JSONValue as compact JSON text

### DIFF
--- a/LiveObjects/Sources/AblyLiveObjects/Utility/JSONValue.swift
+++ b/LiveObjects/Sources/AblyLiveObjects/Utility/JSONValue.swift
@@ -333,3 +333,154 @@ internal extension JSONObjectOrArray {
         return string
     }
 }
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
+extension JSONValue: CustomStringConvertible {
+    /// Compact JSON text, with object keys sorted for deterministic output.
+    ///
+    /// ```swift
+    /// let jsonValue: JSONValue = ["likes": 10, "hearts": 0]
+    /// print("Reactions updated: \(jsonValue)") // Reactions updated: {"hearts":0,"likes":10}
+    /// ```
+    ///
+    /// > Note: JSON has no representation for the non-finite `Double` values, so a `number` whose value
+    /// > is NaN or infinite is written as `null`.
+    ///
+    public var description: String {
+        // The text is built here rather than by `JSONSerialization`, which offers no option to change
+        // any of the three things that make its output unsuitable: it writes numbers to a fixed 17
+        // significant digits rather than the shortest form that round-trips, so `0.1` prints as
+        // `0.10000000000000001`; it escapes the forward slash, so URLs print as
+        // `https:\/\/example.com`; and it raises an Objective-C exception, uncatchable from Swift, when
+        // asked to write a non-finite number, which `number(_:)` makes constructible.
+        //
+        // Sorting the keys also gives a plain lexicographic order, where `JSONSerialization`'s
+        // `sortedKeys` compares digits numerically and treats case as secondary.
+        switch self {
+        case let .object(object):
+            let members = object
+                .sorted { $0.key < $1.key }
+                .map { key, value in "\(Self.jsonText(forString: key)):\(value.description)" }
+            return "{\(members.joined(separator: ","))}"
+        case let .array(array):
+            return "[\(array.map(\.description).joined(separator: ","))]"
+        case let .string(string):
+            return Self.jsonText(forString: string)
+        case let .number(number):
+            return Self.jsonText(forNumber: number)
+        case let .bool(bool):
+            return bool ? "true" : "false"
+        case .null:
+            return "null"
+        }
+    }
+}
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
+extension JSONValue: CustomDebugStringConvertible {
+    /// Compact JSON text, with object keys sorted for deterministic output; the same as ``description``,
+    /// so that `String(reflecting:)` and LLDB's `po` also show the value rather than the enum's structure.
+    public var debugDescription: String {
+        description
+    }
+}
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
+private extension JSONValue {
+    /// The JSON text for a string, including the surrounding quotation marks.
+    ///
+    /// Only the escapes that JSON requires are applied. In particular the forward slash, which JSON
+    /// permits escaping but does not require it to be escaped, is left alone so that URLs stay readable.
+    static func jsonText(forString string: String) -> String {
+        var result = "\""
+
+        for scalar in string.unicodeScalars {
+            switch scalar {
+            case "\"":
+                result += #"\""#
+            case "\\":
+                result += #"\\"#
+            case "\n":
+                result += #"\n"#
+            case "\r":
+                result += #"\r"#
+            case "\t":
+                result += #"\t"#
+            case "\u{08}":
+                result += #"\b"#
+            case "\u{0C}":
+                result += #"\f"#
+            case _ where scalar.value < 0x20:
+                result += String(format: #"\u%04x"#, scalar.value)
+            default:
+                result.unicodeScalars.append(scalar)
+            }
+        }
+
+        return result + "\""
+    }
+
+    /// The JSON text for a number.
+    ///
+    /// `Double`'s own description is the shortest representation that round-trips, so it supplies the
+    /// digits. Two pieces of its punctuation are dropped: the zeros that trail a fractional part, so
+    /// that `10` is not written as `10.0`, and the zeros that pad an exponent, so that `1e-7` is not
+    /// written as `1e-07`.
+    ///
+    /// Where `Double`'s description chooses exponent notation is left as it is, which is not always
+    /// where `JSON.stringify` chooses it: `4.4854284003116864e+17` here is `448542840031168640` there.
+    /// Both are valid JSON carrying the same digits, and both parse back to this value.
+    static func jsonText(forNumber number: Double) -> String {
+        guard number.isFinite else {
+            // NaN and the infinities have no JSON representation.
+            return "null" // .nan, .infinity -> null
+        }
+
+        let text = String(number)
+
+        guard let exponentIndex = text.firstIndex(where: { $0 == "e" || $0 == "E" }) else {
+            return withoutTrailingFractionZeros(text) // 10.0 -> 10; 0.1 -> 0.1; -0.0 -> -0
+        }
+
+        let mantissa = withoutTrailingFractionZeros(String(text[..<exponentIndex]))
+        let exponent = withoutExponentPadding(String(text[text.index(after: exponentIndex)...]))
+
+        return "\(mantissa)e\(exponent)" // 1e-07 -> 1e-7; 1.7976931348623157e+308 unchanged
+    }
+
+    /// Drops the zeros trailing a fractional part, and the decimal point too if they were all of it.
+    static func withoutTrailingFractionZeros(_ text: String) -> String {
+        // Without a point the trailing zeros are significant: 100 must not become 1.
+        guard text.contains(".") else {
+            return text
+        }
+
+        var result = text
+        while result.hasSuffix("0") {
+            result.removeLast()
+        }
+        if result.hasSuffix(".") {
+            result.removeLast()
+        }
+
+        return result // 10.0 -> 10; 1.10 -> 1.1; 0.0 -> 0; 123.456 -> 123.456
+    }
+
+    /// Drops the zeros `Double`'s description pads a single-digit exponent with.
+    static func withoutExponentPadding(_ text: String) -> String {
+        var sign = ""
+        var digits = Substring(text)
+
+        if let first = digits.first, first == "+" || first == "-" {
+            sign = String(first)
+            digits = digits.dropFirst()
+        }
+
+        // Keep the last digit even if it is a zero, so that an exponent of 0 survives.
+        while digits.count > 1, digits.first == "0" {
+            digits = digits.dropFirst()
+        }
+
+        return sign + digits // -07 -> -7; +308 -> +308
+    }
+}

--- a/LiveObjects/Sources/AblyLiveObjects/Utility/JSONValue.swift
+++ b/LiveObjects/Sources/AblyLiveObjects/Utility/JSONValue.swift
@@ -166,6 +166,11 @@ internal extension JSONValue {
 // MARK: - JSON objects and arrays
 
 /// A subset of ``JSONValue`` that has only `object` or `array` cases.
+///
+/// > Note: These are the two cases a JSON *text* was restricted to under RFC 4627, so `JSON` would be a
+/// > natural name for this type. It is spelled out instead: `JSON` is broad enough to be mistaken for
+/// > `JSONValue`, and current JSON (RFC 8259, and the json.org grammar linked above) allows any value at
+/// > the top level, so the short name would no longer say what the restriction is.
 @available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
 internal enum JSONObjectOrArray: Equatable {
     case object([String: JSONValue])
@@ -343,9 +348,11 @@ extension JSONValue: CustomStringConvertible {
     /// print("Reactions updated: \(jsonValue)") // Reactions updated: {"hearts":0,"likes":10}
     /// ```
     ///
+    /// > Note: This is a display and debugging aid, not a guaranteed-stable serialization format; the
+    /// > exact bytes — for example where exponent notation is used — may change.
+    ///
     /// > Note: JSON has no representation for the non-finite `Double` values, so a `number` whose value
     /// > is NaN or infinite is written as `null`.
-    ///
     public var description: String {
         // The text is built here rather than by `JSONSerialization`, which offers no option to change
         // any of the three things that make its output unsuitable: it writes numbers to a fixed 17
@@ -482,5 +489,31 @@ private extension JSONValue {
         }
 
         return sign + digits // -07 -> -7; +308 -> +308
+    }
+}
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
+extension JSONObjectOrArray: CustomStringConvertible {
+    /// Compact JSON text, with object keys sorted for deterministic output.
+    ///
+    /// ```swift
+    /// let jsonObject: JSONObjectOrArray = ["likes": 10, "hearts": 0]
+    /// print("Reactions updated: \(jsonObject)") // Reactions updated: {"hearts":0,"likes":10}
+    /// ```
+    ///
+    /// Since this type is the `object`/`array` subset of ``JSONValue``, it defers to that type's
+    /// ``JSONValue/description`` rather than repeating the rendering; see there for how numbers and
+    /// strings are written.
+    internal var description: String {
+        toJSONValue.description
+    }
+}
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
+extension JSONObjectOrArray: CustomDebugStringConvertible {
+    /// Compact JSON text, with object keys sorted for deterministic output; the same as ``description``,
+    /// so that `String(reflecting:)` and LLDB's `po` also show the value rather than the enum's structure.
+    internal var debugDescription: String {
+        description
     }
 }

--- a/LiveObjects/Tests/AblyLiveObjectsTests/Unit/JSONValueDescriptionTests.swift
+++ b/LiveObjects/Tests/AblyLiveObjectsTests/Unit/JSONValueDescriptionTests.swift
@@ -92,11 +92,18 @@ struct JSONValueDescriptionTests {
         #expect(JSONValue.number(value).description == expected)
     }
 
-    // Whatever layout is chosen, the digits have to identify the original value exactly.
+    // Whatever layout is chosen, the digits have to identify the original value exactly. `Double(_:)`
+    // is the oracle because it is correctly rounded, which `JSONSerialization`'s number parser is not;
+    // this is where numeric fidelity is guaranteed, rather than in the container round-trip below.
     @Test(arguments: [
         0.1,
         0.1 + 0.2,
         123.456,
+        // Awkward fractional values — the motivating case, a `LiveCounter` holding a fractional
+        // amount. `JSONSerialization` re-parses both of these one ULP out, so they would not survive
+        // that parser; they do survive a correctly-rounded one, which is what this asserts.
+        0.015034388851090229,
+        0.023942638935083197,
         1e-7,
         1e-21,
         1_000_000_000_000_000_128,
@@ -283,7 +290,13 @@ struct JSONValueDescriptionTests {
 
     // MARK: - Output is valid JSON
 
-    // Whatever is printed has to parse back to the value it came from.
+    // Whatever is printed has to be valid JSON that parses back to the same structure — the same keys,
+    // the same nesting, the same cases.
+    //
+    // This deliberately does not claim numeric fidelity. The oracle is `JSONSerialization`, whose
+    // number parser is not correctly rounded, so it cannot witness that a fractional value survives
+    // exactly; the arguments below stay clear of values it would misparse. `numbersRoundTrip` covers
+    // fidelity instead, through the correctly-rounded `Double(_:)`.
     @Test(arguments: [
         JSONValue.null,
         true,

--- a/LiveObjects/Tests/AblyLiveObjectsTests/Unit/JSONValueDescriptionTests.swift
+++ b/LiveObjects/Tests/AblyLiveObjectsTests/Unit/JSONValueDescriptionTests.swift
@@ -1,0 +1,337 @@
+@testable import AblyLiveObjects
+import Foundation
+import Testing
+
+/// Tests for `JSONValue`'s `CustomStringConvertible` and `CustomDebugStringConvertible` conformances
+///
+/// The conformances render compact JSON text directly rather than going through
+/// `JSONSerialization`, which writes numbers to 17 significant digits rather than the shortest form
+/// that round-trips. Numbers come from `Double`'s own description, so where that chooses exponent
+/// notation differently from JS `JSON.stringify` the output differs too; the tests below record
+/// those cases.
+struct JSONValueDescriptionTests {
+    // MARK: - Scalars
+
+    @Test(arguments: [
+        (value: JSONValue.null, expected: "null"),
+        (value: true, expected: "true"),
+        (value: false, expected: "false"),
+        (value: "someString", expected: #""someString""#),
+        (value: "", expected: #""""#),
+    ] as [(value: JSONValue, expected: String)])
+    func scalars(value: JSONValue, expected: String) {
+        #expect(value.description == expected)
+    }
+
+    // MARK: - Numbers
+
+    @Test(arguments: [
+        // The point of the issue: an integral value is written without the fractional part that
+        // `Double`'s own description would give it.
+        (value: 0.0, expected: "0"),
+        (value: 1, expected: "1"),
+        (value: 10, expected: "10"),
+        (value: -42, expected: "-42"),
+        (value: 123.456, expected: "123.456"),
+        (value: -0.5, expected: "-0.5"),
+        (value: 1e15, expected: "1000000000000000"),
+    ] as [(value: Double, expected: String)])
+    func numbers(value: Double, expected: String) {
+        #expect(JSONValue.number(value).description == expected)
+    }
+
+    // A value that is not exactly representable in binary floating point is written with the fewest
+    // digits that identify it uniquely, rather than its full 17-significant-digit expansion. This is
+    // the case a LiveObjects user is most likely to hit — a counter holding a fractional amount.
+    @Test(arguments: [
+        (value: 0.1, expected: "0.1"),
+        (value: 0.3, expected: "0.3"),
+        (value: 1.1, expected: "1.1"),
+        (value: 0.1 + 0.2, expected: "0.30000000000000004"), // genuinely a different Double from 0.3
+    ] as [(value: Double, expected: String)])
+    func fractionalNumbersUseShortestRoundTrip(value: Double, expected: String) {
+        #expect(JSONValue.number(value).description == expected)
+    }
+
+    // Where `Double`'s description switches to exponent notation is inherited rather than chosen, so it
+    // does not always agree with the other SDKs: the trailing comments give `JSON.stringify`'s output
+    // where it differs.
+    @Test(arguments: [
+        (value: -0.0, expected: "-0"), // JSON.stringify: 0
+        (value: 1e18, expected: "1e+18"), // JSON.stringify: 1000000000000000000
+        (value: 1e19, expected: "1e+19"), // JSON.stringify: 10000000000000000000
+        (value: 1e21, expected: "1e+21"),
+        // 2^53, the last integer whose neighbours are all exactly representable.
+        (value: 0x1p53, expected: "9007199254740992"),
+        // Above 2^53 the digits are still the shortest that round-trip, so no exact expansion appears.
+        (value: 1_000_000_000_000_000_128, expected: "1.0000000000000001e+18"), // JSON.stringify: 1000000000000000100
+        (value: 1.2345678901234567e19, expected: "1.2345678901234567e+19"), // JSON.stringify: 12345678901234567000
+        (value: 1e-6, expected: "1e-6"), // JSON.stringify: 0.000001
+        (value: 1e-7, expected: "1e-7"),
+        (value: 1e-21, expected: "1e-21"),
+        (value: .greatestFiniteMagnitude, expected: "1.7976931348623157e+308"),
+        (value: .leastNonzeroMagnitude, expected: "5e-324"),
+    ] as [(value: Double, expected: String)])
+    func numberEdgeCases(value: Double, expected: String) {
+        #expect(JSONValue.number(value).description == expected)
+    }
+
+    // The two pieces of punctuation that are stripped from `Double`'s description.
+    @Test(arguments: [
+        (value: 10.0, expected: "10"), // not 10.0
+        (value: 0.0, expected: "0"), // not 0.0
+        (value: 1e15, expected: "1000000000000000"), // not 1000000000000000.0
+        (value: 1e-7, expected: "1e-7"), // not 1e-07
+        (value: 8.706394e-7, expected: "8.706394e-7"), // not 8.706394e-07
+        // Padding is only ever stripped from the exponent, never from the digits themselves.
+        (value: 100.0, expected: "100"),
+        (value: 1e-21, expected: "1e-21"),
+        (value: .greatestFiniteMagnitude, expected: "1.7976931348623157e+308"),
+    ] as [(value: Double, expected: String)])
+    func punctuationStrippedFromDoubleDescription(value: Double, expected: String) {
+        #expect(JSONValue.number(value).description == expected)
+    }
+
+    // Whatever layout is chosen, the digits have to identify the original value exactly.
+    @Test(arguments: [
+        0.1,
+        0.1 + 0.2,
+        123.456,
+        1e-7,
+        1e-21,
+        1_000_000_000_000_000_128,
+        1.2345678901234567e19,
+        1e21,
+        .greatestFiniteMagnitude,
+        .leastNonzeroMagnitude,
+        .pi,
+    ] as [Double])
+    func numbersRoundTrip(value: Double) throws {
+        let text = JSONValue.number(value).description
+
+        #expect(try #require(Double(text)) == value)
+    }
+
+    // `JSONValue.number` wraps a `Double`, so the non-finite values are constructible from public API
+    // and have to render as something. JSON cannot represent them; they are written as null, which is
+    // what `JSON.stringify` does.
+    //
+    // `signalingNaN` is not in the arguments: it takes the same branch as `nan` and describes
+    // identically, which gives the two cases the same identity and makes xcodebuild's reporter
+    // reject the second as already started.
+    @Test(arguments: [Double.nan, .infinity, -.infinity])
+    func nonFiniteNumbersAreNull(value: Double) {
+        #expect(JSONValue.number(value).description == "null")
+    }
+
+    // MARK: - String escaping
+
+    @Test(arguments: [
+        (value: #"say "hi""#, expected: #""say \"hi\"""#),
+        (value: #"back\slash"#, expected: #""back\\slash""#),
+        (value: "line\nbreak", expected: #""line\nbreak""#),
+        (value: "carriage\rreturn", expected: #""carriage\rreturn""#),
+        (value: "tab\tseparated", expected: #""tab\tseparated""#),
+        (value: "back\u{08}space", expected: #""back\bspace""#),
+        (value: "form\u{0C}feed", expected: #""form\ffeed""#),
+        // Other control characters take the \u form, with lowercase hex.
+        (value: "nul\u{00}byte", expected: #""nul\u0000byte""#),
+        (value: "bell\u{07}", expected: #""bell\u0007""#),
+        (value: "escape\u{1B}", expected: #""escape\u001b""#),
+    ] as [(value: String, expected: String)])
+    func stringEscaping(value: String, expected: String) {
+        #expect(JSONValue.string(value).description == expected)
+    }
+
+    // JSON permits escaping the forward slash but does not require it, so it is left alone and URLs
+    // stay readable.
+    @Test
+    func forwardSlashesAreNotEscaped() {
+        let value = JSONValue.string("https://example.com/a/b")
+
+        #expect(value.description == #""https://example.com/a/b""#)
+    }
+
+    @Test(arguments: ["héllo", "日本語", "👍🏽", "a\u{0301}"])
+    func nonASCIICharactersArePreserved(value: String) {
+        #expect(JSONValue.string(value).description == "\"\(value)\"")
+    }
+
+    // MARK: - Objects and arrays
+
+    @Test
+    func emptyContainers() {
+        #expect(JSONValue.object([:]).description == "{}")
+        #expect(JSONValue.array([]).description == "[]")
+    }
+
+    @Test
+    func objectKeysAreSorted() {
+        let value: JSONValue = [
+            "likes": 10,
+            "hearts": 0,
+            "claps": 3,
+            "wows": 7,
+            "laughs": 1,
+        ]
+
+        #expect(value.description == #"{"claps":3,"hearts":0,"laughs":1,"likes":10,"wows":7}"#)
+    }
+
+    // Keys sort lexicographically by Unicode scalar, so digits sort as text ("10" before "2") and
+    // uppercase before lowercase. Pinned because "sorted" admits several readings, and because the
+    // ordering has to be stable for the output to be comparable between runs.
+    @Test
+    func keySortIsLexicographic() {
+        let value = JSONValue.object([
+            "b": 1,
+            "A": 2,
+            "a": 3,
+            "10": 4,
+            "2": 5,
+            "_": 6,
+            "é": 7,
+            "e": 8,
+        ])
+
+        #expect(value.description == #"{"10":4,"2":5,"A":2,"_":6,"a":3,"b":1,"e":8,"é":7}"#)
+    }
+
+    // The point of sorting: the same content renders identically however the dictionary was built,
+    // and whatever order it happens to have internally on this run.
+    @Test
+    func objectRenderingIsDeterministic() {
+        let insertionOrders: [[(String, JSONValue)]] = [
+            [("likes", 10), ("hearts", 0), ("claps", 3)],
+            [("claps", 3), ("likes", 10), ("hearts", 0)],
+            [("hearts", 0), ("claps", 3), ("likes", 10)],
+        ]
+
+        let renderings = insertionOrders.map { pairs in
+            JSONValue.object(.init(uniqueKeysWithValues: pairs)).description
+        }
+
+        #expect(Set(renderings).count == 1)
+        #expect(renderings[0] == #"{"claps":3,"hearts":0,"likes":10}"#)
+    }
+
+    @Test
+    func objectKeysAreEscaped() {
+        let value = JSONValue.object([#"a"b"#: 1])
+
+        #expect(value.description == #"{"a\"b":1}"#)
+    }
+
+    // Unlike objects, arrays keep their order.
+    @Test
+    func arrayOrderIsPreserved() {
+        let value: JSONValue = ["c", "a", "b"]
+
+        #expect(value.description == #"["c","a","b"]"#)
+    }
+
+    @Test
+    func nestedContainers() {
+        let value: JSONValue = [
+            "counter": 10,
+            "meta": [
+                "tags": ["x", "y"],
+                "enabled": false,
+                "missing": .null,
+            ],
+            "list": [1, [2, [3]]],
+        ]
+
+        #expect(
+            value.description == #"{"counter":10,"list":[1,[2,[3]]],"meta":{"enabled":false,"missing":null,"tags":["x","y"]}}"#,
+        )
+    }
+
+    // MARK: - Debug description
+
+    @Test(arguments: [
+        JSONValue.null,
+        true,
+        123.456,
+        "someString",
+        ["someKey": "someValue"],
+        ["someElement", 1],
+    ] as [JSONValue])
+    func debugDescriptionMatchesDescription(value: JSONValue) {
+        #expect(value.debugDescription == value.description)
+    }
+
+    // The conformances are what `print`, string interpolation and LLDB's `po` go through, so check the
+    // value reaches them rather than only reading the properties directly.
+    @Test
+    func standardRenderingEntryPoints() {
+        let value: JSONValue = ["likes": 10, "hearts": 0]
+        let expected = #"{"hearts":0,"likes":10}"#
+        let interpolated = "\(value)"
+
+        #expect(interpolated == expected)
+        #expect(String(describing: value) == expected)
+        #expect(String(reflecting: value) == expected)
+    }
+
+    // MARK: - Output is valid JSON
+
+    // Whatever is printed has to parse back to the value it came from.
+    @Test(arguments: [
+        JSONValue.null,
+        true,
+        false,
+        0,
+        10,
+        -42,
+        123.456,
+        0.1,
+        1e21,
+        "someString",
+        "",
+        .string(#"quotes " backslash \ newline"# + "\n\u{07}"),
+        "https://example.com/a/b",
+        "日本語 👍🏽",
+        [:],
+        [],
+        ["someKey": "someValue", "nested": ["a": [1, 2, .null]], "n": 10],
+        ["someElement", 1, true, .null, ["k": "v"]],
+    ] as [JSONValue])
+    func descriptionRoundTrips(value: JSONValue) throws {
+        let data = try #require(value.description.data(using: .utf8))
+        let deserialized = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+
+        #expect(JSONValue(jsonSerializationOutput: deserialized) == value)
+    }
+
+    // The rendering has to agree with the `JSONSerialization` bridge that is used to put a `JSONValue`
+    // on the wire, otherwise what a user is shown is not what gets published.
+    @Test(arguments: [
+        JSONValue.null,
+        true,
+        0,
+        10,
+        -42,
+        123.456,
+        0.1,
+        "someString",
+        "https://example.com/a/b",
+        "日本語 👍🏽",
+        [:],
+        [],
+        ["someKey": "someValue", "nested": ["a": [1, 2, .null]], "n": 10],
+        ["someElement", 1, true, .null, ["k": "v"]],
+    ] as [JSONValue])
+    func descriptionAgreesWithJSONSerializationBridge(value: JSONValue) throws {
+        let data = try #require(value.description.data(using: .utf8))
+        let reparsed = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+
+        let bridged = try JSONSerialization.data(
+            withJSONObject: value.toJSONSerializationInputElement,
+            options: [.fragmentsAllowed],
+        )
+        let bridgeParsed = try JSONSerialization.jsonObject(with: bridged, options: [.fragmentsAllowed])
+
+        #expect(JSONValue(jsonSerializationOutput: reparsed) == JSONValue(jsonSerializationOutput: bridgeParsed))
+    }
+}

--- a/LiveObjects/Tests/AblyLiveObjectsTests/Unit/JSONValueDescriptionTests.swift
+++ b/LiveObjects/Tests/AblyLiveObjectsTests/Unit/JSONValueDescriptionTests.swift
@@ -222,6 +222,13 @@ struct JSONValueDescriptionTests {
         #expect(value.description == #"{"a\"b":1}"#)
     }
 
+    @Test
+    func emptyKeyIsValid() {
+        let value = JSONValue.object(["": 1])
+
+        #expect(value.description == #"{"":1}"#)
+    }
+
     // Unlike objects, arrays keep their order.
     @Test
     func arrayOrderIsPreserved() {
@@ -314,6 +321,11 @@ struct JSONValueDescriptionTests {
         -42,
         123.456,
         0.1,
+        // `JSONSerialization` hands these back as `NSDecimalNumber` rather than as a `Double`. Both
+        // sides of the comparison go through the same bridge, so what is checked is that the printer
+        // and the bridge agree, whatever that conversion does to the value.
+        0.015034388851090229,
+        0.023942638935083197,
         "someString",
         "https://example.com/a/b",
         "日本語 👍🏽",


### PR DESCRIPTION
Fixes #2245.

`JSONValue` declared no `CustomStringConvertible` conformance, so printing one — the first thing a reader does with the result of `compactJson()` — fell back to Swift's reflection form:

```text
Reactions updated: object(["hearts": AblyLiveObjects.JSONValue.number(0.0), "likes": AblyLiveObjects.JSONValue.number(10.0)])
```

It now prints:

```text
Reactions updated: {"hearts":0,"likes":10}
```

Conforms `JSONValue` to `CustomStringConvertible` and `CustomDebugStringConvertible`, rendering compact JSON text with object keys sorted so the output is stable between runs. Additive — no signature changes, and no change to any value the SDK computes.

> **Scope note.** This PR previously also carried a fix to how numbers are *read back* from `JSONSerialization` (`art_exactDoubleValue`). @sacOO7 asked for that to be looked at separately, which was right: it touches counters, maps and protocol conversion, and unlike this PR it changes computed values. It is now **#2261**. Both target `main`, and they do not conflict, so they can land in either order.

## Why the text is built directly rather than by `JSONSerialization`

`JSONSerialization` was the obvious implementation, and it is unsuitable in three ways, none of which it offers an option to change:

- **Numbers get a fixed 17 significant digits** rather than the shortest representation that round-trips, so a value that is not exactly representable in binary floating point prints its full expansion: `0.1` → `0.10000000000000001`, `0.3` → `0.29999999999999999`. This is the case a reader is most likely to meet, since a `LiveCounter` holding a fractional amount produces it.
- **The forward slash is escaped**, which JSON permits but does not require, so URLs — a common thing for a `LiveMap` to hold — print as `https:\/\/example.com\/a\/b`.
- **Non-finite numbers raise an uncatchable Objective-C exception.** `JSONValue.number` wraps a `Double`, so `.number(.nan)` is constructible through the public API, and `JSONSerialization` raises rather than throwing, which `try?` cannot catch — printing one would terminate the process. They are written as `null` instead, as `JSON.stringify` does.

That reasoning is recorded as a comment on the implementation rather than in the public doc comment: it explains a choice a maintainer might otherwise redo, and is not something a caller of `description` needs. What stays on the public API is the usage example and two `> Note:` asides that are contractual — the stability caveat and the non-finite behaviour.

Numbers come from `Double`'s own description, which is already shortest-round-trip, with two pieces of its punctuation dropped: the zeros trailing a fractional part, so `10.0` prints as `10` — the complaint the issue opens with — and the zeros padding an exponent, so `1e-07` prints as `1e-7`.

Where `Double`'s description chooses exponent notation is left alone, and that is not always where `JSON.stringify` chooses it: `448542840031168640` prints here as `4.4854284003116864e+17`. The digits are identical in every such case; only the threshold differs, and both forms are valid JSON that parse back to the same value. Fuzzed against `node` over 54,514 doubles, that threshold is the sole remaining difference — the digits never disagree.

Sorting the keys here also gives a plain lexicographic order, where `JSONSerialization`'s `sortedKeys` compares digits numerically and treats case as secondary.

## `JSONObjectOrArray`

Given the same two conformances, deferring to `JSONValue.description`. There was already a consumer: `ProtocolTypes.ObjectData.debugDescription` interpolates its `json` field, so every debug rendering of an object message — including Swift Testing's failure output — was printing reflection mid-message.

## Tests

`JSONValueDescriptionTests` — 22 tests covering scalars, integral and fractional numbers, the numeric edge cases (`-0`, `1e18`, `1e21`, `2^53`, `greatestFiniteMagnitude`, `leastNonzeroMagnitude`), non-finite values, both punctuation strips, every string escape including the `\u00xx` form, non-ASCII passthrough, empty/nested containers, key sorting and its determinism across three different insertion orders, escaped keys, empty keys, array order, and that interpolation, `String(describing:)` and `String(reflecting:)` all route through the conformances.

Each edge case where the output differs from `JSON.stringify` carries a `// JSON.stringify: …` comment giving the other value, so the divergence is recorded at the assertion rather than left implicit.

Two are worth calling out:

- `descriptionAgreesWithJSONSerializationBridge` checks that `description` and the internal `JSONSerialization` bridge parse back to the same value. They are independent implementations and the bridge is what actually goes on the wire, so they must not drift. Both sides go through the same bridge, so the check is agreement, not absolute fidelity — the fidelity question is #2261's.
- `0.1 + 0.2` is asserted as `0.30000000000000004`, which is correct: that genuinely is a different `Double` from `0.3`, so the long form there is not a formatting artifact.

## Verification

- `JSONValueDescriptionTests`: 22 tests passing; LiveObjects unit suite: 404 tests in 105 suites passing.
- SwiftLint (0.59.1, as pinned in `Mintfile`), EditorConfig, availability annotations and `xcodebuild docbuild` all clean.
- Fuzzed against `node` over 54,514 doubles: digits identical in all of them; the only differences are the exponent-notation threshold described above.

## Note for the docs

The quickstart and reference examples in ably/website#9502 show outputs like `// console: {"likes":10.0,"hearts":0.0}`. The actual output is `{"hearts":0,"likes":10}` — integral values print without the `.0`, and keys are sorted. Those examples need updating to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)