### PR TITLE
liveobjects: expand the README usage section and point to the web docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,10 +180,9 @@ make lint
 
 The repository has a single version number, applied to everything it publishes. Since the LiveObjects plugin moved into this repository it no longer has a version of its own: the standalone [ably-liveobjects-swift-plugin](https://github.com/ably/ably-liveobjects-swift-plugin) package stopped at 0.4.1, and the first release of `AblyLiveObjects` from here carries this repository's next version number. There is no 0.x line to continue, and the plugin's [historical changelog](LiveObjects/CHANGELOG.md) is kept only for reference.
 
-Because a shared version number implies more than it delivers, two things are worth stating explicitly in release notes:
+Because a shared version number implies more than it delivers, one thing is worth stating explicitly in release notes:
 
 * **A tag does not mean the same thing on every channel.** CocoaPods and Carthage consumers receive only the `Ably` product; see [Distribution](#distribution). A release whose only change is to LiveObjects is a no-op for them, and the changelog entry should say so.
-* **`AblyLiveObjects` is exempt from semantic versioning.** It is experimental: breaking changes to its API may be made in minor or patch releases without a major version bump, and the repository's semver guarantees apply to the `Ably` product only. Repeat this in the changelog entry of any release that changes the LiveObjects API.
 
 Minor versions are not bumped ahead of 2.0.0; use `make bump_patch` unless the `Ably` product's public API has changed. Standard semantic versioning begins at 2.0.0.
 

--- a/LiveObjects/CONTRIBUTING.md
+++ b/LiveObjects/CONTRIBUTING.md
@@ -149,6 +149,6 @@ Some of our integration tests require access to ably-cocoa internals that are no
 
 ## Release process
 
-The plugin is released as part of ably-cocoa; see ably-cocoa's [CONTRIBUTING.md](../CONTRIBUTING.md) for the release process, and its [Versioning](../CONTRIBUTING.md#versioning) and [Distribution](../CONTRIBUTING.md#distribution) sections for what a release tag means for this plugin in particular. In short: the plugin shares ably-cocoa's version number, is published via Swift Package Manager only, and is exempt from the repository's semantic versioning guarantees while it remains experimental.
+The plugin is released as part of ably-cocoa; see ably-cocoa's [CONTRIBUTING.md](../CONTRIBUTING.md) for the release process, and its [Versioning](../CONTRIBUTING.md#versioning) and [Distribution](../CONTRIBUTING.md#distribution) sections for what a release tag means for this plugin in particular. In short: the plugin shares ably-cocoa's version number and is published via Swift Package Manager only.
 
 (This plugin previously had its own, independent releases in the [ably-liveobjects-swift-plugin](https://github.com/ably/ably-liveobjects-swift-plugin/releases) repository; those releases remain on that repository's releases page.)

--- a/LiveObjects/README.md
+++ b/LiveObjects/README.md
@@ -96,10 +96,10 @@ try await reactions.remove(key: "hearts")
 ```swift
 // Read individual values
 let visitCount = try visits.value() // 5.0
-let likes = try reactions.get(key: "likes").asPrimitive().value()?.numberValue // 10.0
+let likes = try reactions.get(key: "likes").asPrimitive().numberValue() // 10.0
 
 // Or take a JSON-serializable snapshot of an entire object
-let snapshot = try rootObject.compactJson() // {"visits":5.0,"reactions":{"likes":10.0}}
+let snapshot = try rootObject.compactJson() // {"reactions":{"likes":10},"visits":5}
 ```
 
 ### Subscribe to updates

--- a/LiveObjects/README.md
+++ b/LiveObjects/README.md
@@ -8,9 +8,6 @@
 
 The Ably LiveObjects plugin enables real-time collaborative data synchronization for the [ably-cocoa](https://github.com/ably/ably-cocoa/) SDK. LiveObjects provides a simple way to build collaborative applications with synchronized state across multiple clients in real-time. Built on [Ably's](https://ably.com/) core service, it abstracts complex details to enable efficient collaborative architectures.
 
-> [!WARNING]
-> This plugin is currently experimental. Breaking changes to its API may be made in minor or patch releases of ably-cocoa, without a major version bump; ably-cocoa's semantic versioning guarantees apply only to the `Ably` product.
-
 > [!NOTE]
 > The plugin lives in the [ably-cocoa](https://github.com/ably/ably-cocoa/) repository and is versioned and released as part of ably-cocoa: add the ably-cocoa package to your project and select its `AblyLiveObjects` product. It was previously developed in the [ably-liveobjects-swift-plugin](https://github.com/ably/ably-liveobjects-swift-plugin) repository; if you are coming from that package, see the [migration guide](#migrating-from-the-standalone-plugin-package).
 

--- a/LiveObjects/README.md
+++ b/LiveObjects/README.md
@@ -45,6 +45,8 @@ This plugin supports the following platforms:
 
 ## Usage
 
+The examples below are a quick tour of the API. Check the [LiveObjects documentation](https://ably.com/docs/liveobjects) for a comprehensive guide — starting with the [Swift quickstart](https://ably.com/docs/liveobjects/quickstart/swift), it covers maps, counters, path objects, subscriptions, lifecycle events and more.
+
 After [installing the plugin](../README.md#liveobjects), pass it to the client via
 `ARTClientOptions`, and fetch channels with the LiveObjects channel modes:
 
@@ -60,10 +62,61 @@ let realtime = ARTRealtime(options: clientOptions)
 let channelOptions = ARTRealtimeChannelOptions()
 channelOptions.modes = [.objectPublish, .objectSubscribe]
 let channel = realtime.channels.get("my-channel", options: channelOptions)
+```
 
-// `channel.object` is the entry point into the LiveObjects API. Attach the
-// channel, then fetch the channel's root map once objects are synchronized:
-let root = try await channel.object.get()
+`channel.object` is the entry point into the LiveObjects API. Fetch the channel's root map — this implicitly attaches the channel and waits for the channel's objects to be synchronized:
+
+```swift
+let rootObject = try await channel.object.get()
+```
+
+### Create and update objects
+
+LiveObjects provides two synchronized data structures — `LiveMap`, a key/value map, and `LiveCounter`, a numeric counter — which you create and assign to keys on the root object:
+
+```swift
+// Create a counter and a map, and assign them to keys on the root object
+try await rootObject.set(key: "visits", value: .liveCounter(LiveCounter.create(initialCount: 0)))
+try await rootObject.set(key: "reactions", value: .liveMap(LiveMap.create(entries: [
+    "likes": 0,
+    "hearts": 0,
+])))
+```
+
+Navigate the object graph with [path objects](https://ably.com/docs/liveobjects/concepts/path-object) — stable references to locations within the channel's objects that resolve to values at the time each method is called — and send operations to update the objects. Updates are synchronized to all clients subscribed to the channel:
+
+```swift
+let visits = rootObject.get(key: "visits").asLiveCounter()
+try await visits.increment(amount: 5)
+
+let reactions = rootObject.get(key: "reactions").asLiveMap()
+try await reactions.set(key: "likes", value: 10)
+try await reactions.remove(key: "hearts")
+```
+
+### Read values
+
+```swift
+// Read individual values
+let visitCount = try visits.value() // 5.0
+let likes = try reactions.get(key: "likes").asPrimitive().value()?.numberValue // 10.0
+
+// Or take a JSON-serializable snapshot of an entire object
+let snapshot = try rootObject.compactJson() // {"visits":5.0,"reactions":{"likes":10.0}}
+```
+
+### Subscribe to updates
+
+Subscribe to a path object to be notified whenever the object at that path is updated, by any client:
+
+```swift
+let subscription = try visits.subscribe { event in
+    guard let value = try? event.object.asLiveCounter().value() else { return }
+    print("Visits updated: \(value)")
+}
+
+// Later, stop receiving updates
+subscription.unsubscribe()
 ```
 
 ---
@@ -103,24 +156,24 @@ ably-cocoa 1.3.0 replaces the instance-based API of the standalone plugin (last 
 
 The headline API changes:
 
-| Standalone plugin (≤ 0.4.1)                                    | ably-cocoa 1.3.0+                                                                                                 |
-| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `channel.objects`, returning `RealtimeObjects`                 | `channel.object`, returning `RealtimeObject`                                                                      |
-| `try await channel.objects.getRoot()`, returning `any LiveMap` | `try await channel.object.get()`, returning `any LiveMapPathObject`                                               |
-| Operate on explicit `LiveMap`/`LiveCounter` instances          | Navigate with `PathObject`s: `root.get(key:)`, then cast with `asLiveMap()` / `asLiveCounter()` / `asPrimitive()` |
+| Standalone plugin (≤ 0.4.1)                                    | ably-cocoa 1.3.0+                                                                                                       |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `channel.objects`, returning `RealtimeObjects`                 | `channel.object`, returning `RealtimeObject`                                                                            |
+| `try await channel.objects.getRoot()`, returning `any LiveMap` | `try await channel.object.get()`, returning `any LiveMapPathObject`                                                     |
+| Operate on explicit `LiveMap`/`LiveCounter` instances          | Navigate with `PathObject`s: `rootObject.get(key:)`, then cast with `asLiveMap()` / `asLiveCounter()` / `asPrimitive()` |
 
 For example:
 
 ```swift
 // Standalone plugin (≤ 0.4.1) — instance-based
-let root = try await channel.objects.getRoot()
-try await root.set(key: "myKey", value: "myValue")
-let value = try root.get(key: "myKey")?.stringValue
+let rootObject = try await channel.objects.getRoot()
+try await rootObject.set(key: "myKey", value: "myValue")
+let value = try rootObject.get(key: "myKey")?.stringValue
 
 // ably-cocoa 1.3.0+ — path-based
-let root = try await channel.object.get()
-try await root.set(key: "myKey", value: "myValue")
-let value = try root.get(key: "myKey").asPrimitive().stringValue()
+let rootObject = try await channel.object.get()
+try await rootObject.set(key: "myKey", value: "myValue")
+let value = try rootObject.get(key: "myKey").asPrimitive().stringValue()
 ```
 
 A `PathObject` is purely navigational: it can be created before the data at its path exists, and it survives the object at its path being replaced — there is no need to re-fetch anything when the underlying object changes. The [example app](Example) demonstrates the path-based API.

--- a/README.md
+++ b/README.md
@@ -192,9 +192,6 @@ realtime.connection.on { stateChange in
 structures that automatically synchronize state across all connected clients. This repository
 contains the Ably LiveObjects plugin, which enables LiveObjects on top of the core Pub/Sub SDK.
 
-> [!WARNING]
-> LiveObjects is currently experimental — see the [LiveObjects README](LiveObjects/README.md) for details.
-
 ### Install LiveObjects
 
 The plugin is available via **Swift Package Manager only** (there is no CocoaPods or Carthage

--- a/README.md
+++ b/README.md
@@ -218,7 +218,9 @@ To install it in another Swift package, add the product to your target's depende
 
 For usage, platform requirements, the example app and the
 [migration guide](LiveObjects/README.md#migrating-from-the-standalone-plugin-package) for users
-of the standalone plugin package, see the [LiveObjects README](LiveObjects/README.md).
+of the standalone plugin package, see the [LiveObjects README](LiveObjects/README.md). For a
+comprehensive guide, check the [LiveObjects documentation](https://ably.com/docs/liveobjects),
+starting with the [Swift quickstart](https://ably.com/docs/liveobjects/quickstart/swift).
 
 ---
 


### PR DESCRIPTION
## What

Expands the `Usage` section of the LiveObjects README, which previously stopped right at fetching the root object, and adds pointers from both READMEs to the [LiveObjects web documentation](https://ably.com/docs/liveobjects) as the comprehensive guide.

## Changes

### `LiveObjects/README.md`

- **Expanded the `Usage` section** into a quick tour of the path-based API, structured after the official [Swift quickstart](https://ably.com/docs/liveobjects/quickstart/swift):
  - Creating `LiveMap`/`LiveCounter` objects and assigning them to the root object
  - Navigating with path objects and sending update operations (`increment`, `set`, `remove`)
  - Reading values (typed reads and `compactJson()` snapshots)
  - Subscribing to updates and unsubscribing
- **Renamed `root` → `rootObject`** throughout (Usage section, migration table and migration example), matching the naming used consistently across the LiveObjects documentation.
- **Fixed a misleading comment**: the old snippet said to attach the channel before fetching the root map; `channel.object.get()` implicitly attaches and awaits synchronization, and the prose now says so.
- Added an intro line pointing readers to the web documentation for the comprehensive guide.

### `README.md`

- Added a pointer at the end of the `LiveObjects` section to the web documentation and Swift quickstart.

## Notes

- All snippets follow the official LiveObjects documentation (Swift quickstart, map, counter, path-object and typing pages) and were compile-checked against the SDK by temporarily adding them to the `AblyLiveObjectsTests` target.
- Batch operations are deliberately not mentioned: the docs state they are not supported in LiveObjects Swift.

## Removal of experimental status (second commit)

LiveObjects is no longer experimental. This PR additionally:

- Removes the experimental warning blocks from `README.md` and `LiveObjects/README.md`.
- Removes the semantic-versioning exemption statements from `CONTRIBUTING.md` and `LiveObjects/CONTRIBUTING.md` — `AblyLiveObjects` is now covered by the repository's normal semver guarantees.

Historical records (`CHANGELOG.md` and the 1.3.0 release notes) intentionally retain their "experimental" wording, as they describe releases made while the plugin was experimental.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated LiveObjects documentation with a broader API overview and path-based examples for creating, reading, updating, and subscribing to objects.
  * Added migration guidance distinguishing standalone instance-based and path-based APIs.
  * Updated value-reading examples and snapshot output descriptions.
  * Removed experimental-status warnings from LiveObjects documentation.
  * Added links to LiveObjects documentation and the Swift quickstart guide.
  * Clarified versioning and release-process guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->