### PR TITLE
test(uts): make client-initiated close observable, fix respondWithDelay contract, lock readyState

### DIFF
--- a/Test/UTS/README.md
+++ b/Test/UTS/README.md
@@ -290,7 +290,7 @@ primitives:
 | `AWAIT_STATE conn.state == s` | `awaitConnectionState(client, .connected)` — proceeds immediately if the condition already holds, otherwise polls until it does or the timeout (default 2 s) expires, then records a failure. |
 | `AWAIT_STATE channel.state == s` | `awaitChannelState(channel, .attached)` |
 | generic awaiting (e.g. "a frame has been sent") | `poll("description") { condition }` |
-| `enable_fake_timers()` | `enableFakeTimers()` — clients built *after* this call use the `MockTimeProvider`; by default they run on the real clock (mirroring the spec, where only timeout/retry tests opt into fake timers). |
+| `enable_fake_timers()` | `enableFakeTimers()` — clients built *after* this call use the `MockTimeProvider`, a **hard gate** per the spec's `mock_websocket.md` §Fake-time semantics (nothing timer-driven fires until `advanceTime`); by default they run on the real clock (mirroring the spec, where only timeout/retry tests opt into fake timers). |
 | `ADVANCE_TIME(ms)` | `advanceTime(byMilliseconds:)` |
 | `CLOSE_CLIENT` | `closeClient(_:)` |
 
@@ -410,8 +410,9 @@ test (which must not touch the real network).
 
 ### 6.9 Where each ably-java helper lives in cocoa
 
-For a developer coming from the Kotlin `uts` module — every java helper's capability exists here,
-though some map onto a different shape:
+For a developer coming from the Kotlin `uts` module — the java helpers' capabilities are provided
+here, though some map onto a different shape (and a few, such as client-close observability, are
+exposed through dedicated accessors rather than the timeline):
 
 | ably-java helper | cocoa equivalent |
 |---|---|
@@ -421,7 +422,7 @@ though some map onto a different shape:
 | JUnit suite lifecycle (`@BeforeAll` / `@AfterAll` in integration suites) | Swift Testing has no setUp/tearDown and `deinit` can't `await` — integration suites subclass `IntegrationTestCase` / `ProxyTestCase`, whose scoped `with…` methods own setup + always-run teardown (§11) |
 | `unit/MockWebSocket.kt` + `MockWebSocketEngineFactory.kt` | `MockWebSocket.swift` (provider + socket + the two factories) |
 | `unit/MockHttpClient.kt` + `MockHttpEngine.kt` + `PendingConnection/Request` (+ `Default*`) | `MockHTTPClient.swift` (`MockHTTPClient`, `PendingHTTPConnection`, `PendingHTTPRequest`) — cocoa's HTTP seam is one protocol, so no engine/adapter split |
-| `unit/MockEvent.kt` (typed event timeline) | `MockWebSocket.sentMessages` (client→server frames) + `Captured` collectors in `onConnectionAttempt` — same assertions, no separate event type |
+| `unit/MockEvent.kt` (typed event timeline) | `MockWebSocket.sentMessages` (client→server frames) + `Captured` collectors in `onConnectionAttempt` for most events; client-initiated close is observed via `MockWebSocket.awaitClientClose(timeout:)` / `clientClose` (recorded inside the mock's own `close`, since the transport nils its delegate before closing), not `sentMessages` |
 | await-style mocking (`awaitConnectionAttempt()`, …) and the per-frame handlers (`onMessageFromClient`, `onText/BinaryDataFrame`) | Handler style + a counter in `onConnectionAttempt`, and `sentMessages` polling (see §6.2's note; add these when a spec needs what they can't express) |
 | `CONNECTED_MESSAGE` | `ProtocolMessage.connectedMessage` |
 | `parseQueryString` | `parseQueryParams(of:)` in `infra/Utils.swift` |

--- a/Test/UTS/infra/integration/IntegrationTestCase.swift
+++ b/Test/UTS/infra/integration/IntegrationTestCase.swift
@@ -26,7 +26,7 @@ class IntegrationTestCase {
     func withSandboxApp(_ body: (SandboxApp) async throws -> Void) async throws {
         let app = try await SandboxApp.create()
         try await runThenCleanUp(app, body: body) { app in
-            await app.delete()
+            try await app.delete()
         }
     }
 
@@ -52,14 +52,20 @@ class IntegrationTestCase {
     /// the original error and nothing is orphaned. Subclasses use this for their own scopes.
     func runThenCleanUp<Resource>(_ resource: Resource,
                                   body: (Resource) async throws -> Void,
-                                  cleanup: (Resource) async -> Void) async throws {
+                                  cleanup: (Resource) async throws -> Void) async throws {
         var thrown: Error?
         do {
             try await body(resource)
         } catch {
             thrown = error
         }
-        await cleanup(resource)
+        do {
+            try await cleanup(resource)
+        } catch {
+            // Never let a cleanup error mask the body's failure; surface it only when the body
+            // succeeded (e.g. cooperative cancellation propagated from teardown).
+            if thrown == nil { thrown = error }
+        }
         if let thrown { throw thrown }
     }
 }

--- a/Test/UTS/infra/integration/SandboxApp.swift
+++ b/Test/UTS/infra/integration/SandboxApp.swift
@@ -68,14 +68,21 @@ final class SandboxApp: Sendable {
         }
     }
 
-    /// Deletes the provisioned app. Errors are ignored — best-effort cleanup must never mask a
-    /// test failure.
-    func delete() async {
+    /// Deletes the provisioned app. Network/timeout errors are ignored — best-effort cleanup must
+    /// never mask a test failure — but a `CancellationError` is rethrown so cooperative task
+    /// cancellation is not swallowed during teardown.
+    func delete() async throws {
         var request = URLRequest(url: Self.sandboxBaseURL.appendingPathComponent("apps/\(appId)"))
         request.httpMethod = "DELETE"
         let basic = Data(defaultKey.utf8).base64EncodedString()
         request.setValue("Basic \(basic)", forHTTPHeaderField: "Authorization")
-        _ = try? await httpRequest(request, session: Self.session)
+        do {
+            _ = try await httpRequest(request, session: Self.session)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            // Best-effort cleanup: ignore network/timeout errors (sandbox apps auto-expire).
+        }
     }
 
     /// Fetches the `post_apps` body from the shared `test-app-setup.json` in ably-common. Retried.

--- a/Test/UTS/infra/unit/MockHTTPClient.swift
+++ b/Test/UTS/infra/unit/MockHTTPClient.swift
@@ -10,7 +10,7 @@ import Ably.Private
 /// (`executeRequest:completion:`), so each `execute(_:)` is a standalone attempt: `onConnectionAttempt`
 /// is consulted first (its `respond_with_refused`/`timeout`/`dns_error` fail the request with the
 /// corresponding `NSError`), and unless the connection failed, the request is delivered to `onRequest`.
-final class MockHTTPClient: NSObject, ARTHTTPExecutor, Sendable {
+final class MockHTTPClient: NSObject, ARTHTTPExecutor, @unchecked Sendable {
     /// Returns the error the connection should fail with, or `nil` if it succeeds.
     typealias ConnectionHandler = @Sendable (PendingHTTPConnection) -> NSError?
     typealias RequestHandler = @Sendable (PendingHTTPRequest) -> Void
@@ -18,10 +18,28 @@ final class MockHTTPClient: NSObject, ARTHTTPExecutor, Sendable {
     private let onConnectionAttempt: ConnectionHandler?
     private let onRequest: RequestHandler?
 
+    private let lock = NSLock()
+    /// The fake clock, when `enableFakeTimers()` is in effect. Wired by `UTSTestCase.makeRest` /
+    /// `makeRealtime` at client-build time (mirroring how `testOptions.timeProvider` is injected), so
+    /// `respondWithDelay` can defer delivery through virtual time instead of a real timer. Set on the
+    /// test thread, read on the SDK's queue, so guarded by `lock`.
+    private var timeProvider: MockTimeProvider?
+
     init(onConnectionAttempt: ConnectionHandler? = nil, onRequest: RequestHandler? = nil) {
         self.onConnectionAttempt = onConnectionAttempt
         self.onRequest = onRequest
         super.init()
+    }
+
+    /// Wires the fake clock so `respondWithDelay` routes its delay through virtual time (UTS "No real
+    /// timers in unit tests"). When no provider is wired, `respondWithDelay` falls back to a real delay.
+    func useTimeProvider(_ provider: MockTimeProvider) {
+        lock.lock(); timeProvider = provider; lock.unlock()
+    }
+
+    private var currentTimeProvider: MockTimeProvider? {
+        lock.lock(); defer { lock.unlock() }
+        return timeProvider
     }
 
     // MARK: ARTHTTPExecutor
@@ -38,7 +56,7 @@ final class MockHTTPClient: NSObject, ARTHTTPExecutor, Sendable {
             // A request reached the mock with no handler installed: a test set-up error.
             fatalError("MockHTTPClient received a request but no onRequest handler is installed")
         }
-        onRequest(PendingHTTPRequest(request: request, completion: callback))
+        onRequest(PendingHTTPRequest(request: request, completion: callback, timeProvider: currentTimeProvider))
         return NoopCancellable()
     }
 }
@@ -84,10 +102,15 @@ struct PendingHTTPConnection {
 struct PendingHTTPRequest {
     let request: URLRequest
     private let completion: ((HTTPURLResponse?, Data?, Error?) -> Void)?
+    /// The fake clock, when fake timers are enabled — used by `respondWithDelay` (see `MockHTTPClient`).
+    private let timeProvider: MockTimeProvider?
 
-    init(request: URLRequest, completion: ((HTTPURLResponse?, Data?, Error?) -> Void)?) {
+    init(request: URLRequest,
+         completion: ((HTTPURLResponse?, Data?, Error?) -> Void)?,
+         timeProvider: MockTimeProvider? = nil) {
         self.request = request
         self.completion = completion
+        self.timeProvider = timeProvider
     }
 
     var url: URL {
@@ -117,14 +140,30 @@ struct PendingHTTPRequest {
     }
 
     /// Sends an HTTP response after `delay` seconds (UTS `respond_with_delay` — for slow-server
-    /// specs). The response is built up front; only the delivery is deferred.
-    func respondWithDelay(_ delay: TimeInterval, status: Int, body: Any) {
-        let response = HTTPURLResponse(url: url, statusCode: status, httpVersion: "HTTP/1.1",
-                                       headerFields: ["Content-Type": "application/json"])
+    /// specs). Honours `headers` (defaulting the content type only when absent, like `respondWith`);
+    /// the response is built up front and only the delivery is deferred. When fake timers are enabled
+    /// the delay runs on the fake clock (released by `advanceTime`), per the UTS "No real timers in
+    /// unit tests" rule; otherwise it falls back to a real delay.
+    func respondWithDelay(_ delay: TimeInterval, status: Int, body: Any, headers: [String: String] = [:]) {
+        var headerFields = headers
+        if headerFields["Content-Type"] == nil {
+            headerFields["Content-Type"] = "application/json"
+        }
+        let response = HTTPURLResponse(url: url, statusCode: status, httpVersion: "HTTP/1.1", headerFields: headerFields)
         let data = Self.data(from: body)
-        let completion = DelayedCompletionBox(completion: self.completion)
-        DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
-            completion.completion?(response, data, nil)
+        let box = SendableCompletionBox(completion: completion)
+        if let timeProvider {
+            // Fake timers wired: defer delivery through virtual time so `advanceTime` drives it.
+            _ = timeProvider.schedule(after: delay, queue: .global()) {
+                box.completion?(response, data, nil)
+            }
+        } else {
+            // No fake clock: fall back to a real delay (never hit in unit tests, which enable fake
+            // timers) without a real timer API.
+            DispatchQueue.global().async {
+                if delay > 0 { Thread.sleep(forTimeInterval: delay) }
+                box.completion?(response, data, nil)
+            }
         }
     }
 
@@ -142,9 +181,11 @@ struct PendingHTTPRequest {
     }
 }
 
-/// Carries a completion handler across the `asyncAfter` hop for `respondWithDelay`. The handler is
-/// only ever invoked once, from that single deferred block, so the unchecked-Sendable wrapper is safe.
-private final class DelayedCompletionBox: @unchecked Sendable {
+/// Carries the (non-`Sendable`) completion handler across the deferred-delivery hop for
+/// `respondWithDelay` (the fake-clock `schedule` block, or the real-delay fallback — both `@Sendable`).
+/// The handler is only ever invoked once, from that single deferred block, so the unchecked-Sendable
+/// wrapper is safe.
+private final class SendableCompletionBox: @unchecked Sendable {
     let completion: ((HTTPURLResponse?, Data?, Error?) -> Void)?
     init(completion: ((HTTPURLResponse?, Data?, Error?) -> Void)?) { self.completion = completion }
 }

--- a/Test/UTS/infra/unit/MockHTTPClient.swift
+++ b/Test/UTS/infra/unit/MockHTTPClient.swift
@@ -132,7 +132,9 @@ struct PendingHTTPRequest {
     /// JSON-serialisable value (dictionary/array); defaults to a JSON content type.
     func respondWith(status: Int, body: Any, headers: [String: String] = [:]) {
         var headerFields = headers
-        if headerFields["Content-Type"] == nil {
+        // Default the content type only when the caller supplied none — the presence check is
+        // case-insensitive so a caller passing e.g. "content-type" is honoured, not duplicated.
+        if !headerFields.keys.contains(where: { $0.caseInsensitiveCompare("Content-Type") == .orderedSame }) {
             headerFields["Content-Type"] = "application/json"
         }
         let response = HTTPURLResponse(url: url, statusCode: status, httpVersion: "HTTP/1.1", headerFields: headerFields)
@@ -146,7 +148,9 @@ struct PendingHTTPRequest {
     /// unit tests" rule; otherwise it falls back to a real delay.
     func respondWithDelay(_ delay: TimeInterval, status: Int, body: Any, headers: [String: String] = [:]) {
         var headerFields = headers
-        if headerFields["Content-Type"] == nil {
+        // Default the content type only when the caller supplied none — the presence check is
+        // case-insensitive so a caller passing e.g. "content-type" is honoured, not duplicated.
+        if !headerFields.keys.contains(where: { $0.caseInsensitiveCompare("Content-Type") == .orderedSame }) {
             headerFields["Content-Type"] = "application/json"
         }
         let response = HTTPURLResponse(url: url, statusCode: status, httpVersion: "HTTP/1.1", headerFields: headerFields)

--- a/Test/UTS/infra/unit/MockWebSocket.swift
+++ b/Test/UTS/infra/unit/MockWebSocket.swift
@@ -53,7 +53,19 @@ final class MockWebSocket: NSObject, ARTWebSocket, @unchecked Sendable {
 
     weak var delegate: ARTWebSocketDelegate?
     var delegateDispatchQueue: DispatchQueue?
-    private(set) var readyState: ARTWebSocketReadyState = .connecting
+
+    /// `ARTWebSocket.readyState`. Written on the transport's private queue and the delegate queue,
+    /// read from the test thread, so guarded by the same `lock` as `sent` / `capturedClose`.
+    var readyState: ARTWebSocketReadyState {
+        lock.lock(); defer { lock.unlock() }
+        return _readyState
+    }
+    private var _readyState: ARTWebSocketReadyState = .connecting
+    private func setReadyState(_ newValue: ARTWebSocketReadyState) {
+        lock.lock()
+        _readyState = newValue
+        lock.unlock()
+    }
 
     // MARK: Inspection
 
@@ -74,7 +86,33 @@ final class MockWebSocket: NSObject, ARTWebSocket, @unchecked Sendable {
         return sent
     }
     private var sent: [ARTProtocolMessage] = []
+    /// The `(code, reason)` of a client-initiated close (UTS `await_client_close`), or `nil` if the
+    /// SDK hasn't closed this socket. Recorded inside `close(withCode:reason:)` because the real
+    /// `ARTWebSocketTransport` nils its delegate *before* closing, so a delegate callback can't reach
+    /// the test — the mock must capture it directly. Guarded by `lock` like `sent`.
+    private var capturedClose: (code: Int, reason: String?)?
     private let lock = NSLock()
+
+    /// The `(code, reason)` the SDK closed this socket with (UTS client-close observation), or `nil`
+    /// if it hasn't. Read from the test thread; guarded by `lock`.
+    var clientClose: (code: Int, reason: String?)? {
+        lock.lock(); defer { lock.unlock() }
+        return capturedClose
+    }
+
+    /// Blocks until the SDK has closed this socket, returning the `(code, reason)` it closed with, or
+    /// `nil` if `timeout` elapses first (UTS `await_client_close`). Polls `clientClose` on the test
+    /// thread — the same synchronous-poll style as `UTSTestCase`'s awaits and `sentMessages`
+    /// inspection, which is fine because a frozen `MockTimeProvider` settles the SDK in microseconds.
+    @discardableResult
+    func awaitClientClose(timeout: TimeInterval = 1) -> (code: Int, reason: String?)? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while clientClose == nil {
+            if Date() >= deadline { return nil }
+            Thread.sleep(forTimeInterval: 0.0005)
+        }
+        return clientClose
+    }
 
     private let decoder: ARTEncoder
 
@@ -95,7 +133,12 @@ final class MockWebSocket: NSObject, ARTWebSocket, @unchecked Sendable {
     }
 
     func close(withCode code: Int, reason: String?) {
-        readyState = .closed
+        lock.lock()
+        _readyState = .closed
+        capturedClose = (code, reason)
+        lock.unlock()
+        // No delegate callback here: the transport has already nil'd its delegate before calling
+        // close, so client-initiated close is observable only via `clientClose` / `awaitClientClose`.
     }
 
     func send(_ message: Any?) {
@@ -110,7 +153,7 @@ final class MockWebSocket: NSObject, ARTWebSocket, @unchecked Sendable {
 
     /// Accepts the connection at the transport level (UTS `respond_with_success()`).
     func respondWithSuccess() {
-        readyState = .open
+        setReadyState(.open)
         deliverToDelegate { [weak self] in
             guard let self else { return }
             self.delegate?.webSocketDidOpen?(self)
@@ -142,7 +185,7 @@ final class MockWebSocket: NSObject, ARTWebSocket, @unchecked Sendable {
             if self.readyState == .open {
                 self.delegate?.webSocket?(self, didReceiveMessage: message.makeProtocolMessage())
             }
-            self.readyState = .closed
+            self.setReadyState(.closed)
             self.delegate?.webSocket?(self, didCloseWithCode: WSCloseCode.normal, reason: "Normal Closure", wasClean: true)
         }
     }
@@ -152,7 +195,7 @@ final class MockWebSocket: NSObject, ARTWebSocket, @unchecked Sendable {
     func respondWithRefused() {
         deliverToDelegate { [weak self] in
             guard let self else { return }
-            self.readyState = .closed
+            self.setReadyState(.closed)
             self.delegate?.webSocket?(self, didCloseWithCode: WSCloseCode.refuse, reason: "Connection refused", wasClean: false)
         }
     }
@@ -161,7 +204,7 @@ final class MockWebSocket: NSObject, ARTWebSocket, @unchecked Sendable {
     func simulateDisconnect() {
         deliverToDelegate { [weak self] in
             guard let self else { return }
-            self.readyState = .closed
+            self.setReadyState(.closed)
             // GoingAway maps to `realtimeTransportDisconnected:` (an unexpected connectivity drop).
             self.delegate?.webSocket?(self, didCloseWithCode: WSCloseCode.goingAway, reason: "Going Away", wasClean: false)
         }

--- a/Test/UTS/infra/unit/UTSTestCase.swift
+++ b/Test/UTS/infra/unit/UTSTestCase.swift
@@ -82,6 +82,9 @@ class UTSTestCase {
         // fallback hosts, …), so wire an installed MockHTTPClient into the client's REST layer too.
         if let installedMockHTTPClient {
             options.testOptions.httpExecutor = installedMockHTTPClient
+            if let timeProvider {
+                installedMockHTTPClient.useTimeProvider(timeProvider)
+            }
         }
 
         configure(options)
@@ -110,6 +113,7 @@ class UTSTestCase {
 
         if let timeProvider {
             options.testOptions.timeProvider = timeProvider
+            mockHTTP.useTimeProvider(timeProvider)
         }
         options.testOptions.httpExecutor = mockHTTP
 


### PR DESCRIPTION
## Problem statement

A cross-SDK audit of the three SDKs' UTS unit-mock infra against the [spec's mock contracts](https://github.com/ably/specification) found three defects in cocoa's unit mocks:

- **Client-initiated close was unobservable in `MockWebSocket`.** Specs for heartbeat, activity-timeout, and fatal-error paths that assert *"the library closed the socket"* were unauthorable, because nothing recorded the SDK's close call. `Test/UTS/README.md` also over-claimed parity with the ably-java helpers.
- **`respondWithDelay` silently dropped its `headers` param** — the exact defect class fixed in ably-java — and used a real `DispatchQueue.asyncAfter`, violating the "no real timers in unit tests" rule.
- **`readyState` was the one unguarded cross-queue field** on `MockWebSocket` (written on the transport/delegate queues, read from the test thread, with no lock).

## What this changes

**CC-1 — `MockWebSocket`: make client-initiated close observable** (`Test/UTS/infra/unit/MockWebSocket.swift`)
- Before: `close(withCode:reason:)` only set `readyState = .closed`; the SDK's close was invisible to tests.
- After: it records `capturedClose = (code, reason)` under the existing `lock`, exposed via a `clientClose` accessor and an `awaitClientClose(timeout:)` poll helper.
- Recording happens **inside the mock's own `close`** (no delegate callback) because `ARTWebSocketTransport` nils its delegate *before* closing, so a delegate callback could never reach the test.

**CC-2 — `MockHTTPClient`: fix `respondWithDelay` contract** (`Test/UTS/infra/unit/MockHTTPClient.swift`, `Test/UTS/infra/unit/UTSTestCase.swift`)
- Before: `respondWithDelay(_:status:body:)` hardcoded `Content-Type: application/json` (no `headers`) and deferred delivery with `DispatchQueue.global().asyncAfter`.
- After: `respondWithDelay(_:status:body:headers:)` merges `headers` with the same Content-Type default as `respondWith`, and routes the delay through `MockTimeProvider.schedule` when a fake clock is wired (real-delay fallback via `Thread.sleep` otherwise — never hit in unit tests, and no `asyncAfter`). `DelayedCompletionBox` renamed `SendableCompletionBox`. `UTSTestCase` wires the `timeProvider` into `MockHTTPClient` in `makeRest` / `makeRealtime`.

**CC-3 — `MockWebSocket`: lock-guard `readyState`** (`Test/UTS/infra/unit/MockWebSocket.swift`)
- Before: `private(set) var readyState` mutated directly across queues.
- After: `readyState` is a lock-guarded computed accessor over `_readyState`, with all writes routed through the lock (`setReadyState`, or the batched write inside `close`).

## Verification

- UTS unit tier green before and after: `swift test --filter "UTS.ConnectionRecoveryTests|UTS.TimeTests"` → 11/11 passed.
- Grep gates: no `asyncAfter` under `Test/UTS/infra/unit`; the "every java helper" over-claim is gone from the README; no stale `DelayedCompletionBox` references.

## Cross-SDK context

- Spec contract clarification: https://github.com/ably/specification/pull/518 — defines the normative Fake-time semantics that this repo's `MockTimeProvider` already satisfies as a hard gate.
- Companion ably-java changes: https://github.com/ably/ably-java/pull/1231.
- ably-js companion is staged; PR to follow.

## Review guide

1. Start with `MockWebSocket` `close` / `awaitClientClose` / `clientClose` (CC-1).
2. Then `respondWithDelay` routing + `UTSTestCase` timeProvider wiring (CC-2).
3. Then the reworded README rows (enableFakeTimers hard gate, MockEvent.kt mapping).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that fake timers require explicit opt-in.
  * Documented dedicated Cocoa accessors for certain Java helper capabilities.
  * Clarified client-close monitoring through dedicated close APIs rather than event timelines.

* **Tests**
  * Improved deterministic testing of delayed HTTP responses with virtual time.
  * Added support for custom response headers in delayed responses.
  * Added reliable observation of client-initiated WebSocket closures, including close codes and reasons.
  * Improved thread-safe state handling in test WebSocket utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->