### PR TITLE
[AIT-1330] Add per-case value accessors to the primitive path object and instance

### DIFF
--- a/LiveObjects/Example/AblyLiveObjectsExample/ViewModels/TaskBoardViewModel.swift
+++ b/LiveObjects/Example/AblyLiveObjectsExample/ViewModels/TaskBoardViewModel.swift
@@ -76,7 +76,7 @@ final class TaskBoardViewModel: ObservableObject {
 
             var currentTasks: [String: String] = [:]
             for (key, value) in try tasksMapPath.entries() {
-                if let primitive = try value.asPrimitive().value(), let stringValue = primitive.stringValue {
+                if let stringValue = try value.asPrimitive().stringValue() {
                     currentTasks[key] = stringValue
                 }
             }

--- a/LiveObjects/README.md
+++ b/LiveObjects/README.md
@@ -120,7 +120,7 @@ let value = try root.get(key: "myKey")?.stringValue
 // ably-cocoa 1.3.0+ — path-based
 let root = try await channel.object.get()
 try await root.set(key: "myKey", value: "myValue")
-let value = try root.get(key: "myKey").asPrimitive().value()?.stringValue
+let value = try root.get(key: "myKey").asPrimitive().stringValue()
 ```
 
 A `PathObject` is purely navigational: it can be created before the data at its path exists, and it survives the object at its path being replaced — there is no need to re-fetch anything when the underlying object changes. The [example app](Example) demonstrates the path-based API.

--- a/LiveObjects/Sources/AblyLiveObjects/Path Based API/Public/Instance.swift
+++ b/LiveObjects/Sources/AblyLiveObjects/Path Based API/Public/Instance.swift
@@ -171,6 +171,55 @@ public protocol PrimitiveInstance: Sendable {
     func compactJson() throws(ARTErrorInfo) -> JSONValue
 }
 
+/// Convenience accessors for a single expected primitive type.
+///
+/// Each of these reads ``PrimitiveInstance/value`` and then the correspondingly-named getter on the
+/// resulting ``Primitive``, so `nil` means that the wrapped primitive is of a different case.
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
+public extension PrimitiveInstance {
+    /// If the wrapped primitive has case `string`, this returns the associated value. Else, it returns `nil`.
+    var stringValue: String? {
+        get throws(ARTErrorInfo) {
+            try value.stringValue
+        }
+    }
+
+    /// If the wrapped primitive has case `number`, this returns the associated value. Else, it returns `nil`.
+    var numberValue: Double? {
+        get throws(ARTErrorInfo) {
+            try value.numberValue
+        }
+    }
+
+    /// If the wrapped primitive has case `bool`, this returns the associated value. Else, it returns `nil`.
+    var boolValue: Bool? {
+        get throws(ARTErrorInfo) {
+            try value.boolValue
+        }
+    }
+
+    /// If the wrapped primitive has case `data`, this returns the associated value. Else, it returns `nil`.
+    var dataValue: Data? {
+        get throws(ARTErrorInfo) {
+            try value.dataValue
+        }
+    }
+
+    /// If the wrapped primitive has case `jsonArray`, this returns the associated value. Else, it returns `nil`.
+    var jsonArrayValue: [JSONValue]? {
+        get throws(ARTErrorInfo) {
+            try value.jsonArrayValue
+        }
+    }
+
+    /// If the wrapped primitive has case `jsonObject`, this returns the associated value. Else, it returns `nil`.
+    var jsonObjectValue: [String: JSONValue]? {
+        get throws(ARTErrorInfo) {
+            try value.jsonObjectValue
+        }
+    }
+}
+
 // MARK: - AsyncSequence subscription variants
 
 /// `AsyncStream`-based subscription for map instances.

--- a/LiveObjects/Sources/AblyLiveObjects/Path Based API/Public/PathObject.swift
+++ b/LiveObjects/Sources/AblyLiveObjects/Path Based API/Public/PathObject.swift
@@ -185,3 +185,44 @@ public protocol PrimitivePathObject: PathObject {
     /// `RTTS6b`.
     func value() throws(ARTErrorInfo) -> Primitive?
 }
+
+/// Convenience accessors for a single expected primitive type.
+///
+/// Each of these resolves the path via ``PrimitivePathObject/value()`` and then reads the
+/// correspondingly-named getter on the resulting ``Primitive``, so `nil` means either that nothing
+/// primitive resolved at the path or that what did resolve was a primitive of a different case.
+///
+/// These are methods, not properties, for the same reason as the rest of ``PathObject``'s
+/// path-resolving accessors: each resolves the path at call time and is therefore O(path length).
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
+public extension PrimitivePathObject {
+    /// If the value at this path is a `string` primitive, this returns the associated value. Else, it returns `nil`.
+    func stringValue() throws(ARTErrorInfo) -> String? {
+        try value()?.stringValue
+    }
+
+    /// If the value at this path is a `number` primitive, this returns the associated value. Else, it returns `nil`.
+    func numberValue() throws(ARTErrorInfo) -> Double? {
+        try value()?.numberValue
+    }
+
+    /// If the value at this path is a `bool` primitive, this returns the associated value. Else, it returns `nil`.
+    func boolValue() throws(ARTErrorInfo) -> Bool? {
+        try value()?.boolValue
+    }
+
+    /// If the value at this path is a `data` primitive, this returns the associated value. Else, it returns `nil`.
+    func dataValue() throws(ARTErrorInfo) -> Data? {
+        try value()?.dataValue
+    }
+
+    /// If the value at this path is a `jsonArray` primitive, this returns the associated value. Else, it returns `nil`.
+    func jsonArrayValue() throws(ARTErrorInfo) -> [JSONValue]? {
+        try value()?.jsonArrayValue
+    }
+
+    /// If the value at this path is a `jsonObject` primitive, this returns the associated value. Else, it returns `nil`.
+    func jsonObjectValue() throws(ARTErrorInfo) -> [String: JSONValue]? {
+        try value()?.jsonObjectValue
+    }
+}

--- a/LiveObjects/Sources/AblyLiveObjects/Path Based API/Public/ValueTypes.swift
+++ b/LiveObjects/Sources/AblyLiveObjects/Path Based API/Public/ValueTypes.swift
@@ -46,11 +46,16 @@ public enum Primitive: Sendable, Equatable {
     case data(Data)
     case jsonArray([JSONValue])
     case jsonObject([String: JSONValue])
+}
 
-    // MARK: - Convenience getters for associated values
+// MARK: - Primitive convenience getters for associated values
 
+/// These back the same-named accessors on ``PrimitivePathObject`` and ``PrimitiveInstance``, which is
+/// how callers outside the SDK reach them; on a `Primitive` in hand, `switch` over the cases.
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
+internal extension Primitive {
     /// If this `Primitive` has case `string`, this returns the associated value. Else, it returns `nil`.
-    public var stringValue: String? {
+    var stringValue: String? {
         if case let .string(value) = self {
             return value
         }
@@ -58,7 +63,7 @@ public enum Primitive: Sendable, Equatable {
     }
 
     /// If this `Primitive` has case `number`, this returns the associated value. Else, it returns `nil`.
-    public var numberValue: Double? {
+    var numberValue: Double? {
         if case let .number(value) = self {
             return value
         }
@@ -66,7 +71,7 @@ public enum Primitive: Sendable, Equatable {
     }
 
     /// If this `Primitive` has case `bool`, this returns the associated value. Else, it returns `nil`.
-    public var boolValue: Bool? {
+    var boolValue: Bool? {
         if case let .bool(value) = self {
             return value
         }
@@ -74,7 +79,7 @@ public enum Primitive: Sendable, Equatable {
     }
 
     /// If this `Primitive` has case `data`, this returns the associated value. Else, it returns `nil`.
-    public var dataValue: Data? {
+    var dataValue: Data? {
         if case let .data(value) = self {
             return value
         }
@@ -82,7 +87,7 @@ public enum Primitive: Sendable, Equatable {
     }
 
     /// If this `Primitive` has case `jsonArray`, this returns the associated value. Else, it returns `nil`.
-    public var jsonArrayValue: [JSONValue]? {
+    var jsonArrayValue: [JSONValue]? {
         if case let .jsonArray(value) = self {
             return value
         }
@@ -90,7 +95,7 @@ public enum Primitive: Sendable, Equatable {
     }
 
     /// If this `Primitive` has case `jsonObject`, this returns the associated value. Else, it returns `nil`.
-    public var jsonObjectValue: [String: JSONValue]? {
+    var jsonObjectValue: [String: JSONValue]? {
         if case let .jsonObject(value) = self {
             return value
         }

--- a/LiveObjects/Sources/AblyLiveObjects/Path Based API/Public/ValueTypes.swift
+++ b/LiveObjects/Sources/AblyLiveObjects/Path Based API/Public/ValueTypes.swift
@@ -223,24 +223,6 @@ public enum LiveMapValue: Sendable, Equatable {
         }
         return nil
     }
-
-    /// If this `LiveMapValue` wraps a `string` primitive, this returns the associated value. Else, it returns `nil`.
-    public var stringValue: String? { primitiveValue?.stringValue }
-
-    /// If this `LiveMapValue` wraps a `number` primitive, this returns the associated value. Else, it returns `nil`.
-    public var numberValue: Double? { primitiveValue?.numberValue }
-
-    /// If this `LiveMapValue` wraps a `bool` primitive, this returns the associated value. Else, it returns `nil`.
-    public var boolValue: Bool? { primitiveValue?.boolValue }
-
-    /// If this `LiveMapValue` wraps a `data` primitive, this returns the associated value. Else, it returns `nil`.
-    public var dataValue: Data? { primitiveValue?.dataValue }
-
-    /// If this `LiveMapValue` wraps a `jsonArray` primitive, this returns the associated value. Else, it returns `nil`.
-    public var jsonArrayValue: [JSONValue]? { primitiveValue?.jsonArrayValue }
-
-    /// If this `LiveMapValue` wraps a `jsonObject` primitive, this returns the associated value. Else, it returns `nil`.
-    public var jsonObjectValue: [String: JSONValue]? { primitiveValue?.jsonObjectValue }
 }
 
 // MARK: - ExpressibleBy*Literal conformances

--- a/LiveObjects/Tests/AblyLiveObjectsTests/Unit/DefaultInstanceTests.swift
+++ b/LiveObjects/Tests/AblyLiveObjectsTests/Unit/DefaultInstanceTests.swift
@@ -212,6 +212,11 @@ struct DefaultInstanceTests {
         #expect(throws: ARTErrorInfo.self) {
             _ = try primitive.value
         }
+
+        // The convenience accessors delegate to `value`, so they must propagate the same error.
+        #expect(throws: ARTErrorInfo.self) {
+            _ = try primitive.stringValue
+        }
     }
 
     // MARK: - compactJson (RTINS11 -> RTPO13c / RTPO14b)

--- a/LiveObjects/Tests/AblyLiveObjectsTests/Unit/DefaultInstanceTests.swift
+++ b/LiveObjects/Tests/AblyLiveObjectsTests/Unit/DefaultInstanceTests.swift
@@ -163,6 +163,33 @@ struct DefaultInstanceTests {
         #expect(primitive.type == .string)
     }
 
+    @Test
+    func primitiveConvenienceAccessors() throws {
+        let internalQueue = TestFactories.createInternalQueue()
+        let coreSDK = MockCoreSDK(channelState: .attached, internalQueue: internalQueue)
+
+        func primitiveInstance(_ value: InternalLiveMapValue) throws -> any PrimitiveInstance {
+            let instance = Instance.from(internalValue: value, coreSDK: coreSDK, realtimeObjects: MockRealtimeObjects(), internalQueue: internalQueue)
+            let primitive: (any PrimitiveInstance)? = switch instance {
+            case let .primitive(primitive):
+                primitive
+            case .liveMap, .liveCounter:
+                nil
+            }
+            return try #require(primitive)
+        }
+
+        #expect(try primitiveInstance(.string("hi")).stringValue == "hi")
+        #expect(try primitiveInstance(.number(5)).numberValue == 5)
+        #expect(try primitiveInstance(.bool(true)).boolValue == true)
+        #expect(try primitiveInstance(.data(Data([1, 2, 3]))).dataValue == Data([1, 2, 3]))
+        #expect(try primitiveInstance(.jsonArray(["a"])).jsonArrayValue == ["a"])
+        #expect(try primitiveInstance(.jsonObject(["k": "v"])).jsonObjectValue == ["k": "v"])
+
+        // An accessor for a case other than the wrapped one yields nil.
+        #expect(try primitiveInstance(.string("hi")).numberValue == nil)
+    }
+
     // @spec RTO25b - a read on a DETACHED channel throws
     @Test
     func readOnDetachedChannelThrows() throws {

--- a/LiveObjects/Tests/AblyLiveObjectsTests/Unit/DefaultPathObjectTests.swift
+++ b/LiveObjects/Tests/AblyLiveObjectsTests/Unit/DefaultPathObjectTests.swift
@@ -344,6 +344,11 @@ struct DefaultPathObjectTests {
         #expect(throws: ARTErrorInfo.self) {
             _ = try root.get(key: "s").type()
         }
+
+        // The convenience accessors delegate to `value()`, so they must propagate the same error.
+        #expect(throws: ARTErrorInfo.self) {
+            _ = try root.get(key: "s").asPrimitive().stringValue()
+        }
     }
 
     // @spec RTO26 - a write on a SUSPENDED channel throws (implementable state-check portion of the guard)

--- a/LiveObjects/Tests/AblyLiveObjectsTests/Unit/DefaultPathObjectTests.swift
+++ b/LiveObjects/Tests/AblyLiveObjectsTests/Unit/DefaultPathObjectTests.swift
@@ -231,6 +231,55 @@ struct DefaultPathObjectTests {
         #expect(try root.get(key: "s").asLiveCounter().value() == nil)
     }
 
+    // MARK: - Primitive reads (RTTS6b) and the per-case convenience accessors
+
+    /// A root map holding one entry per ``Primitive`` case, keyed by the case name. Separate from
+    /// ``makeFixture()`` so that the entry count the map-read tests assert on stays fixed.
+    private static func makePrimitivesRootPathObject() -> DefaultLiveMapPathObject {
+        let internalQueue = TestFactories.createInternalQueue()
+        let coreSDK = MockCoreSDK(channelState: .attached, internalQueue: internalQueue)
+
+        let root = makeMap(
+            objectID: ObjectsPool.rootKey,
+            data: [
+                "string": TestFactories.internalMapEntry(data: ProtocolTypes.ObjectData(string: "hi")),
+                "number": TestFactories.internalMapEntry(data: ProtocolTypes.ObjectData(number: NSNumber(value: 5))),
+                "bool": TestFactories.internalMapEntry(data: ProtocolTypes.ObjectData(boolean: true)),
+                "data": TestFactories.internalMapEntry(data: ProtocolTypes.ObjectData(bytes: Data([1, 2, 3]))),
+                "jsonArray": TestFactories.internalMapEntry(data: ProtocolTypes.ObjectData(json: ["a"])),
+                "jsonObject": TestFactories.internalMapEntry(data: ProtocolTypes.ObjectData(json: ["k": "v"])),
+            ],
+            internalQueue: internalQueue,
+        )
+
+        var pool = ObjectsPool(logger: TestLogger(), internalQueue: internalQueue, userCallbackQueue: .main, clock: MockSimpleClock())
+        pool.testsOnly_setEntry(.map(root), forObjectID: ObjectsPool.rootKey)
+
+        return DefaultLiveMapPathObject(
+            channelObject: SeededRealtimeObjects(pool: pool, internalQueue: internalQueue),
+            coreSDK: coreSDK,
+            internalQueue: internalQueue,
+            segments: [],
+        )
+    }
+
+    @Test
+    func primitiveConvenienceAccessors() throws {
+        let root = Self.makePrimitivesRootPathObject()
+
+        #expect(try root.get(key: "string").asPrimitive().stringValue() == "hi")
+        #expect(try root.get(key: "number").asPrimitive().numberValue() == 5)
+        #expect(try root.get(key: "bool").asPrimitive().boolValue() == true)
+        #expect(try root.get(key: "data").asPrimitive().dataValue() == Data([1, 2, 3]))
+        #expect(try root.get(key: "jsonArray").asPrimitive().jsonArrayValue() == ["a"])
+        #expect(try root.get(key: "jsonObject").asPrimitive().jsonObjectValue() == ["k": "v"])
+
+        // An accessor for a case other than the one that resolved yields nil, as does any accessor on
+        // a path that does not resolve to a primitive at all.
+        #expect(try root.get(key: "string").asPrimitive().numberValue() == nil)
+        #expect(try root.get(key: "nope").asPrimitive().stringValue() == nil)
+    }
+
     // MARK: - Writes via the publish path (RTPO15, RTPO17)
 
     // @spec RTPO15d - set publishes a MAP_SET operation for the resolved map

--- a/Test/UTS/integration/standard/objects/helpers/ObjectsIntegrationHelpers.swift
+++ b/Test/UTS/integration/standard/objects/helpers/ObjectsIntegrationHelpers.swift
@@ -44,14 +44,12 @@ func counterValue(at node: any PathObject) -> Double? {
 
 /// The spec's `pathObj.value()` against an expected **string** primitive.
 func stringValue(at node: any PathObject) -> String? {
-    guard let primitive = try? node.asPrimitive().value() else { return nil }
-    return primitive.stringValue
+    try? node.asPrimitive().stringValue()
 }
 
 /// The spec's `pathObj.value()` against an expected **number** primitive.
 func numberValue(at node: any PathObject) -> Double? {
-    guard let primitive = try? node.asPrimitive().value() else { return nil }
-    return primitive.numberValue
+    try? node.asPrimitive().numberValue()
 }
 
 /// Signals that a UTS objects helper could not satisfy its expected-type contract. The paired

--- a/Test/UTS/unit/objects/ValueTypesTests.swift
+++ b/Test/UTS/unit/objects/ValueTypesTests.swift
@@ -167,8 +167,8 @@ struct ValueTypesTests {
         // Assertions
         // ASSERT vt IS LiveMap — statically guaranteed: `create` returns `LiveMap` (RTLMV3b/RTLMV3d).
         // ASSERT vt.entries["name"] == "Alice" / vt.entries["age"] == 30
-        #expect(vt.entries?["name"]?.stringValue == "Alice")
-        #expect(vt.entries?["age"]?.numberValue == 30)
+        #expect(vt.entries?["name"] == "Alice")
+        #expect(vt.entries?["age"] == 30)
     }
 
     // UTS: objects/unit/RTLMV3/create-no-entries-0


### PR DESCRIPTION
Closes https://github.com/ably/ably-cocoa/issues/2244

Docs PR - https://github.com/ably/website/pull/9704

Reading a single expected primitive type meant unwrapping a `Primitive` first — `try node.asPrimitive().value()?.stringValue` — even though the expected type is usually known at the call site. This lifts `Primitive`'s per-case getters onto both places you hold a primitive from.

`PrimitivePathObject` gains six methods:

```swift
let name = try root.get(key: "name").asPrimitive().stringValue()
```

Methods rather than properties, for the same reason as the rest of `PathObject`'s accessors (`instance()`, `exists()`, `type()`, …): each resolves the path at call time and is therefore O(path length), so the call parentheses are carrying real information. `PrimitiveInstance` gains the same six as throwing properties, matching the shape of the `value` requirement they wrap — an `Instance` is bound to an already-resolved value, so those reads are O(1).

Both sets delegate to `Primitive`'s getters, which move to an `internal extension`. Callers outside the SDK now reach them through these accessors, or by `switch`ing over the enum — which is how `Primitive`'s own doc comment already describes discriminating it. Three external call sites moved across as a result:

- `Test/UTS/integration/standard/objects/helpers/ObjectsIntegrationHelpers.swift` — the only non-`@testable` importer in the test tree; both helpers collapse to one line.
- `LiveObjects/Example/.../TaskBoardViewModel.swift` — a two-clause `if let` becomes one.
- `LiveObjects/README.md` — the 1.3.0 migration example, which would otherwise no longer compile for a reader following it.

## Public API removals

Two, both deliberate:

- A user holding a `Primitive` can no longer write `.stringValue` on it. The getters are reached through the accessors above, or by `switch`ing the enum.
- `LiveMapValue` loses the same six. It is the **write** type — the value you construct and pass to `set` — so asking it which case it holds answers a question its holder settled when they built it. They came from plugin `main`, where `LiveMapValue` doubled as the read type (`map.get(key:) -> LiveMapValue?`), so `?.stringValue` *was* how you read a map entry; [ably-liveobjects-swift-plugin#134](https://github.com/ably/ably-liveobjects-swift-plugin/pull/134) narrowed it to write-only and its review called them vestigial there. `primitiveValue`, `liveMapValue`, `liveCounterValue` and the `ExpressibleBy*Literal` conformances stay — the conformances being the part that review called valuable. One call site: `Test/UTS/unit/objects/ValueTypesTests.swift`, which drops to comparing the whole value through those conformances and so now reads exactly like the UTS line above it (`vt.entries["name"] == "Alice"`), while also rejecting an absent key or a non-primitive entry that the case getter let through.

The rule that leaves: the read types (`PrimitivePathObject`, `PrimitiveInstance`) carry the typed shortcuts, a bare `Primitive` is discriminated by `switch`, and the write type carries neither.

Both getters were `public` at the `1.3.0` tag, so this is source-breaking against a shipped release — permitted by the experimental warning in `LiveObjects/README.md`, but the compiler error (`value of type 'Primitive' has no member 'stringValue'`) names no replacement. `LiveObjects/CHANGELOG.md` is kept only for the standalone plugin's history (`CONTRIBUTING.md`), and the root `CHANGELOG.md` is written at release time from the release's PR list, so here is that entry ready to copy:

> * The per-case getters on `Primitive` (`stringValue`, `numberValue`, `boolValue`, `dataValue`, `jsonArrayValue`, `jsonObjectValue`) and the same six on `LiveMapValue` are no longer public. Read one expected primitive type through the new accessors on `PrimitivePathObject` (`try node.asPrimitive().stringValue()`) or `PrimitiveInstance` (`try instance.stringValue`), or `switch` over `Primitive`'s cases. `LiveMapValue` keeps `primitiveValue`, `liveMapValue`, `liveCounterValue` and its `ExpressibleBy*Literal` conformances.

## Tests

`DefaultPathObjectTests.primitiveConvenienceAccessors` and `DefaultInstanceTests.primitiveConvenienceAccessors`, one per protocol. Each exercises all six accessors positively plus a wrong-case read; the path-object case also covers a path that does not resolve. The path-object test seeds its own root map holding one entry per `Primitive` case, kept separate from the shared `makeFixture()` so the entry counts `mapReads` asserts on do not shift.

`readOnDetachedChannelThrows` on both sides gains one assertion that an accessor propagates the `RTO25` precondition error. The regression that guards is silent: SE-0230 flattens nested optionals, so `try? value.stringValue` has type `String?` rather than `String??` and compiles cleanly in the `String?`-returning throwing getter, turning the error into `nil` — indistinguishable from a wrong-case read. Verified by mutation: with that one-character change the suite is green without the assertion and fails with it.

These accessors are SDK conveniences rather than spec points, so the tests carry no `@spec` tag.

## Checks

- `swift build --build-tests` clean
- 409/409 LiveObjects unit tests
- 380/380 `swift test --filter UTS`
- Example app builds for macOS via `BuildTool build-example-app`
- `Scripts/annotate-liveobjects-availability.py --check` clean

> [!NOTE]
> Stacked on #2257, so the base is `fix/2245-JSONValue-printing` and GitHub will retarget this to `main` once that merges. The two changes are independent — nothing here touches `JSONValue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added convenient accessors for reading string, number, Boolean, binary, and JSON values from path-based objects and primitive instances.
  * Accessors return no value when the requested type does not match.

* **Documentation**
  * Updated the migration example to reflect the current primitive-value access pattern.

* **Bug Fixes**
  * Updated task-board and integration helpers to use supported primitive accessors.

* **Tests**
  * Added coverage for matching, mismatched, and error-propagating primitive accessors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

