### PR TITLE
liveobjects: preserve exact Double values for numbers read over the JSON protocol

### DIFF
--- a/LiveObjects/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
+++ b/LiveObjects/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
@@ -332,7 +332,8 @@ internal final class InternalDefaultLiveCounter: Sendable {
             liveObjectMutableState.createOperationIsMerged = false
 
             // RTLC6c: Set data to the value of ObjectState.counter.count, or to 0 if it does not exist
-            data = state.counter?.count?.doubleValue ?? 0
+            // art_doubleValue: this count came off the wire, where JSON decoding can give us an NSDecimalNumber
+            data = state.counter?.count?.art_doubleValue ?? 0
 
             // RTLC6d: If ObjectState.createOp is present, merge the initial value into the LiveCounter as described in RTLC16
             // Discard the LiveCounterUpdate object returned by the merge operation
@@ -353,7 +354,9 @@ internal final class InternalDefaultLiveCounter: Sendable {
             let counterCreate = operation.counterCreate ?? operation.counterCreateWithObjectId?.derivedFrom
 
             // RTLC16a: Add counterCreate.count to data, if it exists
-            if let operationCount = counterCreate?.count?.doubleValue {
+            // art_doubleValue: for a remotely-created counter this count came off the wire (a locally-created
+            // one comes from `derivedFrom`, where it is already a Double, and is unaffected)
+            if let operationCount = counterCreate?.count?.art_doubleValue {
                 data += operationCount
                 // RTLC16c
                 update = .update(DefaultLiveCounterUpdate(amount: operationCount))
@@ -457,7 +460,8 @@ internal final class InternalDefaultLiveCounter: Sendable {
             }
 
             // RTLC9f, RTLC9g
-            let amount = operation.number.doubleValue
+            // art_doubleValue: an inbound counterInc number arrives as JSON decoded it
+            let amount = operation.number.art_doubleValue
             data += amount
             return .update(DefaultLiveCounterUpdate(amount: amount))
         }

--- a/LiveObjects/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
+++ b/LiveObjects/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
@@ -1178,7 +1178,8 @@ internal final class InternalDefaultLiveMap: Sendable {
 
             // RTLM5d2d: If ObjectsMapEntry.data.number exists, return it
             if let number = entry.data?.number {
-                return .number(number.doubleValue)
+                // art_doubleValue: an entry set by another client holds the number as JSON decoded it
+                return .number(number.art_doubleValue)
             }
 
             // RTLM5d2e: If ObjectsMapEntry.data.string exists, return it

--- a/LiveObjects/Sources/AblyLiveObjects/Protocol/ObjectMessage.swift
+++ b/LiveObjects/Sources/AblyLiveObjects/Protocol/ObjectMessage.swift
@@ -309,7 +309,7 @@ internal extension ProtocolTypes.ObjectData {
             case .messagePack:
                 // OD4c: When the MessagePack protocol is used
                 // OD4c3 A number payload is encoded as a MessagePack float64 type, and the result is set on the ObjectData.number attribute
-                .init(value: number.doubleValue)
+                .init(value: number.doubleValue) // `doubleValue`, not `art_doubleValue`: an outbound number is always one we built from a Swift Double (RTLMV4d), not a JSON-decoded NSDecimalNumber, so there are no digits to recover here.
             }
         } else {
             nil
@@ -570,8 +570,10 @@ internal extension ProtocolTypes.ObjectOperation {
             mapCreate: resolvedMapCreate?.toPublicMapCreate(), // PAOOP2c/PAOOP3b
             mapSet: mapSet.map { .init(key: $0.key, value: $0.value?.toPublicObjectData() ?? .init()) }, // PAOOP2d
             mapRemove: mapRemove.map { .init(key: $0.key) }, // PAOOP2e
-            counterCreate: resolvedCounterCreate.map { .init(count: $0.count?.doubleValue ?? 0) }, // PAOOP2f/PAOOP3c
-            counterInc: counterInc.map { .init(number: $0.number.doubleValue) }, // PAOOP2g
+            // art_doubleValue on both counts below: this operation came off the wire, where JSON decoding
+            // can give us an NSDecimalNumber
+            counterCreate: resolvedCounterCreate.map { .init(count: $0.count?.art_doubleValue ?? 0) }, // PAOOP2f/PAOOP3c
+            counterInc: counterInc.map { .init(number: $0.number.art_doubleValue) }, // PAOOP2g
             objectDelete: objectDelete.map { _ in .init() }, // PAOOP2h
             mapClear: mapClear.map { _ in .init() }, // PAOOP2i
         )
@@ -613,7 +615,7 @@ internal extension ProtocolTypes.ObjectData {
             encoding: nil, // OD2b — internal data is already decoded
             boolean: boolean, // OD2c
             bytes: bytes, // OD2d
-            number: number?.doubleValue, // OD2e
+            number: number?.art_doubleValue, // OD2e — art_doubleValue: this data came off the wire, as JSON decoded it
             string: string, // OD2f
             json: json?.toJSONValue, // OD2g — pass the decoded value through, no re-serialization
         )

--- a/LiveObjects/Sources/AblyLiveObjects/Utility/JSONValue.swift
+++ b/LiveObjects/Sources/AblyLiveObjects/Utility/JSONValue.swift
@@ -144,7 +144,9 @@ internal extension JSONValue {
     /// - The result of serializing an array or dictionary using `JSONSerialization`
     /// - Some nested element of the result of serializing such an array or dictionary
     init(jsonSerializationOutput: Any) {
-        let extended = ExtendedJSONValue<Double, Never>(deserialized: jsonSerializationOutput, createNumberValue: { $0.doubleValue }, createExtraValue: { deserializedExtraValue in
+        // art_doubleValue, not doubleValue: this is the JSONSerialization boundary itself, where a
+        // high-precision number arrives as an NSDecimalNumber
+        let extended = ExtendedJSONValue<Double, Never>(deserialized: jsonSerializationOutput, createNumberValue: { $0.art_doubleValue }, createExtraValue: { deserializedExtraValue in
             // JSONSerialization is not conforming to our assumptions; our assumptions are probably wrong. Either way, bring this loudly to our attention instead of trying to carry on
             preconditionFailure("JSONValue(jsonSerializationOutput:) was given unsupported value \(deserializedExtraValue)")
         })

--- a/LiveObjects/Sources/AblyLiveObjects/Utility/NSNumber+Extensions.swift
+++ b/LiveObjects/Sources/AblyLiveObjects/Utility/NSNumber+Extensions.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)
+internal extension NSNumber {
+    /// The `Double` closest to this number's value, which `doubleValue` does not always give.
+    ///
+    /// `JSONSerialization.jsonObject` does not represent every JSON number as a `Double`. A number
+    /// whose text needs more than about 16 significant digits comes back as an `NSDecimalNumber`
+    /// holding the exact decimal, and `NSDecimalNumber`'s conversion to binary floating point is not
+    /// correctly rounded: it can land one unit in the last place away from the nearest `Double`.
+    ///
+    /// ```
+    /// text          0.015034388851090229
+    /// .stringValue  0.015034388851090229   exact
+    /// .doubleValue  0.015034388851090227   one ULP low
+    /// Double(text)  0.015034388851090229   correctly rounded
+    /// ```
+    ///
+    /// Every other bridge Foundation offers — `Double(truncating:)`, `Double(exactly:)`, `as? Double` —
+    /// shares that conversion and is wrong on exactly the same values. `Double(exactly:)` is worth
+    /// singling out: it never returns `nil` for these, so it reports success while handing back a
+    /// rounded value.
+    ///
+    /// The exact digits survive in the decimal representation, so the way out is to read them back as
+    /// text and let `Double(_: String)`, which is correctly rounded, do the conversion.
+    ///
+    /// This only makes a difference when the JSON protocol is in use, that is when
+    /// `ARTClientOptions.useBinaryProtocol` is `false` (it defaults to `true`). Under MessagePack a
+    /// number arrives as a float64 and is decoded into a plain `NSNumber` that already holds the
+    /// closest `Double`, so nothing here changes the value; there is no decimal text to misread.
+    ///
+    /// `NSNumberExactDoubleValueTests` covers this property and the `JSONValue` bridge above it;
+    /// `NumberPrecisionTests` covers the whole round trip through the Ably system, and its JSON tests
+    /// fail if any of the SDK's reads go back to `doubleValue`.
+    ///
+    /// The `NSDecimalNumber` test is not defensive. For an ordinary `NSNumber`, which already holds a
+    /// `Double`, `stringValue` rounds to 16 significant digits and loses precision that `doubleValue`
+    /// would have preserved — `greatestFiniteMagnitude` comes back as `1.797693134862316e+308`, which
+    /// re-parses to infinity — so the text route must not be taken unconditionally.
+    var art_doubleValue: Double {
+        // Only NSDecimalNumber holds digits that `doubleValue` cannot see; for anything else it is
+        // already the closest Double, and the textual route would be a downgrade.
+        guard self is NSDecimalNumber, let exact = Double(stringValue) else {
+            return doubleValue
+        }
+
+        return exact
+    }
+}

--- a/LiveObjects/Sources/AblyLiveObjects/Utility/WireValue.swift
+++ b/LiveObjects/Sources/AblyLiveObjects/Utility/WireValue.swift
@@ -247,7 +247,8 @@ internal extension WireValue {
     var toJSONValue: JSONValue {
         get throws(ARTErrorInfo) {
             let neverExtended = try toExtendedJSONValue.map(number: { (number: NSNumber) throws(ARTErrorInfo) -> Double in
-                number.doubleValue
+                // art_doubleValue: an inbound WireValue's numbers are as JSON decoded them
+                number.art_doubleValue
             }, extra: { (extra: ExtraValue) throws(ARTErrorInfo) -> Never in
                 switch extra {
                 case .data:

--- a/LiveObjects/Tests/AblyLiveObjectsTests/Integration/NumberPrecisionTests.swift
+++ b/LiveObjects/Tests/AblyLiveObjectsTests/Integration/NumberPrecisionTests.swift
@@ -1,0 +1,139 @@
+import Ably
+@testable import AblyLiveObjects
+import Foundation
+import Testing
+
+/// Values that survive `Double` → JSON text → `Double` only if the text is parsed exactly: they are
+/// the ones `JSONSerialization` hands back as an `NSDecimalNumber` whose `doubleValue` lands one or
+/// two ULP away from what was written. A subset of the list in `NSNumberExactDoubleValueTests`; three
+/// is enough for tests that each pay for a sandbox round trip.
+///
+/// At file scope so that the suite's `@Test(arguments:)` attributes can refer to it.
+private let impreciselyConvertedValues: [Double] = [
+    0.015034388851090229,
+    0.023942638935083197,
+    0.050053335337711245,
+]
+
+/// Checks that a `Double` written into the graph comes back bit-for-bit identical after a round trip
+/// through the Ably system.
+///
+/// This is the integration-level counterpart of `NSNumberExactDoubleValueTests`, covering the reason
+/// the SDK reads wire numbers through `NSNumber.art_doubleValue`. Reverting any of those reads to
+/// `doubleValue` fails the JSON tests here.
+///
+/// The MessagePack tests pass either way — a float64 on the wire decodes to a plain `NSNumber` that
+/// already holds the closest `Double` — and are here to pin that down.
+@Suite(.tags(.integration))
+struct NumberPrecisionTests {
+    @Test(arguments: impreciselyConvertedValues)
+    func mapNumberSurvivesJSONRoundTrip(value: Double) async throws {
+        try await Self.checkMapNumberSurvivesRoundTrip(value: value, useBinaryProtocol: false)
+    }
+
+    @Test(arguments: impreciselyConvertedValues)
+    func mapNumberSurvivesMessagePackRoundTrip(value: Double) async throws {
+        try await Self.checkMapNumberSurvivesRoundTrip(value: value, useBinaryProtocol: true)
+    }
+
+    @Test(arguments: impreciselyConvertedValues)
+    func counterValueSurvivesJSONRoundTrip(value: Double) async throws {
+        try await Self.checkCounterValueSurvivesRoundTrip(value: value, useBinaryProtocol: false)
+    }
+
+    @Test(arguments: impreciselyConvertedValues)
+    func counterValueSurvivesMessagePackRoundTrip(value: Double) async throws {
+        try await Self.checkCounterValueSurvivesRoundTrip(value: value, useBinaryProtocol: true)
+    }
+
+    // MARK: - Round trips
+
+    /// Covers the `ObjectsMapEntry.data.number` read (RTLM5d2d).
+    private static func checkMapNumberSurvivesRoundTrip(
+        value: Double,
+        useBinaryProtocol: Bool,
+        sourceLocation: SourceLocation = #_sourceLocation,
+    ) async throws {
+        try await withRootMap(useBinaryProtocol: useBinaryProtocol) { root in
+            try await root.set(key: "number", value: .primitive(.number(value)))
+
+            try await waitUntil("the value is in the graph", sourceLocation: sourceLocation) {
+                try root.get(key: "number").asPrimitive().value() != nil
+            }
+
+            let actual = try root.get(key: "number").asPrimitive().value()?.numberValue
+            #expect(actual == value, sourceLocation: sourceLocation)
+        }
+    }
+
+    /// Covers the `counterCreate.count` (RTLC6c, RTLC16a) and `counterInc.number` (RTLC9f) reads. The
+    /// same value serves as both the initial count and the increment; doubling it is exact in binary
+    /// floating point, so a misread of either read still shows up in the final count.
+    private static func checkCounterValueSurvivesRoundTrip(
+        value: Double,
+        useBinaryProtocol: Bool,
+        sourceLocation: SourceLocation = #_sourceLocation,
+    ) async throws {
+        try await withRootMap(useBinaryProtocol: useBinaryProtocol) { root in
+            try await root.set(key: "counter", value: .liveCounter(.create(initialCount: value)))
+            let counter = root.get(key: "counter").asLiveCounter()
+
+            try await waitUntil("the counter is in the graph", sourceLocation: sourceLocation) {
+                try counter.value() != nil
+            }
+
+            // The initial count reaches us as ObjectState.counter.count in the OBJECT_SYNC, or as
+            // ObjectOperation.counterCreate.count in the echoed OBJECT
+            let countAfterCreate = try counter.value()
+            #expect(countAfterCreate == value, sourceLocation: sourceLocation)
+
+            try await counter.increment(amount: value)
+
+            try await waitUntil("the increment has been applied", sourceLocation: sourceLocation) {
+                try counter.value() != value
+            }
+
+            // The increment reaches us as ObjectOperation.counterInc.number
+            let countAfterIncrement = try counter.value()
+            #expect(countAfterIncrement == value + value, sourceLocation: sourceLocation)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Creates a sandbox client, attaches to a fresh channel, and calls `body` with the channel's root
+    /// map. Holds on to the client (which the path object does not) until `body` returns.
+    private static func withRootMap(
+        useBinaryProtocol: Bool,
+        _ body: (any LiveMapPathObject) async throws -> Void,
+    ) async throws {
+        let realtime = try await ClientHelper.realtimeWithObjects(options: .init(useBinaryProtocol: useBinaryProtocol))
+        defer { realtime.close() }
+
+        let channel = realtime.channels.get(UUID().uuidString, options: ClientHelper.channelOptionsWithObjects())
+        try await channel.attachAsync()
+
+        let root = try await channel.object.get()
+        try await body(root)
+    }
+
+    /// Polls `condition` until it holds, recording a failure if it does not do so within `timeout`.
+    /// `set` and `increment` return once the operation has been ACKed, which is before the echoed
+    /// OBJECT message that puts the value into the graph has been applied — hence the wait.
+    private static func waitUntil(
+        _ description: String,
+        timeout: TimeInterval = 10,
+        sourceLocation: SourceLocation = #_sourceLocation,
+        _ condition: () throws -> Bool,
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if try condition() {
+                return
+            }
+            try await Task.sleep(nanoseconds: 50 * NSEC_PER_MSEC)
+        }
+
+        Issue.record("Timed out after \(timeout)s waiting for: \(description)", sourceLocation: sourceLocation)
+    }
+}

--- a/LiveObjects/Tests/AblyLiveObjectsTests/Unit/NSNumberExactDoubleValueTests.swift
+++ b/LiveObjects/Tests/AblyLiveObjectsTests/Unit/NSNumberExactDoubleValueTests.swift
@@ -1,0 +1,74 @@
+@testable import AblyLiveObjects
+import Foundation
+import Testing
+
+/// Tests for `NSNumber.art_doubleValue`, which the SDK uses in place of `doubleValue`
+/// when reading numbers that came out of `JSONSerialization`. See the doc comment on that property for
+/// why it exists.
+struct NSNumberExactDoubleValueTests {
+    private static func parse(_ text: String) throws -> NSNumber {
+        let object = try JSONSerialization.jsonObject(with: Data(text.utf8), options: [.fragmentsAllowed])
+        return try #require(object as? NSNumber)
+    }
+
+    // Values whose shortest textual form `JSONSerialization` hands back as an `NSDecimalNumber`, where
+    // `doubleValue` lands one or two ULP away from the original. Found by fuzzing in the 0.001...1000
+    // range, so these are the sort of amount a `LiveCounter` might plausibly hold.
+    @Test(arguments: [
+        0.015034388851090229,
+        0.023942638935083197,
+        0.033958698936617585,
+        0.025558854016674924,
+        0.012719384279025869,
+        0.013029106591963293,
+        0.034000795543243395,
+        0.050053335337711245,
+        0.010050170732297348,
+    ] as [Double])
+    func recoversValuesThatDoubleValueRounds(value: Double) throws {
+        let parsed = try Self.parse(String(value))
+
+        #expect(parsed.art_doubleValue == value)
+    }
+
+    // Ordinary numbers, which arrive as a plain `NSNumber` already holding the closest `Double`. These
+    // guard the `NSDecimalNumber` test in the implementation: reading them back from `stringValue`
+    // instead would round to 16 significant digits, turning `greatestFiniteMagnitude` into infinity.
+    @Test(arguments: [
+        0,
+        1,
+        -42,
+        0.1,
+        0.5,
+        123.456,
+        1e21,
+        0x1p53,
+        1e-7,
+        .leastNonzeroMagnitude,
+        .greatestFiniteMagnitude,
+        -.greatestFiniteMagnitude,
+        .pi,
+    ] as [Double])
+    func agreesWithDoubleValueForOrdinaryNumbers(value: Double) throws {
+        let parsed = try Self.parse(String(value))
+
+        #expect(parsed.art_doubleValue == value)
+    }
+
+    // The reason the property exists is the bridge that reads decoded JSON into a `JSONValue`, so check
+    // it end to end rather than only through the property.
+    @Test(arguments: [
+        0.015034388851090229,
+        0.023942638935083197,
+        123.456,
+        .greatestFiniteMagnitude,
+    ] as [Double])
+    func jsonValueBridgePreservesTheValue(value: Double) throws {
+        let text = #"{"amount":\#(String(value))}"#
+        let deserialized = try JSONSerialization.jsonObject(with: Data(text.utf8))
+
+        let jsonValue = JSONValue(jsonSerializationOutput: deserialized)
+
+        #expect(jsonValue == ["amount": .number(value)])
+    }
+}


### PR DESCRIPTION
Jira: [AIT-1339](https://ably.atlassian.net/browse/AIT-1339)

Split out of #2257, which was carrying this alongside an unrelated change.

## What happens today

`NumberPrecisionTests` (new, integration, against the sandbox) writes a `Double` into the graph and reads it back bit-for-bit — once for a map value, once for a counter (`counterCreate.count` then `counterInc.number`), each parametrized over three values and split per protocol.

Against the current reads it fails on every JSON case and passes on every MessagePack one:

```text
✘ mapNumberSurvivesJSONRoundTrip          (actual → 0.015034388851090227)  == (value → 0.015034388851090229)
✘ mapNumberSurvivesJSONRoundTrip          (actual → 0.023942638935083194)  == (value → 0.023942638935083197)
✘ mapNumberSurvivesJSONRoundTrip          (actual → 0.05005333533771126)   == (value → 0.050053335337711245)
✘ counterValueSurvivesJSONRoundTrip       (countAfterCreate → 0.015034388851090227) == (value → 0.015034388851090229)
✘ counterValueSurvivesJSONRoundTrip       (countAfterIncrement → 0.030068777702180454) == (value + value → 0.030068777702180458)
   (9 failures in total: 3 map, 6 counter)
✔ mapNumberSurvivesMessagePackRoundTrip       3 cases
✔ counterValueSurvivesMessagePackRoundTrip    3 cases
```

The counter case is the one that matters most: the amount is accumulated, so the divergence persists.

## Why

`JSONSerialization` does not represent every JSON number as a `Double`. Fixed-point text with enough significant digits comes back as an `NSDecimalNumber`, whose conversion to binary floating point is not correctly rounded:

```text
text          0.015034388851090229
.stringValue  0.015034388851090229   exact
.doubleValue  0.015034388851090227   one ULP low
Double(text)  0.015034388851090229   correctly rounded
```

The parser is fine — every digit survives. The loss is in the `NSNumber` → `Double` conversion, and every bridge Foundation offers shares it: `doubleValue`, `Double(truncating:)`, `Double(exactly:)`, `as? Double`. `Double(exactly:)` never returns `nil` for these, so it reports success while handing back a rounded value.

The trigger is textual shape, not magnitude — `1.2345678901234567e-5` is fine, `0.000012345678901234567` is not — and ably-js writes fixed-point notation for everything down to `1e-6`. So a JS client calling `counter.increment(0.004910368508982831)` leaves the Swift client's counter one ULP from what every other SDK reports. MessagePack is unaffected: a float64 decodes to a plain `NSNumber` already holding the closest `Double`.

## The fix

`NSNumber.art_doubleValue` reads the digits back as text for the `NSDecimalNumber` case and lets `Double(_: String)` convert. The type test is load-bearing, not defensive: an ordinary `NSNumber`'s `stringValue` rounds to 16 significant digits, which would turn `greatestFiniteMagnitude` into infinity.

Applied at the nine sites that read wire-derived numbers, each carrying a one-line note on why it needs the exact read. Two reads stay on `doubleValue`: the MessagePack branch of `ObjectData.toWire`, the only outbound conversion, where the number is always one the SDK built from a Swift `Double`; and the `objectsGCGracePeriod` reads, a duration rather than object data.

`NSNumberExactDoubleValueTests` (unit) covers the property and the `JSONValue` bridge directly, including the ordinary values that guard the type test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric precision when processing counters, maps, object data, JSON values, and wire data.
  * Prevented rounding errors for high-precision decimal values received or converted by the SDK.
  * Preserved numeric values accurately across JSON and MessagePack round trips.

* **Tests**
  * Added coverage for high-precision decimal handling and standard numeric values.
  * Added integration coverage for precise map and counter values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[AIT-1339]: https://ably.atlassian.net/browse/AIT-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ