### PR TITLE
Point CI workflows at the ably-pubsub-cocoa sdk-builds role

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:
           aws-region: eu-west-2
-          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-cocoa
+          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-pubsub-cocoa
           role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
 
       - name: Upload Jazzy Documentation

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -17,6 +17,6 @@ jobs:
       id-token: write
     uses: ably/features/.github/workflows/sdk-features.yml@6b3fc7a8ede2ebdd7a6325314f3a96c6466f1453 # main as of 2026-05-26
     with:
-      repository-name: ably-cocoa
+      repository-name: ably-pubsub-cocoa
     secrets:
       ABLY_AWS_ACCOUNT_ID_SDK: ${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}

--- a/.github/workflows/liveobjects.yaml
+++ b/.github/workflows/liveobjects.yaml
@@ -411,7 +411,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-region: eu-west-2
-          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-cocoa
+          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-pubsub-cocoa
           role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
 
       # Upload the generated documentation


### PR DESCRIPTION
**Do not merge until the repository is renamed `ably-cocoa` → `ably-pubsub-cocoa`, in the programme's rename freeze window.** Merging early points three workflows at the `ably-sdk-builds-ably-pubsub-cocoa` IAM role, whose OIDC trust is bound to the new repository name, so the credential step would fail. Conversely, once the rename happens the old role name stops matching, so this is a same-window change in both directions.

## Why workflows-only

ably-cocoa follows the **copy-then-rename** route in [PDR-091b2](https://ably.atlassian.net/wiki/spaces/product/pages/5348425729): a maintenance copy keeps the `ably/ably-cocoa` name, and this repo is renamed. Because the old name is reclaimed there is **no GitHub redirect**, so the consumer-facing identity strings are part of the split's public API change, not a rename follow-through:

- `Ably.podspec` `s.source` git URL
- SPM package URL in `README.md` install snippets
- `README.md` / `LiveObjects/README.md` badges and links, `Docs/Main.md`, `CONTRIBUTING.md`

Those are left to the split chain (#2264 → #2268), which rewrites the same files. This PR carries only what the rename itself breaks. Sibling of the rename PRs in the other SDK repos ([ably-pubsub-ruby#457](https://github.com/ably/ably-pubsub-ruby/pull/457) et al.).

## What changed

- **`.github/workflows/docs.yml`, `.github/workflows/liveobjects.yaml`** — `role-to-assume` → `ably-sdk-builds-ably-pubsub-cocoa`.
- **`.github/workflows/features.yml`** — `repository-name: ably-pubsub-cocoa`.

## ⚠️ Infrastructure prerequisite

The `ably-pubsub-cocoa` sdk-builds role exists ([infrastructure#13005](https://github.com/ably/infrastructure/pull/13005)) but, unlike the other renamed repos, has **no ID-qualified OIDC subject** in its trust policy. The renamed repo keeps its numeric ID and GitHub issues the ID-qualified subject for repos renamed after 2026-07-15, so without that entry the credential step fails post-rename. Tracked in https://github.com/ably/infrastructure/pull/13087; merge and apply that first.

## Post-rename verification

- [ ] `docs.yml`, `liveobjects.yaml` (docs job) and `features.yml` runs: AWS credential step succeeds **and the upload lands** at `sdk.ably.com/builds/ably/ably-pubsub-cocoa/main/…` (the upload failure mode is silent).
- [ ] Merge `main` into the `split/*` branches, which carry their own copies of these workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated documentation publishing credentials for the Pub/Sub Cocoa repository.
  - Updated feature workflow configuration to reference the Pub/Sub Cocoa repository.
  - Documentation generation, builds, and artifact uploads remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->