### PR TITLE
PROBE (do not merge): does UTS_SIDE reach the test process on simulators?

### DIFF
--- a/.github/workflows/uts.yaml
+++ b/.github/workflows/uts.yaml
@@ -117,7 +117,7 @@ jobs:
           bundle install
 
       - name: Run Tests
-        run: bundle exec fastlane ${{ matrix.lane }} suite:uts test_plan:${{ matrix.test_plan }}
+        run: bundle exec fastlane ${{ matrix.lane }} suite:uts test_plan:${{ matrix.test_plan }} only_testing:UTS/SideSeamTests
 
       - name: Check Static Analyzer Output
         id: analyzer-output

--- a/Test/UTSDevice.xctestplan
+++ b/Test/UTSDevice.xctestplan
@@ -7,7 +7,7 @@
         "environmentVariableEntries": [
           {
             "key": "UTS_SIDE",
-            "value": "device"
+            "value": "bogus"
           }
         ]
       }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,7 +13,7 @@ class LaneConfig < Struct.new(:name, :devices)
   # UTS_SIDE=device, so the suite reaches the SDK through AblyPubSubDevice's factory
   # instead. Plans are declared in
   # .swiftpm/xcode/xcshareddata/xcschemes/ably-cocoa.xcscheme.
-  def args_for_run_tests(suite: nil, test_plan: nil)
+  def args_for_run_tests(suite: nil, test_plan: nil, only_testing: nil)
     ably_env = ENV['ABLY_ENV']
 
     unless ably_env && !ably_env.empty?
@@ -39,6 +39,7 @@ class LaneConfig < Struct.new(:name, :devices)
     }
 
     args[:testplan] = test_plan if test_plan && !test_plan.empty?
+    args[:only_testing] = [only_testing] if only_testing && !only_testing.empty?
 
     case suite
     when 'uts'
@@ -75,7 +76,7 @@ platform :ios do
 
   LANE_CONFIGS.each do |lane_config|
     lane(lane_config.name) do |options|
-      run_tests(**lane_config.args_for_run_tests(suite: options[:suite], test_plan: options[:test_plan]))
+      run_tests(**lane_config.args_for_run_tests(suite: options[:suite], test_plan: options[:test_plan], only_testing: options[:only_testing]))
     end
   end
 


### PR DESCRIPTION
Throwaway, to be closed as soon as it has answered its question.

Sets `Test/UTSDevice.xctestplan`'s configuration value to `bogus` and restricts the run to `SideSeamTests`.

`Side.swift` aborts on an unrecognised `UTS_SIDE`, so the two outcomes are unambiguous:

* **device legs crash** with `Fatal error: UTS_SIDE must be 'core' or 'device', got 'bogus'` — the plan delivers the variable on that platform.
* **device legs pass** — the variable never arrived, the leg silently ran as `core`, and the device coverage on that platform is illusory.

The `core` legs are the control and should pass either way.

This is the only way to tell, because a device leg that receives nothing runs as `core` and passes exactly like one that works.