### PR TITLE
UTS: record issues on the test's own task, not in SDK callbacks

### DIFF
--- a/Test/UTS/integration/standard/objects/ObjectsSyncTests.swift
+++ b/Test/UTS/integration/standard/objects/ObjectsSyncTests.swift
@@ -158,13 +158,14 @@ extension ObjectsSyncTests {
     /// an issue on error.
     private func awaitDetach(_ channel: ARTRealtimeChannel,
                              sourceLocation: SourceLocation = #_sourceLocation) async {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        let failure: String? = await withCheckedContinuation { continuation in
             channel.detach { error in
-                if let error {
-                    Issue.record("detach() failed: \(error)", sourceLocation: sourceLocation)
-                }
-                continuation.resume()
+                continuation.resume(returning: error.map { "\($0)" })
             }
+        }
+
+        if let failure {
+            Issue.record("detach() failed: \(failure)", sourceLocation: sourceLocation)
         }
     }
 
@@ -172,13 +173,14 @@ extension ObjectsSyncTests {
     /// an issue on error.
     private func awaitAttach(_ channel: ARTRealtimeChannel,
                              sourceLocation: SourceLocation = #_sourceLocation) async {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        let failure: String? = await withCheckedContinuation { continuation in
             channel.attach { error in
-                if let error {
-                    Issue.record("attach() failed: \(error)", sourceLocation: sourceLocation)
-                }
-                continuation.resume()
+                continuation.resume(returning: error.map { "\($0)" })
             }
+        }
+
+        if let failure {
+            Issue.record("attach() failed: \(failure)", sourceLocation: sourceLocation)
         }
     }
 }

--- a/Test/UTS/integration/standard/realtime/ChannelHistoryTests.swift
+++ b/Test/UTS/integration/standard/realtime/ChannelHistoryTests.swift
@@ -94,13 +94,14 @@ extension ChannelHistoryTests {
                               name: String,
                               data: String,
                               sourceLocation: SourceLocation = #_sourceLocation) async {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        let failure: String? = await withCheckedContinuation { continuation in
             channel.publish(name, data: data) { error in
-                if let error {
-                    Issue.record("publish(\(name)) failed: \(error)", sourceLocation: sourceLocation)
-                }
-                continuation.resume()
+                continuation.resume(returning: error.map { "\($0)" })
             }
+        }
+
+        if let failure {
+            Issue.record("publish(\(name)) failed: \(failure)", sourceLocation: sourceLocation)
         }
     }
 

--- a/Test/UTS/integration/standard/rest/HistoryTests.swift
+++ b/Test/UTS/integration/standard/rest/HistoryTests.swift
@@ -236,13 +236,14 @@ extension HistoryTests {
                               name: String,
                               data: Any,
                               sourceLocation: SourceLocation = #_sourceLocation) async {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        let failure: String? = await withCheckedContinuation { continuation in
             channel.publish(name, data: data, callback: { error in
-                if let error {
-                    Issue.record("publish(\(name)) failed: \(error)", sourceLocation: sourceLocation)
-                }
-                continuation.resume()
+                continuation.resume(returning: error.map { "\($0)" })
             })
+        }
+
+        if let failure {
+            Issue.record("publish(\(name)) failed: \(failure)", sourceLocation: sourceLocation)
         }
     }
 
@@ -252,19 +253,21 @@ extension HistoryTests {
     private func historyItems(of channel: ARTRestChannel,
                               query: ARTDataQuery? = nil,
                               sourceLocation: SourceLocation = #_sourceLocation) async -> [ARTMessage] {
-        await withCheckedContinuation { (continuation: CheckedContinuation<[ARTMessage], Never>) in
+        let (items, failure): ([ARTMessage], String?) = await withCheckedContinuation { continuation in
             do {
                 try channel.history(query, callback: { result, error in
-                    if let error {
-                        Issue.record("history() failed: \(error)", sourceLocation: sourceLocation)
-                    }
-                    continuation.resume(returning: result?.items ?? [])
+                    continuation.resume(returning: (result?.items ?? [], error.map { "history() failed: \($0)" }))
                 })
             } catch {
-                Issue.record("history(query) rejected the query: \(error)", sourceLocation: sourceLocation)
-                continuation.resume(returning: [])
+                continuation.resume(returning: ([], "history(query) rejected the query: \(error)"))
             }
         }
+
+        if let failure {
+            Issue.record("\(failure)", sourceLocation: sourceLocation)
+        }
+
+        return items
     }
 
     /// Fetches the channel's history (default query) and returns its items, propagating any
@@ -289,16 +292,20 @@ extension HistoryTests {
     private func historyPage(of channel: ARTRestChannel,
                              sourceLocation: SourceLocation = #_sourceLocation) async
         -> (items: [ARTMessage], hasNext: Bool, isLast: Bool) {
-        await withCheckedContinuation { (continuation: CheckedContinuation<(items: [ARTMessage], hasNext: Bool, isLast: Bool), Never>) in
+        let (page, failure): ((items: [ARTMessage], hasNext: Bool, isLast: Bool), String?) = await withCheckedContinuation { continuation in
             channel.history { result, error in
-                if let error {
-                    Issue.record("history() failed: \(error)", sourceLocation: sourceLocation)
-                }
-                continuation.resume(returning: (items: result?.items ?? [],
-                                                hasNext: result?.hasNext ?? false,
-                                                isLast: result?.isLast ?? true))
+                continuation.resume(returning: ((items: result?.items ?? [],
+                                                 hasNext: result?.hasNext ?? false,
+                                                 isLast: result?.isLast ?? true),
+                                                error.map { "\($0)" }))
             }
         }
+
+        if let failure {
+            Issue.record("history() failed: \(failure)", sourceLocation: sourceLocation)
+        }
+
+        return page
     }
 
     /// Builds a `Date` from a Unix-epoch millisecond timestamp (the spec's ms arithmetic on

--- a/Test/UTS/integration/standard/rest/PresenceTests.swift
+++ b/Test/UTS/integration/standard/rest/PresenceTests.swift
@@ -560,14 +560,17 @@ extension PresenceTests {
     /// `try #require`).
     private func presenceGet(_ presence: ARTRestPresence,
                              sourceLocation: SourceLocation = #_sourceLocation) async -> ARTPaginatedResult<ARTPresenceMessage>? {
-        await withCheckedContinuation { (continuation: CheckedContinuation<ARTPaginatedResult<ARTPresenceMessage>?, Never>) in
+        let (result, failure): (ARTPaginatedResult<ARTPresenceMessage>?, String?) = await withCheckedContinuation { continuation in
             presence.get { result, error in
-                if let error {
-                    Issue.record("presence.get() failed: \(error)", sourceLocation: sourceLocation)
-                }
-                continuation.resume(returning: result)
+                continuation.resume(returning: (result, error.map { "\($0)" }))
             }
         }
+
+        if let failure {
+            Issue.record("presence.get() failed: \(failure)", sourceLocation: sourceLocation)
+        }
+
+        return result
     }
 
     /// Awaits `presence.get(query)` (the spec's `AWAIT channel.presence.get(limit:/clientId:)`),
@@ -575,19 +578,21 @@ extension PresenceTests {
     private func presenceGet(_ presence: ARTRestPresence,
                              query: ARTPresenceQuery,
                              sourceLocation: SourceLocation = #_sourceLocation) async -> ARTPaginatedResult<ARTPresenceMessage>? {
-        await withCheckedContinuation { (continuation: CheckedContinuation<ARTPaginatedResult<ARTPresenceMessage>?, Never>) in
+        let (result, failure): (ARTPaginatedResult<ARTPresenceMessage>?, String?) = await withCheckedContinuation { continuation in
             do {
                 try presence.get(query) { result, error in
-                    if let error {
-                        Issue.record("presence.get(query) failed: \(error)", sourceLocation: sourceLocation)
-                    }
-                    continuation.resume(returning: result)
+                    continuation.resume(returning: (result, error.map { "presence.get(query) failed: \($0)" }))
                 }
             } catch {
-                Issue.record("presence.get(query) threw: \(error)", sourceLocation: sourceLocation)
-                continuation.resume(returning: nil)
+                continuation.resume(returning: (nil, "presence.get(query) threw: \(error)"))
             }
         }
+
+        if let failure {
+            Issue.record("\(failure)", sourceLocation: sourceLocation)
+        }
+
+        return result
     }
 
     /// Awaits `presence.get()` expecting it to fail (the spec's `AWAIT presence.get() FAILS WITH
@@ -595,28 +600,34 @@ extension PresenceTests {
     /// succeeded (tests unwrap with `try #require`).
     private func presenceGetError(_ presence: ARTRestPresence,
                                   sourceLocation: SourceLocation = #_sourceLocation) async -> ARTErrorInfo? {
-        await withCheckedContinuation { (continuation: CheckedContinuation<ARTErrorInfo?, Never>) in
+        let error: ARTErrorInfo? = await withCheckedContinuation { continuation in
             presence.get { _, error in
-                if error == nil {
-                    Issue.record("presence.get() unexpectedly succeeded", sourceLocation: sourceLocation)
-                }
                 continuation.resume(returning: error)
             }
         }
+
+        if error == nil {
+            Issue.record("presence.get() unexpectedly succeeded", sourceLocation: sourceLocation)
+        }
+
+        return error
     }
 
     /// Awaits `presence.history()` (the spec's `result = AWAIT rest_channel.presence.history()`),
     /// returning the paginated result — or nil, after recording an issue, on failure.
     private func presenceHistory(_ presence: ARTRestPresence,
                                  sourceLocation: SourceLocation = #_sourceLocation) async -> ARTPaginatedResult<ARTPresenceMessage>? {
-        await withCheckedContinuation { (continuation: CheckedContinuation<ARTPaginatedResult<ARTPresenceMessage>?, Never>) in
+        let (result, failure): (ARTPaginatedResult<ARTPresenceMessage>?, String?) = await withCheckedContinuation { continuation in
             presence.history { result, error in
-                if let error {
-                    Issue.record("presence.history() failed: \(error)", sourceLocation: sourceLocation)
-                }
-                continuation.resume(returning: result)
+                continuation.resume(returning: (result, error.map { "\($0)" }))
             }
         }
+
+        if let failure {
+            Issue.record("presence.history() failed: \(failure)", sourceLocation: sourceLocation)
+        }
+
+        return result
     }
 
     /// Fetches presence history (default query), propagating any `presence.history()` error so it
@@ -641,33 +652,38 @@ extension PresenceTests {
     private func presenceHistory(_ presence: ARTRestPresence,
                                  query: ARTDataQuery,
                                  sourceLocation: SourceLocation = #_sourceLocation) async -> ARTPaginatedResult<ARTPresenceMessage>? {
-        await withCheckedContinuation { (continuation: CheckedContinuation<ARTPaginatedResult<ARTPresenceMessage>?, Never>) in
+        let (result, failure): (ARTPaginatedResult<ARTPresenceMessage>?, String?) = await withCheckedContinuation { continuation in
             do {
                 try presence.history(query) { result, error in
-                    if let error {
-                        Issue.record("presence.history(query) failed: \(error)", sourceLocation: sourceLocation)
-                    }
-                    continuation.resume(returning: result)
+                    continuation.resume(returning: (result, error.map { "presence.history(query) failed: \($0)" }))
                 }
             } catch {
-                Issue.record("presence.history(query) threw: \(error)", sourceLocation: sourceLocation)
-                continuation.resume(returning: nil)
+                continuation.resume(returning: (nil, "presence.history(query) threw: \(error)"))
             }
         }
+
+        if let failure {
+            Issue.record("\(failure)", sourceLocation: sourceLocation)
+        }
+
+        return result
     }
 
     /// Awaits `page.next()` (the spec's `page2 = AWAIT page1.next()`), returning the next page —
     /// or nil, after recording an issue, on failure.
     private func nextPage(of page: ARTPaginatedResult<ARTPresenceMessage>,
                           sourceLocation: SourceLocation = #_sourceLocation) async -> ARTPaginatedResult<ARTPresenceMessage>? {
-        await withCheckedContinuation { (continuation: CheckedContinuation<ARTPaginatedResult<ARTPresenceMessage>?, Never>) in
+        let (result, failure): (ARTPaginatedResult<ARTPresenceMessage>?, String?) = await withCheckedContinuation { continuation in
             page.next { result, error in
-                if let error {
-                    Issue.record("next() failed: \(error)", sourceLocation: sourceLocation)
-                }
-                continuation.resume(returning: result)
+                continuation.resume(returning: (result, error.map { "\($0)" }))
             }
         }
+
+        if let failure {
+            Issue.record("next() failed: \(failure)", sourceLocation: sourceLocation)
+        }
+
+        return result
     }
 
     /// Awaits a realtime presence operation's acknowledgement (the spec's
@@ -675,13 +691,14 @@ extension PresenceTests {
     private func awaitPresenceOp(_ label: String,
                                  sourceLocation: SourceLocation = #_sourceLocation,
                                  _ operation: (@escaping ARTCallback) -> Void) async {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        let failure: String? = await withCheckedContinuation { continuation in
             operation { error in
-                if let error {
-                    Issue.record("\(label) failed: \(error)", sourceLocation: sourceLocation)
-                }
-                continuation.resume()
+                continuation.resume(returning: error.map { "\($0)" })
             }
+        }
+
+        if let failure {
+            Issue.record("\(label) failed: \(failure)", sourceLocation: sourceLocation)
         }
     }
 }

--- a/Test/UTS/integration/standard/rest/PublishTests.swift
+++ b/Test/UTS/integration/standard/rest/PublishTests.swift
@@ -188,14 +188,17 @@ extension PublishTests {
                               name: String,
                               data: String,
                               sourceLocation: SourceLocation = #_sourceLocation) async -> ARTErrorInfo? {
-        await withCheckedContinuation { (continuation: CheckedContinuation<ARTErrorInfo?, Never>) in
+        let error: ARTErrorInfo? = await withCheckedContinuation { continuation in
             channel.publish(name, data: data, callback: { error in
-                if error == nil {
-                    Issue.record("publish(\(name)) unexpectedly succeeded", sourceLocation: sourceLocation)
-                }
                 continuation.resume(returning: error)
             })
         }
+
+        if error == nil {
+            Issue.record("publish(\(name)) unexpectedly succeeded", sourceLocation: sourceLocation)
+        }
+
+        return error
     }
 
     /// Awaits `publish(messages:)` expecting it to fail, returning the error — or nil, after
@@ -203,14 +206,17 @@ extension PublishTests {
     private func publishError(_ channel: ARTRestChannel,
                               messages: [ARTMessage],
                               sourceLocation: SourceLocation = #_sourceLocation) async -> ARTErrorInfo? {
-        await withCheckedContinuation { (continuation: CheckedContinuation<ARTErrorInfo?, Never>) in
+        let error: ARTErrorInfo? = await withCheckedContinuation { continuation in
             channel.publish(messages, callback: { error in
-                if error == nil {
-                    Issue.record("publish(messages) unexpectedly succeeded", sourceLocation: sourceLocation)
-                }
                 continuation.resume(returning: error)
             })
         }
+
+        if error == nil {
+            Issue.record("publish(messages) unexpectedly succeeded", sourceLocation: sourceLocation)
+        }
+
+        return error
     }
 
     /// Awaits the publish acknowledgement and returns the `ARTPublishResult` (the spec's
@@ -219,14 +225,17 @@ extension PublishTests {
                                name: String,
                                data: String,
                                sourceLocation: SourceLocation = #_sourceLocation) async -> ARTPublishResult? {
-        await withCheckedContinuation { (continuation: CheckedContinuation<ARTPublishResult?, Never>) in
+        let (result, failure): (ARTPublishResult?, String?) = await withCheckedContinuation { continuation in
             channel.publish(name, data: data, resultCallback: { result, error in
-                if let error {
-                    Issue.record("publish(\(name)) failed: \(error)", sourceLocation: sourceLocation)
-                }
-                continuation.resume(returning: result)
+                continuation.resume(returning: (result, error.map { "\($0)" }))
             })
         }
+
+        if let failure {
+            Issue.record("publish(\(name)) failed: \(failure)", sourceLocation: sourceLocation)
+        }
+
+        return result
     }
 
     /// Awaits the publish acknowledgement for an array of messages and returns the
@@ -235,14 +244,17 @@ extension PublishTests {
     private func publishResult(_ channel: ARTRestChannel,
                                messages: [ARTMessage],
                                sourceLocation: SourceLocation = #_sourceLocation) async -> ARTPublishResult? {
-        await withCheckedContinuation { (continuation: CheckedContinuation<ARTPublishResult?, Never>) in
+        let (result, failure): (ARTPublishResult?, String?) = await withCheckedContinuation { continuation in
             channel.publish(messages, resultCallback: { result, error in
-                if let error {
-                    Issue.record("publish(messages) failed: \(error)", sourceLocation: sourceLocation)
-                }
-                continuation.resume(returning: result)
+                continuation.resume(returning: (result, error.map { "\($0)" }))
             })
         }
+
+        if let failure {
+            Issue.record("publish(messages) failed: \(failure)", sourceLocation: sourceLocation)
+        }
+
+        return result
     }
 
     /// Awaits the publish acknowledgement of a single pre-built message (the spec's
@@ -250,13 +262,14 @@ extension PublishTests {
     private func awaitPublish(_ channel: ARTRestChannel,
                               message: ARTMessage,
                               sourceLocation: SourceLocation = #_sourceLocation) async {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        let failure: String? = await withCheckedContinuation { continuation in
             channel.publish([message], callback: { error in
-                if let error {
-                    Issue.record("publish(\(message.id ?? "?")) failed: \(error)", sourceLocation: sourceLocation)
-                }
-                continuation.resume()
+                continuation.resume(returning: error.map { "\($0)" })
             })
+        }
+
+        if let failure {
+            Issue.record("publish(\(message.id ?? "?")) failed: \(failure)", sourceLocation: sourceLocation)
         }
     }
 
@@ -264,14 +277,17 @@ extension PublishTests {
     /// error.
     private func historyItems(of channel: ARTRestChannel,
                               sourceLocation: SourceLocation = #_sourceLocation) async -> [ARTMessage] {
-        await withCheckedContinuation { (continuation: CheckedContinuation<[ARTMessage], Never>) in
+        let (items, failure): ([ARTMessage], String?) = await withCheckedContinuation { continuation in
             channel.history { result, error in
-                if let error {
-                    Issue.record("history() failed: \(error)", sourceLocation: sourceLocation)
-                }
-                continuation.resume(returning: result?.items ?? [])
+                continuation.resume(returning: (result?.items ?? [], error.map { "\($0)" }))
             }
         }
+
+        if let failure {
+            Issue.record("history() failed: \(failure)", sourceLocation: sourceLocation)
+        }
+
+        return items
     }
 
     /// Fetches the channel's history (default query) and returns its items, propagating any
@@ -296,13 +312,16 @@ extension PublishTests {
     private func requestToken(_ client: ARTRest,
                               tokenParams: ARTTokenParams,
                               sourceLocation: SourceLocation = #_sourceLocation) async -> String? {
-        await withCheckedContinuation { (continuation: CheckedContinuation<String?, Never>) in
+        let (token, failure): (String?, String?) = await withCheckedContinuation { continuation in
             client.auth.requestToken(tokenParams, with: nil) { tokenDetails, error in
-                if let error {
-                    Issue.record("requestToken failed: \(error)", sourceLocation: sourceLocation)
-                }
-                continuation.resume(returning: tokenDetails?.token)
+                continuation.resume(returning: (tokenDetails?.token, error.map { "\($0)" }))
             }
         }
+
+        if let failure {
+            Issue.record("requestToken failed: \(failure)", sourceLocation: sourceLocation)
+        }
+
+        return token
     }
 }

--- a/Test/UTS/unit/rest/TimeTests.swift
+++ b/Test/UTS/unit/rest/TimeTests.swift
@@ -179,31 +179,35 @@ final class TimeTests: UTSTestCase {
 extension TimeTests {
     /// Bridges the completion-handler `time:` API (UTS `AWAIT client.time()`, success path).
     func awaitTime(_ rest: ARTRest, sourceLocation: SourceLocation = #_sourceLocation) async throws -> Date {
-        let date: Date? = await withCheckedContinuation { continuation in
+        let (date, failure): (Date?, String?) = await withCheckedContinuation { continuation in
             rest.time { date, error in
-                if let error {
-                    Issue.record("time() failed unexpectedly: \(error)", sourceLocation: sourceLocation)
-                    continuation.resume(returning: nil)
-                    return
-                }
-                continuation.resume(returning: date)
+                continuation.resume(returning: (date, error.map { "\($0)" }))
             }
         }
+
+        if let failure {
+            Issue.record("time() failed unexpectedly: \(failure)", sourceLocation: sourceLocation)
+        }
+
         return try #require(date, "time() returned no date", sourceLocation: sourceLocation)
     }
 
     /// Bridges the completion-handler `time:` API (UTS `AWAIT client.time() FAILS WITH error`).
     func awaitTimeError(_ rest: ARTRest, sourceLocation: SourceLocation = #_sourceLocation) async throws -> ARTErrorInfo {
-        let error: ARTErrorInfo? = await withCheckedContinuation { continuation in
+        let (error, unexpectedDate): (ARTErrorInfo?, String?) = await withCheckedContinuation { continuation in
             rest.time { date, error in
                 if let error {
-                    continuation.resume(returning: error as? ARTErrorInfo ?? ARTErrorInfo.create(from: error))
-                    return
+                    continuation.resume(returning: (error as? ARTErrorInfo ?? ARTErrorInfo.create(from: error), nil))
+                } else {
+                    continuation.resume(returning: (nil, String(describing: date)))
                 }
-                Issue.record("time() succeeded unexpectedly with date \(String(describing: date))", sourceLocation: sourceLocation)
-                continuation.resume(returning: nil)
             }
         }
+
+        if let unexpectedDate {
+            Issue.record("time() succeeded unexpectedly with date \(unexpectedDate)", sourceLocation: sourceLocation)
+        }
+
         return try #require(error, "time() returned no error", sourceLocation: sourceLocation)
     }
 }


### PR DESCRIPTION
Fixes #2272. Split out of #2268, which is stacked above this.

Preparation for https://github.com/ably/ably-cocoa/pull/2275

## Why

The integration helpers wrapped an SDK callback in a continuation and recorded the issue *inside* that callback, which runs on the SDK's callback queue. swift-testing cannot attribute an issue recorded there to the running test, so instead of failing one test it aborts the process:

```
Fatal error: Issue 'Issue recorded: publish(messages) failed: Error -1001 - The request timed out.'
was recorded at PublishTests.swift:72 without an associated test. This may be due to calling
#expect() or Issue.record() from a detached Task or another unknown context.
```

The whole platform leg then fails with an empty `Failing tests:` list. `-retry-tests-on-failure` cannot help either, because there is no attributed failure to re-run — so a transient sandbox timeout takes out a leg that retry exists to rescue. On the happy path nothing records, which is why this stayed invisible until a request actually failed.

## What

Each helper now carries the outcome across the continuation and records after the `await`. Two shapes, depending on what the callback returns:

- Where the value itself is the verdict (`publishError`, `presenceGetError`), resume with just the value and check it afterwards.
- Otherwise resume with a tuple. Only the error's *description* crosses, since `ARTErrorInfo` is not `Sendable` — the same constraint that already made `requestToken` return `tokenDetails?.token` rather than the details object. Where the message differs by path (the two `do`/`catch` helpers) the whole message crosses instead.

22 sites across six files. Nothing about what is asserted changes, only where the recording happens. There was already a correct precedent in the same file — `historyItems(of:) async throws` propagates the error out rather than recording inside.

| File | Sites |
| --- | --- |
| `PublishTests.swift` | 7 |
| `PresenceTests.swift` | 7 |
| `HistoryTests.swift` | 3 |
| `ObjectsSyncTests.swift` | 2 |
| `TimeTests.swift` | 2 |
| `ChannelHistoryTests.swift` | 1 |

## Verification

`swift build --build-tests` clean, and these suites green against sandbox: `TimeTests` (5), `ChannelHistoryTests` (1), `ObjectsSyncTests` (4), `PublishTests` (5), `HistoryTests` (6 in 2 suites). `PresenceTests` was left to CI, which has since run it green.

A brace-matched scan confirms no continuation closure anywhere in `Test/UTS` still records an issue or evaluates an expectation.

Confirmed working in CI on the combined branch: the same flakes now appear as `Suite HistoryTests failed … with 3 issue(s)`, attributed and retryable, where before they were fatal errors that killed the process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved asynchronous test handling across realtime, REST, presence, publishing, history, object synchronization, and time-related scenarios.
  - Test failures are now captured consistently and reported after asynchronous operations complete.
  - Preserved existing test results, error messages, and asynchronous acknowledgment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->