### PR TITLE
CI: fix the EditorConfig job after editorconfig-checker v4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,8 +20,10 @@ jobs:
         with:
           persist-credentials: false
 
+      # v3.0.0 is the first release that resolves editorconfig-checker v4's
+      # asset names; earlier ones fail against `version: latest`.
       - name: Set up editorconfig-checker
-        uses: editorconfig-checker/action-editorconfig-checker@840e866d93b8e032123c23bac69dece044d4d84c # v2.2.0
+        uses: editorconfig-checker/action-editorconfig-checker@51f63319f592f97930c73d9c46184d20bd206393 # v3.0.0
 
       - name: Run editorconfig-checker
         run: editorconfig-checker


### PR DESCRIPTION
Every push to `main` and every pull request currently shows a red **EditorConfig** check, including [the run on `main` after #2261 merged](https://github.com/ably/ably-cocoa/actions/runs/34359712613):

```
Find 'latest' release
##[error]Error: The binary 'ec-linux-amd64*' not found
```

It fails before checking anything, which is why the log lists no file violations.

## Cause

editorconfig-checker **v4.0.0** (3 September) renamed its release assets from `ec-<os>-<arch>` to `editorconfig-checker-<os>-<arch>`. `lint.yml` pins the action at v2.2.0 and passes `version: latest`, so it resolves v4 and then looks for an asset name that no longer exists. Nothing in this repository changed; the last green lint run was 3 September, before that release.

## Fix

Bump the action to v3.0.0, the release that understands the new names. Two lines plus a comment saying why the pin matters, so nobody downgrades it back.

## Verification

editorconfig-checker v4.0.1 run against this commit's tree passes clean (exit 0), so the newer checker introduces no violations of its own — the job should go green rather than swap one failure for another.

This change also exists as one commit of #2264, at the bottom of the device/server split stack, where it is stuck behind several PRs gated on external work. It is unrelated to that split and blocking the whole repository, so it is worth landing on its own. The patches are identical, so git will drop the duplicate when that stack merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated lint validation to use a newer EditorConfig checker release.
  * Improved compatibility with the latest checker assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->